### PR TITLE
Move generated flatbuffer includes to compilation units.

### DIFF
--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -30,6 +30,7 @@
 #include <ctime>
 
 #include "Cache/Cache.h"
+#include "Cache/preproc_generated.h"
 #include "CommandLine/CommandLineParser.h"
 #include "ErrorReporting/ErrorContainer.h"
 #include "Package/Precompiled.h"

--- a/src/Cache/PPCache.h
+++ b/src/Cache/PPCache.h
@@ -25,7 +25,6 @@
 #define PPCACHE_H
 
 #include "Cache/Cache.h"
-#include "Cache/preproc_generated.h"
 #include "ErrorReporting/Error.h"
 #include "SourceCompile/PreprocessFile.h"
 #include "SourceCompile/SymbolTable.h"

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -38,6 +38,7 @@
 #include <ctime>
 
 #include "Cache/Cache.h"
+#include "Cache/parser_generated.h"
 #include "CommandLine/CommandLineParser.h"
 #include "Design/FileContent.h"
 #include "ErrorReporting/ErrorContainer.h"

--- a/src/Cache/ParseCache.h
+++ b/src/Cache/ParseCache.h
@@ -25,7 +25,6 @@
 #define PARSECACHE_H
 
 #include "Cache/Cache.h"
-#include "Cache/parser_generated.h"
 #include "SourceCompile/ParseFile.h"
 
 namespace SURELOG {


### PR DESCRIPTION
This reduces symbols spilled into the namespace of files including
these and makes it simpler later to possibly change the serialization
format.

Signed-off-by: Henner Zeller <h.zeller@acm.org>