### PR TITLE
Smallish warning fixes

### DIFF
--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -216,6 +216,7 @@ bool CompileClass::compile() {
         break;
       case VObjectType::slClass_type:
         compile_class_type_(fC, id);
+        break;
       default:
         break;
     }

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -4112,7 +4112,7 @@ UHDM::any* CompileHelper::compileExpression(
                 elems->push_back(ref);
                 ref->VpiName(tmpName);
                 ref->VpiFullName(tmpName);
-                tmpName == "";
+                tmpName = "";
                 is_hierarchical = true;
               }
               tmpName = fC->SymName(dotedName);
@@ -4185,14 +4185,14 @@ UHDM::any* CompileHelper::compileExpression(
               elems->push_back(ref);
               ref->VpiName(tmpName);
               ref->VpiFullName(tmpName);
-              tmpName == "";
+              tmpName = "";
               result = path;
             }
           } else {
             ref_obj* ref = s.MakeRef_obj();
             ref->VpiName(tmpName);
             ref->VpiParent(pexpr);
-            tmpName == "";
+            tmpName = "";
             result = ref;
             break;
           }

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -967,6 +967,7 @@ bool CompileHelper::compileLoop_stmt(Scope* parent, Statement* parentStmt,
       break;
     case VObjectType::slForeach:
       compileForeachLoop_stmt(parent, parentStmt, fC, fC->Sibling(loop));
+      break;
     default:
       break;
   }
@@ -1419,6 +1420,7 @@ bool CompileHelper::compilePortDeclaration(DesignComponent* component,
               output n1; */
           subNode = fC->Sibling(subNode);
           subType = fC->Type(subNode);
+          [[fallthrough]];
         case VObjectType::slInput_declaration:
         case VObjectType::slOutput_declaration:
         case VObjectType::slInout_declaration: {
@@ -2430,7 +2432,7 @@ UHDM::any* CompileHelper::compileTfCall(DesignComponent* component,
 
   NodeId dollar_or_string = fC->Child(Tf_call_stmt);
   VObjectType leaf_type = fC->Type(dollar_or_string);
-  NodeId tfNameNode;
+  NodeId tfNameNode = InvalidNodeId;
   UHDM::tf_call* call = nullptr;
   std::string name;
   if (leaf_type == slDollar_keyword) {

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -516,6 +516,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
       // TODO: flavors
       UHDM::disable* disable = s.MakeDisable();
       stmt = disable;
+      break;
     }
     case VObjectType::slContinueStmt: {
       UHDM::continue_stmt* cstmt = s.MakeContinue_stmt();

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -1328,6 +1328,7 @@ void DesignElaboration::elaborateInstance_(
                   use.setUsed();
                   break;
                 }
+                break;
               }
               break;
             }
@@ -1605,9 +1606,9 @@ void DesignElaboration::collectParams_(std::vector<std::string>& params,
               bool replay = false;
               // GDB: p replay=true
               if (replay) {
-                (UHDM::expr*)m_helper.compileExpression(
-                    parentDefinition, parentFile, expr, m_compileDesign,
-                    nullptr, parentInstance, true, false);
+                m_helper.compileExpression(parentDefinition, parentFile, expr,
+                                           m_compileDesign, nullptr,
+                                           parentInstance, true, false);
 
                 m_exprBuilder.evalExpr(parentFile, expr, parentInstance, true);
               }
@@ -1678,9 +1679,9 @@ void DesignElaboration::collectParams_(std::vector<std::string>& params,
             bool replay = false;
             // GDB: p replay=true
             if (replay) {
-              (UHDM::expr*)m_helper.compileExpression(
-                  parentDefinition, parentFile, expr, m_compileDesign, nullptr,
-                  parentInstance, true, false);
+              m_helper.compileExpression(parentDefinition, parentFile, expr,
+                                         m_compileDesign, nullptr,
+                                         parentInstance, true, false);
             }
 
             const std::string& pname = parentFile->SymName(child);

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -417,7 +417,6 @@ ModuleInstance* NetlistElaboration::getInterfaceInstance_(
   ModuleInstance* parent = instance->getParent();
   const FileContent* fC = instance->getFileContent();
   NodeId Udp_instantiation = instance->getNodeId();
-  const std::string& instName = instance->getFullPathName();
   VObjectType inst_type = fC->Type(Udp_instantiation);
 
   if ((inst_type == VObjectType::slUdp_instantiation) ||
@@ -564,7 +563,6 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
   NodeId Udp_instantiation = instance->getNodeId();
   Serializer& s = m_compileDesign->getSerializer();
   Netlist* netlist = instance->getNetlist();
-  const std::string& instName = instance->getFullPathName();
   VObjectType inst_type = fC->Type(Udp_instantiation);
   std::vector<UHDM::port*>* ports = netlist->ports();
   DesignComponent* comp = instance->getDefinition();

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -714,8 +714,8 @@ bool TestbenchElaboration::bindProperties_() {
       const std::string& signame = sig->getName();
 
       // Packed and unpacked ranges
-      int packedSize;
-      int unpackedSize;
+      int packedSize = 0;
+      int unpackedSize = 0;
       std::vector<UHDM::range*>* packedDimensions = m_helper.compileRanges(
           classDefinition, fC, packedDimension, m_compileDesign, nullptr,
           nullptr, true, packedSize, false);


### PR DESCRIPTION
 * Variables that stay uninitialized in some branches.
 * Missing 'break' in switches.
 * missing [[fallthrough]] in switches.
 * Fix a comparison meant to be an assignment.
 * Remove unused variables.

Signed-off-by: Henner Zeller <h.zeller@acm.org>