### PR TITLE
operator==() should take const reference parameters and be const itself.

### DIFF
--- a/src/ErrorReporting/Error.cpp
+++ b/src/ErrorReporting/Error.cpp
@@ -46,16 +46,14 @@ Error::Error(ErrorDefinition::ErrorType errorId,
   for (auto loc : (locations)) m_locations.push_back(loc);
 }
 
-bool Error::operator==(Error& rhs) {
+bool Error::operator==(const Error& rhs) const {
   if (m_errorId != rhs.m_errorId) return false;
-  bool is_equal = false;
   if (m_locations.size() < rhs.m_locations.size())
-    is_equal = std::equal(m_locations.begin(), m_locations.end(),
-                          rhs.m_locations.begin());
+    return std::equal(m_locations.begin(), m_locations.end(),
+                      rhs.m_locations.begin());
   else
-    is_equal = std::equal(rhs.m_locations.begin(), rhs.m_locations.end(),
-                          m_locations.begin());
-  return is_equal;
+    return std::equal(rhs.m_locations.begin(), rhs.m_locations.end(),
+                      m_locations.begin());
 }
 
 bool Error::operator<(const Error& rhs) const {

--- a/src/ErrorReporting/Error.h
+++ b/src/ErrorReporting/Error.h
@@ -39,7 +39,7 @@ class Error {
         std::vector<Location>* extraLocs = NULL);
   Error(ErrorDefinition::ErrorType errorId, Location& loc, Location& extra);
   Error(ErrorDefinition::ErrorType errorId, std::vector<Location>& locations);
-  bool operator==(Error& rhs);
+  bool operator==(const Error& rhs) const;
   bool operator<(const Error& rhs) const;
   struct compare {
     bool operator()(const Error& e1, const Error& e2) const { return e1 < e2; }

--- a/src/ErrorReporting/Location.cpp
+++ b/src/ErrorReporting/Location.cpp
@@ -27,7 +27,7 @@ using namespace SURELOG;
 
 Location::~Location() {}
 
-bool Location::operator==(Location& rhs) {
+bool Location::operator==(const Location& rhs) const {
   if (m_fileId != rhs.m_fileId) return false;
   if (m_line != rhs.m_line) return false;
   if (m_column != rhs.m_column) return false;

--- a/src/ErrorReporting/Location.h
+++ b/src/ErrorReporting/Location.h
@@ -37,7 +37,7 @@ class Location {
       : m_fileId(fileId), m_line(line), m_column(column), m_object(object){};
   /* Do not create a copy constructor, use default*/
   // Location(const Location& orig);
-  bool operator==(Location& rhs);
+  bool operator==(const Location& rhs) const;
   bool operator<(const Location& rhs) const;
   virtual ~Location();
   SymbolId m_fileId;


### PR DESCRIPTION
...otherwise a lot of algorithm implementations will be confused and not
compile.

Signed-off-by: Henner Zeller <h.zeller@acm.org>