### PR TITLE
Remove double parenthesis in if-condition.

### DIFF
--- a/src/DesignCompile/EvalFunc.cpp
+++ b/src/DesignCompile/EvalFunc.cpp
@@ -370,7 +370,7 @@ expr* CompileHelper::EvalFunc(UHDM::function* func, std::vector<any*>* args,
                               ValuedComponentI* instance,
                               const std::string& fileName, int lineNumber,
                               any* pexpr) {
-  if ((func == nullptr)) {
+  if (func == nullptr) {
     invalidValue = true;
     return nullptr;
   }


### PR DESCRIPTION
This pattern is used to silence compile warnings in assignments
in if-conditions, so this being a pure comparison is raised as
a warning for not being such assignment.

Signed-off-by: Henner Zeller <h.zeller@acm.org>