### PR TITLE
Avoid including uhdm.h in headers to reduce compile time.

### DIFF
--- a/src/Design/ModuleDefinition.h
+++ b/src/Design/ModuleDefinition.h
@@ -34,7 +34,7 @@
 #include "Design/ModPort.h"
 #include "Design/Signal.h"
 #include "Design/ValuedComponentI.h"
-#include "uhdm.h"
+#include "headers/containers.h"  // uhdm
 
 namespace UHDM {
 class udp_defn;

--- a/src/DesignCompile/CompileHelper.h
+++ b/src/DesignCompile/CompileHelper.h
@@ -33,7 +33,7 @@
 #include "Expression/ExprBuilder.h"
 #include "SourceCompile/SymbolTable.h"
 #include "SourceCompile/VObjectTypes.h"
-#include "headers/uhdm.h"
+
 namespace SURELOG {
 class Scope;
 class Statement;

--- a/src/DesignCompile/CompileModule.h
+++ b/src/DesignCompile/CompileModule.h
@@ -25,7 +25,6 @@
 #define COMPILEMODULE_H
 
 #include "DesignCompile/CompileHelper.h"
-#include "uhdm.h"
 
 namespace SURELOG {
 

--- a/src/Package/Package.h
+++ b/src/Package/Package.h
@@ -31,7 +31,7 @@
 #include "Design/ValuedComponentI.h"
 #include "Expression/ExprBuilder.h"
 #include "Library/Library.h"
-#include "uhdm.h"
+#include "headers/containers.h"  // uhdm
 
 namespace SURELOG {
 class CompilePackage;

--- a/src/Testbench/ClassDefinition.h
+++ b/src/Testbench/ClassDefinition.h
@@ -34,8 +34,8 @@
 #include "Testbench/Property.h"
 #include "Testbench/TaskMethod.h"
 #include "Testbench/TypeDef.h"
+#include "headers/containers.h"  // uhdm
 #include "headers/uhdm_forward_decl.h"
-#include "uhdm.h"
 
 namespace SURELOG {
 class CompileClass;

--- a/src/Testbench/Program.h
+++ b/src/Testbench/Program.h
@@ -25,7 +25,7 @@
 #define PROGRAM_H
 #include "Common/ClockingBlockHolder.h"
 #include "Design/DesignComponent.h"
-#include "uhdm.h"
+#include "headers/containers.h"  // uhdm
 
 namespace SURELOG {
 


### PR DESCRIPTION
The uhdm.h header includes every other class, which are
mostly not needed in the surelog headers. Typically, we
only need forward-declared containers, so include that
instead.

Signed-off-by: Henner Zeller <h.zeller@acm.org>