### PR TITLE
Fix override that was not actually overridden due to differenet

### DIFF
--- a/src/Design/DataType.h
+++ b/src/Design/DataType.h
@@ -102,7 +102,7 @@ class DataType {
   static bool isString_type(VObjectType type);
   static bool isNumber(VObjectType type);
 
-  virtual bool isNet() { return false; }
+  virtual bool isNet() const { return false; }
 
   UHDM::typespec* getTypespec() const { return m_typespec; }
   void setTypespec(UHDM::typespec* typespec) { m_typespec = typespec; }

--- a/src/Design/Struct.h
+++ b/src/Design/Struct.h
@@ -39,7 +39,7 @@ class Struct : public DataType {
 
   NodeId getNameId() const { return m_nameId; }
 
-  bool isNet() const;
+  bool isNet() const override;
 
  private:
   const NodeId m_nameId;


### PR DESCRIPTION
qualifiers.

Also, use the 'override' keyword to make this hard to break in the
future.

Signed-off-by: Henner Zeller <h.zeller@acm.org>