### PR TITLE
Unmark errors as reported right when created

### DIFF
--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -396,6 +396,9 @@ bool ErrorContainer::printMessage(Error& error, bool muteStdout) {
 
 bool ErrorContainer::printMessages(bool muteStdout) {
   std::pair<std::string, bool> report = createReport_();
+  for (auto &err:m_errors) {
+    err.m_reported = true;
+  }
 
   if (!muteStdout) {
     std::cout << report.first << std::flush;

--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -396,7 +396,7 @@ bool ErrorContainer::printMessage(Error& error, bool muteStdout) {
 
 bool ErrorContainer::printMessages(bool muteStdout) {
   std::pair<std::string, bool> report = createReport_();
-  for (auto &err:m_errors) {
+  for (auto& err : m_errors) {
     err.m_reported = true;
   }
 

--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -298,7 +298,6 @@ std::pair<std::string, bool> ErrorContainer::createReport_() {
     if (std::get<2>(textStatus))  // Filtered
       continue;
     report += std::get<0>(textStatus);
-    msg.m_reported = true;
   }
   return std::make_pair(report, reportFatalError);
 }
@@ -311,7 +310,6 @@ std::pair<std::string, bool> ErrorContainer::createReport_(Error& error) {
   if (std::get<1>(textStatus)) reportFatalError = true;
   if (!std::get<2>(textStatus))  // Filtered
     report += std::get<0>(textStatus);
-  msg.m_reported = true;
   return std::make_pair(report, reportFatalError);
 }
 


### PR DESCRIPTION
Currently errors are marked as reported right when the report text is created. This means that when the compiler runs with muteStdOut enabled, the errors are never displayed and never programmatically obtainable, since `ErrorContainer::createErrorMessage` exits right away if the error is marked as reported.

This change removes the error mark when the report text is created. It should be safe, since the only time the private `ErrorContainer::createReport_` methods are called, the calling functions already set the `m_reported` to true anyway. Without this change, that was redundant.