### PR TITLE
bit_select and range_select parent and binding

### DIFF
--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -2601,6 +2601,10 @@ UHDM::any* CompileHelper::compileSelectExpression(
             bit_select->VpiIndex(sel);
             result = bit_select;
             if (sel->VpiParent() == nullptr) sel->VpiParent(bit_select);
+            ref_obj* ref = s.MakeRef_obj();
+            bit_select->VpiParent(ref);
+            ref->VpiName(name);
+            ref->VpiParent(pexpr);
           }
           lastBitExp = bitexp;
           bitexp = fC->Sibling(bitexp);
@@ -2637,6 +2641,7 @@ UHDM::any* CompileHelper::compileSelectExpression(
       r1->VpiFullName(name);
       path->Path_elems(elems);
       elems->push_back(r1);
+      r1->VpiParent(path);
       while (Bit_select) {
         if (fC->Type(Bit_select) == VObjectType::slStringConst) {
           NodeId tmp = fC->Sibling(Bit_select);
@@ -2651,6 +2656,7 @@ UHDM::any* CompileHelper::compileSelectExpression(
                 hier_path* p = (hier_path*)sel;
                 for (auto el : *p->Path_elems()) {
                   elems->push_back(el);
+                  el->VpiParent(path);
                   std::string n = el->VpiName();
                   if (el->UhdmType() == uhdmbit_select) {
                     bit_select* s = (bit_select*)el;
@@ -2664,6 +2670,7 @@ UHDM::any* CompileHelper::compileSelectExpression(
                 break;
               } else {
                 elems->push_back(sel);
+                sel->VpiParent(path);
                 hname += "." + sel->VpiName();
               }
             }
@@ -5746,6 +5753,7 @@ UHDM::any* CompileHelper::compileComplexFuncCall(
       select->VpiIndex(index);
       select->VpiName(sval);
       select->VpiFullName(sval);
+      select->VpiParent(path);
       path->Path_elems(elems);
       elems->push_back(select);
       std::string indexval;
@@ -5757,6 +5765,7 @@ UHDM::any* CompileHelper::compileComplexFuncCall(
         }
       }
       ref_obj* selobj = s.MakeRef_obj();
+      selobj->VpiParent(path);
       selobj->VpiName(sel);
       selobj->VpiFullName(sel);
       elems->push_back(selobj);

--- a/tests/AssignPlus/AssignPlus.log
+++ b/tests/AssignPlus/AssignPlus.log
@@ -255,7 +255,7 @@ design: (work@top)
             |vpiName:is_clear
             |vpiFullName:work@top.wval[0].is_clear
           |vpiOperand:
-          \_bit_select: (work@top.wval[0].bht_init_lp), line:7:42, endln:7:56
+          \_bit_select: (work@top.wval[0].bht_init_lp), line:7:42, endln:7:56, parent:work@top.wval[0].bht_init_lp
             |vpiName:bht_init_lp
             |vpiFullName:work@top.wval[0].bht_init_lp
             |vpiIndex:
@@ -272,13 +272,13 @@ design: (work@top)
               |vpiName:correct_i
               |vpiFullName:work@top.wval[0].correct_i
         |vpiLhs:
-        \_bit_select: (work@top.wval[0].w_data_li), line:7:14, endln:7:23
+        \_bit_select: (work@top.wval[0].w_data_li), line:7:14, endln:7:23, parent:work@top.wval[0].w_data_li
           |vpiName:w_data_li
           |vpiFullName:work@top.wval[0].w_data_li
           |vpiIndex:
-          \_ref_obj: (work@top.wval[0].i), line:7:24, endln:7:25, parent:work@top.wval[0].w_data_li
+          \_ref_obj: (work@top.wval[0].w_data_li.i), line:7:24, endln:7:25, parent:work@top.wval[0].w_data_li
             |vpiName:i
-            |vpiFullName:work@top.wval[0].i
+            |vpiFullName:work@top.wval[0].w_data_li.i
             |vpiActual:
             \_parameter: (work@top.wval[0].i), line:5, parent:work@top.wval[0]
               |vpiName:i
@@ -294,7 +294,7 @@ design: (work@top)
             |vpiName:is_clear
             |vpiFullName:work@top.wval[0].is_clear
           |vpiOperand:
-          \_bit_select: (work@top.wval[0].bht_init_lp), line:8:42, endln:8:56
+          \_bit_select: (work@top.wval[0].bht_init_lp), line:8:42, endln:8:56, parent:work@top.wval[0].bht_init_lp
             |vpiName:bht_init_lp
             |vpiFullName:work@top.wval[0].bht_init_lp
             |vpiIndex:
@@ -307,7 +307,7 @@ design: (work@top)
           \_operation: , line:8:59, endln:8:69
             |vpiOpType:30
             |vpiOperand:
-            \_bit_select: (work@top.wval[0].val_i), line:8:59, endln:8:69
+            \_bit_select: (work@top.wval[0].val_i), line:8:59, endln:8:69, parent:work@top.wval[0].val_i
               |vpiName:val_i
               |vpiFullName:work@top.wval[0].val_i
               |vpiIndex:
@@ -336,17 +336,17 @@ design: (work@top)
                   |vpiName:correct_i
                   |vpiFullName:work@top.wval[0].correct_i
               |vpiOperand:
-              \_bit_select: (work@top.wval[0].val_i), line:8:86, endln:8:94
+              \_bit_select: (work@top.wval[0].val_i), line:8:86, endln:8:94, parent:work@top.wval[0].val_i
                 |vpiName:val_i
                 |vpiFullName:work@top.wval[0].val_i
                 |vpiIndex:
-                \_ref_obj: (work@top.wval[0].i), line:8:92, endln:8:93, parent:work@top.wval[0].val_i
+                \_ref_obj: (work@top.wval[0].val_i.i), line:8:92, endln:8:93, parent:work@top.wval[0].val_i
                   |vpiName:i
-                  |vpiFullName:work@top.wval[0].i
+                  |vpiFullName:work@top.wval[0].val_i.i
                   |vpiActual:
                   \_parameter: (work@top.wval[0].i), line:5, parent:work@top.wval[0]
         |vpiLhs:
-        \_bit_select: (work@top.wval[0].w_data_li), line:8:14, endln:8:23
+        \_bit_select: (work@top.wval[0].w_data_li), line:8:14, endln:8:23, parent:work@top.wval[0].w_data_li
           |vpiName:w_data_li
           |vpiFullName:work@top.wval[0].w_data_li
           |vpiIndex:
@@ -383,7 +383,7 @@ design: (work@top)
             |vpiName:is_clear
             |vpiFullName:work@top.wval[2].is_clear
           |vpiOperand:
-          \_bit_select: (work@top.wval[2].bht_init_lp), line:7:42, endln:7:56
+          \_bit_select: (work@top.wval[2].bht_init_lp), line:7:42, endln:7:56, parent:work@top.wval[2].bht_init_lp
             |vpiName:bht_init_lp
             |vpiFullName:work@top.wval[2].bht_init_lp
             |vpiIndex:
@@ -400,13 +400,13 @@ design: (work@top)
               |vpiName:correct_i
               |vpiFullName:work@top.wval[2].correct_i
         |vpiLhs:
-        \_bit_select: (work@top.wval[2].w_data_li), line:7:14, endln:7:23
+        \_bit_select: (work@top.wval[2].w_data_li), line:7:14, endln:7:23, parent:work@top.wval[2].w_data_li
           |vpiName:w_data_li
           |vpiFullName:work@top.wval[2].w_data_li
           |vpiIndex:
-          \_ref_obj: (work@top.wval[2].i), line:7:24, endln:7:25, parent:work@top.wval[2].w_data_li
+          \_ref_obj: (work@top.wval[2].w_data_li.i), line:7:24, endln:7:25, parent:work@top.wval[2].w_data_li
             |vpiName:i
-            |vpiFullName:work@top.wval[2].i
+            |vpiFullName:work@top.wval[2].w_data_li.i
             |vpiActual:
             \_parameter: (work@top.wval[2].i), line:5, parent:work@top.wval[2]
               |vpiName:i
@@ -422,7 +422,7 @@ design: (work@top)
             |vpiName:is_clear
             |vpiFullName:work@top.wval[2].is_clear
           |vpiOperand:
-          \_bit_select: (work@top.wval[2].bht_init_lp), line:8:42, endln:8:56
+          \_bit_select: (work@top.wval[2].bht_init_lp), line:8:42, endln:8:56, parent:work@top.wval[2].bht_init_lp
             |vpiName:bht_init_lp
             |vpiFullName:work@top.wval[2].bht_init_lp
             |vpiIndex:
@@ -435,7 +435,7 @@ design: (work@top)
           \_operation: , line:8:59, endln:8:69
             |vpiOpType:30
             |vpiOperand:
-            \_bit_select: (work@top.wval[2].val_i), line:8:59, endln:8:69
+            \_bit_select: (work@top.wval[2].val_i), line:8:59, endln:8:69, parent:work@top.wval[2].val_i
               |vpiName:val_i
               |vpiFullName:work@top.wval[2].val_i
               |vpiIndex:
@@ -464,17 +464,17 @@ design: (work@top)
                   |vpiName:correct_i
                   |vpiFullName:work@top.wval[2].correct_i
               |vpiOperand:
-              \_bit_select: (work@top.wval[2].val_i), line:8:86, endln:8:94
+              \_bit_select: (work@top.wval[2].val_i), line:8:86, endln:8:94, parent:work@top.wval[2].val_i
                 |vpiName:val_i
                 |vpiFullName:work@top.wval[2].val_i
                 |vpiIndex:
-                \_ref_obj: (work@top.wval[2].i), line:8:92, endln:8:93, parent:work@top.wval[2].val_i
+                \_ref_obj: (work@top.wval[2].val_i.i), line:8:92, endln:8:93, parent:work@top.wval[2].val_i
                   |vpiName:i
-                  |vpiFullName:work@top.wval[2].i
+                  |vpiFullName:work@top.wval[2].val_i.i
                   |vpiActual:
                   \_parameter: (work@top.wval[2].i), line:5, parent:work@top.wval[2]
         |vpiLhs:
-        \_bit_select: (work@top.wval[2].w_data_li), line:8:14, endln:8:23
+        \_bit_select: (work@top.wval[2].w_data_li), line:8:14, endln:8:23, parent:work@top.wval[2].w_data_li
           |vpiName:w_data_li
           |vpiFullName:work@top.wval[2].w_data_li
           |vpiIndex:
@@ -511,7 +511,7 @@ design: (work@top)
             |vpiName:is_clear
             |vpiFullName:work@top.wval[4].is_clear
           |vpiOperand:
-          \_bit_select: (work@top.wval[4].bht_init_lp), line:7:42, endln:7:56
+          \_bit_select: (work@top.wval[4].bht_init_lp), line:7:42, endln:7:56, parent:work@top.wval[4].bht_init_lp
             |vpiName:bht_init_lp
             |vpiFullName:work@top.wval[4].bht_init_lp
             |vpiIndex:
@@ -528,13 +528,13 @@ design: (work@top)
               |vpiName:correct_i
               |vpiFullName:work@top.wval[4].correct_i
         |vpiLhs:
-        \_bit_select: (work@top.wval[4].w_data_li), line:7:14, endln:7:23
+        \_bit_select: (work@top.wval[4].w_data_li), line:7:14, endln:7:23, parent:work@top.wval[4].w_data_li
           |vpiName:w_data_li
           |vpiFullName:work@top.wval[4].w_data_li
           |vpiIndex:
-          \_ref_obj: (work@top.wval[4].i), line:7:24, endln:7:25, parent:work@top.wval[4].w_data_li
+          \_ref_obj: (work@top.wval[4].w_data_li.i), line:7:24, endln:7:25, parent:work@top.wval[4].w_data_li
             |vpiName:i
-            |vpiFullName:work@top.wval[4].i
+            |vpiFullName:work@top.wval[4].w_data_li.i
             |vpiActual:
             \_parameter: (work@top.wval[4].i), line:5, parent:work@top.wval[4]
               |vpiName:i
@@ -550,7 +550,7 @@ design: (work@top)
             |vpiName:is_clear
             |vpiFullName:work@top.wval[4].is_clear
           |vpiOperand:
-          \_bit_select: (work@top.wval[4].bht_init_lp), line:8:42, endln:8:56
+          \_bit_select: (work@top.wval[4].bht_init_lp), line:8:42, endln:8:56, parent:work@top.wval[4].bht_init_lp
             |vpiName:bht_init_lp
             |vpiFullName:work@top.wval[4].bht_init_lp
             |vpiIndex:
@@ -563,7 +563,7 @@ design: (work@top)
           \_operation: , line:8:59, endln:8:69
             |vpiOpType:30
             |vpiOperand:
-            \_bit_select: (work@top.wval[4].val_i), line:8:59, endln:8:69
+            \_bit_select: (work@top.wval[4].val_i), line:8:59, endln:8:69, parent:work@top.wval[4].val_i
               |vpiName:val_i
               |vpiFullName:work@top.wval[4].val_i
               |vpiIndex:
@@ -592,17 +592,17 @@ design: (work@top)
                   |vpiName:correct_i
                   |vpiFullName:work@top.wval[4].correct_i
               |vpiOperand:
-              \_bit_select: (work@top.wval[4].val_i), line:8:86, endln:8:94
+              \_bit_select: (work@top.wval[4].val_i), line:8:86, endln:8:94, parent:work@top.wval[4].val_i
                 |vpiName:val_i
                 |vpiFullName:work@top.wval[4].val_i
                 |vpiIndex:
-                \_ref_obj: (work@top.wval[4].i), line:8:92, endln:8:93, parent:work@top.wval[4].val_i
+                \_ref_obj: (work@top.wval[4].val_i.i), line:8:92, endln:8:93, parent:work@top.wval[4].val_i
                   |vpiName:i
-                  |vpiFullName:work@top.wval[4].i
+                  |vpiFullName:work@top.wval[4].val_i.i
                   |vpiActual:
                   \_parameter: (work@top.wval[4].i), line:5, parent:work@top.wval[4]
         |vpiLhs:
-        \_bit_select: (work@top.wval[4].w_data_li), line:8:14, endln:8:23
+        \_bit_select: (work@top.wval[4].w_data_li), line:8:14, endln:8:23, parent:work@top.wval[4].w_data_li
           |vpiName:w_data_li
           |vpiFullName:work@top.wval[4].w_data_li
           |vpiIndex:
@@ -639,7 +639,7 @@ design: (work@top)
             |vpiName:is_clear
             |vpiFullName:work@top.wval[6].is_clear
           |vpiOperand:
-          \_bit_select: (work@top.wval[6].bht_init_lp), line:7:42, endln:7:56
+          \_bit_select: (work@top.wval[6].bht_init_lp), line:7:42, endln:7:56, parent:work@top.wval[6].bht_init_lp
             |vpiName:bht_init_lp
             |vpiFullName:work@top.wval[6].bht_init_lp
             |vpiIndex:
@@ -656,13 +656,13 @@ design: (work@top)
               |vpiName:correct_i
               |vpiFullName:work@top.wval[6].correct_i
         |vpiLhs:
-        \_bit_select: (work@top.wval[6].w_data_li), line:7:14, endln:7:23
+        \_bit_select: (work@top.wval[6].w_data_li), line:7:14, endln:7:23, parent:work@top.wval[6].w_data_li
           |vpiName:w_data_li
           |vpiFullName:work@top.wval[6].w_data_li
           |vpiIndex:
-          \_ref_obj: (work@top.wval[6].i), line:7:24, endln:7:25, parent:work@top.wval[6].w_data_li
+          \_ref_obj: (work@top.wval[6].w_data_li.i), line:7:24, endln:7:25, parent:work@top.wval[6].w_data_li
             |vpiName:i
-            |vpiFullName:work@top.wval[6].i
+            |vpiFullName:work@top.wval[6].w_data_li.i
             |vpiActual:
             \_parameter: (work@top.wval[6].i), line:5, parent:work@top.wval[6]
               |vpiName:i
@@ -678,7 +678,7 @@ design: (work@top)
             |vpiName:is_clear
             |vpiFullName:work@top.wval[6].is_clear
           |vpiOperand:
-          \_bit_select: (work@top.wval[6].bht_init_lp), line:8:42, endln:8:56
+          \_bit_select: (work@top.wval[6].bht_init_lp), line:8:42, endln:8:56, parent:work@top.wval[6].bht_init_lp
             |vpiName:bht_init_lp
             |vpiFullName:work@top.wval[6].bht_init_lp
             |vpiIndex:
@@ -691,7 +691,7 @@ design: (work@top)
           \_operation: , line:8:59, endln:8:69
             |vpiOpType:30
             |vpiOperand:
-            \_bit_select: (work@top.wval[6].val_i), line:8:59, endln:8:69
+            \_bit_select: (work@top.wval[6].val_i), line:8:59, endln:8:69, parent:work@top.wval[6].val_i
               |vpiName:val_i
               |vpiFullName:work@top.wval[6].val_i
               |vpiIndex:
@@ -720,17 +720,17 @@ design: (work@top)
                   |vpiName:correct_i
                   |vpiFullName:work@top.wval[6].correct_i
               |vpiOperand:
-              \_bit_select: (work@top.wval[6].val_i), line:8:86, endln:8:94
+              \_bit_select: (work@top.wval[6].val_i), line:8:86, endln:8:94, parent:work@top.wval[6].val_i
                 |vpiName:val_i
                 |vpiFullName:work@top.wval[6].val_i
                 |vpiIndex:
-                \_ref_obj: (work@top.wval[6].i), line:8:92, endln:8:93, parent:work@top.wval[6].val_i
+                \_ref_obj: (work@top.wval[6].val_i.i), line:8:92, endln:8:93, parent:work@top.wval[6].val_i
                   |vpiName:i
-                  |vpiFullName:work@top.wval[6].i
+                  |vpiFullName:work@top.wval[6].val_i.i
                   |vpiActual:
                   \_parameter: (work@top.wval[6].i), line:5, parent:work@top.wval[6]
         |vpiLhs:
-        \_bit_select: (work@top.wval[6].w_data_li), line:8:14, endln:8:23
+        \_bit_select: (work@top.wval[6].w_data_li), line:8:14, endln:8:23, parent:work@top.wval[6].w_data_li
           |vpiName:w_data_li
           |vpiFullName:work@top.wval[6].w_data_li
           |vpiIndex:
@@ -767,7 +767,7 @@ design: (work@top)
             |vpiName:is_clear
             |vpiFullName:work@top.wval[8].is_clear
           |vpiOperand:
-          \_bit_select: (work@top.wval[8].bht_init_lp), line:7:42, endln:7:56
+          \_bit_select: (work@top.wval[8].bht_init_lp), line:7:42, endln:7:56, parent:work@top.wval[8].bht_init_lp
             |vpiName:bht_init_lp
             |vpiFullName:work@top.wval[8].bht_init_lp
             |vpiIndex:
@@ -784,13 +784,13 @@ design: (work@top)
               |vpiName:correct_i
               |vpiFullName:work@top.wval[8].correct_i
         |vpiLhs:
-        \_bit_select: (work@top.wval[8].w_data_li), line:7:14, endln:7:23
+        \_bit_select: (work@top.wval[8].w_data_li), line:7:14, endln:7:23, parent:work@top.wval[8].w_data_li
           |vpiName:w_data_li
           |vpiFullName:work@top.wval[8].w_data_li
           |vpiIndex:
-          \_ref_obj: (work@top.wval[8].i), line:7:24, endln:7:25, parent:work@top.wval[8].w_data_li
+          \_ref_obj: (work@top.wval[8].w_data_li.i), line:7:24, endln:7:25, parent:work@top.wval[8].w_data_li
             |vpiName:i
-            |vpiFullName:work@top.wval[8].i
+            |vpiFullName:work@top.wval[8].w_data_li.i
             |vpiActual:
             \_parameter: (work@top.wval[8].i), line:5, parent:work@top.wval[8]
               |vpiName:i
@@ -806,7 +806,7 @@ design: (work@top)
             |vpiName:is_clear
             |vpiFullName:work@top.wval[8].is_clear
           |vpiOperand:
-          \_bit_select: (work@top.wval[8].bht_init_lp), line:8:42, endln:8:56
+          \_bit_select: (work@top.wval[8].bht_init_lp), line:8:42, endln:8:56, parent:work@top.wval[8].bht_init_lp
             |vpiName:bht_init_lp
             |vpiFullName:work@top.wval[8].bht_init_lp
             |vpiIndex:
@@ -819,7 +819,7 @@ design: (work@top)
           \_operation: , line:8:59, endln:8:69
             |vpiOpType:30
             |vpiOperand:
-            \_bit_select: (work@top.wval[8].val_i), line:8:59, endln:8:69
+            \_bit_select: (work@top.wval[8].val_i), line:8:59, endln:8:69, parent:work@top.wval[8].val_i
               |vpiName:val_i
               |vpiFullName:work@top.wval[8].val_i
               |vpiIndex:
@@ -848,17 +848,17 @@ design: (work@top)
                   |vpiName:correct_i
                   |vpiFullName:work@top.wval[8].correct_i
               |vpiOperand:
-              \_bit_select: (work@top.wval[8].val_i), line:8:86, endln:8:94
+              \_bit_select: (work@top.wval[8].val_i), line:8:86, endln:8:94, parent:work@top.wval[8].val_i
                 |vpiName:val_i
                 |vpiFullName:work@top.wval[8].val_i
                 |vpiIndex:
-                \_ref_obj: (work@top.wval[8].i), line:8:92, endln:8:93, parent:work@top.wval[8].val_i
+                \_ref_obj: (work@top.wval[8].val_i.i), line:8:92, endln:8:93, parent:work@top.wval[8].val_i
                   |vpiName:i
-                  |vpiFullName:work@top.wval[8].i
+                  |vpiFullName:work@top.wval[8].val_i.i
                   |vpiActual:
                   \_parameter: (work@top.wval[8].i), line:5, parent:work@top.wval[8]
         |vpiLhs:
-        \_bit_select: (work@top.wval[8].w_data_li), line:8:14, endln:8:23
+        \_bit_select: (work@top.wval[8].w_data_li), line:8:14, endln:8:23, parent:work@top.wval[8].w_data_li
           |vpiName:w_data_li
           |vpiFullName:work@top.wval[8].w_data_li
           |vpiIndex:

--- a/tests/AssignSubs/AssignSubs.log
+++ b/tests/AssignSubs/AssignSubs.log
@@ -334,13 +334,13 @@ design: (work@dut)
               |vpiOpType:82
               |vpiBlocking:1
               |vpiLhs:
-              \_bit_select: (work@dut.c), line:16:4, endln:16:5
+              \_bit_select: (work@dut.c), line:16:4, endln:16:5, parent:work@dut.genblk1[0].c
                 |vpiName:c
                 |vpiFullName:work@dut.c
                 |vpiIndex:
-                \_ref_obj: (work@dut.genblk1[0].i), line:16:6, endln:16:7, parent:work@dut.c
+                \_ref_obj: (work@dut.genblk1[0].c.i), line:16:6, endln:16:7, parent:work@dut.c
                   |vpiName:i
-                  |vpiFullName:work@dut.genblk1[0].i
+                  |vpiFullName:work@dut.genblk1[0].c.i
                   |vpiActual:
                   \_parameter: (work@dut.genblk1[0].i), line:14, parent:work@dut.genblk1[0]
                     |vpiName:i

--- a/tests/Assignments/Assignments.log
+++ b/tests/Assignments/Assignments.log
@@ -962,7 +962,7 @@ design: (work@dut)
           |vpiOpType:82
           |vpiBlocking:1
           |vpiLhs:
-          \_bit_select: (work@dut.uvm_packer::get_packed_bits.stream), line:11:7, endln:11:13
+          \_bit_select: (work@dut.uvm_packer::get_packed_bits.stream), line:11:7, endln:11:13, parent:work@dut.uvm_packer::get_packed_bits.stream
             |vpiName:stream
             |vpiFullName:work@dut.uvm_packer::get_packed_bits.stream
             |vpiIndex:
@@ -970,7 +970,7 @@ design: (work@dut)
               |vpiName:i
               |vpiFullName:work@dut.uvm_packer::get_packed_bits.i
           |vpiRhs:
-          \_bit_select: (work@dut.uvm_packer::get_packed_bits.m_bits), line:11:19, endln:11:28
+          \_bit_select: (work@dut.uvm_packer::get_packed_bits.m_bits), line:11:19, endln:11:28, parent:work@dut.uvm_packer::get_packed_bits.m_bits
             |vpiName:m_bits
             |vpiFullName:work@dut.uvm_packer::get_packed_bits.m_bits
             |vpiIndex:
@@ -1258,21 +1258,21 @@ design: (work@dut)
           |vpiOpType:82
           |vpiBlocking:1
           |vpiLhs:
-          \_bit_select: (work@dut.uvm_packer::get_packed_bits.stream), line:11:7, endln:11:13
+          \_bit_select: (work@dut.uvm_packer::get_packed_bits.stream), line:11:7, endln:11:13, parent:work@dut.uvm_packer::get_packed_bits.stream
             |vpiName:stream
             |vpiFullName:work@dut.uvm_packer::get_packed_bits.stream
             |vpiIndex:
-            \_ref_obj: (work@dut.uvm_packer::get_packed_bits.i), line:11:14, endln:11:15, parent:work@dut.uvm_packer::get_packed_bits.stream
+            \_ref_obj: (work@dut.uvm_packer::get_packed_bits.stream.i), line:11:14, endln:11:15, parent:work@dut.uvm_packer::get_packed_bits.stream
               |vpiName:i
-              |vpiFullName:work@dut.uvm_packer::get_packed_bits.i
+              |vpiFullName:work@dut.uvm_packer::get_packed_bits.stream.i
           |vpiRhs:
-          \_bit_select: (work@dut.uvm_packer::get_packed_bits.m_bits), line:11:19, endln:11:28
+          \_bit_select: (work@dut.uvm_packer::get_packed_bits.m_bits), line:11:19, endln:11:28, parent:work@dut.uvm_packer::get_packed_bits.m_bits
             |vpiName:m_bits
             |vpiFullName:work@dut.uvm_packer::get_packed_bits.m_bits
             |vpiIndex:
-            \_ref_obj: (work@dut.uvm_packer::get_packed_bits.i), line:11:26, endln:11:27, parent:work@dut.uvm_packer::get_packed_bits.m_bits
+            \_ref_obj: (work@dut.uvm_packer::get_packed_bits.m_bits.i), line:11:26, endln:11:27, parent:work@dut.uvm_packer::get_packed_bits.m_bits
               |vpiName:i
-              |vpiFullName:work@dut.uvm_packer::get_packed_bits.i
+              |vpiFullName:work@dut.uvm_packer::get_packed_bits.m_bits.i
   |vpiNet:
   \_logic_net: (work@dut.clk), line:1:12, endln:1:15, parent:work@dut
   |vpiNet:

--- a/tests/Bindings/Bindings.log
+++ b/tests/Bindings/Bindings.log
@@ -1849,10 +1849,11 @@ design: (work@dut1)
             \_operation: , line:60:58, endln:60:67
               |vpiOpType:33
               |vpiOperand:
-              \_bit_select: (lfsr_q), line:60:58, endln:60:67
+              \_bit_select: (work@dut3.lfsr_q), line:60:58, endln:60:67, parent:work@dut3.lfsr_q
                 |vpiName:lfsr_q
+                |vpiFullName:work@dut3.lfsr_q
                 |vpiIndex:
-                \_constant: , line:60:65, endln:60:66, parent:lfsr_q
+                \_constant: , line:60:65, endln:60:66, parent:work@dut3.lfsr_q
                   |vpiConstType:9
                   |vpiDecompile:0
                   |vpiSize:64
@@ -2333,11 +2334,11 @@ design: (work@dut1)
             \_operation: , line:60:58, endln:60:67
               |vpiOpType:33
               |vpiOperand:
-              \_bit_select: (work@dut3.lfsr_q), line:60:58, endln:60:67
+              \_bit_select: (work@dut3.lfsr_q), line:60:58, endln:60:67, parent:work@dut3.lfsr_q
                 |vpiName:lfsr_q
                 |vpiFullName:work@dut3.lfsr_q
                 |vpiIndex:
-                \_constant: , line:60:65, endln:60:66, parent:lfsr_q
+                \_constant: , line:60:65, endln:60:66, parent:work@dut3.lfsr_q
                   |vpiConstType:9
                   |vpiDecompile:0
                   |vpiSize:64
@@ -2615,13 +2616,13 @@ design: (work@dut1)
             |vpiName:fill
             |vpiFullName:work@dut5.fill
           |vpiOperand:
-          \_bit_select: (work@dut5.t), line:96:51, endln:96:55
+          \_bit_select: (work@dut5.t), line:96:51, endln:96:55, parent:work@dut5.t
             |vpiName:t
             |vpiFullName:work@dut5.t
             |vpiIndex:
-            \_ref_obj: (work@dut5.j), line:96:53, endln:96:54, parent:work@dut5.t
+            \_ref_obj: (work@dut5.t.j), line:96:53, endln:96:54, parent:work@dut5.t
               |vpiName:j
-              |vpiFullName:work@dut5.j
+              |vpiFullName:work@dut5.t.j
         |vpiOperand:
         \_operation: , line:96:61, endln:96:67
           |vpiOpType:22

--- a/tests/BitPartSelect/BitPartSelect.log
+++ b/tests/BitPartSelect/BitPartSelect.log
@@ -256,7 +256,7 @@ design: (work@top)
   |vpiContAssign:
   \_cont_assign: , line:9:11, endln:9:60, parent:work@top
     |vpiRhs:
-    \_bit_select: (work@top.storage), line:9:27, endln:9:60
+    \_bit_select: (work@top.storage), line:9:27, endln:9:60, parent:work@top.storage
       |vpiName:storage
       |vpiFullName:work@top.storage
       |vpiIndex:
@@ -363,21 +363,21 @@ design: (work@top)
   |vpiContAssign:
   \_cont_assign: , line:9:11, endln:9:60, parent:work@top
     |vpiRhs:
-    \_bit_select: (work@top.storage), line:9:27, endln:9:60
+    \_bit_select: (work@top.storage), line:9:27, endln:9:60, parent:work@top.storage
       |vpiName:storage
       |vpiFullName:work@top.storage
       |vpiIndex:
-      \_part_select: , line:9:35, endln:9:59, parent:work@top.fifo_rptr
+      \_part_select: , line:9:35, endln:9:59, parent:work@top.storage.fifo_rptr
         |vpiConstantSelect:1
         |vpiParent:
-        \_ref_obj: (work@top.fifo_rptr), parent:work@top.storage
+        \_ref_obj: (work@top.storage.fifo_rptr), parent:work@top.storage
         |vpiLeftRange:
         \_operation: , line:9:45, endln:9:54
           |vpiOpType:11
           |vpiOperand:
-          \_ref_obj: (work@top.fifo_rptr.PTR_WIDTH), line:9:45, endln:9:54
+          \_ref_obj: (work@top.storage.fifo_rptr.PTR_WIDTH), line:9:45, endln:9:54
             |vpiName:PTR_WIDTH
-            |vpiFullName:work@top.fifo_rptr.PTR_WIDTH
+            |vpiFullName:work@top.storage.fifo_rptr.PTR_WIDTH
             |vpiActual:
             \_parameter: (work@top.PTR_WIDTH), line:4:28, endln:4:41, parent:work@top
               |vpiName:PTR_WIDTH

--- a/tests/BitSelect/BitSelect.log
+++ b/tests/BitSelect/BitSelect.log
@@ -300,7 +300,7 @@ design: (work@dut)
   |vpiParamAssign:
   \_param_assign: , line:9:11, endln:9:33, parent:work@dut
     |vpiRhs:
-    \_bit_select: (AlertAsyncOn), line:9:18, endln:9:33
+    \_bit_select: (AlertAsyncOn), line:9:18, endln:9:33, parent:AlertAsyncOn
       |vpiName:AlertAsyncOn
       |vpiIndex:
       \_constant: , line:9:31, endln:9:32, parent:AlertAsyncOn

--- a/tests/BitsStructMember/BitsStructMember.log
+++ b/tests/BitsStructMember/BitsStructMember.log
@@ -469,12 +469,11 @@ design: (work@top)
                               |vpiInstance:
                               \_package: keymgr_pkg (keymgr_pkg::) dut.sv:1:1: , endln:14:11, parent:work@top
                         |vpiActual:
-                        \_bit_select: (strb), parent:keymgr_data_i.strb[i]
+                        \_bit_select: (strb)
                           |vpiName:strb
                           |vpiIndex:
-                          \_ref_obj: (work@top.keymgr_data_i.strb[i].i), line:23:55, endln:23:56, parent:strb
+                          \_ref_obj: (i), line:23:55, endln:23:56, parent:strb
                             |vpiName:i
-                            |vpiFullName:work@top.keymgr_data_i.strb[i].i
   |vpiPort:
   \_port: (keymgr_data_i), line:16:48, endln:16:61, parent:work@top
     |vpiName:keymgr_data_i

--- a/tests/BlackParrotComplex/BlackParrotComplex.log
+++ b/tests/BlackParrotComplex/BlackParrotComplex.log
@@ -3300,7 +3300,7 @@ design: (work@top)
   |vpiParamAssign:
   \_param_assign: , line:82:13, endln:82:22, parent:work@bottom
     |vpiRhs:
-    \_bit_select: (A3), line:82:17, endln:82:22
+    \_bit_select: (A3), line:82:17, endln:82:22, parent:A3
       |vpiName:A3
       |vpiIndex:
       \_constant: , line:82:20, endln:82:21, parent:A3
@@ -3368,7 +3368,7 @@ design: (work@top)
   |vpiParamAssign:
   \_param_assign: , line:70:13, endln:70:22, parent:work@middle
     |vpiRhs:
-    \_bit_select: (A3), line:70:17, endln:70:22
+    \_bit_select: (A3), line:70:17, endln:70:22, parent:A3
       |vpiName:A3
       |vpiIndex:
       \_constant: , line:70:20, endln:70:21, parent:A3

--- a/tests/BlackParrotParam/BlackParrotParam.log
+++ b/tests/BlackParrotParam/BlackParrotParam.log
@@ -18889,7 +18889,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (tlb_w_entry.ptag), line:4625:10, endln:4625:21
       |vpiName:tlb_w_entry.ptag
       |vpiActual:
-      \_ref_obj: (tlb_w_entry)
+      \_ref_obj: (tlb_w_entry), parent:tlb_w_entry.ptag
         |vpiName:tlb_w_entry
       |vpiActual:
       \_ref_obj: (ptag)
@@ -35389,11 +35389,12 @@ design: (work@bp_be_ptw)
   |vpiParamAssign:
   \_param_assign: , line:4379:32, endln:4379:66, parent:work@bp_be_ptw
     |vpiRhs:
-    \_bit_select: (all_cfgs_gp), line:4379:48, endln:4379:66
+    \_bit_select: (all_cfgs_gp), line:4379:48, endln:4379:66, parent:all_cfgs_gp
       |vpiName:all_cfgs_gp
       |vpiIndex:
-      \_ref_obj: (cfg_p), line:4379:60, endln:4379:65, parent:all_cfgs_gp
+      \_ref_obj: (all_cfgs_gp.cfg_p), line:4379:60, endln:4379:65, parent:all_cfgs_gp
         |vpiName:cfg_p
+        |vpiFullName:all_cfgs_gp.cfg_p
     |vpiLhs:
     \_parameter: (work@bp_be_ptw.proc_param_lp), line:4379:32, endln:4379:66, parent:work@bp_be_ptw
       |vpiName:proc_param_lp
@@ -35407,7 +35408,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.num_core), line:4381:29, endln:4381:51
       |vpiName:proc_param_lp.num_core
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.num_core
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (num_core)
@@ -35423,7 +35424,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.num_cce), line:4382:29, endln:4382:50
       |vpiName:proc_param_lp.num_cce
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.num_cce
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (num_cce)
@@ -35439,7 +35440,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.num_lce), line:4383:29, endln:4383:50
       |vpiName:proc_param_lp.num_lce
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.num_lce
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (num_lce)
@@ -35455,7 +35456,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.vaddr_width), line:4385:32, endln:4385:57
       |vpiName:proc_param_lp.vaddr_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.vaddr_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (vaddr_width)
@@ -35471,7 +35472,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.paddr_width), line:4386:32, endln:4386:57
       |vpiName:proc_param_lp.paddr_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.paddr_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (paddr_width)
@@ -35487,7 +35488,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.asid_width), line:4387:32, endln:4387:56
       |vpiName:proc_param_lp.asid_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.asid_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (asid_width)
@@ -35503,7 +35504,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.branch_metadata_fwd_width), line:4389:46, endln:4389:85
       |vpiName:proc_param_lp.branch_metadata_fwd_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.branch_metadata_fwd_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (branch_metadata_fwd_width)
@@ -35519,7 +35520,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.btb_tag_width), line:4390:46, endln:4390:73
       |vpiName:proc_param_lp.btb_tag_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.btb_tag_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (btb_tag_width)
@@ -35535,7 +35536,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.btb_idx_width), line:4391:46, endln:4391:73
       |vpiName:proc_param_lp.btb_idx_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.btb_idx_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (btb_idx_width)
@@ -35551,7 +35552,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.bht_idx_width), line:4392:46, endln:4392:73
       |vpiName:proc_param_lp.bht_idx_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.bht_idx_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (bht_idx_width)
@@ -35567,7 +35568,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.ras_idx_width), line:4393:46, endln:4393:73
       |vpiName:proc_param_lp.ras_idx_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.ras_idx_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (ras_idx_width)
@@ -35583,7 +35584,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.itlb_els), line:4395:42, endln:4395:64
       |vpiName:proc_param_lp.itlb_els
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.itlb_els
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (itlb_els)
@@ -35599,7 +35600,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.dtlb_els), line:4396:42, endln:4396:64
       |vpiName:proc_param_lp.dtlb_els
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.dtlb_els
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (dtlb_els)
@@ -35615,7 +35616,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.lce_sets), line:4398:42, endln:4398:64
       |vpiName:proc_param_lp.lce_sets
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.lce_sets
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (lce_sets)
@@ -35631,7 +35632,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.lce_assoc), line:4399:42, endln:4399:65
       |vpiName:proc_param_lp.lce_assoc
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.lce_assoc
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (lce_assoc)
@@ -35647,7 +35648,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.cce_block_width), line:4400:42, endln:4400:71
       |vpiName:proc_param_lp.cce_block_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.cce_block_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (cce_block_width)
@@ -35663,7 +35664,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.num_cce_instr_ram_els), line:4401:42, endln:4401:77
       |vpiName:proc_param_lp.num_cce_instr_ram_els
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.num_cce_instr_ram_els
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (num_cce_instr_ram_els)
@@ -35679,7 +35680,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.fe_queue_fifo_els), line:4403:38, endln:4403:69
       |vpiName:proc_param_lp.fe_queue_fifo_els
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.fe_queue_fifo_els
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (fe_queue_fifo_els)
@@ -35695,7 +35696,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.fe_cmd_fifo_els), line:4404:38, endln:4404:67
       |vpiName:proc_param_lp.fe_cmd_fifo_els
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.fe_cmd_fifo_els
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (fe_cmd_fifo_els)
@@ -35711,7 +35712,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.async_coh_clk), line:4406:41, endln:4406:68
       |vpiName:proc_param_lp.async_coh_clk
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.async_coh_clk
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (async_coh_clk)
@@ -35727,7 +35728,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.coh_noc_flit_width), line:4407:41, endln:4407:73
       |vpiName:proc_param_lp.coh_noc_flit_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.coh_noc_flit_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (coh_noc_flit_width)
@@ -35743,7 +35744,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.coh_noc_cid_width), line:4408:41, endln:4408:72
       |vpiName:proc_param_lp.coh_noc_cid_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.coh_noc_cid_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (coh_noc_cid_width)
@@ -35759,7 +35760,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.coh_noc_len_width), line:4409:41, endln:4409:72
       |vpiName:proc_param_lp.coh_noc_len_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.coh_noc_len_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (coh_noc_len_width)
@@ -35775,7 +35776,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.coh_noc_y_cord_width), line:4410:41, endln:4410:75
       |vpiName:proc_param_lp.coh_noc_y_cord_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.coh_noc_y_cord_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (coh_noc_y_cord_width)
@@ -35791,7 +35792,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.coh_noc_x_cord_width), line:4411:41, endln:4411:75
       |vpiName:proc_param_lp.coh_noc_x_cord_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.coh_noc_x_cord_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (coh_noc_x_cord_width)
@@ -35807,7 +35808,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.coh_noc_y_dim), line:4412:41, endln:4412:68
       |vpiName:proc_param_lp.coh_noc_y_dim
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.coh_noc_y_dim
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (coh_noc_y_dim)
@@ -35823,7 +35824,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.coh_noc_x_dim), line:4413:41, endln:4413:68
       |vpiName:proc_param_lp.coh_noc_x_dim
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.coh_noc_x_dim
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (coh_noc_x_dim)
@@ -35956,7 +35957,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.cfg_core_width), line:4420:35, endln:4420:63
       |vpiName:proc_param_lp.cfg_core_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.cfg_core_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (cfg_core_width)
@@ -35972,7 +35973,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.cfg_addr_width), line:4421:35, endln:4421:63
       |vpiName:proc_param_lp.cfg_addr_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.cfg_addr_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (cfg_addr_width)
@@ -35988,7 +35989,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.cfg_data_width), line:4422:35, endln:4422:63
       |vpiName:proc_param_lp.cfg_data_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.cfg_data_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (cfg_data_width)
@@ -36004,7 +36005,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.async_mem_clk), line:4424:44, endln:4424:71
       |vpiName:proc_param_lp.async_mem_clk
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.async_mem_clk
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (async_mem_clk)
@@ -36020,7 +36021,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.mem_noc_max_credits), line:4425:44, endln:4425:77
       |vpiName:proc_param_lp.mem_noc_max_credits
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.mem_noc_max_credits
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (mem_noc_max_credits)
@@ -36036,7 +36037,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.mem_noc_flit_width), line:4426:44, endln:4426:76
       |vpiName:proc_param_lp.mem_noc_flit_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.mem_noc_flit_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (mem_noc_flit_width)
@@ -36052,7 +36053,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.mem_noc_reserved_width), line:4427:44, endln:4427:80
       |vpiName:proc_param_lp.mem_noc_reserved_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.mem_noc_reserved_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (mem_noc_reserved_width)
@@ -36068,7 +36069,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.mem_noc_cid_width), line:4428:44, endln:4428:75
       |vpiName:proc_param_lp.mem_noc_cid_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.mem_noc_cid_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (mem_noc_cid_width)
@@ -36084,7 +36085,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.mem_noc_len_width), line:4429:44, endln:4429:75
       |vpiName:proc_param_lp.mem_noc_len_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.mem_noc_len_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (mem_noc_len_width)
@@ -36100,7 +36101,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.mem_noc_y_cord_width), line:4430:44, endln:4430:78
       |vpiName:proc_param_lp.mem_noc_y_cord_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.mem_noc_y_cord_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (mem_noc_y_cord_width)
@@ -36116,7 +36117,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.mem_noc_x_cord_width), line:4431:44, endln:4431:78
       |vpiName:proc_param_lp.mem_noc_x_cord_width
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.mem_noc_x_cord_width
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (mem_noc_x_cord_width)
@@ -36132,7 +36133,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.mem_noc_y_dim), line:4432:44, endln:4432:71
       |vpiName:proc_param_lp.mem_noc_y_dim
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.mem_noc_y_dim
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (mem_noc_y_dim)
@@ -36148,7 +36149,7 @@ design: (work@bp_be_ptw)
     \_hier_path: (proc_param_lp.mem_noc_x_dim), line:4433:44, endln:4433:71
       |vpiName:proc_param_lp.mem_noc_x_dim
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.mem_noc_x_dim
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (mem_noc_x_dim)
@@ -36387,7 +36388,7 @@ design: (work@bp_be_ptw)
       \_hier_path: (proc_param_lp.vaddr_width), line:4448:32, endln:4448:57
         |vpiName:proc_param_lp.vaddr_width
         |vpiActual:
-        \_ref_obj: (proc_param_lp)
+        \_ref_obj: (proc_param_lp), parent:proc_param_lp.vaddr_width
           |vpiName:proc_param_lp
         |vpiActual:
         \_ref_obj: (vaddr_width)
@@ -36415,7 +36416,7 @@ design: (work@bp_be_ptw)
       \_hier_path: (proc_param_lp.paddr_width), line:4449:32, endln:4449:57
         |vpiName:proc_param_lp.paddr_width
         |vpiActual:
-        \_ref_obj: (proc_param_lp)
+        \_ref_obj: (proc_param_lp), parent:proc_param_lp.paddr_width
           |vpiName:proc_param_lp
         |vpiActual:
         \_ref_obj: (paddr_width)
@@ -50543,11 +50544,12 @@ design: (work@bp_be_ptw)
   |vpiParamAssign:
   \_param_assign: , line:4379:32, endln:4379:66, parent:work@bp_be_ptw
     |vpiRhs:
-    \_bit_select: (all_cfgs_gp), line:4379:48, endln:4379:66
+    \_bit_select: (all_cfgs_gp), line:4379:48, endln:4379:66, parent:all_cfgs_gp
       |vpiName:all_cfgs_gp
       |vpiIndex:
-      \_ref_obj: (cfg_p), line:4379:60, endln:4379:65, parent:all_cfgs_gp
+      \_ref_obj: (all_cfgs_gp.cfg_p), line:4379:60, endln:4379:65, parent:all_cfgs_gp
         |vpiName:cfg_p
+        |vpiFullName:all_cfgs_gp.cfg_p
         |vpiActual:
         \_parameter: (work@bp_be_ptw.cfg_p), line:4377:24, endln:4377:44, parent:work@bp_be_ptw
     |vpiLhs:

--- a/tests/BlackParrotStructParam/BlackParrotStructParam.log
+++ b/tests/BlackParrotStructParam/BlackParrotStructParam.log
@@ -1415,11 +1415,12 @@ design: (work@top)
   |vpiParamAssign:
   \_param_assign: , line:57:30, endln:57:70, parent:work@top
     |vpiRhs:
-    \_bit_select: (all_cfgs_gp), line:57:46, endln:57:70
+    \_bit_select: (all_cfgs_gp), line:57:46, endln:57:70, parent:all_cfgs_gp
       |vpiName:all_cfgs_gp
       |vpiIndex:
-      \_ref_obj: (bp_params_p), line:57:58, endln:57:69, parent:all_cfgs_gp
+      \_ref_obj: (all_cfgs_gp.bp_params_p), line:57:58, endln:57:69, parent:all_cfgs_gp
         |vpiName:bp_params_p
+        |vpiFullName:all_cfgs_gp.bp_params_p
     |vpiLhs:
     \_parameter: (work@top.proc_param_lp), line:57:30, endln:57:70, parent:work@top
       |vpiName:proc_param_lp
@@ -1433,7 +1434,7 @@ design: (work@top)
     \_hier_path: (proc_param_lp.cc_x_dim), line:58:28, endln:58:50
       |vpiName:proc_param_lp.cc_x_dim
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.cc_x_dim
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (cc_x_dim)
@@ -1884,11 +1885,12 @@ design: (work@top)
   |vpiParamAssign:
   \_param_assign: , line:57:30, endln:57:70, parent:work@top
     |vpiRhs:
-    \_bit_select: (all_cfgs_gp), line:57:46, endln:57:70
+    \_bit_select: (all_cfgs_gp), line:57:46, endln:57:70, parent:all_cfgs_gp
       |vpiName:all_cfgs_gp
       |vpiIndex:
-      \_ref_obj: (bp_params_p), line:57:58, endln:57:69, parent:all_cfgs_gp
+      \_ref_obj: (all_cfgs_gp.bp_params_p), line:57:58, endln:57:69, parent:all_cfgs_gp
         |vpiName:bp_params_p
+        |vpiFullName:all_cfgs_gp.bp_params_p
         |vpiActual:
         \_parameter: (work@top.bp_params_p), line:56:25, endln:56:55, parent:work@top
     |vpiLhs:

--- a/tests/CastUnsigned/CastUnsigned.log
+++ b/tests/CastUnsigned/CastUnsigned.log
@@ -589,7 +589,7 @@ design: (work@top)
             \_hier_path: (hw2reg.stall), line:9:9, endln:9:15, parent:work@top.proc_stall_tieoff
               |vpiName:hw2reg.stall
               |vpiActual:
-              \_ref_obj: (hw2reg)
+              \_ref_obj: (hw2reg), parent:hw2reg.stall
                 |vpiName:hw2reg
               |vpiActual:
               \_ref_obj: (stall)

--- a/tests/ClassFsm/ClassFsm.log
+++ b/tests/ClassFsm/ClassFsm.log
@@ -184,13 +184,13 @@ design: (work@fsm_class)
           |vpiOpType:82
           |vpiBlocking:1
           |vpiLhs:
-          \_bit_select: (work@fsm_class::baseFsm::next_state), line:12:9, endln:12:19
+          \_bit_select: (work@fsm_class::baseFsm::next_state), line:12:9, endln:12:19, parent:work@fsm_class::baseFsm::next_state_transition::next_state
             |vpiName:next_state
             |vpiFullName:work@fsm_class::baseFsm::next_state
             |vpiIndex:
-            \_ref_obj: (work@fsm_class::baseFsm::next_state_transition::state_to_bit), line:12:21, endln:12:33, parent:work@fsm_class::baseFsm::next_state
+            \_ref_obj: (work@fsm_class::baseFsm::next_state_transition::next_state::state_to_bit), line:12:21, endln:12:33, parent:work@fsm_class::baseFsm::next_state
               |vpiName:state_to_bit
-              |vpiFullName:work@fsm_class::baseFsm::next_state_transition::state_to_bit
+              |vpiFullName:work@fsm_class::baseFsm::next_state_transition::next_state::state_to_bit
               |vpiActual:
               \_io_decl: (state_to_bit), parent:work@fsm_class::baseFsm::next_state_transition
           |vpiRhs:
@@ -473,13 +473,13 @@ design: (work@fsm_class)
             |vpiCaseItem:
             \_case_item: , line:72:11, endln:72:54
               |vpiExpr:
-              \_bit_select: (work@fsm_class::baseFsm::current_state), line:72:11, endln:72:38
+              \_bit_select: (work@fsm_class::baseFsm::current_state), line:72:11, endln:72:38, parent:work@fsm_class::specificFSM::main_comb::current_state
                 |vpiName:current_state
                 |vpiFullName:work@fsm_class::baseFsm::current_state
                 |vpiIndex:
-                \_ref_obj: (work@fsm_class::specificFSM::main_comb::STATE_00_BIT), line:72:25, endln:72:37, parent:work@fsm_class::baseFsm::current_state
+                \_ref_obj: (work@fsm_class::specificFSM::main_comb::current_state::STATE_00_BIT), line:72:25, endln:72:37, parent:work@fsm_class::baseFsm::current_state
                   |vpiName:STATE_00_BIT
-                  |vpiFullName:work@fsm_class::specificFSM::main_comb::STATE_00_BIT
+                  |vpiFullName:work@fsm_class::specificFSM::main_comb::current_state::STATE_00_BIT
                   |vpiActual:
                   \_parameter: (work@fsm_class::specificFSM::STATE_00_BIT), line:28:17, endln:28:33, parent:work@fsm_class::specificFSM
               |vpiStmt:
@@ -490,13 +490,13 @@ design: (work@fsm_class)
             |vpiCaseItem:
             \_case_item: , line:73:11, endln:73:54
               |vpiExpr:
-              \_bit_select: (work@fsm_class::baseFsm::current_state), line:73:11, endln:73:38
+              \_bit_select: (work@fsm_class::baseFsm::current_state), line:73:11, endln:73:38, parent:work@fsm_class::specificFSM::main_comb::current_state
                 |vpiName:current_state
                 |vpiFullName:work@fsm_class::baseFsm::current_state
                 |vpiIndex:
-                \_ref_obj: (work@fsm_class::specificFSM::main_comb::STATE_01_BIT), line:73:25, endln:73:37, parent:work@fsm_class::baseFsm::current_state
+                \_ref_obj: (work@fsm_class::specificFSM::main_comb::current_state::STATE_01_BIT), line:73:25, endln:73:37, parent:work@fsm_class::baseFsm::current_state
                   |vpiName:STATE_01_BIT
-                  |vpiFullName:work@fsm_class::specificFSM::main_comb::STATE_01_BIT
+                  |vpiFullName:work@fsm_class::specificFSM::main_comb::current_state::STATE_01_BIT
                   |vpiActual:
                   \_parameter: (work@fsm_class::specificFSM::STATE_01_BIT), line:29:17, endln:29:33, parent:work@fsm_class::specificFSM
               |vpiStmt:
@@ -507,13 +507,13 @@ design: (work@fsm_class)
             |vpiCaseItem:
             \_case_item: , line:74:11, endln:74:54
               |vpiExpr:
-              \_bit_select: (work@fsm_class::baseFsm::current_state), line:74:11, endln:74:38
+              \_bit_select: (work@fsm_class::baseFsm::current_state), line:74:11, endln:74:38, parent:work@fsm_class::specificFSM::main_comb::current_state
                 |vpiName:current_state
                 |vpiFullName:work@fsm_class::baseFsm::current_state
                 |vpiIndex:
-                \_ref_obj: (work@fsm_class::specificFSM::main_comb::STATE_10_BIT), line:74:25, endln:74:37, parent:work@fsm_class::baseFsm::current_state
+                \_ref_obj: (work@fsm_class::specificFSM::main_comb::current_state::STATE_10_BIT), line:74:25, endln:74:37, parent:work@fsm_class::baseFsm::current_state
                   |vpiName:STATE_10_BIT
-                  |vpiFullName:work@fsm_class::specificFSM::main_comb::STATE_10_BIT
+                  |vpiFullName:work@fsm_class::specificFSM::main_comb::current_state::STATE_10_BIT
                   |vpiActual:
                   \_parameter: (work@fsm_class::specificFSM::STATE_10_BIT), line:30:17, endln:30:33, parent:work@fsm_class::specificFSM
               |vpiStmt:
@@ -524,13 +524,13 @@ design: (work@fsm_class)
             |vpiCaseItem:
             \_case_item: , line:75:11, endln:75:54
               |vpiExpr:
-              \_bit_select: (work@fsm_class::baseFsm::current_state), line:75:11, endln:75:38
+              \_bit_select: (work@fsm_class::baseFsm::current_state), line:75:11, endln:75:38, parent:work@fsm_class::specificFSM::main_comb::current_state
                 |vpiName:current_state
                 |vpiFullName:work@fsm_class::baseFsm::current_state
                 |vpiIndex:
-                \_ref_obj: (work@fsm_class::specificFSM::main_comb::STATE_11_BIT), line:75:25, endln:75:37, parent:work@fsm_class::baseFsm::current_state
+                \_ref_obj: (work@fsm_class::specificFSM::main_comb::current_state::STATE_11_BIT), line:75:25, endln:75:37, parent:work@fsm_class::baseFsm::current_state
                   |vpiName:STATE_11_BIT
-                  |vpiFullName:work@fsm_class::specificFSM::main_comb::STATE_11_BIT
+                  |vpiFullName:work@fsm_class::specificFSM::main_comb::current_state::STATE_11_BIT
                   |vpiActual:
                   \_parameter: (work@fsm_class::specificFSM::STATE_11_BIT), line:31:17, endln:31:33, parent:work@fsm_class::specificFSM
               |vpiStmt:
@@ -859,13 +859,13 @@ design: (work@fsm_class)
                         |vpiCaseItem:
                         \_case_item: , line:72:11, endln:72:54
                           |vpiExpr:
-                          \_bit_select: (work@fsm_class::baseFsm::current_state), line:72:11, endln:72:38
+                          \_bit_select: (work@fsm_class::baseFsm::current_state), line:72:11, endln:72:38, parent:work@fsm_class::specificFSM::main_comb::current_state
                             |vpiName:current_state
                             |vpiFullName:work@fsm_class::baseFsm::current_state
                             |vpiIndex:
-                            \_ref_obj: (work@fsm_class::specificFSM::main_comb::STATE_00_BIT), line:72:25, endln:72:37, parent:work@fsm_class::baseFsm::current_state
+                            \_ref_obj: (work@fsm_class::specificFSM::main_comb::current_state::STATE_00_BIT), line:72:25, endln:72:37, parent:work@fsm_class::baseFsm::current_state
                               |vpiName:STATE_00_BIT
-                              |vpiFullName:work@fsm_class::specificFSM::main_comb::STATE_00_BIT
+                              |vpiFullName:work@fsm_class::specificFSM::main_comb::current_state::STATE_00_BIT
                               |vpiActual:
                               \_parameter: (work@fsm_class::specificFSM::STATE_00_BIT), line:28:17, endln:28:33, parent:work@fsm_class::specificFSM
                           |vpiStmt:
@@ -876,13 +876,13 @@ design: (work@fsm_class)
                         |vpiCaseItem:
                         \_case_item: , line:73:11, endln:73:54
                           |vpiExpr:
-                          \_bit_select: (work@fsm_class::baseFsm::current_state), line:73:11, endln:73:38
+                          \_bit_select: (work@fsm_class::baseFsm::current_state), line:73:11, endln:73:38, parent:work@fsm_class::specificFSM::main_comb::current_state
                             |vpiName:current_state
                             |vpiFullName:work@fsm_class::baseFsm::current_state
                             |vpiIndex:
-                            \_ref_obj: (work@fsm_class::specificFSM::main_comb::STATE_01_BIT), line:73:25, endln:73:37, parent:work@fsm_class::baseFsm::current_state
+                            \_ref_obj: (work@fsm_class::specificFSM::main_comb::current_state::STATE_01_BIT), line:73:25, endln:73:37, parent:work@fsm_class::baseFsm::current_state
                               |vpiName:STATE_01_BIT
-                              |vpiFullName:work@fsm_class::specificFSM::main_comb::STATE_01_BIT
+                              |vpiFullName:work@fsm_class::specificFSM::main_comb::current_state::STATE_01_BIT
                               |vpiActual:
                               \_parameter: (work@fsm_class::specificFSM::STATE_01_BIT), line:29:17, endln:29:33, parent:work@fsm_class::specificFSM
                           |vpiStmt:
@@ -893,13 +893,13 @@ design: (work@fsm_class)
                         |vpiCaseItem:
                         \_case_item: , line:74:11, endln:74:54
                           |vpiExpr:
-                          \_bit_select: (work@fsm_class::baseFsm::current_state), line:74:11, endln:74:38
+                          \_bit_select: (work@fsm_class::baseFsm::current_state), line:74:11, endln:74:38, parent:work@fsm_class::specificFSM::main_comb::current_state
                             |vpiName:current_state
                             |vpiFullName:work@fsm_class::baseFsm::current_state
                             |vpiIndex:
-                            \_ref_obj: (work@fsm_class::specificFSM::main_comb::STATE_10_BIT), line:74:25, endln:74:37, parent:work@fsm_class::baseFsm::current_state
+                            \_ref_obj: (work@fsm_class::specificFSM::main_comb::current_state::STATE_10_BIT), line:74:25, endln:74:37, parent:work@fsm_class::baseFsm::current_state
                               |vpiName:STATE_10_BIT
-                              |vpiFullName:work@fsm_class::specificFSM::main_comb::STATE_10_BIT
+                              |vpiFullName:work@fsm_class::specificFSM::main_comb::current_state::STATE_10_BIT
                               |vpiActual:
                               \_parameter: (work@fsm_class::specificFSM::STATE_10_BIT), line:30:17, endln:30:33, parent:work@fsm_class::specificFSM
                           |vpiStmt:
@@ -910,13 +910,13 @@ design: (work@fsm_class)
                         |vpiCaseItem:
                         \_case_item: , line:75:11, endln:75:54
                           |vpiExpr:
-                          \_bit_select: (work@fsm_class::baseFsm::current_state), line:75:11, endln:75:38
+                          \_bit_select: (work@fsm_class::baseFsm::current_state), line:75:11, endln:75:38, parent:work@fsm_class::specificFSM::main_comb::current_state
                             |vpiName:current_state
                             |vpiFullName:work@fsm_class::baseFsm::current_state
                             |vpiIndex:
-                            \_ref_obj: (work@fsm_class::specificFSM::main_comb::STATE_11_BIT), line:75:25, endln:75:37, parent:work@fsm_class::baseFsm::current_state
+                            \_ref_obj: (work@fsm_class::specificFSM::main_comb::current_state::STATE_11_BIT), line:75:25, endln:75:37, parent:work@fsm_class::baseFsm::current_state
                               |vpiName:STATE_11_BIT
-                              |vpiFullName:work@fsm_class::specificFSM::main_comb::STATE_11_BIT
+                              |vpiFullName:work@fsm_class::specificFSM::main_comb::current_state::STATE_11_BIT
                               |vpiActual:
                               \_parameter: (work@fsm_class::specificFSM::STATE_11_BIT), line:31:17, endln:31:33, parent:work@fsm_class::specificFSM
                           |vpiStmt:
@@ -986,13 +986,13 @@ design: (work@fsm_class)
                               |vpiOpType:82
                               |vpiBlocking:1
                               |vpiLhs:
-                              \_bit_select: (work@fsm_class::baseFsm::next_state), line:12:9, endln:12:19
+                              \_bit_select: (work@fsm_class::baseFsm::next_state), line:12:9, endln:12:19, parent:work@fsm_class::baseFsm::next_state_transition::next_state
                                 |vpiName:next_state
                                 |vpiFullName:work@fsm_class::baseFsm::next_state
                                 |vpiIndex:
-                                \_ref_obj: (work@fsm_class::baseFsm::next_state_transition::state_to_bit), line:12:21, endln:12:33, parent:work@fsm_class::baseFsm::next_state
+                                \_ref_obj: (work@fsm_class::baseFsm::next_state_transition::next_state::state_to_bit), line:12:21, endln:12:33, parent:work@fsm_class::baseFsm::next_state
                                   |vpiName:state_to_bit
-                                  |vpiFullName:work@fsm_class::baseFsm::next_state_transition::state_to_bit
+                                  |vpiFullName:work@fsm_class::baseFsm::next_state_transition::next_state::state_to_bit
                                   |vpiActual:
                                   \_io_decl: (state_to_bit), parent:work@fsm_class::baseFsm::next_state_transition
                               |vpiRhs:
@@ -1249,13 +1249,13 @@ design: (work@fsm_class)
           |vpiOpType:82
           |vpiBlocking:1
           |vpiLhs:
-          \_bit_select: (work@fsm_class::baseFsm::next_state), line:12:9, endln:12:19
+          \_bit_select: (work@fsm_class::baseFsm::next_state), line:12:9, endln:12:19, parent:work@fsm_class::baseFsm::next_state_transition::next_state
             |vpiName:next_state
             |vpiFullName:work@fsm_class::baseFsm::next_state
             |vpiIndex:
-            \_ref_obj: (work@fsm_class::baseFsm::next_state_transition::state_to_bit), line:12:21, endln:12:33, parent:work@fsm_class::baseFsm::next_state
+            \_ref_obj: (work@fsm_class::baseFsm::next_state_transition::next_state::state_to_bit), line:12:21, endln:12:33, parent:work@fsm_class::baseFsm::next_state
               |vpiName:state_to_bit
-              |vpiFullName:work@fsm_class::baseFsm::next_state_transition::state_to_bit
+              |vpiFullName:work@fsm_class::baseFsm::next_state_transition::next_state::state_to_bit
               |vpiActual:
               \_io_decl: (state_to_bit), parent:work@fsm_class::baseFsm::next_state_transition
           |vpiRhs:
@@ -1542,13 +1542,13 @@ design: (work@fsm_class)
           |vpiCaseItem:
           \_case_item: , line:72:11, endln:72:54
             |vpiExpr:
-            \_bit_select: (work@fsm_class::baseFsm::current_state), line:72:11, endln:72:38
+            \_bit_select: (work@fsm_class::baseFsm::current_state), line:72:11, endln:72:38, parent:work@fsm_class::specificFSM::main_comb::current_state
               |vpiName:current_state
               |vpiFullName:work@fsm_class::baseFsm::current_state
               |vpiIndex:
-              \_ref_obj: (work@fsm_class::specificFSM::main_comb::STATE_00_BIT), line:72:25, endln:72:37, parent:work@fsm_class::baseFsm::current_state
+              \_ref_obj: (work@fsm_class::specificFSM::main_comb::current_state::STATE_00_BIT), line:72:25, endln:72:37, parent:work@fsm_class::baseFsm::current_state
                 |vpiName:STATE_00_BIT
-                |vpiFullName:work@fsm_class::specificFSM::main_comb::STATE_00_BIT
+                |vpiFullName:work@fsm_class::specificFSM::main_comb::current_state::STATE_00_BIT
                 |vpiActual:
                 \_parameter: (work@fsm_class::specificFSM::STATE_00_BIT), line:28:17, endln:28:33, parent:work@fsm_class::specificFSM
             |vpiStmt:
@@ -1559,13 +1559,13 @@ design: (work@fsm_class)
           |vpiCaseItem:
           \_case_item: , line:73:11, endln:73:54
             |vpiExpr:
-            \_bit_select: (work@fsm_class::baseFsm::current_state), line:73:11, endln:73:38
+            \_bit_select: (work@fsm_class::baseFsm::current_state), line:73:11, endln:73:38, parent:work@fsm_class::specificFSM::main_comb::current_state
               |vpiName:current_state
               |vpiFullName:work@fsm_class::baseFsm::current_state
               |vpiIndex:
-              \_ref_obj: (work@fsm_class::specificFSM::main_comb::STATE_01_BIT), line:73:25, endln:73:37, parent:work@fsm_class::baseFsm::current_state
+              \_ref_obj: (work@fsm_class::specificFSM::main_comb::current_state::STATE_01_BIT), line:73:25, endln:73:37, parent:work@fsm_class::baseFsm::current_state
                 |vpiName:STATE_01_BIT
-                |vpiFullName:work@fsm_class::specificFSM::main_comb::STATE_01_BIT
+                |vpiFullName:work@fsm_class::specificFSM::main_comb::current_state::STATE_01_BIT
                 |vpiActual:
                 \_parameter: (work@fsm_class::specificFSM::STATE_01_BIT), line:29:17, endln:29:33, parent:work@fsm_class::specificFSM
             |vpiStmt:
@@ -1576,13 +1576,13 @@ design: (work@fsm_class)
           |vpiCaseItem:
           \_case_item: , line:74:11, endln:74:54
             |vpiExpr:
-            \_bit_select: (work@fsm_class::baseFsm::current_state), line:74:11, endln:74:38
+            \_bit_select: (work@fsm_class::baseFsm::current_state), line:74:11, endln:74:38, parent:work@fsm_class::specificFSM::main_comb::current_state
               |vpiName:current_state
               |vpiFullName:work@fsm_class::baseFsm::current_state
               |vpiIndex:
-              \_ref_obj: (work@fsm_class::specificFSM::main_comb::STATE_10_BIT), line:74:25, endln:74:37, parent:work@fsm_class::baseFsm::current_state
+              \_ref_obj: (work@fsm_class::specificFSM::main_comb::current_state::STATE_10_BIT), line:74:25, endln:74:37, parent:work@fsm_class::baseFsm::current_state
                 |vpiName:STATE_10_BIT
-                |vpiFullName:work@fsm_class::specificFSM::main_comb::STATE_10_BIT
+                |vpiFullName:work@fsm_class::specificFSM::main_comb::current_state::STATE_10_BIT
                 |vpiActual:
                 \_parameter: (work@fsm_class::specificFSM::STATE_10_BIT), line:30:17, endln:30:33, parent:work@fsm_class::specificFSM
             |vpiStmt:
@@ -1593,13 +1593,13 @@ design: (work@fsm_class)
           |vpiCaseItem:
           \_case_item: , line:75:11, endln:75:54
             |vpiExpr:
-            \_bit_select: (work@fsm_class::baseFsm::current_state), line:75:11, endln:75:38
+            \_bit_select: (work@fsm_class::baseFsm::current_state), line:75:11, endln:75:38, parent:work@fsm_class::specificFSM::main_comb::current_state
               |vpiName:current_state
               |vpiFullName:work@fsm_class::baseFsm::current_state
               |vpiIndex:
-              \_ref_obj: (work@fsm_class::specificFSM::main_comb::STATE_11_BIT), line:75:25, endln:75:37, parent:work@fsm_class::baseFsm::current_state
+              \_ref_obj: (work@fsm_class::specificFSM::main_comb::current_state::STATE_11_BIT), line:75:25, endln:75:37, parent:work@fsm_class::baseFsm::current_state
                 |vpiName:STATE_11_BIT
-                |vpiFullName:work@fsm_class::specificFSM::main_comb::STATE_11_BIT
+                |vpiFullName:work@fsm_class::specificFSM::main_comb::current_state::STATE_11_BIT
                 |vpiActual:
                 \_parameter: (work@fsm_class::specificFSM::STATE_11_BIT), line:31:17, endln:31:33, parent:work@fsm_class::specificFSM
             |vpiStmt:

--- a/tests/ClogCast/ClogCast.log
+++ b/tests/ClogCast/ClogCast.log
@@ -939,7 +939,7 @@ design: (work@debug_rom)
               |vpiActual:
               \_logic_net: (work@debug_rom.rdata_o), line:7:25, endln:7:32, parent:work@debug_rom
             |vpiRhs:
-            \_bit_select: (work@debug_rom.p_outmux.mem), line:47:20, endln:47:31
+            \_bit_select: (work@debug_rom.p_outmux.mem), line:47:20, endln:47:31, parent:work@debug_rom.p_outmux.mem
               |vpiName:mem
               |vpiFullName:work@debug_rom.p_outmux.mem
               |vpiIndex:
@@ -1214,13 +1214,13 @@ design: (work@debug_rom)
               |vpiActual:
               \_logic_net: (work@debug_rom.rdata_o), line:7:25, endln:7:32, parent:work@debug_rom
             |vpiRhs:
-            \_bit_select: (work@debug_rom.p_outmux.mem), line:47:20, endln:47:31
+            \_bit_select: (work@debug_rom.p_outmux.mem), line:47:20, endln:47:31, parent:work@debug_rom.p_outmux.mem
               |vpiName:mem
               |vpiFullName:work@debug_rom.p_outmux.mem
               |vpiIndex:
-              \_ref_obj: (work@debug_rom.p_outmux.addr_q), line:47:24, endln:47:30, parent:work@debug_rom.p_outmux.mem
+              \_ref_obj: (work@debug_rom.p_outmux.mem.addr_q), line:47:24, endln:47:30, parent:work@debug_rom.p_outmux.mem
                 |vpiName:addr_q
-                |vpiFullName:work@debug_rom.p_outmux.addr_q
+                |vpiFullName:work@debug_rom.p_outmux.mem.addr_q
                 |vpiActual:
                 \_logic_net: (work@debug_rom.addr_q), line:34:32, endln:34:38, parent:work@debug_rom
   |vpiPort:

--- a/tests/ComplexBitSelect/ComplexBitSelect.log
+++ b/tests/ComplexBitSelect/ComplexBitSelect.log
@@ -1023,13 +1023,13 @@ design: (work@flash_ctrl_info_cfg)
               |vpiDecompile:'b0
               |BIN:0
             |vpiLhs:
-            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[3].gen_invalid_region.cfgs_o), line:20:14, endln:20:20
+            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[3].gen_invalid_region.cfgs_o), line:20:14, endln:20:20, parent:work@flash_ctrl_info_cfg.gen_info_priv[3].gen_invalid_region.cfgs_o
               |vpiName:cfgs_o
               |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[3].gen_invalid_region.cfgs_o
               |vpiIndex:
-              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[3].gen_invalid_region.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[3].gen_invalid_region.cfgs_o
+              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[3].gen_invalid_region.cfgs_o.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[3].gen_invalid_region.cfgs_o
                 |vpiName:i
-                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[3].gen_invalid_region.i
+                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[3].gen_invalid_region.cfgs_o.i
                 |vpiActual:
                 \_parameter: (work@flash_ctrl_info_cfg.gen_info_priv[3].i), line:16, parent:work@flash_ctrl_info_cfg.gen_info_priv[3]
                   |vpiName:i
@@ -1059,13 +1059,13 @@ design: (work@flash_ctrl_info_cfg)
               |vpiDecompile:'b0
               |BIN:0
             |vpiLhs:
-            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[4].gen_invalid_region.cfgs_o), line:20:14, endln:20:20
+            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[4].gen_invalid_region.cfgs_o), line:20:14, endln:20:20, parent:work@flash_ctrl_info_cfg.gen_info_priv[4].gen_invalid_region.cfgs_o
               |vpiName:cfgs_o
               |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[4].gen_invalid_region.cfgs_o
               |vpiIndex:
-              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[4].gen_invalid_region.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[4].gen_invalid_region.cfgs_o
+              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[4].gen_invalid_region.cfgs_o.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[4].gen_invalid_region.cfgs_o
                 |vpiName:i
-                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[4].gen_invalid_region.i
+                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[4].gen_invalid_region.cfgs_o.i
                 |vpiActual:
                 \_parameter: (work@flash_ctrl_info_cfg.gen_info_priv[4].i), line:16, parent:work@flash_ctrl_info_cfg.gen_info_priv[4]
                   |vpiName:i
@@ -1095,13 +1095,13 @@ design: (work@flash_ctrl_info_cfg)
               |vpiDecompile:'b0
               |BIN:0
             |vpiLhs:
-            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[5].gen_invalid_region.cfgs_o), line:20:14, endln:20:20
+            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[5].gen_invalid_region.cfgs_o), line:20:14, endln:20:20, parent:work@flash_ctrl_info_cfg.gen_info_priv[5].gen_invalid_region.cfgs_o
               |vpiName:cfgs_o
               |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[5].gen_invalid_region.cfgs_o
               |vpiIndex:
-              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[5].gen_invalid_region.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[5].gen_invalid_region.cfgs_o
+              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[5].gen_invalid_region.cfgs_o.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[5].gen_invalid_region.cfgs_o
                 |vpiName:i
-                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[5].gen_invalid_region.i
+                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[5].gen_invalid_region.cfgs_o.i
                 |vpiActual:
                 \_parameter: (work@flash_ctrl_info_cfg.gen_info_priv[5].i), line:16, parent:work@flash_ctrl_info_cfg.gen_info_priv[5]
                   |vpiName:i
@@ -1131,13 +1131,13 @@ design: (work@flash_ctrl_info_cfg)
               |vpiDecompile:'b0
               |BIN:0
             |vpiLhs:
-            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[6].gen_invalid_region.cfgs_o), line:20:14, endln:20:20
+            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[6].gen_invalid_region.cfgs_o), line:20:14, endln:20:20, parent:work@flash_ctrl_info_cfg.gen_info_priv[6].gen_invalid_region.cfgs_o
               |vpiName:cfgs_o
               |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[6].gen_invalid_region.cfgs_o
               |vpiIndex:
-              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[6].gen_invalid_region.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[6].gen_invalid_region.cfgs_o
+              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[6].gen_invalid_region.cfgs_o.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[6].gen_invalid_region.cfgs_o
                 |vpiName:i
-                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[6].gen_invalid_region.i
+                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[6].gen_invalid_region.cfgs_o.i
                 |vpiActual:
                 \_parameter: (work@flash_ctrl_info_cfg.gen_info_priv[6].i), line:16, parent:work@flash_ctrl_info_cfg.gen_info_priv[6]
                   |vpiName:i
@@ -1167,13 +1167,13 @@ design: (work@flash_ctrl_info_cfg)
               |vpiDecompile:'b0
               |BIN:0
             |vpiLhs:
-            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[7].gen_invalid_region.cfgs_o), line:20:14, endln:20:20
+            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[7].gen_invalid_region.cfgs_o), line:20:14, endln:20:20, parent:work@flash_ctrl_info_cfg.gen_info_priv[7].gen_invalid_region.cfgs_o
               |vpiName:cfgs_o
               |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[7].gen_invalid_region.cfgs_o
               |vpiIndex:
-              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[7].gen_invalid_region.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[7].gen_invalid_region.cfgs_o
+              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[7].gen_invalid_region.cfgs_o.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[7].gen_invalid_region.cfgs_o
                 |vpiName:i
-                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[7].gen_invalid_region.i
+                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[7].gen_invalid_region.cfgs_o.i
                 |vpiActual:
                 \_parameter: (work@flash_ctrl_info_cfg.gen_info_priv[7].i), line:16, parent:work@flash_ctrl_info_cfg.gen_info_priv[7]
                   |vpiName:i
@@ -1203,13 +1203,13 @@ design: (work@flash_ctrl_info_cfg)
               |vpiDecompile:'b0
               |BIN:0
             |vpiLhs:
-            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[8].gen_invalid_region.cfgs_o), line:20:14, endln:20:20
+            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[8].gen_invalid_region.cfgs_o), line:20:14, endln:20:20, parent:work@flash_ctrl_info_cfg.gen_info_priv[8].gen_invalid_region.cfgs_o
               |vpiName:cfgs_o
               |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[8].gen_invalid_region.cfgs_o
               |vpiIndex:
-              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[8].gen_invalid_region.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[8].gen_invalid_region.cfgs_o
+              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[8].gen_invalid_region.cfgs_o.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[8].gen_invalid_region.cfgs_o
                 |vpiName:i
-                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[8].gen_invalid_region.i
+                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[8].gen_invalid_region.cfgs_o.i
                 |vpiActual:
                 \_parameter: (work@flash_ctrl_info_cfg.gen_info_priv[8].i), line:16, parent:work@flash_ctrl_info_cfg.gen_info_priv[8]
                   |vpiName:i
@@ -1239,13 +1239,13 @@ design: (work@flash_ctrl_info_cfg)
               |vpiDecompile:'b0
               |BIN:0
             |vpiLhs:
-            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[9].gen_invalid_region.cfgs_o), line:20:14, endln:20:20
+            \_bit_select: (work@flash_ctrl_info_cfg.gen_info_priv[9].gen_invalid_region.cfgs_o), line:20:14, endln:20:20, parent:work@flash_ctrl_info_cfg.gen_info_priv[9].gen_invalid_region.cfgs_o
               |vpiName:cfgs_o
               |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[9].gen_invalid_region.cfgs_o
               |vpiIndex:
-              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[9].gen_invalid_region.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[9].gen_invalid_region.cfgs_o
+              \_ref_obj: (work@flash_ctrl_info_cfg.gen_info_priv[9].gen_invalid_region.cfgs_o.i), line:20:21, endln:20:22, parent:work@flash_ctrl_info_cfg.gen_info_priv[9].gen_invalid_region.cfgs_o
                 |vpiName:i
-                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[9].gen_invalid_region.i
+                |vpiFullName:work@flash_ctrl_info_cfg.gen_info_priv[9].gen_invalid_region.cfgs_o.i
                 |vpiActual:
                 \_parameter: (work@flash_ctrl_info_cfg.gen_info_priv[9].i), line:16, parent:work@flash_ctrl_info_cfg.gen_info_priv[9]
                   |vpiName:i

--- a/tests/ConcatOrder/ConcatOrder.log
+++ b/tests/ConcatOrder/ConcatOrder.log
@@ -939,11 +939,12 @@ design: (work@testbench)
   |vpiParamAssign:
   \_param_assign: , line:43:34, endln:43:74, parent:work@testbench
     |vpiRhs:
-    \_bit_select: (all_cfgs_gp), line:43:50, endln:43:74
+    \_bit_select: (all_cfgs_gp), line:43:50, endln:43:74, parent:all_cfgs_gp
       |vpiName:all_cfgs_gp
       |vpiIndex:
-      \_ref_obj: (bp_params_p), line:43:62, endln:43:73, parent:all_cfgs_gp
+      \_ref_obj: (all_cfgs_gp.bp_params_p), line:43:62, endln:43:73, parent:all_cfgs_gp
         |vpiName:bp_params_p
+        |vpiFullName:all_cfgs_gp.bp_params_p
     |vpiLhs:
     \_parameter: (work@testbench.proc_param_lp), line:43:34, endln:43:74, parent:work@testbench
       |vpiName:proc_param_lp
@@ -957,7 +958,7 @@ design: (work@testbench)
     \_hier_path: (proc_param_lp.cce_ucode), line:44:47, endln:44:70
       |vpiName:proc_param_lp.cce_ucode
       |vpiActual:
-      \_ref_obj: (proc_param_lp)
+      \_ref_obj: (proc_param_lp), parent:proc_param_lp.cce_ucode
         |vpiName:proc_param_lp
       |vpiActual:
       \_ref_obj: (cce_ucode)
@@ -1339,11 +1340,12 @@ design: (work@testbench)
   |vpiParamAssign:
   \_param_assign: , line:43:34, endln:43:74, parent:work@testbench
     |vpiRhs:
-    \_bit_select: (all_cfgs_gp), line:43:50, endln:43:74
+    \_bit_select: (all_cfgs_gp), line:43:50, endln:43:74, parent:all_cfgs_gp
       |vpiName:all_cfgs_gp
       |vpiIndex:
-      \_ref_obj: (bp_params_p), line:43:62, endln:43:73, parent:all_cfgs_gp
+      \_ref_obj: (all_cfgs_gp.bp_params_p), line:43:62, endln:43:73, parent:all_cfgs_gp
         |vpiName:bp_params_p
+        |vpiFullName:all_cfgs_gp.bp_params_p
         |vpiActual:
         \_parameter: (work@testbench.bp_params_p), line:41:26, endln:41:70, parent:work@testbench
     |vpiLhs:

--- a/tests/DoWhile/DoWhile.log
+++ b/tests/DoWhile/DoWhile.log
@@ -169,7 +169,7 @@ design: (unnamed)
             \_hier_path: (m_sync[i].m_state), line:7:11, endln:7:28
               |vpiName:m_sync[i].m_state
               |vpiActual:
-              \_bit_select: (m_sync), parent:m_sync[i].m_state
+              \_bit_select: (m_sync), parent:toto::uvm_default_factory::print::m_sync[i].m_state
                 |vpiName:m_sync
                 |vpiIndex:
                 \_ref_obj: (toto::uvm_default_factory::print::m_sync[i].m_state::i), line:7:18, endln:7:19, parent:m_sync

--- a/tests/DollarRoot/DollarRoot.log
+++ b/tests/DollarRoot/DollarRoot.log
@@ -7112,7 +7112,7 @@ design: (work@top)
           \_hier_path: (read_command_queue_master[0].pop_front), line:254:13, endln:254:53, parent:work@test_program
             |vpiName:read_command_queue_master[0].pop_front
             |vpiActual:
-            \_bit_select: (read_command_queue_master)
+            \_bit_select: (read_command_queue_master), parent:read_command_queue_master[0].pop_front
               |vpiName:read_command_queue_master
               |vpiIndex:
               \_constant: , line:254:39, endln:254:40
@@ -7121,7 +7121,7 @@ design: (work@top)
                 |vpiSize:64
                 |UINT:0
             |vpiActual:
-            \_ref_obj: (pop_front)
+            \_ref_obj: (pop_front), parent:read_command_queue_master[0].pop_front
               |vpiName:pop_front
         |vpiStmt:
         \_assignment: , line:255:7, endln:255:53, parent:work@test_program
@@ -7590,7 +7590,7 @@ design: (work@top)
           \_hier_path: (read_command_queue_master[1].pop_front), line:397:13, endln:397:53, parent:work@test_program
             |vpiName:read_command_queue_master[1].pop_front
             |vpiActual:
-            \_bit_select: (read_command_queue_master)
+            \_bit_select: (read_command_queue_master), parent:read_command_queue_master[1].pop_front
               |vpiName:read_command_queue_master
               |vpiIndex:
               \_constant: , line:397:39, endln:397:40
@@ -7599,7 +7599,7 @@ design: (work@top)
                 |vpiSize:64
                 |UINT:1
             |vpiActual:
-            \_ref_obj: (pop_front)
+            \_ref_obj: (pop_front), parent:read_command_queue_master[1].pop_front
               |vpiName:pop_front
         |vpiStmt:
         \_assignment: , line:398:7, endln:398:53, parent:work@test_program
@@ -8450,7 +8450,7 @@ design: (work@top)
         \_hier_path: (rsp.burstcount), line:271:7, endln:271:10, parent:work@test_program.get_read_response_from_master_0
           |vpiName:rsp.burstcount
           |vpiActual:
-          \_ref_obj: (rsp)
+          \_ref_obj: (rsp), parent:rsp.burstcount
             |vpiName:rsp
           |vpiActual:
           \_ref_obj: (burstcount)
@@ -8522,10 +8522,10 @@ design: (work@top)
             \_hier_path: (rsp.data[i]), line:273:10, endln:273:13, parent:work@test_program.get_read_response_from_master_0
               |vpiName:rsp.data[i]
               |vpiActual:
-              \_ref_obj: (rsp)
+              \_ref_obj: (rsp), parent:rsp.data[i]
                 |vpiName:rsp
               |vpiActual:
-              \_bit_select: (data[i]), line:273:14, endln:273:18
+              \_bit_select: (data[i]), line:273:14, endln:273:18, parent:rsp.data[i]
                 |vpiName:data[i]
                 |vpiIndex:
                 \_ref_obj: (work@test_program.get_read_response_from_master_0.i), line:273:19, endln:273:20, parent:work@test_program.get_read_response_from_master_0
@@ -8588,7 +8588,7 @@ design: (work@top)
         \_hier_path: (cmd.burstcount), line:314:7, endln:314:10, parent:work@test_program.get_command_from_slave_0
           |vpiName:cmd.burstcount
           |vpiActual:
-          \_ref_obj: (cmd)
+          \_ref_obj: (cmd), parent:cmd.burstcount
             |vpiName:cmd
           |vpiActual:
           \_ref_obj: (burstcount)
@@ -8620,7 +8620,7 @@ design: (work@top)
         \_hier_path: (cmd.addr), line:315:7, endln:315:10, parent:work@test_program.get_command_from_slave_0
           |vpiName:cmd.addr
           |vpiActual:
-          \_ref_obj: (cmd)
+          \_ref_obj: (cmd), parent:cmd.addr
             |vpiName:cmd
           |vpiActual:
           \_ref_obj: (addr)
@@ -8683,7 +8683,7 @@ design: (work@top)
             \_hier_path: (cmd.trans), line:318:10, endln:318:13, parent:work@test_program.get_command_from_slave_0
               |vpiName:cmd.trans
               |vpiActual:
-              \_ref_obj: (cmd)
+              \_ref_obj: (cmd), parent:cmd.trans
                 |vpiName:cmd
               |vpiActual:
               \_ref_obj: (trans)
@@ -8742,10 +8742,10 @@ design: (work@top)
                 \_hier_path: (cmd.data[i]), line:320:13, endln:320:16, parent:work@test_program.get_command_from_slave_0
                   |vpiName:cmd.data[i]
                   |vpiActual:
-                  \_ref_obj: (cmd)
+                  \_ref_obj: (cmd), parent:cmd.data[i]
                     |vpiName:cmd
                   |vpiActual:
-                  \_bit_select: (data[i]), line:320:17, endln:320:21
+                  \_bit_select: (data[i]), line:320:17, endln:320:21, parent:cmd.data[i]
                     |vpiName:data[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.get_command_from_slave_0.i), line:320:22, endln:320:23, parent:work@test_program.get_command_from_slave_0
@@ -8778,10 +8778,10 @@ design: (work@top)
                 \_hier_path: (cmd.byteenable[i]), line:321:13, endln:321:16, parent:work@test_program.get_command_from_slave_0
                   |vpiName:cmd.byteenable[i]
                   |vpiActual:
-                  \_ref_obj: (cmd)
+                  \_ref_obj: (cmd), parent:cmd.byteenable[i]
                     |vpiName:cmd
                   |vpiActual:
-                  \_bit_select: (byteenable[i]), line:321:17, endln:321:27
+                  \_bit_select: (byteenable[i]), line:321:17, endln:321:27, parent:cmd.byteenable[i]
                     |vpiName:byteenable[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.get_command_from_slave_0.i), line:321:28, endln:321:29, parent:work@test_program.get_command_from_slave_0
@@ -8817,7 +8817,7 @@ design: (work@top)
             \_hier_path: (cmd.trans), line:324:10, endln:324:13, parent:work@test_program.get_command_from_slave_0
               |vpiName:cmd.trans
               |vpiActual:
-              \_ref_obj: (cmd)
+              \_ref_obj: (cmd), parent:cmd.trans
                 |vpiName:cmd
               |vpiActual:
               \_ref_obj: (trans)
@@ -9366,7 +9366,7 @@ design: (work@top)
         \_hier_path: (rsp.burstcount), line:414:7, endln:414:10, parent:work@test_program.get_read_response_from_master_1
           |vpiName:rsp.burstcount
           |vpiActual:
-          \_ref_obj: (rsp)
+          \_ref_obj: (rsp), parent:rsp.burstcount
             |vpiName:rsp
           |vpiActual:
           \_ref_obj: (burstcount)
@@ -9438,10 +9438,10 @@ design: (work@top)
             \_hier_path: (rsp.data[i]), line:416:10, endln:416:13, parent:work@test_program.get_read_response_from_master_1
               |vpiName:rsp.data[i]
               |vpiActual:
-              \_ref_obj: (rsp)
+              \_ref_obj: (rsp), parent:rsp.data[i]
                 |vpiName:rsp
               |vpiActual:
-              \_bit_select: (data[i]), line:416:14, endln:416:18
+              \_bit_select: (data[i]), line:416:14, endln:416:18, parent:rsp.data[i]
                 |vpiName:data[i]
                 |vpiIndex:
                 \_ref_obj: (work@test_program.get_read_response_from_master_1.i), line:416:19, endln:416:20, parent:work@test_program.get_read_response_from_master_1
@@ -9504,7 +9504,7 @@ design: (work@top)
         \_hier_path: (cmd.burstcount), line:457:7, endln:457:10, parent:work@test_program.get_command_from_slave_1
           |vpiName:cmd.burstcount
           |vpiActual:
-          \_ref_obj: (cmd)
+          \_ref_obj: (cmd), parent:cmd.burstcount
             |vpiName:cmd
           |vpiActual:
           \_ref_obj: (burstcount)
@@ -9536,7 +9536,7 @@ design: (work@top)
         \_hier_path: (cmd.addr), line:458:7, endln:458:10, parent:work@test_program.get_command_from_slave_1
           |vpiName:cmd.addr
           |vpiActual:
-          \_ref_obj: (cmd)
+          \_ref_obj: (cmd), parent:cmd.addr
             |vpiName:cmd
           |vpiActual:
           \_ref_obj: (addr)
@@ -9599,7 +9599,7 @@ design: (work@top)
             \_hier_path: (cmd.trans), line:461:10, endln:461:13, parent:work@test_program.get_command_from_slave_1
               |vpiName:cmd.trans
               |vpiActual:
-              \_ref_obj: (cmd)
+              \_ref_obj: (cmd), parent:cmd.trans
                 |vpiName:cmd
               |vpiActual:
               \_ref_obj: (trans)
@@ -9658,10 +9658,10 @@ design: (work@top)
                 \_hier_path: (cmd.data[i]), line:463:13, endln:463:16, parent:work@test_program.get_command_from_slave_1
                   |vpiName:cmd.data[i]
                   |vpiActual:
-                  \_ref_obj: (cmd)
+                  \_ref_obj: (cmd), parent:cmd.data[i]
                     |vpiName:cmd
                   |vpiActual:
-                  \_bit_select: (data[i]), line:463:17, endln:463:21
+                  \_bit_select: (data[i]), line:463:17, endln:463:21, parent:cmd.data[i]
                     |vpiName:data[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.get_command_from_slave_1.i), line:463:22, endln:463:23, parent:work@test_program.get_command_from_slave_1
@@ -9694,10 +9694,10 @@ design: (work@top)
                 \_hier_path: (cmd.byteenable[i]), line:464:13, endln:464:16, parent:work@test_program.get_command_from_slave_1
                   |vpiName:cmd.byteenable[i]
                   |vpiActual:
-                  \_ref_obj: (cmd)
+                  \_ref_obj: (cmd), parent:cmd.byteenable[i]
                     |vpiName:cmd
                   |vpiActual:
-                  \_bit_select: (byteenable[i]), line:464:17, endln:464:27
+                  \_bit_select: (byteenable[i]), line:464:17, endln:464:27, parent:cmd.byteenable[i]
                     |vpiName:byteenable[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.get_command_from_slave_1.i), line:464:28, endln:464:29, parent:work@test_program.get_command_from_slave_1
@@ -9733,7 +9733,7 @@ design: (work@top)
             \_hier_path: (cmd.trans), line:467:10, endln:467:13, parent:work@test_program.get_command_from_slave_1
               |vpiName:cmd.trans
               |vpiActual:
-              \_ref_obj: (cmd)
+              \_ref_obj: (cmd), parent:cmd.trans
                 |vpiName:cmd
               |vpiActual:
               \_ref_obj: (trans)
@@ -10288,7 +10288,7 @@ design: (work@top)
             \_hier_path: (cmd.burstcount), line:579:10, endln:579:13, parent:work@test_program.create_command
               |vpiName:cmd.burstcount
               |vpiActual:
-              \_ref_obj: (cmd)
+              \_ref_obj: (cmd), parent:cmd.burstcount
                 |vpiName:cmd
               |vpiActual:
               \_ref_obj: (burstcount)
@@ -10309,7 +10309,7 @@ design: (work@top)
             \_hier_path: (cmd.burstcount), line:581:10, endln:581:13, parent:work@test_program.create_command
               |vpiName:cmd.burstcount
               |vpiActual:
-              \_ref_obj: (cmd)
+              \_ref_obj: (cmd), parent:cmd.burstcount
                 |vpiName:cmd
               |vpiActual:
               \_ref_obj: (burstcount)
@@ -10328,7 +10328,7 @@ design: (work@top)
         \_hier_path: (cmd.trans), line:584:7, endln:584:10, parent:work@test_program.create_command
           |vpiName:cmd.trans
           |vpiActual:
-          \_ref_obj: (cmd)
+          \_ref_obj: (cmd), parent:cmd.trans
             |vpiName:cmd
           |vpiActual:
           \_ref_obj: (trans)
@@ -10347,7 +10347,7 @@ design: (work@top)
         \_hier_path: (cmd.addr), line:585:7, endln:585:10, parent:work@test_program.create_command
           |vpiName:cmd.addr
           |vpiActual:
-          \_ref_obj: (cmd)
+          \_ref_obj: (cmd), parent:cmd.addr
             |vpiName:cmd
           |vpiActual:
           \_ref_obj: (addr)
@@ -10369,7 +10369,7 @@ design: (work@top)
         \_hier_path: (cmd.cmd_delay), line:586:7, endln:586:10, parent:work@test_program.create_command
           |vpiName:cmd.cmd_delay
           |vpiActual:
-          \_ref_obj: (cmd)
+          \_ref_obj: (cmd), parent:cmd.cmd_delay
             |vpiName:cmd
           |vpiActual:
           \_ref_obj: (cmd_delay)
@@ -10461,10 +10461,10 @@ design: (work@top)
                 \_hier_path: (cmd.data[i]), line:590:13, endln:590:16, parent:work@test_program.create_command
                   |vpiName:cmd.data[i]
                   |vpiActual:
-                  \_ref_obj: (cmd)
+                  \_ref_obj: (cmd), parent:cmd.data[i]
                     |vpiName:cmd
                   |vpiActual:
-                  \_bit_select: (data[i]), line:590:17, endln:590:21
+                  \_bit_select: (data[i]), line:590:17, endln:590:21, parent:cmd.data[i]
                     |vpiName:data[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.create_command.i), line:590:22, endln:590:23, parent:work@test_program.create_command
@@ -10481,10 +10481,10 @@ design: (work@top)
                 \_hier_path: (cmd.byteenable[i]), line:591:13, endln:591:16, parent:work@test_program.create_command
                   |vpiName:cmd.byteenable[i]
                   |vpiActual:
-                  \_ref_obj: (cmd)
+                  \_ref_obj: (cmd), parent:cmd.byteenable[i]
                     |vpiName:cmd
                   |vpiActual:
-                  \_bit_select: (byteenable[i]), line:591:17, endln:591:27
+                  \_bit_select: (byteenable[i]), line:591:17, endln:591:27, parent:cmd.byteenable[i]
                     |vpiName:byteenable[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.create_command.i), line:591:28, endln:591:29, parent:work@test_program.create_command
@@ -10516,10 +10516,10 @@ design: (work@top)
                 \_hier_path: (cmd.data_idles[i]), line:592:13, endln:592:16, parent:work@test_program.create_command
                   |vpiName:cmd.data_idles[i]
                   |vpiActual:
-                  \_ref_obj: (cmd)
+                  \_ref_obj: (cmd), parent:cmd.data_idles[i]
                     |vpiName:cmd
                   |vpiActual:
-                  \_bit_select: (data_idles[i]), line:592:17, endln:592:27
+                  \_bit_select: (data_idles[i]), line:592:17, endln:592:27, parent:cmd.data_idles[i]
                     |vpiName:data_idles[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.create_command.i), line:592:28, endln:592:29, parent:work@test_program.create_command
@@ -10555,10 +10555,10 @@ design: (work@top)
             \_hier_path: (cmd.data_idles[0]), line:595:10, endln:595:13, parent:work@test_program.create_command
               |vpiName:cmd.data_idles[0]
               |vpiActual:
-              \_ref_obj: (cmd)
+              \_ref_obj: (cmd), parent:cmd.data_idles[0]
                 |vpiName:cmd
               |vpiActual:
-              \_bit_select: (data_idles[0]), line:595:14, endln:595:24
+              \_bit_select: (data_idles[0]), line:595:14, endln:595:24, parent:cmd.data_idles[0]
                 |vpiName:data_idles[0]
                 |vpiIndex:
                 \_constant: , line:595:25, endln:595:26
@@ -10981,7 +10981,7 @@ design: (work@top)
         \_hier_path: (cmd.addr), line:649:7, endln:649:10, parent:work@test_program.save_command_slave
           |vpiName:cmd.addr
           |vpiActual:
-          \_ref_obj: (cmd)
+          \_ref_obj: (cmd), parent:cmd.addr
             |vpiName:cmd
           |vpiActual:
           \_ref_obj: (addr)
@@ -11493,14 +11493,14 @@ design: (work@top)
                 \_hier_path: (write_command_queue_slave[slave_id].pop_front), line:700:23, endln:700:70, parent:work@test_program.get_expected_command_for_slave
                   |vpiName:write_command_queue_slave[slave_id].pop_front
                   |vpiActual:
-                  \_bit_select: (write_command_queue_slave)
+                  \_bit_select: (write_command_queue_slave), parent:write_command_queue_slave[slave_id].pop_front
                     |vpiName:write_command_queue_slave
                     |vpiIndex:
                     \_ref_obj: (work@test_program.get_expected_command_for_slave.slave_id), line:700:49, endln:700:57, parent:work@test_program.get_expected_command_for_slave
                       |vpiName:slave_id
                       |vpiFullName:work@test_program.get_expected_command_for_slave.slave_id
                   |vpiActual:
-                  \_ref_obj: (pop_front)
+                  \_ref_obj: (pop_front), parent:write_command_queue_slave[slave_id].pop_front
                     |vpiName:pop_front
         |vpiElseStmt:
         \_begin: (work@test_program.get_expected_command_for_slave), line:702:16, endln:714:10
@@ -11621,14 +11621,14 @@ design: (work@top)
                 \_hier_path: (read_command_queue_slave[slave_id].pop_front), line:712:23, endln:712:69, parent:work@test_program.get_expected_command_for_slave
                   |vpiName:read_command_queue_slave[slave_id].pop_front
                   |vpiActual:
-                  \_bit_select: (read_command_queue_slave)
+                  \_bit_select: (read_command_queue_slave), parent:read_command_queue_slave[slave_id].pop_front
                     |vpiName:read_command_queue_slave
                     |vpiIndex:
                     \_ref_obj: (work@test_program.get_expected_command_for_slave.slave_id), line:712:48, endln:712:56, parent:work@test_program.get_expected_command_for_slave
                       |vpiName:slave_id
                       |vpiFullName:work@test_program.get_expected_command_for_slave.slave_id
                   |vpiActual:
-                  \_ref_obj: (pop_front)
+                  \_ref_obj: (pop_front), parent:read_command_queue_slave[slave_id].pop_front
                     |vpiName:pop_front
       |vpiStmt:
       \_return_stmt: , line:716:7, endln:716:13, parent:work@test_program.get_expected_command_for_slave
@@ -12068,7 +12068,7 @@ design: (work@top)
         \_hier_path: (rsp.burstcount), line:765:7, endln:765:10, parent:work@test_program.create_response
           |vpiName:rsp.burstcount
           |vpiActual:
-          \_ref_obj: (rsp)
+          \_ref_obj: (rsp), parent:rsp.burstcount
             |vpiName:rsp
           |vpiActual:
           \_ref_obj: (burstcount)
@@ -12122,10 +12122,10 @@ design: (work@top)
             \_hier_path: (rsp.data[i]), line:767:10, endln:767:13, parent:work@test_program.create_response
               |vpiName:rsp.data[i]
               |vpiActual:
-              \_ref_obj: (rsp)
+              \_ref_obj: (rsp), parent:rsp.data[i]
                 |vpiName:rsp
               |vpiActual:
-              \_bit_select: (data[i]), line:767:14, endln:767:18
+              \_bit_select: (data[i]), line:767:14, endln:767:18, parent:rsp.data[i]
                 |vpiName:data[i]
                 |vpiIndex:
                 \_ref_obj: (work@test_program.create_response.i), line:767:19, endln:767:20, parent:work@test_program.create_response
@@ -12142,10 +12142,10 @@ design: (work@top)
             \_hier_path: (rsp.latency[i]), line:768:10, endln:768:13, parent:work@test_program.create_response
               |vpiName:rsp.latency[i]
               |vpiActual:
-              \_ref_obj: (rsp)
+              \_ref_obj: (rsp), parent:rsp.latency[i]
                 |vpiName:rsp
               |vpiActual:
-              \_bit_select: (latency[i]), line:768:14, endln:768:21
+              \_bit_select: (latency[i]), line:768:14, endln:768:21, parent:rsp.latency[i]
                 |vpiName:latency[i]
                 |vpiIndex:
                 \_ref_obj: (work@test_program.create_response.i), line:768:22, endln:768:23, parent:work@test_program.create_response
@@ -12241,7 +12241,7 @@ design: (work@top)
         \_hier_path: (read_response_queue_slave[slave_id].pop_front), line:781:13, endln:781:60, parent:work@test_program.get_expected_read_response
           |vpiName:read_response_queue_slave[slave_id].pop_front
           |vpiActual:
-          \_bit_select: (read_response_queue_slave)
+          \_bit_select: (read_response_queue_slave), parent:read_response_queue_slave[slave_id].pop_front
             |vpiName:read_response_queue_slave
             |vpiIndex:
             \_ref_obj: (work@test_program.get_expected_read_response.slave_id), line:781:39, endln:781:47, parent:work@test_program.get_expected_read_response
@@ -12250,7 +12250,7 @@ design: (work@top)
               |vpiActual:
               \_int_var: (work@test_program.get_expected_read_response.slave_id), line:779:7, endln:779:10
           |vpiActual:
-          \_ref_obj: (pop_front)
+          \_ref_obj: (pop_front), parent:read_response_queue_slave[slave_id].pop_front
             |vpiName:pop_front
       |vpiStmt:
       \_return_stmt: , line:783:7, endln:783:13, parent:work@test_program.get_expected_read_response
@@ -12917,7 +12917,7 @@ design: (work@top)
           \_hier_path: (read_command_queue_master[0].pop_front), line:254:13, endln:254:53
             |vpiName:read_command_queue_master[0].pop_front
             |vpiActual:
-            \_bit_select: (read_command_queue_master), parent:read_command_queue_master[0].pop_front
+            \_bit_select: (read_command_queue_master), parent:work@test_program.read_command_queue_master[0].pop_front
               |vpiName:read_command_queue_master
               |vpiIndex:
               \_constant: , line:254:39, endln:254:40
@@ -13637,7 +13637,7 @@ design: (work@top)
           \_hier_path: (read_command_queue_master[1].pop_front), line:397:13, endln:397:53
             |vpiName:read_command_queue_master[1].pop_front
             |vpiActual:
-            \_bit_select: (read_command_queue_master), parent:read_command_queue_master[1].pop_front
+            \_bit_select: (read_command_queue_master), parent:work@test_program.read_command_queue_master[1].pop_front
               |vpiName:read_command_queue_master
               |vpiIndex:
               \_constant: , line:397:39, endln:397:40
@@ -14419,12 +14419,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (cmd), parent:work@test_program.configure_and_push_command_to_master_0
                   |vpiActual:
-                  \_bit_select: (data), parent:cmd.data[i]
+                  \_bit_select: (data)
                     |vpiName:data
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.data[i].i), line:235:61, endln:235:62, parent:data
+                    \_ref_obj: (i), line:235:61, endln:235:62, parent:data
                       |vpiName:i
-                      |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.data[i].i
                 |vpiArgument:
                 \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.i), line:235:65, endln:235:66, parent:$root.tb.dut.master_0.set_command_data
                   |vpiName:i
@@ -14441,12 +14440,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (cmd), parent:work@test_program.configure_and_push_command_to_master_0
                   |vpiActual:
-                  \_bit_select: (byteenable), parent:cmd.byteenable[i]
+                  \_bit_select: (byteenable)
                     |vpiName:byteenable
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.byteenable[i].i), line:236:74, endln:236:75, parent:byteenable
+                    \_ref_obj: (i), line:236:74, endln:236:75, parent:byteenable
                       |vpiName:i
-                      |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.byteenable[i].i
                 |vpiArgument:
                 \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.i), line:236:78, endln:236:79, parent:$root.tb.dut.master_0.set_command_byte_enable
                   |vpiName:i
@@ -14463,12 +14461,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (cmd), parent:work@test_program.configure_and_push_command_to_master_0
                   |vpiActual:
-                  \_bit_select: (data_idles), parent:cmd.data_idles[i]
+                  \_bit_select: (data_idles)
                     |vpiName:data_idles
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.cmd.data_idles[i].i), line:237:67, endln:237:68, parent:data_idles
+                    \_ref_obj: (i), line:237:67, endln:237:68, parent:data_idles
                       |vpiName:i
-                      |vpiFullName:work@test_program.configure_and_push_command_to_master_0.cmd.data_idles[i].i
                 |vpiArgument:
                 \_ref_obj: (work@test_program.configure_and_push_command_to_master_0.i), line:237:71, endln:237:72, parent:$root.tb.dut.master_0.set_command_idle
                   |vpiName:i
@@ -14495,7 +14492,7 @@ design: (work@top)
                 |vpiActual:
                 \_io_decl: (cmd), parent:work@test_program.configure_and_push_command_to_master_0
               |vpiActual:
-              \_bit_select: (data_idles), parent:cmd.data_idles[0]
+              \_bit_select: (data_idles)
                 |vpiName:data_idles
                 |vpiIndex:
                 \_constant: , line:241:64, endln:241:65
@@ -14624,7 +14621,7 @@ design: (work@top)
                 |vpiActual:
                 \_struct_var: (work@test_program.get_read_response_from_master_0.rsp), line:268:7, endln:268:15, parent:work@test_program.get_read_response_from_master_0
               |vpiActual:
-              \_bit_select: (data[i]), line:273:14, endln:273:18, parent:rsp.data[i]
+              \_bit_select: (data[i]), line:273:14, endln:273:18, parent:work@test_program.get_read_response_from_master_0.rsp.data[i]
                 |vpiName:data[i]
                 |vpiIndex:
                 \_ref_obj: (work@test_program.get_read_response_from_master_0.rsp.data[i].i), line:273:19, endln:273:20, parent:data[i]
@@ -14857,7 +14854,7 @@ design: (work@top)
                     |vpiActual:
                     \_struct_var: (work@test_program.get_command_from_slave_0.cmd), line:311:7, endln:311:14, parent:work@test_program.get_command_from_slave_0
                   |vpiActual:
-                  \_bit_select: (data[i]), line:320:17, endln:320:21, parent:cmd.data[i]
+                  \_bit_select: (data[i]), line:320:17, endln:320:21, parent:work@test_program.get_command_from_slave_0.cmd.data[i]
                     |vpiName:data[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.get_command_from_slave_0.cmd.data[i].i), line:320:22, endln:320:23, parent:data[i]
@@ -14895,7 +14892,7 @@ design: (work@top)
                     |vpiActual:
                     \_struct_var: (work@test_program.get_command_from_slave_0.cmd), line:311:7, endln:311:14, parent:work@test_program.get_command_from_slave_0
                   |vpiActual:
-                  \_bit_select: (byteenable[i]), line:321:17, endln:321:27, parent:cmd.byteenable[i]
+                  \_bit_select: (byteenable[i]), line:321:17, endln:321:27, parent:work@test_program.get_command_from_slave_0.cmd.byteenable[i]
                     |vpiName:byteenable[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.get_command_from_slave_0.cmd.byteenable[i].i), line:321:28, endln:321:29, parent:byteenable[i]
@@ -15047,12 +15044,11 @@ design: (work@top)
                 |vpiActual:
                 \_io_decl: (rsp), parent:work@test_program.configure_and_push_response_to_slave_0
               |vpiActual:
-              \_bit_select: (data), parent:rsp.data[i]
+              \_bit_select: (data)
                 |vpiName:data
                 |vpiIndex:
-                \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.data[i].i), line:349:58, endln:349:59, parent:data
+                \_ref_obj: (i), line:349:58, endln:349:59, parent:data
                   |vpiName:i
-                  |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.data[i].i
             |vpiArgument:
             \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.i), line:349:62, endln:349:63, parent:$root.tb.dut.slave_0.set_response_data
               |vpiName:i
@@ -15090,12 +15086,11 @@ design: (work@top)
                       |vpiActual:
                       \_io_decl: (rsp), parent:work@test_program.configure_and_push_response_to_slave_0
                     |vpiActual:
-                    \_bit_select: (latency), parent:rsp.latency[i]
+                    \_bit_select: (latency)
                       |vpiName:latency
                       |vpiIndex:
-                      \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.latency[i].i), line:352:67, endln:352:68, parent:latency
+                      \_ref_obj: (i), line:352:67, endln:352:68, parent:latency
                         |vpiName:i
-                        |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.latency[i].i
                   |vpiOperand:
                   \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.pending_read_cycles_slave_0), line:352:72, endln:352:99
                     |vpiName:pending_read_cycles_slave_0
@@ -15127,12 +15122,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (rsp), parent:work@test_program.configure_and_push_response_to_slave_0
                   |vpiActual:
-                  \_bit_select: (latency), parent:rsp.latency[i]
+                  \_bit_select: (latency)
                     |vpiName:latency
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.latency[i].i), line:353:49, endln:353:50, parent:latency
+                    \_ref_obj: (i), line:353:49, endln:353:50, parent:latency
                       |vpiName:i
-                      |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.latency[i].i
             |vpiElseStmt:
             \_begin: (work@test_program.configure_and_push_response_to_slave_0), line:354:19, endln:357:13
               |vpiFullName:work@test_program.configure_and_push_response_to_slave_0
@@ -15148,12 +15142,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (rsp), parent:work@test_program.configure_and_push_response_to_slave_0
                   |vpiActual:
-                  \_bit_select: (latency), parent:rsp.latency[i]
+                  \_bit_select: (latency)
                     |vpiName:latency
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.latency[i].i), line:355:67, endln:355:68, parent:latency
+                    \_ref_obj: (i), line:355:67, endln:355:68, parent:latency
                       |vpiName:i
-                      |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.latency[i].i
                 |vpiArgument:
                 \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.i), line:355:71, endln:355:72, parent:$root.tb.dut.slave_0.set_response_latency
                   |vpiName:i
@@ -15180,12 +15173,11 @@ design: (work@top)
                       |vpiActual:
                       \_io_decl: (rsp), parent:work@test_program.configure_and_push_response_to_slave_0
                     |vpiActual:
-                    \_bit_select: (latency), parent:rsp.latency[i]
+                    \_bit_select: (latency)
                       |vpiName:latency
                       |vpiIndex:
-                      \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.rsp.latency[i].i), line:356:49, endln:356:50, parent:latency
+                      \_ref_obj: (i), line:356:49, endln:356:50, parent:latency
                         |vpiName:i
-                        |vpiFullName:work@test_program.configure_and_push_response_to_slave_0.rsp.latency[i].i
                   |vpiOperand:
                   \_ref_obj: (work@test_program.configure_and_push_response_to_slave_0.read_response_latency), line:356:54, endln:356:75
                     |vpiName:read_response_latency
@@ -15405,12 +15397,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (cmd), parent:work@test_program.configure_and_push_command_to_master_1
                   |vpiActual:
-                  \_bit_select: (data), parent:cmd.data[i]
+                  \_bit_select: (data)
                     |vpiName:data
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.data[i].i), line:378:61, endln:378:62, parent:data
+                    \_ref_obj: (i), line:378:61, endln:378:62, parent:data
                       |vpiName:i
-                      |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.data[i].i
                 |vpiArgument:
                 \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.i), line:378:65, endln:378:66, parent:$root.tb.dut.master_1.set_command_data
                   |vpiName:i
@@ -15427,12 +15418,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (cmd), parent:work@test_program.configure_and_push_command_to_master_1
                   |vpiActual:
-                  \_bit_select: (byteenable), parent:cmd.byteenable[i]
+                  \_bit_select: (byteenable)
                     |vpiName:byteenable
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.byteenable[i].i), line:379:74, endln:379:75, parent:byteenable
+                    \_ref_obj: (i), line:379:74, endln:379:75, parent:byteenable
                       |vpiName:i
-                      |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.byteenable[i].i
                 |vpiArgument:
                 \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.i), line:379:78, endln:379:79, parent:$root.tb.dut.master_1.set_command_byte_enable
                   |vpiName:i
@@ -15449,12 +15439,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (cmd), parent:work@test_program.configure_and_push_command_to_master_1
                   |vpiActual:
-                  \_bit_select: (data_idles), parent:cmd.data_idles[i]
+                  \_bit_select: (data_idles)
                     |vpiName:data_idles
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.cmd.data_idles[i].i), line:380:67, endln:380:68, parent:data_idles
+                    \_ref_obj: (i), line:380:67, endln:380:68, parent:data_idles
                       |vpiName:i
-                      |vpiFullName:work@test_program.configure_and_push_command_to_master_1.cmd.data_idles[i].i
                 |vpiArgument:
                 \_ref_obj: (work@test_program.configure_and_push_command_to_master_1.i), line:380:71, endln:380:72, parent:$root.tb.dut.master_1.set_command_idle
                   |vpiName:i
@@ -15481,7 +15470,7 @@ design: (work@top)
                 |vpiActual:
                 \_io_decl: (cmd), parent:work@test_program.configure_and_push_command_to_master_1
               |vpiActual:
-              \_bit_select: (data_idles), parent:cmd.data_idles[0]
+              \_bit_select: (data_idles)
                 |vpiName:data_idles
                 |vpiIndex:
                 \_constant: , line:384:64, endln:384:65
@@ -15610,7 +15599,7 @@ design: (work@top)
                 |vpiActual:
                 \_struct_var: (work@test_program.get_read_response_from_master_1.rsp), line:411:7, endln:411:15, parent:work@test_program.get_read_response_from_master_1
               |vpiActual:
-              \_bit_select: (data[i]), line:416:14, endln:416:18, parent:rsp.data[i]
+              \_bit_select: (data[i]), line:416:14, endln:416:18, parent:work@test_program.get_read_response_from_master_1.rsp.data[i]
                 |vpiName:data[i]
                 |vpiIndex:
                 \_ref_obj: (work@test_program.get_read_response_from_master_1.rsp.data[i].i), line:416:19, endln:416:20, parent:data[i]
@@ -15843,7 +15832,7 @@ design: (work@top)
                     |vpiActual:
                     \_struct_var: (work@test_program.get_command_from_slave_1.cmd), line:454:7, endln:454:14, parent:work@test_program.get_command_from_slave_1
                   |vpiActual:
-                  \_bit_select: (data[i]), line:463:17, endln:463:21, parent:cmd.data[i]
+                  \_bit_select: (data[i]), line:463:17, endln:463:21, parent:work@test_program.get_command_from_slave_1.cmd.data[i]
                     |vpiName:data[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.get_command_from_slave_1.cmd.data[i].i), line:463:22, endln:463:23, parent:data[i]
@@ -15881,7 +15870,7 @@ design: (work@top)
                     |vpiActual:
                     \_struct_var: (work@test_program.get_command_from_slave_1.cmd), line:454:7, endln:454:14, parent:work@test_program.get_command_from_slave_1
                   |vpiActual:
-                  \_bit_select: (byteenable[i]), line:464:17, endln:464:27, parent:cmd.byteenable[i]
+                  \_bit_select: (byteenable[i]), line:464:17, endln:464:27, parent:work@test_program.get_command_from_slave_1.cmd.byteenable[i]
                     |vpiName:byteenable[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.get_command_from_slave_1.cmd.byteenable[i].i), line:464:28, endln:464:29, parent:byteenable[i]
@@ -16033,12 +16022,11 @@ design: (work@top)
                 |vpiActual:
                 \_io_decl: (rsp), parent:work@test_program.configure_and_push_response_to_slave_1
               |vpiActual:
-              \_bit_select: (data), parent:rsp.data[i]
+              \_bit_select: (data)
                 |vpiName:data
                 |vpiIndex:
-                \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.data[i].i), line:492:58, endln:492:59, parent:data
+                \_ref_obj: (i), line:492:58, endln:492:59, parent:data
                   |vpiName:i
-                  |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.data[i].i
             |vpiArgument:
             \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.i), line:492:62, endln:492:63, parent:$root.tb.dut.slave_1.set_response_data
               |vpiName:i
@@ -16076,12 +16064,11 @@ design: (work@top)
                       |vpiActual:
                       \_io_decl: (rsp), parent:work@test_program.configure_and_push_response_to_slave_1
                     |vpiActual:
-                    \_bit_select: (latency), parent:rsp.latency[i]
+                    \_bit_select: (latency)
                       |vpiName:latency
                       |vpiIndex:
-                      \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.latency[i].i), line:495:67, endln:495:68, parent:latency
+                      \_ref_obj: (i), line:495:67, endln:495:68, parent:latency
                         |vpiName:i
-                        |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.latency[i].i
                   |vpiOperand:
                   \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.pending_read_cycles_slave_1), line:495:72, endln:495:99
                     |vpiName:pending_read_cycles_slave_1
@@ -16113,12 +16100,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (rsp), parent:work@test_program.configure_and_push_response_to_slave_1
                   |vpiActual:
-                  \_bit_select: (latency), parent:rsp.latency[i]
+                  \_bit_select: (latency)
                     |vpiName:latency
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.latency[i].i), line:496:49, endln:496:50, parent:latency
+                    \_ref_obj: (i), line:496:49, endln:496:50, parent:latency
                       |vpiName:i
-                      |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.latency[i].i
             |vpiElseStmt:
             \_begin: (work@test_program.configure_and_push_response_to_slave_1), line:497:19, endln:500:13
               |vpiFullName:work@test_program.configure_and_push_response_to_slave_1
@@ -16134,12 +16120,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (rsp), parent:work@test_program.configure_and_push_response_to_slave_1
                   |vpiActual:
-                  \_bit_select: (latency), parent:rsp.latency[i]
+                  \_bit_select: (latency)
                     |vpiName:latency
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.latency[i].i), line:498:67, endln:498:68, parent:latency
+                    \_ref_obj: (i), line:498:67, endln:498:68, parent:latency
                       |vpiName:i
-                      |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.latency[i].i
                 |vpiArgument:
                 \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.i), line:498:71, endln:498:72, parent:$root.tb.dut.slave_1.set_response_latency
                   |vpiName:i
@@ -16166,12 +16151,11 @@ design: (work@top)
                       |vpiActual:
                       \_io_decl: (rsp), parent:work@test_program.configure_and_push_response_to_slave_1
                     |vpiActual:
-                    \_bit_select: (latency), parent:rsp.latency[i]
+                    \_bit_select: (latency)
                       |vpiName:latency
                       |vpiIndex:
-                      \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.rsp.latency[i].i), line:499:49, endln:499:50, parent:latency
+                      \_ref_obj: (i), line:499:49, endln:499:50, parent:latency
                         |vpiName:i
-                        |vpiFullName:work@test_program.configure_and_push_response_to_slave_1.rsp.latency[i].i
                   |vpiOperand:
                   \_ref_obj: (work@test_program.configure_and_push_response_to_slave_1.read_response_latency), line:499:54, endln:499:75
                     |vpiName:read_response_latency
@@ -16715,7 +16699,7 @@ design: (work@top)
                     |vpiActual:
                     \_struct_var: (work@test_program.create_command.cmd), line:576:7, endln:576:14, parent:work@test_program.create_command
                   |vpiActual:
-                  \_bit_select: (data[i]), line:590:17, endln:590:21, parent:cmd.data[i]
+                  \_bit_select: (data[i]), line:590:17, endln:590:21, parent:work@test_program.create_command.cmd.data[i]
                     |vpiName:data[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.create_command.cmd.data[i].i), line:590:22, endln:590:23, parent:data[i]
@@ -16737,7 +16721,7 @@ design: (work@top)
                     |vpiActual:
                     \_struct_var: (work@test_program.create_command.cmd), line:576:7, endln:576:14, parent:work@test_program.create_command
                   |vpiActual:
-                  \_bit_select: (byteenable[i]), line:591:17, endln:591:27, parent:cmd.byteenable[i]
+                  \_bit_select: (byteenable[i]), line:591:17, endln:591:27, parent:work@test_program.create_command.cmd.byteenable[i]
                     |vpiName:byteenable[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.create_command.cmd.byteenable[i].i), line:591:28, endln:591:29, parent:byteenable[i]
@@ -16774,7 +16758,7 @@ design: (work@top)
                     |vpiActual:
                     \_struct_var: (work@test_program.create_command.cmd), line:576:7, endln:576:14, parent:work@test_program.create_command
                   |vpiActual:
-                  \_bit_select: (data_idles[i]), line:592:17, endln:592:27, parent:cmd.data_idles[i]
+                  \_bit_select: (data_idles[i]), line:592:17, endln:592:27, parent:work@test_program.create_command.cmd.data_idles[i]
                     |vpiName:data_idles[i]
                     |vpiIndex:
                     \_ref_obj: (work@test_program.create_command.cmd.data_idles[i].i), line:592:28, endln:592:29, parent:data_idles[i]
@@ -16815,7 +16799,7 @@ design: (work@top)
                 |vpiActual:
                 \_struct_var: (work@test_program.create_command.cmd), line:576:7, endln:576:14, parent:work@test_program.create_command
               |vpiActual:
-              \_bit_select: (data_idles[0]), line:595:14, endln:595:24, parent:cmd.data_idles[0]
+              \_bit_select: (data_idles[0]), line:595:14, endln:595:24, parent:work@test_program.create_command.cmd.data_idles[0]
                 |vpiName:data_idles[0]
                 |vpiIndex:
                 \_constant: , line:595:25, endln:595:26
@@ -18025,7 +18009,7 @@ design: (work@top)
                 \_hier_path: (write_command_queue_slave[slave_id].pop_front), line:700:23, endln:700:70
                   |vpiName:write_command_queue_slave[slave_id].pop_front
                   |vpiActual:
-                  \_bit_select: (write_command_queue_slave), parent:write_command_queue_slave[slave_id].pop_front
+                  \_bit_select: (write_command_queue_slave), parent:work@test_program.get_expected_command_for_slave.write_command_queue_slave[slave_id].pop_front
                     |vpiName:write_command_queue_slave
                     |vpiIndex:
                     \_ref_obj: (work@test_program.get_expected_command_for_slave.write_command_queue_slave[slave_id].pop_front.slave_id), line:700:49, endln:700:57, parent:write_command_queue_slave
@@ -18176,7 +18160,7 @@ design: (work@top)
                 \_hier_path: (read_command_queue_slave[slave_id].pop_front), line:712:23, endln:712:69
                   |vpiName:read_command_queue_slave[slave_id].pop_front
                   |vpiActual:
-                  \_bit_select: (read_command_queue_slave), parent:read_command_queue_slave[slave_id].pop_front
+                  \_bit_select: (read_command_queue_slave), parent:work@test_program.get_expected_command_for_slave.read_command_queue_slave[slave_id].pop_front
                     |vpiName:read_command_queue_slave
                     |vpiIndex:
                     \_ref_obj: (work@test_program.get_expected_command_for_slave.read_command_queue_slave[slave_id].pop_front.slave_id), line:712:48, endln:712:56, parent:read_command_queue_slave
@@ -18376,12 +18360,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (exp_cmd), parent:work@test_program.verify_command
                   |vpiActual:
-                  \_bit_select: (data), parent:exp_cmd.data[i]
+                  \_bit_select: (data)
                     |vpiName:data
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.verify_command.exp_cmd.data[i].i), line:728:60, endln:728:61, parent:data
+                    \_ref_obj: (i), line:728:60, endln:728:61, parent:data
                       |vpiName:i
-                      |vpiFullName:work@test_program.verify_command.exp_cmd.data[i].i
                 |vpiArgument:
                 \_hier_path: (actual_cmd.data[i]), line:728:64, endln:728:82, parent:assert_equals
                   |vpiName:actual_cmd.data[i]
@@ -18391,12 +18374,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (actual_cmd), parent:work@test_program.verify_command
                   |vpiActual:
-                  \_bit_select: (data), parent:actual_cmd.data[i]
+                  \_bit_select: (data)
                     |vpiName:data
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.verify_command.actual_cmd.data[i].i), line:728:80, endln:728:81, parent:data
+                    \_ref_obj: (i), line:728:80, endln:728:81, parent:data
                       |vpiName:i
-                      |vpiFullName:work@test_program.verify_command.actual_cmd.data[i].i
               |vpiStmt:
               \_task_call: (assert_equals), line:729:13, endln:729:96, parent:work@test_program.verify_command
                 |vpiName:assert_equals
@@ -18417,12 +18399,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (exp_cmd), parent:work@test_program.verify_command
                   |vpiActual:
-                  \_bit_select: (byteenable), parent:exp_cmd.byteenable[i]
+                  \_bit_select: (byteenable)
                     |vpiName:byteenable
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.verify_command.exp_cmd.byteenable[i].i), line:729:66, endln:729:67, parent:byteenable
+                    \_ref_obj: (i), line:729:66, endln:729:67, parent:byteenable
                       |vpiName:i
-                      |vpiFullName:work@test_program.verify_command.exp_cmd.byteenable[i].i
                 |vpiArgument:
                 \_hier_path: (actual_cmd.byteenable[i]), line:729:70, endln:729:94, parent:assert_equals
                   |vpiName:actual_cmd.byteenable[i]
@@ -18432,12 +18413,11 @@ design: (work@top)
                     |vpiActual:
                     \_io_decl: (actual_cmd), parent:work@test_program.verify_command
                   |vpiActual:
-                  \_bit_select: (byteenable), parent:actual_cmd.byteenable[i]
+                  \_bit_select: (byteenable)
                     |vpiName:byteenable
                     |vpiIndex:
-                    \_ref_obj: (work@test_program.verify_command.actual_cmd.byteenable[i].i), line:729:92, endln:729:93, parent:byteenable
+                    \_ref_obj: (i), line:729:92, endln:729:93, parent:byteenable
                       |vpiName:i
-                      |vpiFullName:work@test_program.verify_command.actual_cmd.byteenable[i].i
   |vpiTaskFunc:
   \_task: (work@test_program.assert_equals), line:735:4, endln:757:11, parent:work@test_program
     |vpiVisibility:1
@@ -18724,7 +18704,7 @@ design: (work@top)
                 |vpiActual:
                 \_struct_var: (work@test_program.create_response.rsp), line:763:7, endln:763:15, parent:work@test_program.create_response
               |vpiActual:
-              \_bit_select: (data[i]), line:767:14, endln:767:18, parent:rsp.data[i]
+              \_bit_select: (data[i]), line:767:14, endln:767:18, parent:work@test_program.create_response.rsp.data[i]
                 |vpiName:data[i]
                 |vpiIndex:
                 \_ref_obj: (work@test_program.create_response.rsp.data[i].i), line:767:19, endln:767:20, parent:data[i]
@@ -18746,7 +18726,7 @@ design: (work@top)
                 |vpiActual:
                 \_struct_var: (work@test_program.create_response.rsp), line:763:7, endln:763:15, parent:work@test_program.create_response
               |vpiActual:
-              \_bit_select: (latency[i]), line:768:14, endln:768:21, parent:rsp.latency[i]
+              \_bit_select: (latency[i]), line:768:14, endln:768:21, parent:work@test_program.create_response.rsp.latency[i]
                 |vpiName:latency[i]
                 |vpiIndex:
                 \_ref_obj: (work@test_program.create_response.rsp.latency[i].i), line:768:22, endln:768:23, parent:latency[i]
@@ -18842,7 +18822,7 @@ design: (work@top)
         \_hier_path: (read_response_queue_slave[slave_id].pop_front), line:781:13, endln:781:60
           |vpiName:read_response_queue_slave[slave_id].pop_front
           |vpiActual:
-          \_bit_select: (read_response_queue_slave), parent:read_response_queue_slave[slave_id].pop_front
+          \_bit_select: (read_response_queue_slave), parent:work@test_program.get_expected_read_response.read_response_queue_slave[slave_id].pop_front
             |vpiName:read_response_queue_slave
             |vpiIndex:
             \_ref_obj: (work@test_program.get_expected_read_response.read_response_queue_slave[slave_id].pop_front.slave_id), line:781:39, endln:781:47, parent:read_response_queue_slave
@@ -18986,12 +18966,11 @@ design: (work@top)
                 |vpiActual:
                 \_io_decl: (exp_rsp), parent:work@test_program.verify_response
               |vpiActual:
-              \_bit_select: (data), parent:exp_rsp.data[i]
+              \_bit_select: (data)
                 |vpiName:data
                 |vpiIndex:
-                \_ref_obj: (work@test_program.verify_response.exp_rsp.data[i].i), line:792:56, endln:792:57, parent:data
+                \_ref_obj: (i), line:792:56, endln:792:57, parent:data
                   |vpiName:i
-                  |vpiFullName:work@test_program.verify_response.exp_rsp.data[i].i
             |vpiArgument:
             \_hier_path: (actual_rsp.data[i]), line:792:60, endln:792:78, parent:assert_equals
               |vpiName:actual_rsp.data[i]
@@ -19001,12 +18980,11 @@ design: (work@top)
                 |vpiActual:
                 \_io_decl: (actual_rsp), parent:work@test_program.verify_response
               |vpiActual:
-              \_bit_select: (data), parent:actual_rsp.data[i]
+              \_bit_select: (data)
                 |vpiName:data
                 |vpiIndex:
-                \_ref_obj: (work@test_program.verify_response.actual_rsp.data[i].i), line:792:76, endln:792:77, parent:data
+                \_ref_obj: (i), line:792:76, endln:792:77, parent:data
                   |vpiName:i
-                  |vpiFullName:work@test_program.verify_response.actual_rsp.data[i].i
   |vpiNet:
   \_logic_net: (work@test_program.assert_fail), line:517:7, endln:517:18, parent:work@test_program
     |vpiName:assert_fail
@@ -19195,8 +19173,7 @@ design: (work@top)
         \_ref_obj: (master_0), parent:work@test_program1.$root.tb.dut.master_0[2].signal_write_response_complete
           |vpiName:master_0
         |vpiActual:
-        \_bit_select: (work@test_program1.$root.tb.dut.master_0[2].signal_write_response_complete), parent:work@test_program1.$root.tb.dut.master_0[2].signal_write_response_complete
-          |vpiFullName:work@test_program1.$root.tb.dut.master_0[2].signal_write_response_complete
+        \_bit_select: 
           |vpiIndex:
           \_constant: , line:802:35, endln:802:36
             |vpiConstType:9

--- a/tests/EvalFuncArray/EvalFuncArray.log
+++ b/tests/EvalFuncArray/EvalFuncArray.log
@@ -366,13 +366,13 @@ design: (unnamed)
             \_operation: , line:16:11, endln:16:33
               |vpiOpType:18
               |vpiOperand:
-              \_bit_select: (earlgrey::max_info_pages::infos), line:16:11, endln:16:19
+              \_bit_select: (earlgrey::max_info_pages::infos), line:16:11, endln:16:19, parent:earlgrey::max_info_pages::infos
                 |vpiName:infos
                 |vpiFullName:earlgrey::max_info_pages::infos
                 |vpiIndex:
-                \_ref_obj: (earlgrey::max_info_pages::i), line:16:17, endln:16:18, parent:earlgrey::max_info_pages::infos
+                \_ref_obj: (earlgrey::max_info_pages::infos::i), line:16:17, endln:16:18, parent:earlgrey::max_info_pages::infos
                   |vpiName:i
-                  |vpiFullName:earlgrey::max_info_pages::i
+                  |vpiFullName:earlgrey::max_info_pages::infos::i
               |vpiOperand:
               \_ref_obj: (earlgrey::max_info_pages::current_max), line:16:22, endln:16:33
                 |vpiName:current_max
@@ -395,13 +395,13 @@ design: (unnamed)
                   |vpiActual:
                   \_int_var: (earlgrey::max_info_pages::current_max), line:14:5, endln:14:8, parent:earlgrey::max_info_pages
                 |vpiRhs:
-                \_bit_select: (earlgrey::max_info_pages::infos), line:17:23, endln:17:31
+                \_bit_select: (earlgrey::max_info_pages::infos), line:17:23, endln:17:31, parent:earlgrey::max_info_pages::infos
                   |vpiName:infos
                   |vpiFullName:earlgrey::max_info_pages::infos
                   |vpiIndex:
-                  \_ref_obj: (earlgrey::max_info_pages::i), line:17:29, endln:17:30, parent:earlgrey::max_info_pages::infos
+                  \_ref_obj: (earlgrey::max_info_pages::infos::i), line:17:29, endln:17:30, parent:earlgrey::max_info_pages::infos
                     |vpiName:i
-                    |vpiFullName:earlgrey::max_info_pages::i
+                    |vpiFullName:earlgrey::max_info_pages::infos::i
       |vpiStmt:
       \_return_stmt: , line:20:5, endln:20:11, parent:earlgrey::max_info_pages
         |vpiCondition:

--- a/tests/EvalFuncPack/EvalFuncPack.log
+++ b/tests/EvalFuncPack/EvalFuncPack.log
@@ -850,13 +850,13 @@ design: (work@flash_ctrl_info_cfg)
             \_operation: , line:38:11, endln:38:33
               |vpiOpType:18
               |vpiOperand:
-              \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:38:11, endln:38:19
+              \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:38:11, endln:38:19, parent:flash_ctrl_pkg::max_info_pages::infos
                 |vpiName:infos
                 |vpiFullName:flash_ctrl_pkg::max_info_pages::infos
                 |vpiIndex:
-                \_ref_obj: (flash_ctrl_pkg::max_info_pages::i), line:38:17, endln:38:18, parent:flash_ctrl_pkg::max_info_pages::infos
+                \_ref_obj: (flash_ctrl_pkg::max_info_pages::infos::i), line:38:17, endln:38:18, parent:flash_ctrl_pkg::max_info_pages::infos
                   |vpiName:i
-                  |vpiFullName:flash_ctrl_pkg::max_info_pages::i
+                  |vpiFullName:flash_ctrl_pkg::max_info_pages::infos::i
               |vpiOperand:
               \_ref_obj: (flash_ctrl_pkg::max_info_pages::current_max), line:38:22, endln:38:33
                 |vpiName:current_max
@@ -879,13 +879,13 @@ design: (work@flash_ctrl_info_cfg)
                   |vpiActual:
                   \_int_var: (flash_ctrl_pkg::max_info_pages::current_max), line:36:5, endln:36:8, parent:flash_ctrl_pkg::max_info_pages
                 |vpiRhs:
-                \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:39:23, endln:39:31
+                \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:39:23, endln:39:31, parent:flash_ctrl_pkg::max_info_pages::infos
                   |vpiName:infos
                   |vpiFullName:flash_ctrl_pkg::max_info_pages::infos
                   |vpiIndex:
-                  \_ref_obj: (flash_ctrl_pkg::max_info_pages::i), line:39:29, endln:39:30, parent:flash_ctrl_pkg::max_info_pages::infos
+                  \_ref_obj: (flash_ctrl_pkg::max_info_pages::infos::i), line:39:29, endln:39:30, parent:flash_ctrl_pkg::max_info_pages::infos
                     |vpiName:i
-                    |vpiFullName:flash_ctrl_pkg::max_info_pages::i
+                    |vpiFullName:flash_ctrl_pkg::max_info_pages::infos::i
       |vpiStmt:
       \_return_stmt: , line:42:5, endln:42:11, parent:flash_ctrl_pkg::max_info_pages
         |vpiCondition:
@@ -1600,13 +1600,13 @@ design: (work@flash_ctrl_info_cfg)
                 \_operation: , line:38:11, endln:38:33
                   |vpiOpType:18
                   |vpiOperand:
-                  \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:38:11, endln:38:19
+                  \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:38:11, endln:38:19, parent:flash_ctrl_pkg::max_info_pages::infos
                     |vpiName:infos
                     |vpiFullName:flash_ctrl_pkg::max_info_pages::infos
                     |vpiIndex:
-                    \_ref_obj: (flash_ctrl_pkg::max_info_pages::i), line:38:17, endln:38:18, parent:flash_ctrl_pkg::max_info_pages::infos
+                    \_ref_obj: (flash_ctrl_pkg::max_info_pages::infos::i), line:38:17, endln:38:18, parent:flash_ctrl_pkg::max_info_pages::infos
                       |vpiName:i
-                      |vpiFullName:flash_ctrl_pkg::max_info_pages::i
+                      |vpiFullName:flash_ctrl_pkg::max_info_pages::infos::i
                   |vpiOperand:
                   \_ref_obj: (flash_ctrl_pkg::max_info_pages::current_max), line:38:22, endln:38:33
                     |vpiName:current_max
@@ -1629,13 +1629,13 @@ design: (work@flash_ctrl_info_cfg)
                       |vpiActual:
                       \_int_var: (flash_ctrl_pkg::max_info_pages::current_max), line:36:5, endln:36:8, parent:flash_ctrl_pkg::max_info_pages
                     |vpiRhs:
-                    \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:39:23, endln:39:31
+                    \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:39:23, endln:39:31, parent:flash_ctrl_pkg::max_info_pages::infos
                       |vpiName:infos
                       |vpiFullName:flash_ctrl_pkg::max_info_pages::infos
                       |vpiIndex:
-                      \_ref_obj: (flash_ctrl_pkg::max_info_pages::i), line:39:29, endln:39:30, parent:flash_ctrl_pkg::max_info_pages::infos
+                      \_ref_obj: (flash_ctrl_pkg::max_info_pages::infos::i), line:39:29, endln:39:30, parent:flash_ctrl_pkg::max_info_pages::infos
                         |vpiName:i
-                        |vpiFullName:flash_ctrl_pkg::max_info_pages::i
+                        |vpiFullName:flash_ctrl_pkg::max_info_pages::infos::i
           |vpiStmt:
           \_return_stmt: , line:42:5, endln:42:11, parent:flash_ctrl_pkg::max_info_pages
             |vpiCondition:
@@ -1773,7 +1773,7 @@ design: (work@flash_ctrl_info_cfg)
             \_operation: , line:38:11, endln:38:33
               |vpiOpType:18
               |vpiOperand:
-              \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:38:11, endln:38:19
+              \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:38:11, endln:38:19, parent:flash_ctrl_pkg::max_info_pages::infos
                 |vpiName:infos
                 |vpiFullName:flash_ctrl_pkg::max_info_pages::infos
                 |vpiIndex:
@@ -1796,7 +1796,7 @@ design: (work@flash_ctrl_info_cfg)
                   |vpiName:current_max
                   |vpiFullName:flash_ctrl_pkg::max_info_pages::current_max
                 |vpiRhs:
-                \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:39:23, endln:39:31
+                \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:39:23, endln:39:31, parent:flash_ctrl_pkg::max_info_pages::infos
                   |vpiName:infos
                   |vpiFullName:flash_ctrl_pkg::max_info_pages::infos
                   |vpiIndex:
@@ -2036,13 +2036,13 @@ design: (work@flash_ctrl_info_cfg)
                     \_operation: , line:38:11, endln:38:33
                       |vpiOpType:18
                       |vpiOperand:
-                      \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:38:11, endln:38:19
+                      \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:38:11, endln:38:19, parent:flash_ctrl_pkg::max_info_pages::infos
                         |vpiName:infos
                         |vpiFullName:flash_ctrl_pkg::max_info_pages::infos
                         |vpiIndex:
-                        \_ref_obj: (flash_ctrl_pkg::max_info_pages::i), line:38:17, endln:38:18, parent:flash_ctrl_pkg::max_info_pages::infos
+                        \_ref_obj: (flash_ctrl_pkg::max_info_pages::infos::i), line:38:17, endln:38:18, parent:flash_ctrl_pkg::max_info_pages::infos
                           |vpiName:i
-                          |vpiFullName:flash_ctrl_pkg::max_info_pages::i
+                          |vpiFullName:flash_ctrl_pkg::max_info_pages::infos::i
                       |vpiOperand:
                       \_ref_obj: (flash_ctrl_pkg::max_info_pages::current_max), line:38:22, endln:38:33
                         |vpiName:current_max
@@ -2065,13 +2065,13 @@ design: (work@flash_ctrl_info_cfg)
                           |vpiActual:
                           \_int_var: (flash_ctrl_pkg::max_info_pages::current_max), line:36:5, endln:36:8, parent:flash_ctrl_pkg::max_info_pages
                         |vpiRhs:
-                        \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:39:23, endln:39:31
+                        \_bit_select: (flash_ctrl_pkg::max_info_pages::infos), line:39:23, endln:39:31, parent:flash_ctrl_pkg::max_info_pages::infos
                           |vpiName:infos
                           |vpiFullName:flash_ctrl_pkg::max_info_pages::infos
                           |vpiIndex:
-                          \_ref_obj: (flash_ctrl_pkg::max_info_pages::i), line:39:29, endln:39:30, parent:flash_ctrl_pkg::max_info_pages::infos
+                          \_ref_obj: (flash_ctrl_pkg::max_info_pages::infos::i), line:39:29, endln:39:30, parent:flash_ctrl_pkg::max_info_pages::infos
                             |vpiName:i
-                            |vpiFullName:flash_ctrl_pkg::max_info_pages::i
+                            |vpiFullName:flash_ctrl_pkg::max_info_pages::infos::i
               |vpiStmt:
               \_return_stmt: , line:42:5, endln:42:11, parent:flash_ctrl_pkg::max_info_pages
                 |vpiCondition:
@@ -2207,13 +2207,13 @@ design: (work@flash_ctrl_info_cfg)
             \_operation: , line:38:11, endln:38:33
               |vpiOpType:18
               |vpiOperand:
-              \_bit_select: (work@flash_ctrl_info_cfg.max_info_pages.infos), line:38:11, endln:38:19
+              \_bit_select: (work@flash_ctrl_info_cfg.max_info_pages.infos), line:38:11, endln:38:19, parent:work@flash_ctrl_info_cfg.max_info_pages.infos
                 |vpiName:infos
                 |vpiFullName:work@flash_ctrl_info_cfg.max_info_pages.infos
                 |vpiIndex:
-                \_ref_obj: (work@flash_ctrl_info_cfg.max_info_pages.i), line:38:17, endln:38:18, parent:work@flash_ctrl_info_cfg.max_info_pages.infos
+                \_ref_obj: (work@flash_ctrl_info_cfg.max_info_pages.infos.i), line:38:17, endln:38:18, parent:work@flash_ctrl_info_cfg.max_info_pages.infos
                   |vpiName:i
-                  |vpiFullName:work@flash_ctrl_info_cfg.max_info_pages.i
+                  |vpiFullName:work@flash_ctrl_info_cfg.max_info_pages.infos.i
               |vpiOperand:
               \_ref_obj: (work@flash_ctrl_info_cfg.max_info_pages.current_max), line:38:22, endln:38:33
                 |vpiName:current_max
@@ -2236,13 +2236,13 @@ design: (work@flash_ctrl_info_cfg)
                   |vpiActual:
                   \_int_var: (work@flash_ctrl_info_cfg.max_info_pages.current_max), line:36:5, endln:36:8, parent:flash_ctrl_pkg::max_info_pages
                 |vpiRhs:
-                \_bit_select: (work@flash_ctrl_info_cfg.max_info_pages.infos), line:39:23, endln:39:31
+                \_bit_select: (work@flash_ctrl_info_cfg.max_info_pages.infos), line:39:23, endln:39:31, parent:work@flash_ctrl_info_cfg.max_info_pages.infos
                   |vpiName:infos
                   |vpiFullName:work@flash_ctrl_info_cfg.max_info_pages.infos
                   |vpiIndex:
-                  \_ref_obj: (work@flash_ctrl_info_cfg.max_info_pages.i), line:39:29, endln:39:30, parent:work@flash_ctrl_info_cfg.max_info_pages.infos
+                  \_ref_obj: (work@flash_ctrl_info_cfg.max_info_pages.infos.i), line:39:29, endln:39:30, parent:work@flash_ctrl_info_cfg.max_info_pages.infos
                     |vpiName:i
-                    |vpiFullName:work@flash_ctrl_info_cfg.max_info_pages.i
+                    |vpiFullName:work@flash_ctrl_info_cfg.max_info_pages.infos.i
       |vpiStmt:
       \_return_stmt: , line:42:5, endln:42:11, parent:work@flash_ctrl_info_cfg.max_info_pages
         |vpiCondition:

--- a/tests/FuncArgDirection/FuncArgDirection.log
+++ b/tests/FuncArgDirection/FuncArgDirection.log
@@ -714,7 +714,7 @@ design: (work@dut)
             |vpiOpType:82
             |vpiBlocking:1
             |vpiLhs:
-            \_bit_select: (work@dut.aes_rev_order_bit.out), line:5:5, endln:5:8
+            \_bit_select: (work@dut.aes_rev_order_bit.out), line:5:5, endln:5:8, parent:work@dut.aes_rev_order_bit.out
               |vpiName:out
               |vpiFullName:work@dut.aes_rev_order_bit.out
               |vpiIndex:
@@ -722,7 +722,7 @@ design: (work@dut)
                 |vpiName:i
                 |vpiFullName:work@dut.aes_rev_order_bit.i
             |vpiRhs:
-            \_bit_select: (work@dut.aes_rev_order_bit.in), line:5:14, endln:5:21
+            \_bit_select: (work@dut.aes_rev_order_bit.in), line:5:14, endln:5:21, parent:work@dut.aes_rev_order_bit.in
               |vpiName:in
               |vpiFullName:work@dut.aes_rev_order_bit.in
               |vpiIndex:
@@ -934,15 +934,15 @@ design: (work@dut)
             |vpiOpType:82
             |vpiBlocking:1
             |vpiLhs:
-            \_bit_select: (work@dut.aes_rev_order_bit.out), line:5:5, endln:5:8
+            \_bit_select: (work@dut.aes_rev_order_bit.out), line:5:5, endln:5:8, parent:work@dut.aes_rev_order_bit.out
               |vpiName:out
               |vpiFullName:work@dut.aes_rev_order_bit.out
               |vpiIndex:
-              \_ref_obj: (work@dut.aes_rev_order_bit.i), line:5:9, endln:5:10, parent:work@dut.aes_rev_order_bit.out
+              \_ref_obj: (work@dut.aes_rev_order_bit.out.i), line:5:9, endln:5:10, parent:work@dut.aes_rev_order_bit.out
                 |vpiName:i
-                |vpiFullName:work@dut.aes_rev_order_bit.i
+                |vpiFullName:work@dut.aes_rev_order_bit.out.i
             |vpiRhs:
-            \_bit_select: (work@dut.aes_rev_order_bit.in), line:5:14, endln:5:21
+            \_bit_select: (work@dut.aes_rev_order_bit.in), line:5:14, endln:5:21, parent:work@dut.aes_rev_order_bit.in
               |vpiName:in
               |vpiFullName:work@dut.aes_rev_order_bit.in
               |vpiIndex:

--- a/tests/FuncNoArgs/FuncNoArgs.log
+++ b/tests/FuncNoArgs/FuncNoArgs.log
@@ -704,8 +704,9 @@ design: (work@my_opt_reduce_or)
           \_operation: , line:12:21, endln:12:45
             |vpiOpType:3
             |vpiOperand:
-            \_bit_select: (_TECHMAP_CONSTMSK_A_), line:12:22, endln:12:45
+            \_bit_select: (work@my_opt_reduce_or.count_nonconst_bits._TECHMAP_CONSTMSK_A_), line:12:22, endln:12:45, parent:work@my_opt_reduce_or.count_nonconst_bits._TECHMAP_CONSTMSK_A_
               |vpiName:_TECHMAP_CONSTMSK_A_
+              |vpiFullName:work@my_opt_reduce_or.count_nonconst_bits._TECHMAP_CONSTMSK_A_
               |vpiIndex:
               \_ref_obj: (work@my_opt_reduce_or.count_nonconst_bits.i), line:12:43, endln:12:44
                 |vpiName:i
@@ -928,13 +929,13 @@ design: (work@my_opt_reduce_or)
           \_operation: , line:12:21, endln:12:45
             |vpiOpType:3
             |vpiOperand:
-            \_bit_select: (work@my_opt_reduce_or.count_nonconst_bits._TECHMAP_CONSTMSK_A_), line:12:22, endln:12:45
+            \_bit_select: (work@my_opt_reduce_or.count_nonconst_bits._TECHMAP_CONSTMSK_A_), line:12:22, endln:12:45, parent:work@my_opt_reduce_or.count_nonconst_bits._TECHMAP_CONSTMSK_A_
               |vpiName:_TECHMAP_CONSTMSK_A_
               |vpiFullName:work@my_opt_reduce_or.count_nonconst_bits._TECHMAP_CONSTMSK_A_
               |vpiIndex:
-              \_ref_obj: (work@my_opt_reduce_or.count_nonconst_bits.i), line:12:43, endln:12:44, parent:work@my_opt_reduce_or.count_nonconst_bits._TECHMAP_CONSTMSK_A_
+              \_ref_obj: (work@my_opt_reduce_or.count_nonconst_bits._TECHMAP_CONSTMSK_A_.i), line:12:43, endln:12:44, parent:work@my_opt_reduce_or.count_nonconst_bits._TECHMAP_CONSTMSK_A_
                 |vpiName:i
-                |vpiFullName:work@my_opt_reduce_or.count_nonconst_bits.i
+                |vpiFullName:work@my_opt_reduce_or.count_nonconst_bits._TECHMAP_CONSTMSK_A_.i
                 |vpiActual:
                 \_int_var: (work@my_opt_reduce_or.count_nonconst_bits.i), line:8:9, endln:8:16, parent:work@my_opt_reduce_or.count_nonconst_bits
           |vpiStmt:

--- a/tests/FuncStruct/FuncStruct.log
+++ b/tests/FuncStruct/FuncStruct.log
@@ -414,7 +414,7 @@ design: (work@dut)
         |vpiOpType:82
         |vpiBlocking:1
         |vpiLhs:
-        \_bit_select: (hmac_pkg::compress::compress), line:7:3, endln:7:11
+        \_bit_select: (hmac_pkg::compress::compress), line:7:3, endln:7:11, parent:hmac_pkg::compress::compress
           |vpiName:compress
           |vpiFullName:hmac_pkg::compress::compress
           |vpiIndex:
@@ -446,7 +446,7 @@ design: (work@dut)
       |vpiSize:32
       |HEX:00000000
     |vpiLhs:
-    \_bit_select: (work@dut.w), line:16:8, endln:16:9
+    \_bit_select: (work@dut.w), line:16:8, endln:16:9, parent:work@dut.w
       |vpiName:w
       |vpiFullName:work@dut.w
       |vpiIndex:
@@ -463,10 +463,11 @@ design: (work@dut)
       |vpiFunction:
       \_function: (hmac_pkg::compress), line:3:1, endln:8:12, parent:hmac_pkg::
       |vpiArgument:
-      \_bit_select: (w), line:17:24, endln:17:28
+      \_bit_select: (work@dut.w), line:17:24, endln:17:28, parent:work@dut.w
         |vpiName:w
+        |vpiFullName:work@dut.w
         |vpiIndex:
-        \_constant: , line:17:26, endln:17:27, parent:w
+        \_constant: , line:17:26, endln:17:27, parent:work@dut.w
           |vpiConstType:9
           |vpiDecompile:0
           |vpiSize:64
@@ -645,7 +646,7 @@ design: (work@dut)
                     |vpiOpType:82
                     |vpiBlocking:1
                     |vpiLhs:
-                    \_bit_select: (hmac_pkg::compress::compress), line:7:3, endln:7:11
+                    \_bit_select: (hmac_pkg::compress::compress), line:7:3, endln:7:11, parent:hmac_pkg::compress::compress
                       |vpiName:compress
                       |vpiFullName:hmac_pkg::compress::compress
                       |vpiIndex:
@@ -717,7 +718,7 @@ design: (work@dut)
         |vpiOpType:82
         |vpiBlocking:1
         |vpiLhs:
-        \_bit_select: (hmac_pkg::compress::compress), line:7:3, endln:7:11
+        \_bit_select: (hmac_pkg::compress::compress), line:7:3, endln:7:11, parent:hmac_pkg::compress::compress
           |vpiName:compress
           |vpiFullName:hmac_pkg::compress::compress
           |vpiIndex:
@@ -757,7 +758,7 @@ design: (work@dut)
       |vpiSize:32
       |HEX:00000000
     |vpiLhs:
-    \_bit_select: (work@dut.w), line:16:8, endln:16:9
+    \_bit_select: (work@dut.w), line:16:8, endln:16:9, parent:work@dut.w
       |vpiName:w
       |vpiFullName:work@dut.w
       |vpiIndex:
@@ -774,11 +775,11 @@ design: (work@dut)
       |vpiFunction:
       \_function: (hmac_pkg::compress), line:3:1, endln:8:12, parent:work@dut
       |vpiArgument:
-      \_bit_select: (work@dut.w), line:17:24, endln:17:28, parent:compress
+      \_bit_select: (work@dut.w), line:17:24, endln:17:28, parent:work@dut.w
         |vpiName:w
         |vpiFullName:work@dut.w
         |vpiIndex:
-        \_constant: , line:17:26, endln:17:27, parent:w
+        \_constant: , line:17:26, endln:17:27, parent:work@dut.w
           |vpiConstType:9
           |vpiDecompile:0
           |vpiSize:64
@@ -957,7 +958,7 @@ design: (work@dut)
                     |vpiOpType:82
                     |vpiBlocking:1
                     |vpiLhs:
-                    \_bit_select: (hmac_pkg::compress::compress), line:7:3, endln:7:11
+                    \_bit_select: (hmac_pkg::compress::compress), line:7:3, endln:7:11, parent:hmac_pkg::compress::compress
                       |vpiName:compress
                       |vpiFullName:hmac_pkg::compress::compress
                       |vpiIndex:
@@ -1031,7 +1032,7 @@ design: (work@dut)
         |vpiOpType:82
         |vpiBlocking:1
         |vpiLhs:
-        \_bit_select: (work@dut.compress.compress), line:7:3, endln:7:11
+        \_bit_select: (work@dut.compress.compress), line:7:3, endln:7:11, parent:work@dut.compress.compress
           |vpiName:compress
           |vpiFullName:work@dut.compress.compress
           |vpiIndex:

--- a/tests/GenScopeFullName/GenScopeFullName.log
+++ b/tests/GenScopeFullName/GenScopeFullName.log
@@ -187,13 +187,13 @@ design: (work@dut)
           |vpiInstance:
           \_module: work@ibex_counter (work@dut.gen_modules[0].module_in_genscope) dut.sv:5: , parent:work@dut.gen_modules[0]
           |vpiHighConn:
-          \_bit_select: (work@dut.a), line:5:42, endln:5:46, parent:b
+          \_bit_select: (work@dut.a), line:5:42, endln:5:46, parent:work@dut.gen_modules[0].module_in_genscope.b.a
             |vpiName:a
             |vpiFullName:work@dut.a
             |vpiIndex:
-            \_ref_obj: (work@dut.gen_modules[0].module_in_genscope.i), line:5:44, endln:5:45, parent:work@dut.a
+            \_ref_obj: (work@dut.gen_modules[0].module_in_genscope.b.a.i), line:5:44, endln:5:45, parent:work@dut.a
               |vpiName:i
-              |vpiFullName:work@dut.gen_modules[0].module_in_genscope.i
+              |vpiFullName:work@dut.gen_modules[0].module_in_genscope.b.a.i
               |vpiActual:
               \_parameter: (work@dut.gen_modules[0].i), line:4, parent:work@dut.gen_modules[0]
                 |vpiName:i

--- a/tests/GenerateInterface/GenerateInterface.log
+++ b/tests/GenerateInterface/GenerateInterface.log
@@ -840,7 +840,7 @@ design: (work@top)
       \_operation: , line:7:25, endln:7:32
         |vpiOpType:39
         |vpiOperand:
-        \_bit_select: (clk_i), line:7:33, endln:7:41
+        \_bit_select: (clk_i), line:7:33, endln:7:41, parent:clk_i
           |vpiName:clk_i
           |vpiIndex:
           \_ref_obj: (i), line:7:39, endln:7:40
@@ -975,7 +975,7 @@ design: (work@top)
             \_operation: , line:7:25, endln:7:32
               |vpiOpType:39
               |vpiOperand:
-              \_bit_select: (clk_i), line:7:33, endln:7:41
+              \_bit_select: (clk_i), line:7:33, endln:7:41, parent:clk_i
                 |vpiName:clk_i
                 |vpiIndex:
                 \_ref_obj: (i), line:7:39, endln:7:40
@@ -1003,7 +1003,7 @@ design: (work@top)
             \_operation: , line:7:25, endln:7:32
               |vpiOpType:39
               |vpiOperand:
-              \_bit_select: (clk_i), line:7:33, endln:7:41
+              \_bit_select: (clk_i), line:7:33, endln:7:41, parent:clk_i
                 |vpiName:clk_i
                 |vpiIndex:
                 \_ref_obj: (i), line:7:39, endln:7:40
@@ -1031,7 +1031,7 @@ design: (work@top)
             \_operation: , line:7:25, endln:7:32
               |vpiOpType:39
               |vpiOperand:
-              \_bit_select: (clk_i), line:7:33, endln:7:41
+              \_bit_select: (clk_i), line:7:33, endln:7:41, parent:clk_i
                 |vpiName:clk_i
                 |vpiIndex:
                 \_ref_obj: (i), line:7:39, endln:7:40
@@ -1176,20 +1176,20 @@ design: (work@top)
           \_operation: , line:29:24, endln:29:34
             |vpiOpType:32
             |vpiOperand:
-            \_bit_select: (work@top2.intf.each_pin_intf[0].pins_oe), line:29:24, endln:29:34
+            \_bit_select: (work@top2.intf.each_pin_intf[0].pins_oe), line:29:24, endln:29:34, parent:work@top2.intf.each_pin_intf[0].pins_oe
               |vpiName:pins_oe
               |vpiFullName:work@top2.intf.each_pin_intf[0].pins_oe
               |vpiIndex:
-              \_ref_obj: (work@top2.intf.each_pin_intf[0].i), line:29:32, endln:29:33, parent:work@top2.intf.each_pin_intf[0].pins_oe
+              \_ref_obj: (work@top2.intf.each_pin_intf[0].pins_oe.i), line:29:32, endln:29:33, parent:work@top2.intf.each_pin_intf[0].pins_oe
                 |vpiName:i
-                |vpiFullName:work@top2.intf.each_pin_intf[0].i
+                |vpiFullName:work@top2.intf.each_pin_intf[0].pins_oe.i
                 |vpiActual:
                 \_parameter: (work@top2.intf.each_pin_intf[0].i), line:28, parent:work@top2.intf.each_pin_intf[0]
                   |vpiName:i
                   |vpiFullName:work@top2.intf.each_pin_intf[0].i
                   |UINT:0
             |vpiOperand:
-            \_bit_select: (work@top2.intf.each_pin_intf[0].pins_o), line:29:37, endln:29:46
+            \_bit_select: (work@top2.intf.each_pin_intf[0].pins_o), line:29:37, endln:29:46, parent:work@top2.intf.each_pin_intf[0].pins_o
               |vpiName:pins_o
               |vpiFullName:work@top2.intf.each_pin_intf[0].pins_o
               |vpiIndex:
@@ -1205,13 +1205,13 @@ design: (work@top)
               |vpiSize:1
               |BIN:z
           |vpiLhs:
-          \_bit_select: (work@top2.intf.each_pin_intf[0].pins), line:29:14, endln:29:18
+          \_bit_select: (work@top2.intf.each_pin_intf[0].pins), line:29:14, endln:29:18, parent:work@top2.intf.each_pin_intf[0].pins
             |vpiName:pins
             |vpiFullName:work@top2.intf.each_pin_intf[0].pins
             |vpiIndex:
-            \_ref_obj: (work@top2.intf.each_pin_intf[0].i), line:29:19, endln:29:20, parent:work@top2.intf.each_pin_intf[0].pins
+            \_ref_obj: (work@top2.intf.each_pin_intf[0].pins.i), line:29:19, endln:29:20, parent:work@top2.intf.each_pin_intf[0].pins
               |vpiName:i
-              |vpiFullName:work@top2.intf.each_pin_intf[0].i
+              |vpiFullName:work@top2.intf.each_pin_intf[0].pins.i
               |vpiActual:
               \_parameter: (work@top2.intf.each_pin_intf[0].i), line:28, parent:work@top2.intf.each_pin_intf[0]
         |vpiParameter:
@@ -1229,20 +1229,20 @@ design: (work@top)
           \_operation: , line:29:24, endln:29:34
             |vpiOpType:32
             |vpiOperand:
-            \_bit_select: (work@top2.intf.each_pin_intf[1].pins_oe), line:29:24, endln:29:34
+            \_bit_select: (work@top2.intf.each_pin_intf[1].pins_oe), line:29:24, endln:29:34, parent:work@top2.intf.each_pin_intf[1].pins_oe
               |vpiName:pins_oe
               |vpiFullName:work@top2.intf.each_pin_intf[1].pins_oe
               |vpiIndex:
-              \_ref_obj: (work@top2.intf.each_pin_intf[1].i), line:29:32, endln:29:33, parent:work@top2.intf.each_pin_intf[1].pins_oe
+              \_ref_obj: (work@top2.intf.each_pin_intf[1].pins_oe.i), line:29:32, endln:29:33, parent:work@top2.intf.each_pin_intf[1].pins_oe
                 |vpiName:i
-                |vpiFullName:work@top2.intf.each_pin_intf[1].i
+                |vpiFullName:work@top2.intf.each_pin_intf[1].pins_oe.i
                 |vpiActual:
                 \_parameter: (work@top2.intf.each_pin_intf[1].i), line:28, parent:work@top2.intf.each_pin_intf[1]
                   |vpiName:i
                   |vpiFullName:work@top2.intf.each_pin_intf[1].i
                   |UINT:1
             |vpiOperand:
-            \_bit_select: (work@top2.intf.each_pin_intf[1].pins_o), line:29:37, endln:29:46
+            \_bit_select: (work@top2.intf.each_pin_intf[1].pins_o), line:29:37, endln:29:46, parent:work@top2.intf.each_pin_intf[1].pins_o
               |vpiName:pins_o
               |vpiFullName:work@top2.intf.each_pin_intf[1].pins_o
               |vpiIndex:
@@ -1258,13 +1258,13 @@ design: (work@top)
               |vpiSize:1
               |BIN:z
           |vpiLhs:
-          \_bit_select: (work@top2.intf.each_pin_intf[1].pins), line:29:14, endln:29:18
+          \_bit_select: (work@top2.intf.each_pin_intf[1].pins), line:29:14, endln:29:18, parent:work@top2.intf.each_pin_intf[1].pins
             |vpiName:pins
             |vpiFullName:work@top2.intf.each_pin_intf[1].pins
             |vpiIndex:
-            \_ref_obj: (work@top2.intf.each_pin_intf[1].i), line:29:19, endln:29:20, parent:work@top2.intf.each_pin_intf[1].pins
+            \_ref_obj: (work@top2.intf.each_pin_intf[1].pins.i), line:29:19, endln:29:20, parent:work@top2.intf.each_pin_intf[1].pins
               |vpiName:i
-              |vpiFullName:work@top2.intf.each_pin_intf[1].i
+              |vpiFullName:work@top2.intf.each_pin_intf[1].pins.i
               |vpiActual:
               \_parameter: (work@top2.intf.each_pin_intf[1].i), line:28, parent:work@top2.intf.each_pin_intf[1]
         |vpiParameter:
@@ -1323,20 +1323,20 @@ design: (work@top)
         \_operation: , line:39:24, endln:39:34
           |vpiOpType:32
           |vpiOperand:
-          \_bit_select: (work@top2.each_pin[0].pins_oe), line:39:24, endln:39:34
+          \_bit_select: (work@top2.each_pin[0].pins_oe), line:39:24, endln:39:34, parent:work@top2.each_pin[0].pins_oe
             |vpiName:pins_oe
             |vpiFullName:work@top2.each_pin[0].pins_oe
             |vpiIndex:
-            \_ref_obj: (work@top2.each_pin[0].i), line:39:32, endln:39:33, parent:work@top2.each_pin[0].pins_oe
+            \_ref_obj: (work@top2.each_pin[0].pins_oe.i), line:39:32, endln:39:33, parent:work@top2.each_pin[0].pins_oe
               |vpiName:i
-              |vpiFullName:work@top2.each_pin[0].i
+              |vpiFullName:work@top2.each_pin[0].pins_oe.i
               |vpiActual:
               \_parameter: (work@top2.each_pin[0].i), line:38, parent:work@top2.each_pin[0]
                 |vpiName:i
                 |vpiFullName:work@top2.each_pin[0].i
                 |UINT:0
           |vpiOperand:
-          \_bit_select: (work@top2.each_pin[0].pins_o), line:39:37, endln:39:46
+          \_bit_select: (work@top2.each_pin[0].pins_o), line:39:37, endln:39:46, parent:work@top2.each_pin[0].pins_o
             |vpiName:pins_o
             |vpiFullName:work@top2.each_pin[0].pins_o
             |vpiIndex:
@@ -1352,13 +1352,13 @@ design: (work@top)
             |vpiSize:1
             |BIN:z
         |vpiLhs:
-        \_bit_select: (work@top2.each_pin[0].pins), line:39:14, endln:39:18
+        \_bit_select: (work@top2.each_pin[0].pins), line:39:14, endln:39:18, parent:work@top2.each_pin[0].pins
           |vpiName:pins
           |vpiFullName:work@top2.each_pin[0].pins
           |vpiIndex:
-          \_ref_obj: (work@top2.each_pin[0].i), line:39:19, endln:39:20, parent:work@top2.each_pin[0].pins
+          \_ref_obj: (work@top2.each_pin[0].pins.i), line:39:19, endln:39:20, parent:work@top2.each_pin[0].pins
             |vpiName:i
-            |vpiFullName:work@top2.each_pin[0].i
+            |vpiFullName:work@top2.each_pin[0].pins.i
             |vpiActual:
             \_parameter: (work@top2.each_pin[0].i), line:38, parent:work@top2.each_pin[0]
       |vpiParameter:
@@ -1376,20 +1376,20 @@ design: (work@top)
         \_operation: , line:39:24, endln:39:34
           |vpiOpType:32
           |vpiOperand:
-          \_bit_select: (work@top2.each_pin[1].pins_oe), line:39:24, endln:39:34
+          \_bit_select: (work@top2.each_pin[1].pins_oe), line:39:24, endln:39:34, parent:work@top2.each_pin[1].pins_oe
             |vpiName:pins_oe
             |vpiFullName:work@top2.each_pin[1].pins_oe
             |vpiIndex:
-            \_ref_obj: (work@top2.each_pin[1].i), line:39:32, endln:39:33, parent:work@top2.each_pin[1].pins_oe
+            \_ref_obj: (work@top2.each_pin[1].pins_oe.i), line:39:32, endln:39:33, parent:work@top2.each_pin[1].pins_oe
               |vpiName:i
-              |vpiFullName:work@top2.each_pin[1].i
+              |vpiFullName:work@top2.each_pin[1].pins_oe.i
               |vpiActual:
               \_parameter: (work@top2.each_pin[1].i), line:38, parent:work@top2.each_pin[1]
                 |vpiName:i
                 |vpiFullName:work@top2.each_pin[1].i
                 |UINT:1
           |vpiOperand:
-          \_bit_select: (work@top2.each_pin[1].pins_o), line:39:37, endln:39:46
+          \_bit_select: (work@top2.each_pin[1].pins_o), line:39:37, endln:39:46, parent:work@top2.each_pin[1].pins_o
             |vpiName:pins_o
             |vpiFullName:work@top2.each_pin[1].pins_o
             |vpiIndex:
@@ -1405,13 +1405,13 @@ design: (work@top)
             |vpiSize:1
             |BIN:z
         |vpiLhs:
-        \_bit_select: (work@top2.each_pin[1].pins), line:39:14, endln:39:18
+        \_bit_select: (work@top2.each_pin[1].pins), line:39:14, endln:39:18, parent:work@top2.each_pin[1].pins
           |vpiName:pins
           |vpiFullName:work@top2.each_pin[1].pins
           |vpiIndex:
-          \_ref_obj: (work@top2.each_pin[1].i), line:39:19, endln:39:20, parent:work@top2.each_pin[1].pins
+          \_ref_obj: (work@top2.each_pin[1].pins.i), line:39:19, endln:39:20, parent:work@top2.each_pin[1].pins
             |vpiName:i
-            |vpiFullName:work@top2.each_pin[1].i
+            |vpiFullName:work@top2.each_pin[1].pins.i
             |vpiActual:
             \_parameter: (work@top2.each_pin[1].i), line:38, parent:work@top2.each_pin[1]
       |vpiParameter:

--- a/tests/GenerateModule/GenerateModule.log
+++ b/tests/GenerateModule/GenerateModule.log
@@ -1238,7 +1238,7 @@ design: (work@small_test)
       |vpiContAssign:
       \_cont_assign: , line:24:14, endln:24:27, parent:work@top.genblk1[0]
         |vpiRhs:
-        \_bit_select: (work@top.genblk1[0].a), line:24:21, endln:24:27
+        \_bit_select: (work@top.genblk1[0].a), line:24:21, endln:24:27, parent:work@top.genblk1[0].a
           |vpiName:a
           |vpiFullName:work@top.genblk1[0].a
           |vpiIndex:
@@ -1260,13 +1260,13 @@ design: (work@small_test)
                 |vpiFullName:work@top.genblk1[0].i
                 |UINT:0
         |vpiLhs:
-        \_bit_select: (work@top.genblk1[0].b), line:24:14, endln:24:15
+        \_bit_select: (work@top.genblk1[0].b), line:24:14, endln:24:15, parent:work@top.genblk1[0].b
           |vpiName:b
           |vpiFullName:work@top.genblk1[0].b
           |vpiIndex:
-          \_ref_obj: (work@top.genblk1[0].i), line:24:16, endln:24:17, parent:work@top.genblk1[0].b
+          \_ref_obj: (work@top.genblk1[0].b.i), line:24:16, endln:24:17, parent:work@top.genblk1[0].b
             |vpiName:i
-            |vpiFullName:work@top.genblk1[0].i
+            |vpiFullName:work@top.genblk1[0].b.i
             |vpiActual:
             \_parameter: (work@top.genblk1[0].i), line:23, parent:work@top.genblk1[0]
       |vpiParameter:
@@ -1281,7 +1281,7 @@ design: (work@small_test)
       |vpiContAssign:
       \_cont_assign: , line:24:14, endln:24:27, parent:work@top.genblk1[1]
         |vpiRhs:
-        \_bit_select: (work@top.genblk1[1].a), line:24:21, endln:24:27
+        \_bit_select: (work@top.genblk1[1].a), line:24:21, endln:24:27, parent:work@top.genblk1[1].a
           |vpiName:a
           |vpiFullName:work@top.genblk1[1].a
           |vpiIndex:
@@ -1303,13 +1303,13 @@ design: (work@small_test)
                 |vpiFullName:work@top.genblk1[1].i
                 |UINT:1
         |vpiLhs:
-        \_bit_select: (work@top.genblk1[1].b), line:24:14, endln:24:15
+        \_bit_select: (work@top.genblk1[1].b), line:24:14, endln:24:15, parent:work@top.genblk1[1].b
           |vpiName:b
           |vpiFullName:work@top.genblk1[1].b
           |vpiIndex:
-          \_ref_obj: (work@top.genblk1[1].i), line:24:16, endln:24:17, parent:work@top.genblk1[1].b
+          \_ref_obj: (work@top.genblk1[1].b.i), line:24:16, endln:24:17, parent:work@top.genblk1[1].b
             |vpiName:i
-            |vpiFullName:work@top.genblk1[1].i
+            |vpiFullName:work@top.genblk1[1].b.i
             |vpiActual:
             \_parameter: (work@top.genblk1[1].i), line:23, parent:work@top.genblk1[1]
       |vpiParameter:
@@ -1324,7 +1324,7 @@ design: (work@small_test)
       |vpiContAssign:
       \_cont_assign: , line:24:14, endln:24:27, parent:work@top.genblk1[2]
         |vpiRhs:
-        \_bit_select: (work@top.genblk1[2].a), line:24:21, endln:24:27
+        \_bit_select: (work@top.genblk1[2].a), line:24:21, endln:24:27, parent:work@top.genblk1[2].a
           |vpiName:a
           |vpiFullName:work@top.genblk1[2].a
           |vpiIndex:
@@ -1346,13 +1346,13 @@ design: (work@small_test)
                 |vpiFullName:work@top.genblk1[2].i
                 |UINT:2
         |vpiLhs:
-        \_bit_select: (work@top.genblk1[2].b), line:24:14, endln:24:15
+        \_bit_select: (work@top.genblk1[2].b), line:24:14, endln:24:15, parent:work@top.genblk1[2].b
           |vpiName:b
           |vpiFullName:work@top.genblk1[2].b
           |vpiIndex:
-          \_ref_obj: (work@top.genblk1[2].i), line:24:16, endln:24:17, parent:work@top.genblk1[2].b
+          \_ref_obj: (work@top.genblk1[2].b.i), line:24:16, endln:24:17, parent:work@top.genblk1[2].b
             |vpiName:i
-            |vpiFullName:work@top.genblk1[2].i
+            |vpiFullName:work@top.genblk1[2].b.i
             |vpiActual:
             \_parameter: (work@top.genblk1[2].i), line:23, parent:work@top.genblk1[2]
       |vpiParameter:

--- a/tests/HierPathLhs/HierPathLhs.log
+++ b/tests/HierPathLhs/HierPathLhs.log
@@ -124,7 +124,7 @@ design: (work@alert_handler_reg_wrap)
           \_ref_obj: (hw2reg), parent:hw2reg.alert_cause[k].d
             |vpiName:hw2reg
           |vpiActual:
-          \_bit_select: (alert_cause), parent:hw2reg.alert_cause[k].d
+          \_bit_select: (alert_cause), parent:work@alert_handler_reg_wrap.gen_alert_cause[0].hw2reg.alert_cause[k].d
             |vpiName:alert_cause
             |vpiIndex:
             \_ref_obj: (work@alert_handler_reg_wrap.gen_alert_cause[0].hw2reg.alert_cause[k].d.k), line:3:31, endln:3:32, parent:alert_cause

--- a/tests/HierPathSelect/HierPathSelect.log
+++ b/tests/HierPathSelect/HierPathSelect.log
@@ -122,10 +122,10 @@ design: (work@dut2)
     \_hier_path: (read_buf.q[1]), line:8:8, endln:8:16
       |vpiName:read_buf.q[1]
       |vpiActual:
-      \_ref_obj: (read_buf)
+      \_ref_obj: (read_buf), parent:read_buf.q[1]
         |vpiName:read_buf
       |vpiActual:
-      \_bit_select: (q[1]), line:8:17, endln:8:18
+      \_bit_select: (q[1]), line:8:17, endln:8:18, parent:read_buf.q[1]
         |vpiName:q[1]
         |vpiIndex:
         \_constant: , line:8:19, endln:8:20
@@ -206,7 +206,7 @@ design: (work@dut2)
                     |vpiSize:64
                     |UINT:0
       |vpiActual:
-      \_bit_select: (q[1]), line:8:17, endln:8:18, parent:read_buf.q[1]
+      \_bit_select: (q[1]), line:8:17, endln:8:18, parent:work@dut2.read_buf.q[1]
         |vpiName:q[1]
         |vpiIndex:
         \_constant: , line:8:19, endln:8:20

--- a/tests/HierPathStruct/HierPathStruct.log
+++ b/tests/HierPathStruct/HierPathStruct.log
@@ -206,7 +206,7 @@ design: (work@dut)
     \_hier_path: (hw2reg.data_in.de), line:17:8, endln:17:14
       |vpiName:hw2reg.data_in.de
       |vpiActual:
-      \_ref_obj: (hw2reg)
+      \_ref_obj: (hw2reg), parent:hw2reg.data_in.de
         |vpiName:hw2reg
       |vpiActual:
       \_ref_obj: (data_in)

--- a/tests/IndexAssign/IndexAssign.log
+++ b/tests/IndexAssign/IndexAssign.log
@@ -49,7 +49,7 @@ design: (work@t)
       |vpiSize:64
       |UINT:3
     |vpiLhs:
-    \_bit_select: (work@t.sig), line:4:10, endln:4:13
+    \_bit_select: (work@t.sig), line:4:10, endln:4:13, parent:work@t.sig
       |vpiName:sig
       |vpiFullName:work@t.sig
       |vpiIndex:
@@ -102,7 +102,7 @@ design: (work@t)
       |vpiSize:64
       |UINT:3
     |vpiLhs:
-    \_bit_select: (work@t.sig), line:4:10, endln:4:13
+    \_bit_select: (work@t.sig), line:4:10, endln:4:13, parent:work@t.sig
       |vpiName:sig
       |vpiFullName:work@t.sig
       |vpiIndex:

--- a/tests/InterfImport/InterfImport.log
+++ b/tests/InterfImport/InterfImport.log
@@ -431,7 +431,7 @@ design: (unnamed)
     \_hier_path: (PACKET_CONFIG.virtual_channels), line:11:31, endln:11:61
       |vpiName:PACKET_CONFIG.virtual_channels
       |vpiActual:
-      \_ref_obj: (PACKET_CONFIG)
+      \_ref_obj: (PACKET_CONFIG), parent:PACKET_CONFIG.virtual_channels
         |vpiName:PACKET_CONFIG
       |vpiActual:
       \_ref_obj: (virtual_channels)

--- a/tests/InterfaceModPort/InterfaceModPort.log
+++ b/tests/InterfaceModPort/InterfaceModPort.log
@@ -1522,7 +1522,7 @@ design: (work@interface_modports)
         \_hier_path: (tif.reset), line:102:7, endln:102:10, parent:work@test
           |vpiName:tif.reset
           |vpiActual:
-          \_ref_obj: (tif)
+          \_ref_obj: (tif), parent:tif.reset
             |vpiName:tif
           |vpiActual:
           \_ref_obj: (reset)
@@ -1719,7 +1719,7 @@ design: (work@interface_modports)
           \_assignment: , line:71:4, endln:71:38, parent:work@memory_model
             |vpiOpType:82
             |vpiLhs:
-            \_bit_select: (work@memory_model.mem), line:71:4, endln:71:7
+            \_bit_select: (work@memory_model.mem), line:71:4, endln:71:7, parent:work@memory_model.mem
               |vpiName:mem
               |vpiFullName:work@memory_model.mem
               |vpiIndex:
@@ -1793,13 +1793,13 @@ design: (work@interface_modports)
             \_hier_path: (mif.datao_mem), line:79:4, endln:79:7, parent:work@memory_model
               |vpiName:mif.datao_mem
               |vpiActual:
-              \_ref_obj: (mif)
+              \_ref_obj: (mif), parent:mif.datao_mem
                 |vpiName:mif
               |vpiActual:
               \_ref_obj: (datao_mem)
                 |vpiName:datao_mem
             |vpiRhs:
-            \_bit_select: (work@memory_model.mem), line:79:21, endln:79:38
+            \_bit_select: (work@memory_model.mem), line:79:21, endln:79:38, parent:work@memory_model.mem
               |vpiName:mem
               |vpiFullName:work@memory_model.mem
               |vpiIndex:

--- a/tests/LogicCast/LogicCast.log
+++ b/tests/LogicCast/LogicCast.log
@@ -448,7 +448,7 @@ design: (work@top)
         \_hier_path: (dmstatus.allnonexistent), line:3:3, endln:3:11, parent:work@top.csr_read_write
           |vpiName:dmstatus.allnonexistent
           |vpiActual:
-          \_ref_obj: (dmstatus)
+          \_ref_obj: (dmstatus), parent:dmstatus.allnonexistent
             |vpiName:dmstatus
           |vpiActual:
           \_ref_obj: (allnonexistent)

--- a/tests/ModPortHighConn/ModPortHighConn.log
+++ b/tests/ModPortHighConn/ModPortHighConn.log
@@ -113,7 +113,7 @@ design: (work@top)
       |vpiName:port0
       |vpiDirection:3
       |vpiHighConn:
-      \_bit_select: (topA), line:7:30, endln:7:37
+      \_bit_select: (topA), line:7:30, endln:7:37, parent:topA
         |vpiName:topA
         |vpiIndex:
         \_constant: , line:7:35, endln:7:36, parent:topA
@@ -132,7 +132,7 @@ design: (work@top)
       |vpiName:port1
       |vpiDirection:3
       |vpiHighConn:
-      \_bit_select: (topB), line:7:47, endln:7:54
+      \_bit_select: (topB), line:7:47, endln:7:54, parent:topB
         |vpiName:topB
         |vpiIndex:
         \_constant: , line:7:52, endln:7:53, parent:topB
@@ -162,7 +162,7 @@ design: (work@top)
       |vpiName:port0
       |vpiDirection:3
       |vpiHighConn:
-      \_bit_select: (topA), line:8:23, endln:8:27
+      \_bit_select: (topA), line:8:23, endln:8:27, parent:topA
         |vpiName:topA
         |vpiIndex:
         \_constant: , line:8:28, endln:8:29, parent:topA
@@ -181,7 +181,7 @@ design: (work@top)
       |vpiName:port1
       |vpiDirection:3
       |vpiHighConn:
-      \_bit_select: (topB), line:8:32, endln:8:39
+      \_bit_select: (topB), line:8:32, endln:8:39, parent:topB
         |vpiName:topB
         |vpiIndex:
         \_constant: , line:8:37, endln:8:38, parent:topB
@@ -211,7 +211,7 @@ design: (work@top)
       |vpiName:port0
       |vpiDirection:3
       |vpiHighConn:
-      \_bit_select: (topA), line:9:23, endln:9:27
+      \_bit_select: (topA), line:9:23, endln:9:27, parent:topA
         |vpiName:topA
         |vpiIndex:
         \_constant: , line:9:28, endln:9:29, parent:topA
@@ -233,7 +233,7 @@ design: (work@top)
       \_operation: , line:9:32, endln:9:39
         |vpiOpType:27
         |vpiOperand:
-        \_bit_select: (topB), line:9:32, endln:9:39
+        \_bit_select: (topB), line:9:32, endln:9:39, parent:topB
           |vpiName:topB
           |vpiIndex:
           \_constant: , line:9:37, endln:9:38, parent:topB
@@ -242,7 +242,7 @@ design: (work@top)
             |vpiSize:64
             |UINT:0
         |vpiOperand:
-        \_bit_select: (topB), line:9:41, endln:9:48
+        \_bit_select: (topB), line:9:41, endln:9:48, parent:topB
           |vpiName:topB
           |vpiIndex:
           \_constant: , line:9:46, endln:9:47, parent:topB
@@ -275,7 +275,7 @@ design: (work@top)
       \_operation: , line:10:23, endln:10:30
         |vpiOpType:27
         |vpiOperand:
-        \_bit_select: (topA), line:10:23, endln:10:30
+        \_bit_select: (topA), line:10:23, endln:10:30, parent:topA
           |vpiName:topA
           |vpiIndex:
           \_constant: , line:10:28, endln:10:29, parent:topA
@@ -284,7 +284,7 @@ design: (work@top)
             |vpiSize:64
             |UINT:1
         |vpiOperand:
-        \_bit_select: (topA), line:10:32, endln:10:39
+        \_bit_select: (topA), line:10:32, endln:10:39, parent:topA
           |vpiName:topA
           |vpiIndex:
           \_constant: , line:10:37, endln:10:38, parent:topA
@@ -303,7 +303,7 @@ design: (work@top)
       |vpiName:port1
       |vpiDirection:3
       |vpiHighConn:
-      \_bit_select: (topB), line:10:41, endln:10:48
+      \_bit_select: (topB), line:10:41, endln:10:48, parent:topB
         |vpiName:topB
         |vpiIndex:
         \_constant: , line:10:46, endln:10:47, parent:topB

--- a/tests/NetLValue/NetLValue.log
+++ b/tests/NetLValue/NetLValue.log
@@ -184,7 +184,7 @@ design: (work@t)
         \_hier_path: (s[0].x), line:7:10, endln:7:16, parent:work@t
           |vpiName:s[0].x
           |vpiActual:
-          \_bit_select: (s)
+          \_bit_select: (s), parent:s[0].x
             |vpiName:s
             |vpiIndex:
             \_constant: , line:7:12, endln:7:13
@@ -193,7 +193,7 @@ design: (work@t)
               |vpiSize:64
               |UINT:0
           |vpiActual:
-          \_ref_obj: (x)
+          \_ref_obj: (x), parent:s[0].x
             |vpiName:x
       |vpiStmt:
       \_assignment: , line:8:6, endln:8:16, parent:work@t
@@ -264,7 +264,7 @@ design: (work@t)
         \_hier_path: (s[0].x), line:7:10, endln:7:16
           |vpiName:s[0].x
           |vpiActual:
-          \_bit_select: (s), parent:s[0].x
+          \_bit_select: (s), parent:work@t.s[0].x
             |vpiName:s
             |vpiIndex:
             \_constant: , line:7:12, endln:7:13
@@ -283,7 +283,7 @@ design: (work@t)
         \_hier_path: (s[1].x), line:8:6, endln:8:7
           |vpiName:s[1].x
           |vpiActual:
-          \_bit_select: (s), parent:s[1].x
+          \_bit_select: (s)
             |vpiName:s
             |vpiIndex:
             \_constant: , line:8:8, endln:8:9

--- a/tests/NonAnsiPort/NonAnsiPort.log
+++ b/tests/NonAnsiPort/NonAnsiPort.log
@@ -359,7 +359,7 @@ design: (work@dut)
     \_hier_path: (var1.first), line:22:12, endln:22:16
       |vpiName:var1.first
       |vpiActual:
-      \_ref_obj: (var1)
+      \_ref_obj: (var1), parent:var1.first
         |vpiName:var1
       |vpiActual:
       \_ref_obj: (first)
@@ -376,7 +376,7 @@ design: (work@dut)
     \_hier_path: (var2.second), line:23:12, endln:23:16
       |vpiName:var2.second
       |vpiActual:
-      \_ref_obj: (var2)
+      \_ref_obj: (var2), parent:var2.second
         |vpiName:var2
       |vpiActual:
       \_ref_obj: (second)
@@ -393,7 +393,7 @@ design: (work@dut)
     \_hier_path: (var3.third), line:24:12, endln:24:16
       |vpiName:var3.third
       |vpiActual:
-      \_ref_obj: (var3)
+      \_ref_obj: (var3), parent:var3.third
         |vpiName:var3
       |vpiActual:
       \_ref_obj: (third)

--- a/tests/OneNetModPort/OneNetModPort.log
+++ b/tests/OneNetModPort/OneNetModPort.log
@@ -150,7 +150,7 @@ design: (work@TOP)
         \_hier_path: (intf.drive), line:6:5, endln:6:9, parent:work@TESTBENCH
           |vpiName:intf.drive
           |vpiActual:
-          \_ref_obj: (intf)
+          \_ref_obj: (intf), parent:intf.drive
             |vpiName:intf
           |vpiActual:
           \_ref_obj: (drive)
@@ -222,7 +222,7 @@ design: (work@TOP)
           \_hier_path: (intf.drive), line:8:10, endln:8:14
             |vpiName:intf.drive
             |vpiActual:
-            \_ref_obj: (intf)
+            \_ref_obj: (intf), parent:intf.drive
               |vpiName:intf
             |vpiActual:
             \_ref_obj: (drive)
@@ -375,7 +375,7 @@ design: (work@TOP)
     \_hier_path: (conntb.drive), line:3:10, endln:3:16
       |vpiName:conntb.drive
       |vpiActual:
-      \_ref_obj: (conntb)
+      \_ref_obj: (conntb), parent:conntb.drive
         |vpiName:conntb
       |vpiActual:
       \_ref_obj: (drive)

--- a/tests/OneNetModPortGeneric/OneNetModPortGeneric.log
+++ b/tests/OneNetModPortGeneric/OneNetModPortGeneric.log
@@ -158,7 +158,7 @@ design: (work@TOP)
         \_hier_path: (intf.drive), line:6:5, endln:6:9, parent:work@TESTBENCH
           |vpiName:intf.drive
           |vpiActual:
-          \_ref_obj: (intf)
+          \_ref_obj: (intf), parent:intf.drive
             |vpiName:intf
           |vpiActual:
           \_ref_obj: (drive)
@@ -230,7 +230,7 @@ design: (work@TOP)
           \_hier_path: (intf.drive), line:8:10, endln:8:14
             |vpiName:intf.drive
             |vpiActual:
-            \_ref_obj: (intf)
+            \_ref_obj: (intf), parent:intf.drive
               |vpiName:intf
             |vpiActual:
             \_ref_obj: (drive)
@@ -420,7 +420,7 @@ design: (work@TOP)
     \_hier_path: (conntb.drive), line:3:10, endln:3:16
       |vpiName:conntb.drive
       |vpiActual:
-      \_ref_obj: (conntb)
+      \_ref_obj: (conntb), parent:conntb.drive
         |vpiName:conntb
       |vpiActual:
       \_ref_obj: (drive)

--- a/tests/PackageFuncCall/PackageFuncCall.log
+++ b/tests/PackageFuncCall/PackageFuncCall.log
@@ -717,7 +717,7 @@ design: (work@top)
                 |vpiSize:64
                 |UINT:4
             |vpiRhs:
-            \_bit_select: (prim_cipher_pkg::sbox4_64bit::sbox4), line:12:29, endln:12:54
+            \_bit_select: (prim_cipher_pkg::sbox4_64bit::sbox4), line:12:29, endln:12:54, parent:prim_cipher_pkg::sbox4_64bit::sbox4
               |vpiName:sbox4
               |vpiFullName:prim_cipher_pkg::sbox4_64bit::sbox4
               |vpiIndex:
@@ -1291,7 +1291,7 @@ design: (work@top)
         \_operation: , line:32:22, endln:32:51, parent:work@top.p_post_round_xor
           |vpiOpType:30
           |vpiOperand:
-          \_bit_select: (work@top.p_post_round_xor.data_state), line:32:22, endln:32:51
+          \_bit_select: (work@top.p_post_round_xor.data_state), line:32:22, endln:32:51, parent:work@top.p_post_round_xor.data_state
             |vpiName:data_state
             |vpiFullName:work@top.p_post_round_xor.data_state
             |vpiIndex:
@@ -1585,7 +1585,7 @@ design: (work@top)
                           |vpiSize:64
                           |UINT:4
                       |vpiRhs:
-                      \_bit_select: (prim_cipher_pkg::sbox4_64bit::sbox4), line:12:29, endln:12:54
+                      \_bit_select: (prim_cipher_pkg::sbox4_64bit::sbox4), line:12:29, endln:12:54, parent:prim_cipher_pkg::sbox4_64bit::sbox4
                         |vpiName:sbox4
                         |vpiFullName:prim_cipher_pkg::sbox4_64bit::sbox4
                         |vpiIndex:
@@ -1825,7 +1825,7 @@ design: (work@top)
         \_operation: , line:32:22, endln:32:51
           |vpiOpType:30
           |vpiOperand:
-          \_bit_select: (work@top.p_post_round_xor.data_state), line:32:22, endln:32:51
+          \_bit_select: (work@top.p_post_round_xor.data_state), line:32:22, endln:32:51, parent:work@top.p_post_round_xor.data_state
             |vpiName:data_state
             |vpiFullName:work@top.p_post_round_xor.data_state
             |vpiIndex:
@@ -2119,7 +2119,7 @@ design: (work@top)
                           |vpiSize:64
                           |UINT:4
                       |vpiRhs:
-                      \_bit_select: (prim_cipher_pkg::sbox4_64bit::sbox4), line:12:29, endln:12:54
+                      \_bit_select: (prim_cipher_pkg::sbox4_64bit::sbox4), line:12:29, endln:12:54, parent:prim_cipher_pkg::sbox4_64bit::sbox4
                         |vpiName:sbox4
                         |vpiFullName:prim_cipher_pkg::sbox4_64bit::sbox4
                         |vpiIndex:

--- a/tests/ParamArray/ParamArray.log
+++ b/tests/ParamArray/ParamArray.log
@@ -903,7 +903,7 @@ design: (work@top)
       \_hier_path: (Info.size), line:36:33, endln:36:42
         |vpiName:Info.size
         |vpiActual:
-        \_ref_obj: (Info)
+        \_ref_obj: (Info), parent:Info.size
           |vpiName:Info
         |vpiActual:
         \_ref_obj: (size)

--- a/tests/ParamArraySelect/ParamArraySelect.log
+++ b/tests/ParamArraySelect/ParamArraySelect.log
@@ -1170,7 +1170,7 @@ design: (work@top)
       \_hier_path: (Info.size), line:39:33, endln:39:42
         |vpiName:Info.size
         |vpiActual:
-        \_ref_obj: (Info)
+        \_ref_obj: (Info), parent:Info.size
           |vpiName:Info
         |vpiActual:
         \_ref_obj: (size)

--- a/tests/PartSelectHier/PartSelectHier.log
+++ b/tests/PartSelectHier/PartSelectHier.log
@@ -272,10 +272,10 @@ design: (work@dut)
             |vpiInstance:
             \_package: tlul_pkg (tlul_pkg::) dut.sv:1:1: , endln:5:11, parent:work@dut
       |vpiActual:
-      \_part_select: , parent:work@dut.drsp_fifo_o.d_source[8:3]
+      \_part_select: , parent:work@dut
         |vpiConstantSelect:1
         |vpiParent:
-        \_ref_obj: (work@dut.drsp_fifo_o.d_source[8:3]), parent:drsp_fifo_o.d_source[8:3]
+        \_ref_obj: (work@dut), parent:drsp_fifo_o.d_source[8:3]
         |vpiLeftRange:
         \_constant: , line:9:45, endln:9:46
           |vpiConstType:9

--- a/tests/PatAssignOp/PatAssignOp.log
+++ b/tests/PatAssignOp/PatAssignOp.log
@@ -764,11 +764,12 @@ design: (work@top)
   |vpiParamAssign:
   \_param_assign: , line:9:14, endln:9:81, parent:work@top
     |vpiRhs:
-    \_bit_select: (coh_noc_cord_markers_pos_p), line:9:39, endln:9:81
+    \_bit_select: (coh_noc_cord_markers_pos_p), line:9:39, endln:9:81, parent:coh_noc_cord_markers_pos_p
       |vpiName:coh_noc_cord_markers_pos_p
       |vpiIndex:
-      \_ref_obj: (coh_noc_dims_p), line:9:66, endln:9:80, parent:coh_noc_cord_markers_pos_p
+      \_ref_obj: (coh_noc_cord_markers_pos_p.coh_noc_dims_p), line:9:66, endln:9:80, parent:coh_noc_cord_markers_pos_p
         |vpiName:coh_noc_dims_p
+        |vpiFullName:coh_noc_cord_markers_pos_p.coh_noc_dims_p
     |vpiLhs:
     \_parameter: (work@top.coh_noc_cord_width_p), line:9:14, endln:9:81, parent:work@top
       |vpiName:coh_noc_cord_width_p

--- a/tests/RangeInf/RangeInf.log
+++ b/tests/RangeInf/RangeInf.log
@@ -684,7 +684,7 @@ design: (work@FullAdder)
   |vpiContAssign:
   \_cont_assign: , line:9:11, endln:9:23, parent:work@FullAdder
     |vpiRhs:
-    \_bit_select: (work@FullAdder.temp), line:9:16, endln:9:23
+    \_bit_select: (work@FullAdder.temp), line:9:16, endln:9:23, parent:work@FullAdder.temp
       |vpiName:temp
       |vpiFullName:work@FullAdder.temp
       |vpiIndex:
@@ -887,7 +887,7 @@ design: (work@FullAdder)
   |vpiContAssign:
   \_cont_assign: , line:9:11, endln:9:23, parent:work@FullAdder
     |vpiRhs:
-    \_bit_select: (work@FullAdder.temp), line:9:16, endln:9:23
+    \_bit_select: (work@FullAdder.temp), line:9:16, endln:9:23, parent:work@FullAdder.temp
       |vpiName:temp
       |vpiFullName:work@FullAdder.temp
       |vpiIndex:

--- a/tests/ReorderPatt/ReorderPatt.log
+++ b/tests/ReorderPatt/ReorderPatt.log
@@ -187,7 +187,7 @@ design: (work@top)
   |vpiParamAssign:
   \_param_assign: , line:3:14, endln:3:22, parent:work@top
     |vpiRhs:
-    \_bit_select: (x), line:3:18, endln:3:22
+    \_bit_select: (x), line:3:18, endln:3:22, parent:x
       |vpiName:x
       |vpiIndex:
       \_constant: , line:3:20, endln:3:21, parent:x

--- a/tests/Selects/Selects.log
+++ b/tests/Selects/Selects.log
@@ -282,7 +282,7 @@ design: (work@t)
                     |vpiTypespec:
                     \_logic_typespec: , line:4:5, endln:4:10
       |vpiActual:
-      \_bit_select: (sw_rst_ctrl_n), parent:reg2hw.sw_rst_ctrl_n[0].q
+      \_bit_select: (sw_rst_ctrl_n)
         |vpiName:sw_rst_ctrl_n
         |vpiIndex:
         \_constant: , line:14:34, endln:14:35
@@ -305,7 +305,7 @@ design: (work@t)
     \_hier_path: (sw_rst_ctrl_n[0].q), line:15:13, endln:15:31
       |vpiName:sw_rst_ctrl_n[0].q
       |vpiActual:
-      \_bit_select: (sw_rst_ctrl_n), parent:sw_rst_ctrl_n[0].q
+      \_bit_select: (sw_rst_ctrl_n), parent:work@t.sw_rst_ctrl_n[0].q
         |vpiName:sw_rst_ctrl_n
         |vpiIndex:
         \_constant: , line:15:27, endln:15:28

--- a/tests/StructAccess/StructAccess.log
+++ b/tests/StructAccess/StructAccess.log
@@ -627,7 +627,7 @@ design: (work@top)
     \_hier_path: (csr_pmp_cfg_ie.mode), line:28:9, endln:28:23
       |vpiName:csr_pmp_cfg_ie.mode
       |vpiActual:
-      \_ref_obj: (csr_pmp_cfg_ie)
+      \_ref_obj: (csr_pmp_cfg_ie), parent:csr_pmp_cfg_ie.mode
         |vpiName:csr_pmp_cfg_ie
       |vpiActual:
       \_ref_obj: (mode)
@@ -719,7 +719,7 @@ design: (work@top)
   \_cont_assign: , line:22:8, endln:22:9, parent:work@top
     |vpiNetDeclAssign:1
     |vpiRhs:
-    \_bit_select: (work@top.enum_test), line:22:12, endln:22:24
+    \_bit_select: (work@top.enum_test), line:22:12, endln:22:24, parent:work@top.enum_test
       |vpiName:enum_test
       |vpiFullName:work@top.enum_test
       |vpiIndex:
@@ -793,7 +793,7 @@ design: (work@top)
                   |vpiTypespec:
                   \_logic_typespec: , line:8:4, endln:8:9
       |vpiActual:
-      \_bit_select: (mode), parent:csr_pmp_cfg_ie.mode[0]
+      \_bit_select: (mode)
         |vpiName:mode
         |vpiIndex:
         \_constant: , line:25:37, endln:25:38
@@ -923,7 +923,7 @@ design: (work@top)
     \_hier_path: (csr_pmp_cfg_i[0].mode), line:24:23, endln:24:44
       |vpiName:csr_pmp_cfg_i[0].mode
       |vpiActual:
-      \_bit_select: (csr_pmp_cfg_i)
+      \_bit_select: (csr_pmp_cfg_i), parent:csr_pmp_cfg_i[0].mode
         |vpiName:csr_pmp_cfg_i
         |vpiIndex:
         \_constant: , line:24:37, endln:24:38
@@ -932,7 +932,7 @@ design: (work@top)
           |vpiSize:64
           |UINT:0
       |vpiActual:
-      \_ref_obj: (mode)
+      \_ref_obj: (mode), parent:csr_pmp_cfg_i[0].mode
         |vpiName:mode
     |vpiTypespec:
     \_enum_typespec: (pmp_cfg_enum), line:5:4, endln:5:16

--- a/tests/StructVar/StructVar.log
+++ b/tests/StructVar/StructVar.log
@@ -858,7 +858,7 @@ design: (work@test)
               \_hier_path: (pmp_cfg[i].lock), line:61:25, endln:61:40
                 |vpiName:pmp_cfg[i].lock
                 |vpiActual:
-                \_bit_select: (pmp_cfg), parent:pmp_cfg[i].lock
+                \_bit_select: (pmp_cfg), parent:work@test.u3.g_pmp_csrs[0].pmp_cfg[i].lock
                   |vpiName:pmp_cfg
                   |vpiIndex:
                   \_ref_obj: (work@test.u3.g_pmp_csrs[0].pmp_cfg[i].lock.i), line:61:33, endln:61:34, parent:pmp_cfg
@@ -879,15 +879,15 @@ design: (work@test)
               \_hier_path: (pmp_cfg.mode), line:62:4, endln:62:21
                 |vpiName:pmp_cfg.mode
                 |vpiActual:
-                \_bit_select: (pmp_cfg), parent:pmp_cfg.mode
+                \_bit_select: (pmp_cfg), parent:work@test.u3.g_pmp_csrs[0].pmp_cfg.mode
                   |vpiName:pmp_cfg
                   |vpiIndex:
                   \_operation: , line:62:12, endln:62:13, parent:pmp_cfg
                     |vpiOpType:24
                     |vpiOperand:
-                    \_ref_obj: (work@test.u3.g_pmp_csrs[0].pmp_cfg.mode.pmp_cfg.i), line:62:12, endln:62:13
+                    \_ref_obj: (work@test.u3.g_pmp_csrs[0].pmp_cfg.mode.i), line:62:12, endln:62:13
                       |vpiName:i
-                      |vpiFullName:work@test.u3.g_pmp_csrs[0].pmp_cfg.mode.pmp_cfg.i
+                      |vpiFullName:work@test.u3.g_pmp_csrs[0].pmp_cfg.mode.i
                       |vpiActual:
                       \_parameter: (work@test.u3.g_pmp_csrs[0].i), line:59, parent:work@test.u3.g_pmp_csrs[0]
                     |vpiOperand:
@@ -934,7 +934,7 @@ design: (work@test)
               \_hier_path: (pmp_cfg[i].lock), line:61:25, endln:61:40
                 |vpiName:pmp_cfg[i].lock
                 |vpiActual:
-                \_bit_select: (pmp_cfg), parent:pmp_cfg[i].lock
+                \_bit_select: (pmp_cfg), parent:work@test.u3.g_pmp_csrs[1].pmp_cfg[i].lock
                   |vpiName:pmp_cfg
                   |vpiIndex:
                   \_ref_obj: (work@test.u3.g_pmp_csrs[1].pmp_cfg[i].lock.i), line:61:33, endln:61:34, parent:pmp_cfg
@@ -955,15 +955,15 @@ design: (work@test)
               \_hier_path: (pmp_cfg.mode), line:62:4, endln:62:21
                 |vpiName:pmp_cfg.mode
                 |vpiActual:
-                \_bit_select: (pmp_cfg), parent:pmp_cfg.mode
+                \_bit_select: (pmp_cfg), parent:work@test.u3.g_pmp_csrs[1].pmp_cfg.mode
                   |vpiName:pmp_cfg
                   |vpiIndex:
                   \_operation: , line:62:12, endln:62:13, parent:pmp_cfg
                     |vpiOpType:24
                     |vpiOperand:
-                    \_ref_obj: (work@test.u3.g_pmp_csrs[1].pmp_cfg.mode.pmp_cfg.i), line:62:12, endln:62:13
+                    \_ref_obj: (work@test.u3.g_pmp_csrs[1].pmp_cfg.mode.i), line:62:12, endln:62:13
                       |vpiName:i
-                      |vpiFullName:work@test.u3.g_pmp_csrs[1].pmp_cfg.mode.pmp_cfg.i
+                      |vpiFullName:work@test.u3.g_pmp_csrs[1].pmp_cfg.mode.i
                       |vpiActual:
                       \_parameter: (work@test.u3.g_pmp_csrs[1].i), line:59, parent:work@test.u3.g_pmp_csrs[1]
                     |vpiOperand:

--- a/tests/Ternary/Ternary.log
+++ b/tests/Ternary/Ternary.log
@@ -1709,7 +1709,7 @@ design: (work@test)
                           \_operation: , line:63:48, endln:63:66
                             |vpiOpType:14
                             |vpiOperand:
-                            \_bit_select: (work@test.InterruptStatus), line:63:48, endln:63:66
+                            \_bit_select: (work@test.InterruptStatus), line:63:48, endln:63:66, parent:work@test.InterruptStatus
                               |vpiName:InterruptStatus
                               |vpiFullName:work@test.InterruptStatus
                               |vpiIndex:
@@ -2627,7 +2627,7 @@ design: (work@test)
                           \_operation: , line:63:48, endln:63:66
                             |vpiOpType:14
                             |vpiOperand:
-                            \_bit_select: (work@test.InterruptStatus), line:63:48, endln:63:66
+                            \_bit_select: (work@test.InterruptStatus), line:63:48, endln:63:66, parent:work@test.InterruptStatus
                               |vpiName:InterruptStatus
                               |vpiFullName:work@test.InterruptStatus
                               |vpiIndex:

--- a/tests/TypedefUnpacked/TypedefUnpacked.log
+++ b/tests/TypedefUnpacked/TypedefUnpacked.log
@@ -143,7 +143,7 @@ design: (work@dut)
     \_hier_path: (c[1].x), line:11:15, endln:11:21
       |vpiName:c[1].x
       |vpiActual:
-      \_bit_select: (c)
+      \_bit_select: (c), parent:c[1].x
         |vpiName:c
         |vpiIndex:
         \_constant: , line:11:17, endln:11:18
@@ -152,7 +152,7 @@ design: (work@dut)
           |vpiSize:64
           |UINT:1
       |vpiActual:
-      \_ref_obj: (x)
+      \_ref_obj: (x), parent:c[1].x
         |vpiName:x
     |vpiLhs:
     \_ref_obj: (work@dut.o), line:11:11, endln:11:12

--- a/tests/UnitForeach/UnitForeach.log
+++ b/tests/UnitForeach/UnitForeach.log
@@ -605,25 +605,25 @@ design: (unnamed)
             \_hier_path: (arb_sequence_q[i].request), line:10:34, endln:10:66, parent:$sformatf
               |vpiName:arb_sequence_q[i].request
               |vpiActual:
-              \_bit_select: (arb_sequence_q)
+              \_bit_select: (arb_sequence_q), parent:arb_sequence_q[i].request
                 |vpiName:arb_sequence_q
                 |vpiIndex:
                 \_ref_obj: (i), line:10:49, endln:10:50, parent:$sformatf
                   |vpiName:i
               |vpiActual:
-              \_ref_obj: (request)
+              \_ref_obj: (request), parent:arb_sequence_q[i].request
                 |vpiName:request
             |vpiArgument:
             \_hier_path: (arb_sequence_q[i].sequence_id), line:10:67, endln:10:96, parent:$sformatf
               |vpiName:arb_sequence_q[i].sequence_id
               |vpiActual:
-              \_bit_select: (arb_sequence_q)
+              \_bit_select: (arb_sequence_q), parent:arb_sequence_q[i].sequence_id
                 |vpiName:arb_sequence_q
                 |vpiIndex:
                 \_ref_obj: (i), line:10:82, endln:10:83, parent:$sformatf
                   |vpiName:i
               |vpiActual:
-              \_ref_obj: (sequence_id)
+              \_ref_obj: (sequence_id), parent:arb_sequence_q[i].sequence_id
                 |vpiName:sequence_id
           |vpiArgument:
           \_constant: , line:10:99, endln:10:102

--- a/tests/UnitPartSelect/UnitPartSelect.log
+++ b/tests/UnitPartSelect/UnitPartSelect.log
@@ -989,7 +989,7 @@ design: (work@toto)
   |vpiContAssign:
   \_cont_assign: , line:39:10, endln:39:21, parent:work@dut_no_decl
     |vpiRhs:
-    \_bit_select: (work@dut_no_decl.a), line:39:17, endln:39:21
+    \_bit_select: (work@dut_no_decl.a), line:39:17, endln:39:21, parent:work@dut_no_decl.a
       |vpiName:a
       |vpiFullName:work@dut_no_decl.a
       |vpiIndex:
@@ -999,7 +999,7 @@ design: (work@toto)
         |vpiSize:64
         |UINT:0
     |vpiLhs:
-    \_bit_select: (work@dut_no_decl.b), line:39:10, endln:39:11
+    \_bit_select: (work@dut_no_decl.b), line:39:10, endln:39:11, parent:work@dut_no_decl.b
       |vpiName:b
       |vpiFullName:work@dut_no_decl.b
       |vpiIndex:
@@ -1077,7 +1077,7 @@ design: (work@toto)
   |vpiContAssign:
   \_cont_assign: , line:33:10, endln:33:21, parent:work@dut_part_select
     |vpiRhs:
-    \_bit_select: (work@dut_part_select.a), line:33:17, endln:33:21
+    \_bit_select: (work@dut_part_select.a), line:33:17, endln:33:21, parent:work@dut_part_select.a
       |vpiName:a
       |vpiFullName:work@dut_part_select.a
       |vpiIndex:
@@ -1087,7 +1087,7 @@ design: (work@toto)
         |vpiSize:64
         |UINT:0
     |vpiLhs:
-    \_bit_select: (work@dut_part_select.b), line:33:10, endln:33:11
+    \_bit_select: (work@dut_part_select.b), line:33:10, endln:33:11, parent:work@dut_part_select.b
       |vpiName:b
       |vpiFullName:work@dut_part_select.b
       |vpiIndex:
@@ -1167,7 +1167,7 @@ design: (work@toto)
         \_assignment: , line:9:5, endln:9:24, parent:work@toto
           |vpiOpType:82
           |vpiLhs:
-          \_bit_select: (work@toto.state), line:9:5, endln:9:10
+          \_bit_select: (work@toto.state), line:9:5, endln:9:10, parent:work@toto.state
             |vpiName:state
             |vpiFullName:work@toto.state
             |vpiIndex:
@@ -1191,7 +1191,7 @@ design: (work@toto)
           \_operation: , line:11:9, endln:11:30
             |vpiOpType:14
             |vpiOperand:
-            \_bit_select: (work@toto.InterruptStatus), line:11:9, endln:11:27
+            \_bit_select: (work@toto.InterruptStatus), line:11:9, endln:11:27, parent:work@toto.InterruptStatus
               |vpiName:InterruptStatus
               |vpiFullName:work@toto.InterruptStatus
               |vpiIndex:
@@ -1286,13 +1286,13 @@ design: (work@toto)
         \_assignment: , line:9:5, endln:9:24, parent:work@toto
           |vpiOpType:82
           |vpiLhs:
-          \_bit_select: (work@toto.state), line:9:5, endln:9:10
+          \_bit_select: (work@toto.state), line:9:5, endln:9:10, parent:work@toto.state
             |vpiName:state
             |vpiFullName:work@toto.state
             |vpiIndex:
-            \_ref_obj: (work@toto.IDLE), line:9:11, endln:9:15, parent:work@toto.state
+            \_ref_obj: (work@toto.state.IDLE), line:9:11, endln:9:15, parent:work@toto.state
               |vpiName:IDLE
-              |vpiFullName:work@toto.IDLE
+              |vpiFullName:work@toto.state.IDLE
               |vpiActual:
               \_parameter: (work@toto.IDLE), line:3:13, endln:3:21, parent:work@toto
                 |vpiName:IDLE
@@ -1310,7 +1310,7 @@ design: (work@toto)
           \_operation: , line:11:9, endln:11:30
             |vpiOpType:14
             |vpiOperand:
-            \_bit_select: (work@toto.InterruptStatus), line:11:9, endln:11:27
+            \_bit_select: (work@toto.InterruptStatus), line:11:9, endln:11:27, parent:work@toto.InterruptStatus
               |vpiName:InterruptStatus
               |vpiFullName:work@toto.InterruptStatus
               |vpiIndex:
@@ -1545,7 +1545,7 @@ design: (work@toto)
   |vpiContAssign:
   \_cont_assign: , line:33:10, endln:33:21, parent:work@dut_part_select
     |vpiRhs:
-    \_bit_select: (work@dut_part_select.a), line:33:17, endln:33:21
+    \_bit_select: (work@dut_part_select.a), line:33:17, endln:33:21, parent:work@dut_part_select.a
       |vpiName:a
       |vpiFullName:work@dut_part_select.a
       |vpiIndex:
@@ -1555,7 +1555,7 @@ design: (work@toto)
         |vpiSize:64
         |UINT:0
     |vpiLhs:
-    \_bit_select: (work@dut_part_select.b), line:33:10, endln:33:11
+    \_bit_select: (work@dut_part_select.b), line:33:10, endln:33:11, parent:work@dut_part_select.b
       |vpiName:b
       |vpiFullName:work@dut_part_select.b
       |vpiIndex:
@@ -1697,7 +1697,7 @@ design: (work@toto)
   |vpiContAssign:
   \_cont_assign: , line:39:10, endln:39:21, parent:work@dut_no_decl
     |vpiRhs:
-    \_bit_select: (work@dut_no_decl.a), line:39:17, endln:39:21
+    \_bit_select: (work@dut_no_decl.a), line:39:17, endln:39:21, parent:work@dut_no_decl.a
       |vpiName:a
       |vpiFullName:work@dut_no_decl.a
       |vpiIndex:
@@ -1707,7 +1707,7 @@ design: (work@toto)
         |vpiSize:64
         |UINT:0
     |vpiLhs:
-    \_bit_select: (work@dut_no_decl.b), line:39:10, endln:39:11
+    \_bit_select: (work@dut_no_decl.b), line:39:10, endln:39:11, parent:work@dut_no_decl.b
       |vpiName:b
       |vpiFullName:work@dut_no_decl.b
       |vpiIndex:

--- a/tests/UnpackPort/UnpackPort.log
+++ b/tests/UnpackPort/UnpackPort.log
@@ -593,13 +593,13 @@ design: (work@dut)
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:11, endln:2:17
         |vpiLhs:
-        \_bit_select: (work@dut.var3), line:9:14, endln:9:18
+        \_bit_select: (work@dut.var3), line:9:14, endln:9:18, parent:work@dut.g_fill[0].var3
           |vpiName:var3
           |vpiFullName:work@dut.var3
           |vpiIndex:
-          \_ref_obj: (work@dut.g_fill[0].i), line:9:19, endln:9:20, parent:work@dut.var3
+          \_ref_obj: (work@dut.g_fill[0].var3.i), line:9:19, endln:9:20, parent:work@dut.var3
             |vpiName:i
-            |vpiFullName:work@dut.g_fill[0].i
+            |vpiFullName:work@dut.g_fill[0].var3.i
             |vpiActual:
             \_parameter: (work@dut.g_fill[0].i), line:8, parent:work@dut.g_fill[0]
               |vpiName:i
@@ -628,13 +628,13 @@ design: (work@dut)
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:11, endln:2:17
         |vpiLhs:
-        \_bit_select: (work@dut.var3), line:9:14, endln:9:18
+        \_bit_select: (work@dut.var3), line:9:14, endln:9:18, parent:work@dut.g_fill[1].var3
           |vpiName:var3
           |vpiFullName:work@dut.var3
           |vpiIndex:
-          \_ref_obj: (work@dut.g_fill[1].i), line:9:19, endln:9:20, parent:work@dut.var3
+          \_ref_obj: (work@dut.g_fill[1].var3.i), line:9:19, endln:9:20, parent:work@dut.var3
             |vpiName:i
-            |vpiFullName:work@dut.g_fill[1].i
+            |vpiFullName:work@dut.g_fill[1].var3.i
             |vpiActual:
             \_parameter: (work@dut.g_fill[1].i), line:8, parent:work@dut.g_fill[1]
               |vpiName:i
@@ -663,13 +663,13 @@ design: (work@dut)
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:11, endln:2:17
         |vpiLhs:
-        \_bit_select: (work@dut.var3), line:9:14, endln:9:18
+        \_bit_select: (work@dut.var3), line:9:14, endln:9:18, parent:work@dut.g_fill[2].var3
           |vpiName:var3
           |vpiFullName:work@dut.var3
           |vpiIndex:
-          \_ref_obj: (work@dut.g_fill[2].i), line:9:19, endln:9:20, parent:work@dut.var3
+          \_ref_obj: (work@dut.g_fill[2].var3.i), line:9:19, endln:9:20, parent:work@dut.var3
             |vpiName:i
-            |vpiFullName:work@dut.g_fill[2].i
+            |vpiFullName:work@dut.g_fill[2].var3.i
             |vpiActual:
             \_parameter: (work@dut.g_fill[2].i), line:8, parent:work@dut.g_fill[2]
               |vpiName:i
@@ -698,13 +698,13 @@ design: (work@dut)
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:11, endln:2:17
         |vpiLhs:
-        \_bit_select: (work@dut.var3), line:9:14, endln:9:18
+        \_bit_select: (work@dut.var3), line:9:14, endln:9:18, parent:work@dut.g_fill[3].var3
           |vpiName:var3
           |vpiFullName:work@dut.var3
           |vpiIndex:
-          \_ref_obj: (work@dut.g_fill[3].i), line:9:19, endln:9:20, parent:work@dut.var3
+          \_ref_obj: (work@dut.g_fill[3].var3.i), line:9:19, endln:9:20, parent:work@dut.var3
             |vpiName:i
-            |vpiFullName:work@dut.g_fill[3].i
+            |vpiFullName:work@dut.g_fill[3].var3.i
             |vpiActual:
             \_parameter: (work@dut.g_fill[3].i), line:8, parent:work@dut.g_fill[3]
               |vpiName:i
@@ -733,13 +733,13 @@ design: (work@dut)
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:11, endln:2:17
         |vpiLhs:
-        \_bit_select: (work@dut.var3), line:9:14, endln:9:18
+        \_bit_select: (work@dut.var3), line:9:14, endln:9:18, parent:work@dut.g_fill[4].var3
           |vpiName:var3
           |vpiFullName:work@dut.var3
           |vpiIndex:
-          \_ref_obj: (work@dut.g_fill[4].i), line:9:19, endln:9:20, parent:work@dut.var3
+          \_ref_obj: (work@dut.g_fill[4].var3.i), line:9:19, endln:9:20, parent:work@dut.var3
             |vpiName:i
-            |vpiFullName:work@dut.g_fill[4].i
+            |vpiFullName:work@dut.g_fill[4].var3.i
             |vpiActual:
             \_parameter: (work@dut.g_fill[4].i), line:8, parent:work@dut.g_fill[4]
               |vpiName:i
@@ -768,13 +768,13 @@ design: (work@dut)
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:11, endln:2:17
         |vpiLhs:
-        \_bit_select: (work@dut.var3), line:9:14, endln:9:18
+        \_bit_select: (work@dut.var3), line:9:14, endln:9:18, parent:work@dut.g_fill[5].var3
           |vpiName:var3
           |vpiFullName:work@dut.var3
           |vpiIndex:
-          \_ref_obj: (work@dut.g_fill[5].i), line:9:19, endln:9:20, parent:work@dut.var3
+          \_ref_obj: (work@dut.g_fill[5].var3.i), line:9:19, endln:9:20, parent:work@dut.var3
             |vpiName:i
-            |vpiFullName:work@dut.g_fill[5].i
+            |vpiFullName:work@dut.g_fill[5].var3.i
             |vpiActual:
             \_parameter: (work@dut.g_fill[5].i), line:8, parent:work@dut.g_fill[5]
               |vpiName:i
@@ -803,13 +803,13 @@ design: (work@dut)
           |vpiTypespec:
           \_struct_typespec: (struct2), line:2:11, endln:2:17
         |vpiLhs:
-        \_bit_select: (work@dut.var3), line:9:14, endln:9:18
+        \_bit_select: (work@dut.var3), line:9:14, endln:9:18, parent:work@dut.g_fill[6].var3
           |vpiName:var3
           |vpiFullName:work@dut.var3
           |vpiIndex:
-          \_ref_obj: (work@dut.g_fill[6].i), line:9:19, endln:9:20, parent:work@dut.var3
+          \_ref_obj: (work@dut.g_fill[6].var3.i), line:9:19, endln:9:20, parent:work@dut.var3
             |vpiName:i
-            |vpiFullName:work@dut.g_fill[6].i
+            |vpiFullName:work@dut.g_fill[6].var3.i
             |vpiActual:
             \_parameter: (work@dut.g_fill[6].i), line:8, parent:work@dut.g_fill[6]
               |vpiName:i

--- a/tests/VarSelect/VarSelect.log
+++ b/tests/VarSelect/VarSelect.log
@@ -580,7 +580,7 @@ design: (work@top)
             |vpiOpType:82
             |vpiBlocking:1
             |vpiLhs:
-            \_bit_select: (work@top.test_net), line:9:3, endln:9:11
+            \_bit_select: (work@top.test_net), line:9:3, endln:9:11, parent:work@top.test_net
               |vpiName:test_net
               |vpiFullName:work@top.test_net
               |vpiIndex:
@@ -695,13 +695,13 @@ design: (work@top)
             |vpiOpType:82
             |vpiBlocking:1
             |vpiLhs:
-            \_bit_select: (work@top.test_net), line:9:3, endln:9:11
+            \_bit_select: (work@top.test_net), line:9:3, endln:9:11, parent:work@top.test_net
               |vpiName:test_net
               |vpiFullName:work@top.test_net
               |vpiIndex:
-              \_ref_obj: (work@top.i), line:9:12, endln:9:13, parent:work@top.test_net
+              \_ref_obj: (work@top.test_net.i), line:9:12, endln:9:13, parent:work@top.test_net
                 |vpiName:i
-                |vpiFullName:work@top.i
+                |vpiFullName:work@top.test_net.i
             |vpiRhs:
             \_constant: , line:9:22, endln:9:24
               |vpiConstType:3

--- a/third_party/tests/Earlgrey_Verilator_01_05_21/sim-icarus/Earlgrey_Verilator_01_05_21.log
+++ b/third_party/tests/Earlgrey_Verilator_01_05_21/sim-icarus/Earlgrey_Verilator_01_05_21.log
@@ -1029,7 +1029,7 @@ Surelog preproc status: 0
 [INF:PP0122] Preprocessing source file "../src/lowrisc_systems_top_earlgrey_verilator_0.1/rtl/top_earlgrey_verilator.sv".
 
 Running: cd ../../../../build/tests/Earlgrey_Verilator_01_05_21/slpp_all/;${SURELOG_DIR}/build/bin/surelog -nostdout -batch parser_batch.txt
-Surelog parsing status: 0
+Surelog parsing status: 35072
 [INF:PA0201] Parsing source file "builtin.sv".
 
 [INF:PA0201] Parsing source file "../src/lowrisc_constants_top_pkg_0/rtl/top_pkg.sv".
@@ -2644,19 +2644,19 @@ Surelog parsing status: 0
 
 [WRN:PA0205] ../src/lowrisc_top_earlgrey_rv_plic_0.1/rtl/autogen/rv_plic_reg_pkg.sv:7: No timescale set for "rv_plic_reg_pkg".
 
-[WRN:PA0205] ../src/lowrisc_top_earlgrey_rv_plic_0.1/rtl/autogen/rv_plic_reg_top.sv:9: No timescale set for "rv_plic_reg_top".
+[WRN:PA0205] ../src/lowrisc_top_earlgrey_rv_plic_0.1/rtl/autogen/rv_plic_reg_top.sv:140: No timescale set for "rv_plic_reg_top".
 
 [WRN:PA0205] ../src/lowrisc_top_earlgrey_rv_plic_0.1/rtl/autogen/rv_plic.sv:25: No timescale set for "rv_plic".
 
-[WRN:PA0205] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:9: No timescale set for "sensor_ctrl".
+[WRN:PA0205] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:140: No timescale set for "sensor_ctrl".
 
-[WRN:PA0205] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:16: No timescale set for "rstmgr".
+[WRN:PA0205] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:147: No timescale set for "rstmgr".
 
-[WRN:PA0205] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_ctrl.sv:10: No timescale set for "rstmgr_ctrl".
+[WRN:PA0205] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_ctrl.sv:141: No timescale set for "rstmgr_ctrl".
 
-[WRN:PA0205] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_por.sv:10: No timescale set for "rstmgr_por".
+[WRN:PA0205] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_por.sv:141: No timescale set for "rstmgr_por".
 
-[WRN:PA0205] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_crash_info.sv:8: No timescale set for "rstmgr_crash_info".
+[WRN:PA0205] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_crash_info.sv:139: No timescale set for "rstmgr_crash_info".
 
 [WRN:PA0205] ../src/lowrisc_systems_top_earlgrey_0.1/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv:14: No timescale set for "top_earlgrey_rnd_cnst_pkg".
 
@@ -3352,13 +3352,13 @@ Surelog parsing status: 0
 
 [INF:CP0303] ../src/lowrisc_ip_pwrmgr_0.1/rtl/pwrmgr_wake_info.sv:10: Compile module "work@pwrmgr_wake_info".
 
-[INF:CP0303] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:16: Compile module "work@rstmgr".
+[INF:CP0303] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:147: Compile module "work@rstmgr".
 
-[INF:CP0303] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_crash_info.sv:8: Compile module "work@rstmgr_crash_info".
+[INF:CP0303] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_crash_info.sv:139: Compile module "work@rstmgr_crash_info".
 
-[INF:CP0303] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_ctrl.sv:10: Compile module "work@rstmgr_ctrl".
+[INF:CP0303] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_ctrl.sv:141: Compile module "work@rstmgr_ctrl".
 
-[INF:CP0303] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_por.sv:10: Compile module "work@rstmgr_por".
+[INF:CP0303] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_por.sv:141: Compile module "work@rstmgr_por".
 
 [INF:CP0303] ../src/lowrisc_systems_rstmgr_reg_0.1/rtl/autogen/rstmgr_reg_top.sv:9: Compile module "work@rstmgr_reg_top".
 
@@ -3370,7 +3370,7 @@ Surelog parsing status: 0
 
 [INF:CP0303] ../src/lowrisc_ip_rv_plic_component_0.1/rtl/rv_plic_gateway.sv:7: Compile module "work@rv_plic_gateway".
 
-[INF:CP0303] ../src/lowrisc_top_earlgrey_rv_plic_0.1/rtl/autogen/rv_plic_reg_top.sv:9: Compile module "work@rv_plic_reg_top".
+[INF:CP0303] ../src/lowrisc_top_earlgrey_rv_plic_0.1/rtl/autogen/rv_plic_reg_top.sv:140: Compile module "work@rv_plic_reg_top".
 
 [INF:CP0303] ../src/lowrisc_ip_rv_plic_component_0.1/rtl/rv_plic_target.sv:17: Compile module "work@rv_plic_target".
 
@@ -3378,7 +3378,7 @@ Surelog parsing status: 0
 
 [INF:CP0303] ../src/lowrisc_ip_rv_timer_0.1/rtl/rv_timer_reg_top.sv:9: Compile module "work@rv_timer_reg_top".
 
-[INF:CP0303] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:9: Compile module "work@sensor_ctrl".
+[INF:CP0303] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:140: Compile module "work@sensor_ctrl".
 
 [INF:CP0303] ../src/lowrisc_systems_sensor_ctrl_reg_0.1/rtl/sensor_ctrl_reg_top.sv:9: Compile module "work@sensor_ctrl_reg_top".
 
@@ -8055,7 +8055,7 @@ there are 2 more instances of this message.
 
 [INF:CP0335] ../src/lowrisc_prim_all_0.1/rtl/prim_subreg_arb.sv:35: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.u_reg.u_status.wr_en_data_arb.gen_ro".
 
-[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:85: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[0]".
+[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:216: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[0]".
 
 [INF:CP0335] ../src/lowrisc_prim_diff_decode_0/rtl/prim_diff_decode.sv:179: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[0].i_prim_alert_sender.i_decode_ping.gen_no_async".
 
@@ -8071,7 +8071,7 @@ there are 2 more instances of this message.
 
 [INF:CP0335] ../src/lowrisc_prim_all_0.1/rtl/prim_alert_sender.sv:265: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[0].i_prim_alert_sender.gen_sync_assert".
 
-[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:85: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[1]".
+[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:216: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[1]".
 
 [INF:CP0335] ../src/lowrisc_prim_diff_decode_0/rtl/prim_diff_decode.sv:179: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[1].i_prim_alert_sender.i_decode_ping.gen_no_async".
 
@@ -8087,7 +8087,7 @@ there are 2 more instances of this message.
 
 [INF:CP0335] ../src/lowrisc_prim_all_0.1/rtl/prim_alert_sender.sv:265: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[1].i_prim_alert_sender.gen_sync_assert".
 
-[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:85: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[2]".
+[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:216: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[2]".
 
 [INF:CP0335] ../src/lowrisc_prim_diff_decode_0/rtl/prim_diff_decode.sv:179: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[2].i_prim_alert_sender.i_decode_ping.gen_no_async".
 
@@ -8103,7 +8103,7 @@ there are 2 more instances of this message.
 
 [INF:CP0335] ../src/lowrisc_prim_all_0.1/rtl/prim_alert_sender.sv:265: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[2].i_prim_alert_sender.gen_sync_assert".
 
-[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:85: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[3]".
+[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:216: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[3]".
 
 [INF:CP0335] ../src/lowrisc_prim_diff_decode_0/rtl/prim_diff_decode.sv:179: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[3].i_prim_alert_sender.i_decode_ping.gen_no_async".
 
@@ -8119,7 +8119,7 @@ there are 2 more instances of this message.
 
 [INF:CP0335] ../src/lowrisc_prim_all_0.1/rtl/prim_alert_sender.sv:265: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[3].i_prim_alert_sender.gen_sync_assert".
 
-[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:85: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[4]".
+[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:216: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[4]".
 
 [INF:CP0335] ../src/lowrisc_prim_diff_decode_0/rtl/prim_diff_decode.sv:179: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[4].i_prim_alert_sender.i_decode_ping.gen_no_async".
 
@@ -8135,7 +8135,7 @@ there are 2 more instances of this message.
 
 [INF:CP0335] ../src/lowrisc_prim_all_0.1/rtl/prim_alert_sender.sv:265: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[4].i_prim_alert_sender.gen_sync_assert".
 
-[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:85: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[5]".
+[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:216: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[5]".
 
 [INF:CP0335] ../src/lowrisc_prim_diff_decode_0/rtl/prim_diff_decode.sv:179: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[5].i_prim_alert_sender.i_decode_ping.gen_no_async".
 
@@ -8151,7 +8151,7 @@ there are 2 more instances of this message.
 
 [INF:CP0335] ../src/lowrisc_prim_all_0.1/rtl/prim_alert_sender.sv:265: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[5].i_prim_alert_sender.gen_sync_assert".
 
-[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:85: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[6]".
+[INF:CP0335] ../src/lowrisc_systems_sensor_ctrl_0.1/rtl/sensor_ctrl.sv:216: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[6]".
 
 [INF:CP0335] ../src/lowrisc_prim_diff_decode_0/rtl/prim_diff_decode.sv:179: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_sensor_ctrl.gen_alert_senders[6].i_prim_alert_sender.i_decode_ping.gen_no_async".
 
@@ -13657,9 +13657,9 @@ there are 2 more instances of this message.
 
 [INF:CP0335] ../src/lowrisc_prim_all_0.1/rtl/prim_intr_hw.sv:39: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_pwrmgr.intr_wakeup.gen_flop_intr_output".
 
-[INF:CP0335] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:64: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_rst_por_aon[0]".
+[INF:CP0335] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:195: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_rst_por_aon[0]".
 
-[INF:CP0335] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:65: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_rst_por_aon[0].gen_rst_por_aon_normal".
+[INF:CP0335] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:196: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_rst_por_aon[0].gen_rst_por_aon_normal".
 
 [INF:CP0335] ../src/lowrisc_prim_abstract_flop_2sync_0/prim_flop_2sync.sv:28: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_rst_por_aon[0].gen_rst_por_aon_normal.u_rst_por_aon.rst_sync.gen_generic".
 
@@ -13671,9 +13671,9 @@ there are 2 more instances of this message.
 
 [INF:CP0335] ../src/lowrisc_prim_abstract_clock_mux2_0/prim_clock_mux2.sv:36: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_rst_por_aon[0].gen_rst_por_aon_normal.u_rst_por_aon_n_mux.gen_generic".
 
-[INF:CP0335] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:64: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_rst_por_aon[1]".
+[INF:CP0335] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:195: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_rst_por_aon[1]".
 
-[INF:CP0335] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:82: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_rst_por_aon[1].gen_rst_por_aon_tieoff".
+[INF:CP0335] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:213: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_rst_por_aon[1].gen_rst_por_aon_tieoff".
 
 [INF:CP0335] ../src/lowrisc_prim_all_0.1/rtl/prim_subreg_arb.sv:54: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.u_reg.u_reset_info_por.wr_en_data_arb.gen_w1c".
 
@@ -13721,11 +13721,11 @@ there are 2 more instances of this message.
 
 [INF:CP0335] ../src/lowrisc_prim_abstract_flop_0/prim_flop.sv:39: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.u_sys_src.u_pd_rst.gen_generic".
 
-[INF:CP0335] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:174: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_sw_rst_ext_regs[0]".
+[INF:CP0335] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:305: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_sw_rst_ext_regs[0]".
 
 [INF:CP0335] ../src/lowrisc_prim_all_0.1/rtl/prim_subreg_arb.sv:28: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_sw_rst_ext_regs[0].u_rst_sw_ctrl_reg.wr_en_data_arb.gen_w".
 
-[INF:CP0335] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:174: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_sw_rst_ext_regs[1]".
+[INF:CP0335] ../src/lowrisc_systems_rstmgr_0.1/rtl/autogen/rstmgr.sv:305: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_sw_rst_ext_regs[1]".
 
 [INF:CP0335] ../src/lowrisc_prim_all_0.1/rtl/prim_subreg_arb.sv:28: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.gen_sw_rst_ext_regs[1].u_rst_sw_ctrl_reg.wr_en_data_arb.gen_w".
 
@@ -13847,9 +13847,9 @@ there are 2 more instances of this message.
 
 [INF:CP0335] ../src/lowrisc_prim_abstract_flop_0/prim_flop.sv:39: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.u_cpu_reset_synced.gen_generic.u_impl_generic.u_sync_2.gen_generic".
 
-[INF:CP0335] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_crash_info.sv:47: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.u_alert_info.gen_tieoffs".
+[INF:CP0335] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_crash_info.sv:178: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.u_alert_info.gen_tieoffs".
 
-[INF:CP0335] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_crash_info.sv:47: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.u_cpu_info.gen_tieoffs".
+[INF:CP0335] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_crash_info.sv:178: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.u_cpu_info.gen_tieoffs".
 
 [INF:CP0335] ../src/lowrisc_prim_all_0.1/rtl/prim_subreg_arb.sv:28: Compile generate block "work@top_earlgrey_verilator.top_earlgrey.u_clkmgr.u_reg.u_clk_enables_clk_io_div4_peri_en.wr_en_data_arb.gen_w".
 
@@ -27895,13 +27895,11 @@ there are 2 more instances of this message.
 
 [NTE:EL0503] ../src/lowrisc_systems_top_earlgrey_verilator_0.1/rtl/top_earlgrey_verilator.sv:5: Top level module "work@top_earlgrey_verilator".
 
-[NTE:EL0531] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_crash_info.sv:20:10: Negative value in instance "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.u_alert_info"
-             text:   input [CrashDumpWidth-1:0] dump_i,
-             value: INT:-1.
+[NTE:EL0531] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_crash_info.sv:151:10: Negative value in instance "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.u_alert_info"
+             text:              value: INT:-1.
 
-[NTE:EL0531] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_crash_info.sv:29:10: Negative value in instance "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.u_alert_info"
-             text:   logic [CrashStoreSlot-1:0][RdWidth-1:0] slots_q;
-             value: INT:-1.
+[NTE:EL0531] ../src/lowrisc_ip_rstmgr_0.1/rtl/rstmgr_crash_info.sv:160:10: Negative value in instance "work@top_earlgrey_verilator.top_earlgrey.u_rstmgr.u_alert_info"
+             text:              value: INT:-1.
 
 [NTE:EL0508] Nb Top level modules: 1.
 

--- a/third_party/tests/SimpleParserTest/SimpleParserTest.log
+++ b/third_party/tests/SimpleParserTest/SimpleParserTest.log
@@ -937,7 +937,7 @@ design: (work@dff_async_reset)
         \_operation: , line:17:11, endln:17:15, parent:work@LFSR_TASK.LFSR_TAPS8_TASK
           |vpiOpType:30
           |vpiOperand:
-          \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.A), line:17:11, endln:17:15
+          \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.A), line:17:11, endln:17:15, parent:work@LFSR_TASK.LFSR_TAPS8_TASK.A
             |vpiName:A
             |vpiFullName:work@LFSR_TASK.LFSR_TAPS8_TASK.A
             |vpiIndex:
@@ -1021,7 +1021,7 @@ design: (work@dff_async_reset)
           \_operation: , line:19:6, endln:19:21
             |vpiOpType:14
             |vpiOperand:
-            \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.Chain), line:19:6, endln:19:16
+            \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.Chain), line:19:6, endln:19:16, parent:work@LFSR_TASK.LFSR_TAPS8_TASK.Chain
               |vpiName:Chain
               |vpiFullName:work@LFSR_TASK.LFSR_TAPS8_TASK.Chain
               |vpiIndex:
@@ -1048,7 +1048,7 @@ design: (work@dff_async_reset)
             |vpiOpType:82
             |vpiBlocking:1
             |vpiLhs:
-            \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.Next_LFSR_Reg), line:20:2, endln:20:15
+            \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.Next_LFSR_Reg), line:20:2, endln:20:15, parent:work@LFSR_TASK.LFSR_TAPS8_TASK.Next_LFSR_Reg
               |vpiName:Next_LFSR_Reg
               |vpiFullName:work@LFSR_TASK.LFSR_TAPS8_TASK.Next_LFSR_Reg
               |vpiIndex:
@@ -1059,7 +1059,7 @@ design: (work@dff_async_reset)
             \_operation: , line:20:21, endln:20:27
               |vpiOpType:30
               |vpiOperand:
-              \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.A), line:20:21, endln:20:27
+              \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.A), line:20:21, endln:20:27, parent:work@LFSR_TASK.LFSR_TAPS8_TASK.A
                 |vpiName:A
                 |vpiFullName:work@LFSR_TASK.LFSR_TAPS8_TASK.A
                 |vpiIndex:
@@ -1084,7 +1084,7 @@ design: (work@dff_async_reset)
             |vpiOpType:82
             |vpiBlocking:1
             |vpiLhs:
-            \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.Next_LFSR_Reg), line:22:2, endln:22:15
+            \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.Next_LFSR_Reg), line:22:2, endln:22:15, parent:work@LFSR_TASK.LFSR_TAPS8_TASK.Next_LFSR_Reg
               |vpiName:Next_LFSR_Reg
               |vpiFullName:work@LFSR_TASK.LFSR_TAPS8_TASK.Next_LFSR_Reg
               |vpiIndex:
@@ -1092,7 +1092,7 @@ design: (work@dff_async_reset)
                 |vpiName:i
                 |vpiFullName:work@LFSR_TASK.LFSR_TAPS8_TASK.i
             |vpiRhs:
-            \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.A), line:22:21, endln:22:27
+            \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.A), line:22:21, endln:22:27, parent:work@LFSR_TASK.LFSR_TAPS8_TASK.A
               |vpiName:A
               |vpiFullName:work@LFSR_TASK.LFSR_TAPS8_TASK.A
               |vpiIndex:
@@ -1113,7 +1113,7 @@ design: (work@dff_async_reset)
         |vpiOpType:82
         |vpiBlocking:1
         |vpiLhs:
-        \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.Next_LFSR_Reg), line:23:2, endln:23:15
+        \_bit_select: (work@LFSR_TASK.LFSR_TAPS8_TASK.Next_LFSR_Reg), line:23:2, endln:23:15, parent:work@LFSR_TASK.LFSR_TAPS8_TASK.Next_LFSR_Reg
           |vpiName:Next_LFSR_Reg
           |vpiFullName:work@LFSR_TASK.LFSR_TAPS8_TASK.Next_LFSR_Reg
           |vpiIndex:
@@ -1355,7 +1355,7 @@ design: (work@dff_async_reset)
                 |vpiOpType:82
                 |vpiBlocking:1
                 |vpiLhs:
-                \_bit_select: (work@arbiter.tmp_prio), line:26:2, endln:26:10
+                \_bit_select: (work@arbiter.tmp_prio), line:26:2, endln:26:10, parent:work@arbiter.tmp_prio
                   |vpiName:tmp_prio
                   |vpiFullName:work@arbiter.tmp_prio
                   |vpiIndex:
@@ -1365,7 +1365,7 @@ design: (work@dff_async_reset)
                     |vpiActual:
                     \_int_var: (work@top.U.j), line:3:12, endln:3:13, parent:work@top.U
                 |vpiRhs:
-                \_bit_select: (work@arbiter.tpriority), line:26:16, endln:26:45
+                \_bit_select: (work@arbiter.tpriority), line:26:16, endln:26:45, parent:work@arbiter.tpriority
                   |vpiName:tpriority
                   |vpiFullName:work@arbiter.tpriority
                   |vpiIndex:
@@ -1397,7 +1397,7 @@ design: (work@dff_async_reset)
               |vpiOpType:82
               |vpiBlocking:1
               |vpiLhs:
-              \_bit_select: (work@arbiter.prio), line:27:2, endln:27:6
+              \_bit_select: (work@arbiter.prio), line:27:2, endln:27:6, parent:work@arbiter.prio
                 |vpiName:prio
                 |vpiFullName:work@arbiter.prio
                 |vpiIndex:
@@ -1650,7 +1650,7 @@ design: (work@dff_async_reset)
                       \_ref_obj: (request), line:61:10, endln:61:17
                         |vpiName:request
                       |vpiOperand:
-                      \_bit_select: (prio), line:61:21, endln:61:28
+                      \_bit_select: (prio), line:61:21, endln:61:28, parent:prio
                         |vpiName:prio
                         |vpiIndex:
                         \_constant: , line:61:26, endln:61:27, parent:prio
@@ -1659,7 +1659,7 @@ design: (work@dff_async_reset)
                           |vpiSize:64
                           |UINT:7
                     |vpiOperand:
-                    \_bit_select: (prio), line:61:32, endln:61:39
+                    \_bit_select: (prio), line:61:32, endln:61:39, parent:prio
                       |vpiName:prio
                       |vpiIndex:
                       \_constant: , line:61:37, endln:61:38, parent:prio
@@ -1668,7 +1668,7 @@ design: (work@dff_async_reset)
                         |vpiSize:64
                         |UINT:6
                   |vpiOperand:
-                  \_bit_select: (prio), line:61:43, endln:61:50
+                  \_bit_select: (prio), line:61:43, endln:61:50, parent:prio
                     |vpiName:prio
                     |vpiIndex:
                     \_constant: , line:61:48, endln:61:49, parent:prio
@@ -1677,7 +1677,7 @@ design: (work@dff_async_reset)
                       |vpiSize:64
                       |UINT:5
                 |vpiOperand:
-                \_bit_select: (prio), line:61:54, endln:61:61
+                \_bit_select: (prio), line:61:54, endln:61:61, parent:prio
                   |vpiName:prio
                   |vpiIndex:
                   \_constant: , line:61:59, endln:61:60, parent:prio
@@ -1686,7 +1686,7 @@ design: (work@dff_async_reset)
                     |vpiSize:64
                     |UINT:4
               |vpiOperand:
-              \_bit_select: (prio), line:62:2, endln:62:9
+              \_bit_select: (prio), line:62:2, endln:62:9, parent:prio
                 |vpiName:prio
                 |vpiIndex:
                 \_constant: , line:62:7, endln:62:8, parent:prio
@@ -1695,7 +1695,7 @@ design: (work@dff_async_reset)
                   |vpiSize:64
                   |UINT:3
             |vpiOperand:
-            \_bit_select: (prio), line:62:13, endln:62:20
+            \_bit_select: (prio), line:62:13, endln:62:20, parent:prio
               |vpiName:prio
               |vpiIndex:
               \_constant: , line:62:18, endln:62:19, parent:prio
@@ -1704,7 +1704,7 @@ design: (work@dff_async_reset)
                 |vpiSize:64
                 |UINT:2
           |vpiOperand:
-          \_bit_select: (prio), line:62:24, endln:62:31
+          \_bit_select: (prio), line:62:24, endln:62:31, parent:prio
             |vpiName:prio
             |vpiIndex:
             \_constant: , line:62:29, endln:62:30, parent:prio
@@ -1713,7 +1713,7 @@ design: (work@dff_async_reset)
               |vpiSize:64
               |UINT:1
         |vpiOperand:
-        \_bit_select: (prio), line:62:35, endln:62:42
+        \_bit_select: (prio), line:62:35, endln:62:42, parent:prio
           |vpiName:prio
           |vpiIndex:
           \_constant: , line:62:40, endln:62:41, parent:prio
@@ -1786,7 +1786,7 @@ design: (work@dff_async_reset)
             |vpiOpType:82
             |vpiBlocking:1
             |vpiLhs:
-            \_bit_select: (work@arbiter.selectPrio), line:65:2, endln:65:12
+            \_bit_select: (work@arbiter.selectPrio), line:65:2, endln:65:12, parent:work@arbiter.selectPrio
               |vpiName:selectPrio
               |vpiFullName:work@arbiter.selectPrio
               |vpiIndex:
@@ -1799,7 +1799,7 @@ design: (work@dff_async_reset)
             \_operation: , line:65:18, endln:65:28, parent:work@arbiter
               |vpiOpType:32
               |vpiOperand:
-              \_bit_select: (work@arbiter.request), line:65:18, endln:65:28
+              \_bit_select: (work@arbiter.request), line:65:18, endln:65:28, parent:work@arbiter.request
                 |vpiName:request
                 |vpiFullName:work@arbiter.request
                 |vpiIndex:
@@ -1809,7 +1809,7 @@ design: (work@dff_async_reset)
                   |vpiActual:
                   \_int_var: (work@top.U.k), line:3:14, endln:3:15, parent:work@top.U
               |vpiOperand:
-              \_bit_select: (work@arbiter.prio), line:65:31, endln:65:38
+              \_bit_select: (work@arbiter.prio), line:65:31, endln:65:38, parent:work@arbiter.prio
                 |vpiName:prio
                 |vpiFullName:work@arbiter.prio
                 |vpiIndex:
@@ -1918,7 +1918,7 @@ design: (work@dff_async_reset)
             |vpiOpType:82
             |vpiBlocking:1
             |vpiLhs:
-            \_bit_select: (work@arbiter.finalRequest), line:71:2, endln:71:14
+            \_bit_select: (work@arbiter.finalRequest), line:71:2, endln:71:14, parent:work@arbiter.finalRequest
               |vpiName:finalRequest
               |vpiFullName:work@arbiter.finalRequest
               |vpiIndex:
@@ -1939,7 +1939,7 @@ design: (work@dff_async_reset)
                   |vpiName:roundORpriority
                   |vpiFullName:work@top.U.roundORpriority
               |vpiOperand:
-              \_bit_select: (work@arbiter.prioRequest), line:71:38, endln:71:52
+              \_bit_select: (work@arbiter.prioRequest), line:71:38, endln:71:52, parent:work@arbiter.prioRequest
                 |vpiName:prioRequest
                 |vpiFullName:work@arbiter.prioRequest
                 |vpiIndex:
@@ -1949,7 +1949,7 @@ design: (work@dff_async_reset)
                   |vpiActual:
                   \_int_var: (work@top.U.r), line:3:20, endln:3:21, parent:work@top.U
               |vpiOperand:
-              \_bit_select: (work@arbiter.request), line:72:2, endln:72:12
+              \_bit_select: (work@arbiter.request), line:72:2, endln:72:12, parent:work@arbiter.request
                 |vpiName:request
                 |vpiFullName:work@arbiter.request
                 |vpiIndex:
@@ -1985,7 +1985,7 @@ design: (work@dff_async_reset)
                   \_operation: , line:76:10, endln:76:23
                     |vpiOpType:35
                     |vpiOperand:
-                    \_bit_select: (selectPrio), line:76:10, endln:76:23
+                    \_bit_select: (selectPrio), line:76:10, endln:76:23, parent:selectPrio
                       |vpiName:selectPrio
                       |vpiIndex:
                       \_constant: , line:76:21, endln:76:22, parent:selectPrio
@@ -1994,7 +1994,7 @@ design: (work@dff_async_reset)
                         |vpiSize:64
                         |UINT:7
                     |vpiOperand:
-                    \_bit_select: (selectPrio), line:76:27, endln:76:40
+                    \_bit_select: (selectPrio), line:76:27, endln:76:40, parent:selectPrio
                       |vpiName:selectPrio
                       |vpiIndex:
                       \_constant: , line:76:38, endln:76:39, parent:selectPrio
@@ -2003,7 +2003,7 @@ design: (work@dff_async_reset)
                         |vpiSize:64
                         |UINT:6
                   |vpiOperand:
-                  \_bit_select: (selectPrio), line:76:44, endln:76:57
+                  \_bit_select: (selectPrio), line:76:44, endln:76:57, parent:selectPrio
                     |vpiName:selectPrio
                     |vpiIndex:
                     \_constant: , line:76:55, endln:76:56, parent:selectPrio
@@ -2012,7 +2012,7 @@ design: (work@dff_async_reset)
                       |vpiSize:64
                       |UINT:5
                 |vpiOperand:
-                \_bit_select: (selectPrio), line:77:2, endln:77:15
+                \_bit_select: (selectPrio), line:77:2, endln:77:15, parent:selectPrio
                   |vpiName:selectPrio
                   |vpiIndex:
                   \_constant: , line:77:13, endln:77:14, parent:selectPrio
@@ -2021,7 +2021,7 @@ design: (work@dff_async_reset)
                     |vpiSize:64
                     |UINT:4
               |vpiOperand:
-              \_bit_select: (selectPrio), line:77:19, endln:77:32
+              \_bit_select: (selectPrio), line:77:19, endln:77:32, parent:selectPrio
                 |vpiName:selectPrio
                 |vpiIndex:
                 \_constant: , line:77:30, endln:77:31, parent:selectPrio
@@ -2030,7 +2030,7 @@ design: (work@dff_async_reset)
                   |vpiSize:64
                   |UINT:3
             |vpiOperand:
-            \_bit_select: (selectPrio), line:77:36, endln:77:49
+            \_bit_select: (selectPrio), line:77:36, endln:77:49, parent:selectPrio
               |vpiName:selectPrio
               |vpiIndex:
               \_constant: , line:77:47, endln:77:48, parent:selectPrio
@@ -2039,7 +2039,7 @@ design: (work@dff_async_reset)
                 |vpiSize:64
                 |UINT:2
           |vpiOperand:
-          \_bit_select: (selectPrio), line:78:2, endln:78:15
+          \_bit_select: (selectPrio), line:78:2, endln:78:15, parent:selectPrio
             |vpiName:selectPrio
             |vpiIndex:
             \_constant: , line:78:13, endln:78:14, parent:selectPrio
@@ -2048,7 +2048,7 @@ design: (work@dff_async_reset)
               |vpiSize:64
               |UINT:1
         |vpiOperand:
-        \_bit_select: (selectPrio), line:78:19, endln:78:32
+        \_bit_select: (selectPrio), line:78:19, endln:78:32, parent:selectPrio
           |vpiName:selectPrio
           |vpiIndex:
           \_constant: , line:78:30, endln:78:31, parent:selectPrio
@@ -2087,7 +2087,7 @@ design: (work@dff_async_reset)
                   |vpiSize:64
                   |UINT:0
           |vpiRhs:
-          \_bit_select: (work@arbiter.selectPrio), line:80:8, endln:80:21
+          \_bit_select: (work@arbiter.selectPrio), line:80:8, endln:80:21, parent:work@arbiter.selectPrio
             |vpiName:selectPrio
             |vpiFullName:work@arbiter.selectPrio
             |vpiIndex:
@@ -2159,7 +2159,7 @@ design: (work@dff_async_reset)
             \_operation: , line:82:6, endln:82:25
               |vpiOpType:20
               |vpiOperand:
-              \_bit_select: (work@arbiter.selectPrio), line:82:6, endln:82:19
+              \_bit_select: (work@arbiter.selectPrio), line:82:6, endln:82:19, parent:work@arbiter.selectPrio
                 |vpiName:selectPrio
                 |vpiFullName:work@arbiter.selectPrio
                 |vpiIndex:
@@ -2185,7 +2185,7 @@ design: (work@dff_async_reset)
                 |vpiActual:
                 \_logic_net: (work@top.U.min), line:40:27, endln:40:30, parent:work@top.U
               |vpiRhs:
-              \_bit_select: (work@arbiter.selectPrio), line:82:33, endln:82:46
+              \_bit_select: (work@arbiter.selectPrio), line:82:33, endln:82:46, parent:work@arbiter.selectPrio
                 |vpiName:selectPrio
                 |vpiFullName:work@arbiter.selectPrio
                 |vpiIndex:
@@ -2233,7 +2233,7 @@ design: (work@dff_async_reset)
                         \_ref_obj: (minPrio), line:85:17, endln:85:24
                           |vpiName:minPrio
                       |vpiOperand:
-                      \_bit_select: (prio), line:85:28, endln:85:35
+                      \_bit_select: (prio), line:85:28, endln:85:35, parent:prio
                         |vpiName:prio
                         |vpiIndex:
                         \_constant: , line:85:33, endln:85:34, parent:prio
@@ -2242,7 +2242,7 @@ design: (work@dff_async_reset)
                           |vpiSize:64
                           |UINT:7
                     |vpiOperand:
-                    \_bit_select: (prio), line:85:39, endln:85:46
+                    \_bit_select: (prio), line:85:39, endln:85:46, parent:prio
                       |vpiName:prio
                       |vpiIndex:
                       \_constant: , line:85:44, endln:85:45, parent:prio
@@ -2251,7 +2251,7 @@ design: (work@dff_async_reset)
                         |vpiSize:64
                         |UINT:6
                   |vpiOperand:
-                  \_bit_select: (prio), line:85:50, endln:85:57
+                  \_bit_select: (prio), line:85:50, endln:85:57, parent:prio
                     |vpiName:prio
                     |vpiIndex:
                     \_constant: , line:85:55, endln:85:56, parent:prio
@@ -2260,7 +2260,7 @@ design: (work@dff_async_reset)
                       |vpiSize:64
                       |UINT:5
                 |vpiOperand:
-                \_bit_select: (prio), line:85:61, endln:85:68
+                \_bit_select: (prio), line:85:61, endln:85:68, parent:prio
                   |vpiName:prio
                   |vpiIndex:
                   \_constant: , line:85:66, endln:85:67, parent:prio
@@ -2269,7 +2269,7 @@ design: (work@dff_async_reset)
                     |vpiSize:64
                     |UINT:4
               |vpiOperand:
-              \_bit_select: (prio), line:86:5, endln:86:12
+              \_bit_select: (prio), line:86:5, endln:86:12, parent:prio
                 |vpiName:prio
                 |vpiIndex:
                 \_constant: , line:86:10, endln:86:11, parent:prio
@@ -2278,7 +2278,7 @@ design: (work@dff_async_reset)
                   |vpiSize:64
                   |UINT:3
             |vpiOperand:
-            \_bit_select: (prio), line:86:16, endln:86:23
+            \_bit_select: (prio), line:86:16, endln:86:23, parent:prio
               |vpiName:prio
               |vpiIndex:
               \_constant: , line:86:21, endln:86:22, parent:prio
@@ -2287,7 +2287,7 @@ design: (work@dff_async_reset)
                 |vpiSize:64
                 |UINT:2
           |vpiOperand:
-          \_bit_select: (prio), line:86:27, endln:86:34
+          \_bit_select: (prio), line:86:27, endln:86:34, parent:prio
             |vpiName:prio
             |vpiIndex:
             \_constant: , line:86:32, endln:86:33, parent:prio
@@ -2296,7 +2296,7 @@ design: (work@dff_async_reset)
               |vpiSize:64
               |UINT:1
         |vpiOperand:
-        \_bit_select: (prio), line:86:38, endln:86:45
+        \_bit_select: (prio), line:86:38, endln:86:45, parent:prio
           |vpiName:prio
           |vpiIndex:
           \_constant: , line:86:43, endln:86:44, parent:prio
@@ -2369,7 +2369,7 @@ design: (work@dff_async_reset)
             |vpiOpType:82
             |vpiBlocking:1
             |vpiLhs:
-            \_bit_select: (work@arbiter.minPrio), line:89:2, endln:89:9
+            \_bit_select: (work@arbiter.minPrio), line:89:2, endln:89:9, parent:work@arbiter.minPrio
               |vpiName:minPrio
               |vpiFullName:work@arbiter.minPrio
               |vpiIndex:
@@ -2385,7 +2385,7 @@ design: (work@dff_async_reset)
               \_operation: , line:89:16, endln:89:28, parent:work@arbiter
                 |vpiOpType:14
                 |vpiOperand:
-                \_bit_select: (work@arbiter.prio), line:89:16, endln:89:23
+                \_bit_select: (work@arbiter.prio), line:89:16, endln:89:23, parent:work@arbiter.prio
                   |vpiName:prio
                   |vpiFullName:work@arbiter.prio
                   |vpiIndex:
@@ -2486,7 +2486,7 @@ design: (work@dff_async_reset)
             |vpiOpType:82
             |vpiBlocking:1
             |vpiLhs:
-            \_bit_select: (work@arbiter.scan), line:97:2, endln:97:6
+            \_bit_select: (work@arbiter.scan), line:97:2, endln:97:6, parent:work@arbiter.scan
               |vpiName:scan
               |vpiFullName:work@arbiter.scan
               |vpiIndex:
@@ -2594,7 +2594,7 @@ design: (work@dff_async_reset)
                       \_ref_obj: (finalRequest), line:100:10, endln:100:22
                         |vpiName:finalRequest
                       |vpiOperand:
-                      \_bit_select: (scan), line:100:26, endln:100:33
+                      \_bit_select: (scan), line:100:26, endln:100:33, parent:scan
                         |vpiName:scan
                         |vpiIndex:
                         \_constant: , line:100:31, endln:100:32, parent:scan
@@ -2603,7 +2603,7 @@ design: (work@dff_async_reset)
                           |vpiSize:64
                           |UINT:7
                     |vpiOperand:
-                    \_bit_select: (scan), line:100:37, endln:100:44
+                    \_bit_select: (scan), line:100:37, endln:100:44, parent:scan
                       |vpiName:scan
                       |vpiIndex:
                       \_constant: , line:100:42, endln:100:43, parent:scan
@@ -2612,7 +2612,7 @@ design: (work@dff_async_reset)
                         |vpiSize:64
                         |UINT:6
                   |vpiOperand:
-                  \_bit_select: (scan), line:100:48, endln:100:55
+                  \_bit_select: (scan), line:100:48, endln:100:55, parent:scan
                     |vpiName:scan
                     |vpiIndex:
                     \_constant: , line:100:53, endln:100:54, parent:scan
@@ -2621,7 +2621,7 @@ design: (work@dff_async_reset)
                       |vpiSize:64
                       |UINT:5
                 |vpiOperand:
-                \_bit_select: (scan), line:100:59, endln:100:66
+                \_bit_select: (scan), line:100:59, endln:100:66, parent:scan
                   |vpiName:scan
                   |vpiIndex:
                   \_constant: , line:100:64, endln:100:65, parent:scan
@@ -2630,7 +2630,7 @@ design: (work@dff_async_reset)
                     |vpiSize:64
                     |UINT:4
               |vpiOperand:
-              \_bit_select: (scan), line:101:2, endln:101:9
+              \_bit_select: (scan), line:101:2, endln:101:9, parent:scan
                 |vpiName:scan
                 |vpiIndex:
                 \_constant: , line:101:7, endln:101:8, parent:scan
@@ -2639,7 +2639,7 @@ design: (work@dff_async_reset)
                   |vpiSize:64
                   |UINT:3
             |vpiOperand:
-            \_bit_select: (scan), line:101:13, endln:101:20
+            \_bit_select: (scan), line:101:13, endln:101:20, parent:scan
               |vpiName:scan
               |vpiIndex:
               \_constant: , line:101:18, endln:101:19, parent:scan
@@ -2648,7 +2648,7 @@ design: (work@dff_async_reset)
                 |vpiSize:64
                 |UINT:2
           |vpiOperand:
-          \_bit_select: (scan), line:101:24, endln:101:31
+          \_bit_select: (scan), line:101:24, endln:101:31, parent:scan
             |vpiName:scan
             |vpiIndex:
             \_constant: , line:101:29, endln:101:30, parent:scan
@@ -2657,7 +2657,7 @@ design: (work@dff_async_reset)
               |vpiSize:64
               |UINT:1
         |vpiOperand:
-        \_bit_select: (scan), line:101:35, endln:101:42
+        \_bit_select: (scan), line:101:35, endln:101:42, parent:scan
           |vpiName:scan
           |vpiIndex:
           \_constant: , line:101:40, endln:101:41, parent:scan
@@ -2673,7 +2673,7 @@ design: (work@dff_async_reset)
           |vpiOpType:82
           |vpiBlocking:1
           |vpiLhs:
-          \_bit_select: (work@arbiter.found), line:103:2, endln:103:7
+          \_bit_select: (work@arbiter.found), line:103:2, endln:103:7, parent:work@arbiter.found
             |vpiName:found
             |vpiFullName:work@arbiter.found
             |vpiIndex:
@@ -2683,15 +2683,15 @@ design: (work@dff_async_reset)
               |vpiSize:64
               |UINT:0
           |vpiRhs:
-          \_bit_select: (work@arbiter.finalRequest), line:103:13, endln:103:34
+          \_bit_select: (work@arbiter.finalRequest), line:103:13, endln:103:34, parent:work@arbiter.finalRequest
             |vpiName:finalRequest
             |vpiFullName:work@arbiter.finalRequest
             |vpiIndex:
-            \_bit_select: (work@arbiter.finalRequest.scan), line:103:26, endln:103:33, parent:work@arbiter.finalRequest
+            \_bit_select: (work@arbiter.scan), line:103:26, endln:103:33, parent:work@arbiter.scan
               |vpiName:scan
-              |vpiFullName:work@arbiter.finalRequest.scan
+              |vpiFullName:work@arbiter.scan
               |vpiIndex:
-              \_constant: , line:103:31, endln:103:32, parent:work@arbiter.finalRequest.scan
+              \_constant: , line:103:31, endln:103:32, parent:work@arbiter.scan
                 |vpiConstType:9
                 |vpiDecompile:0
                 |vpiSize:64
@@ -2767,7 +2767,7 @@ design: (work@dff_async_reset)
             |vpiOpType:82
             |vpiBlocking:1
             |vpiLhs:
-            \_bit_select: (work@arbiter.found), line:105:2, endln:105:7
+            \_bit_select: (work@arbiter.found), line:105:2, endln:105:7, parent:work@arbiter.found
               |vpiName:found
               |vpiFullName:work@arbiter.found
               |vpiIndex:
@@ -2780,7 +2780,7 @@ design: (work@dff_async_reset)
             \_operation: , line:105:13, endln:105:23, parent:work@arbiter
               |vpiOpType:27
               |vpiOperand:
-              \_bit_select: (work@arbiter.found), line:105:13, endln:105:23
+              \_bit_select: (work@arbiter.found), line:105:13, endln:105:23, parent:work@arbiter.found
                 |vpiName:found
                 |vpiFullName:work@arbiter.found
                 |vpiIndex:
@@ -2799,13 +2799,13 @@ design: (work@dff_async_reset)
                     |vpiSize:64
                     |UINT:1
               |vpiOperand:
-              \_bit_select: (work@arbiter.finalRequest), line:105:27, endln:105:48
+              \_bit_select: (work@arbiter.finalRequest), line:105:27, endln:105:48, parent:work@arbiter.finalRequest
                 |vpiName:finalRequest
                 |vpiFullName:work@arbiter.finalRequest
                 |vpiIndex:
-                \_bit_select: (work@arbiter.finalRequest.scan), line:105:40, endln:105:47, parent:work@arbiter.finalRequest
+                \_bit_select: (work@arbiter.scan), line:105:40, endln:105:47, parent:work@arbiter.scan
                   |vpiName:scan
-                  |vpiFullName:work@arbiter.finalRequest.scan
+                  |vpiFullName:work@arbiter.scan
                   |vpiIndex:
                   \_ref_obj: (work@arbiter.t), line:105:45, endln:105:46
                     |vpiName:t
@@ -2851,7 +2851,7 @@ design: (work@dff_async_reset)
                         \_ref_obj: (found), line:108:26, endln:108:31
                           |vpiName:found
                       |vpiOperand:
-                      \_bit_select: (scan), line:108:35, endln:108:42
+                      \_bit_select: (scan), line:108:35, endln:108:42, parent:scan
                         |vpiName:scan
                         |vpiIndex:
                         \_constant: , line:108:40, endln:108:41, parent:scan
@@ -2860,7 +2860,7 @@ design: (work@dff_async_reset)
                           |vpiSize:64
                           |UINT:7
                     |vpiOperand:
-                    \_bit_select: (scan), line:108:46, endln:108:53
+                    \_bit_select: (scan), line:108:46, endln:108:53, parent:scan
                       |vpiName:scan
                       |vpiIndex:
                       \_constant: , line:108:51, endln:108:52, parent:scan
@@ -2869,7 +2869,7 @@ design: (work@dff_async_reset)
                         |vpiSize:64
                         |UINT:6
                   |vpiOperand:
-                  \_bit_select: (scan), line:108:57, endln:108:64
+                  \_bit_select: (scan), line:108:57, endln:108:64, parent:scan
                     |vpiName:scan
                     |vpiIndex:
                     \_constant: , line:108:62, endln:108:63, parent:scan
@@ -2878,7 +2878,7 @@ design: (work@dff_async_reset)
                       |vpiSize:64
                       |UINT:5
                 |vpiOperand:
-                \_bit_select: (scan), line:109:2, endln:109:9
+                \_bit_select: (scan), line:109:2, endln:109:9, parent:scan
                   |vpiName:scan
                   |vpiIndex:
                   \_constant: , line:109:7, endln:109:8, parent:scan
@@ -2887,7 +2887,7 @@ design: (work@dff_async_reset)
                     |vpiSize:64
                     |UINT:4
               |vpiOperand:
-              \_bit_select: (scan), line:109:13, endln:109:20
+              \_bit_select: (scan), line:109:13, endln:109:20, parent:scan
                 |vpiName:scan
                 |vpiIndex:
                 \_constant: , line:109:18, endln:109:19, parent:scan
@@ -2896,7 +2896,7 @@ design: (work@dff_async_reset)
                   |vpiSize:64
                   |UINT:3
             |vpiOperand:
-            \_bit_select: (scan), line:109:24, endln:109:31
+            \_bit_select: (scan), line:109:24, endln:109:31, parent:scan
               |vpiName:scan
               |vpiIndex:
               \_constant: , line:109:29, endln:109:30, parent:scan
@@ -2905,7 +2905,7 @@ design: (work@dff_async_reset)
                 |vpiSize:64
                 |UINT:2
           |vpiOperand:
-          \_bit_select: (scan), line:109:35, endln:109:42
+          \_bit_select: (scan), line:109:35, endln:109:42, parent:scan
             |vpiName:scan
             |vpiIndex:
             \_constant: , line:109:40, endln:109:41, parent:scan
@@ -2914,7 +2914,7 @@ design: (work@dff_async_reset)
               |vpiSize:64
               |UINT:1
         |vpiOperand:
-        \_bit_select: (scan), line:109:46, endln:109:53
+        \_bit_select: (scan), line:109:46, endln:109:53, parent:scan
           |vpiName:scan
           |vpiIndex:
           \_constant: , line:109:51, endln:109:52, parent:scan
@@ -2930,29 +2930,29 @@ design: (work@dff_async_reset)
           |vpiOpType:82
           |vpiBlocking:1
           |vpiLhs:
-          \_bit_select: (work@arbiter.grantD), line:111:2, endln:111:8
+          \_bit_select: (work@arbiter.grantD), line:111:2, endln:111:8, parent:work@arbiter.grantD
             |vpiName:grantD
             |vpiFullName:work@arbiter.grantD
             |vpiIndex:
-            \_bit_select: (work@arbiter.grantD.scan), line:111:9, endln:111:16, parent:work@arbiter.grantD
+            \_bit_select: (work@arbiter.scan), line:111:9, endln:111:16, parent:work@arbiter.scan
               |vpiName:scan
-              |vpiFullName:work@arbiter.grantD.scan
+              |vpiFullName:work@arbiter.scan
               |vpiIndex:
-              \_constant: , line:111:14, endln:111:15, parent:work@arbiter.grantD.scan
+              \_constant: , line:111:14, endln:111:15, parent:work@arbiter.scan
                 |vpiConstType:9
                 |vpiDecompile:0
                 |vpiSize:64
                 |UINT:0
           |vpiRhs:
-          \_bit_select: (work@arbiter.finalRequest), line:111:20, endln:111:41
+          \_bit_select: (work@arbiter.finalRequest), line:111:20, endln:111:41, parent:work@arbiter.finalRequest
             |vpiName:finalRequest
             |vpiFullName:work@arbiter.finalRequest
             |vpiIndex:
-            \_bit_select: (work@arbiter.finalRequest.scan), line:111:33, endln:111:40, parent:work@arbiter.finalRequest
+            \_bit_select: (work@arbiter.scan), line:111:33, endln:111:40, parent:work@arbiter.scan
               |vpiName:scan
-              |vpiFullName:work@arbiter.finalRequest.scan
+              |vpiFullName:work@arbiter.scan
               |vpiIndex:
-              \_constant: , line:111:38, endln:111:39, parent:work@arbiter.finalRequest.scan
+              \_constant: , line:111:38, endln:111:39, parent:work@arbiter.scan
                 |vpiConstType:9
                 |vpiDecompile:0
                 |vpiSize:64
@@ -3019,13 +3019,13 @@ design: (work@dff_async_reset)
             |vpiOpType:82
             |vpiBlocking:1
             |vpiLhs:
-            \_bit_select: (work@arbiter.grantD), line:113:2, endln:113:8
+            \_bit_select: (work@arbiter.grantD), line:113:2, endln:113:8, parent:work@arbiter.grantD
               |vpiName:grantD
               |vpiFullName:work@arbiter.grantD
               |vpiIndex:
-              \_bit_select: (work@arbiter.grantD.scan), line:113:9, endln:113:16, parent:work@arbiter.grantD
+              \_bit_select: (work@arbiter.scan), line:113:9, endln:113:16, parent:work@arbiter.scan
                 |vpiName:scan
-                |vpiFullName:work@arbiter.grantD.scan
+                |vpiFullName:work@arbiter.scan
                 |vpiIndex:
                 \_ref_obj: (work@arbiter.u), line:113:14, endln:113:15, parent:work@arbiter
                   |vpiName:u
@@ -3036,13 +3036,13 @@ design: (work@dff_async_reset)
             \_operation: , line:113:20, endln:113:41, parent:work@arbiter
               |vpiOpType:26
               |vpiOperand:
-              \_bit_select: (work@arbiter.finalRequest), line:113:20, endln:113:41
+              \_bit_select: (work@arbiter.finalRequest), line:113:20, endln:113:41, parent:work@arbiter.finalRequest
                 |vpiName:finalRequest
                 |vpiFullName:work@arbiter.finalRequest
                 |vpiIndex:
-                \_bit_select: (work@arbiter.finalRequest.scan), line:113:33, endln:113:40, parent:work@arbiter.finalRequest
+                \_bit_select: (work@arbiter.scan), line:113:33, endln:113:40, parent:work@arbiter.scan
                   |vpiName:scan
-                  |vpiFullName:work@arbiter.finalRequest.scan
+                  |vpiFullName:work@arbiter.scan
                   |vpiIndex:
                   \_ref_obj: (work@arbiter.u), line:113:38, endln:113:39, parent:work@arbiter
                     |vpiName:u
@@ -3053,8 +3053,9 @@ design: (work@dff_async_reset)
               \_operation: , line:113:45, endln:113:46
                 |vpiOpType:4
                 |vpiOperand:
-                \_bit_select: (found), line:113:46, endln:113:56
+                \_bit_select: (work@arbiter.found), line:113:46, endln:113:56, parent:work@arbiter.found
                   |vpiName:found
+                  |vpiFullName:work@arbiter.found
                   |vpiIndex:
                   \_operation: , line:113:52, endln:113:53
                     |vpiOpType:11
@@ -3503,7 +3504,7 @@ design: (work@dff_async_reset)
                 |vpiName:out2
                 |vpiFullName:work@case1.out2
             |vpiRhs:
-            \_bit_select: (work@case1.in1), line:8:18, endln:8:24
+            \_bit_select: (work@case1.in1), line:8:18, endln:8:24, parent:work@case1.in1
               |vpiName:in1
               |vpiFullName:work@case1.in1
               |vpiIndex:
@@ -3531,7 +3532,7 @@ design: (work@dff_async_reset)
               |vpiActual:
               \_logic_net: (work@case1.out2), line:2:25, endln:2:29, parent:work@case1
             |vpiRhs:
-            \_bit_select: (work@case1.in1), line:9:18, endln:9:24
+            \_bit_select: (work@case1.in1), line:9:18, endln:9:24, parent:work@case1.in1
               |vpiName:in1
               |vpiFullName:work@case1.in1
               |vpiIndex:
@@ -3559,7 +3560,7 @@ design: (work@dff_async_reset)
               |vpiActual:
               \_logic_net: (work@case1.out2), line:2:25, endln:2:29, parent:work@case1
             |vpiRhs:
-            \_bit_select: (work@case1.in1), line:10:18, endln:10:24
+            \_bit_select: (work@case1.in1), line:10:18, endln:10:24, parent:work@case1.in1
               |vpiName:in1
               |vpiFullName:work@case1.in1
               |vpiIndex:
@@ -3587,7 +3588,7 @@ design: (work@dff_async_reset)
               |vpiActual:
               \_logic_net: (work@case1.out2), line:2:25, endln:2:29, parent:work@case1
             |vpiRhs:
-            \_bit_select: (work@case1.in1), line:11:18, endln:11:24
+            \_bit_select: (work@case1.in1), line:11:18, endln:11:24, parent:work@case1.in1
               |vpiName:in1
               |vpiFullName:work@case1.in1
               |vpiIndex:
@@ -3615,7 +3616,7 @@ design: (work@dff_async_reset)
               |vpiActual:
               \_logic_net: (work@case1.out2), line:2:25, endln:2:29, parent:work@case1
             |vpiRhs:
-            \_bit_select: (work@case1.in1), line:12:18, endln:12:24
+            \_bit_select: (work@case1.in1), line:12:18, endln:12:24, parent:work@case1.in1
               |vpiName:in1
               |vpiFullName:work@case1.in1
               |vpiIndex:
@@ -3643,7 +3644,7 @@ design: (work@dff_async_reset)
               |vpiActual:
               \_logic_net: (work@case1.out2), line:2:25, endln:2:29, parent:work@case1
             |vpiRhs:
-            \_bit_select: (work@case1.in1), line:13:18, endln:13:24
+            \_bit_select: (work@case1.in1), line:13:18, endln:13:24, parent:work@case1.in1
               |vpiName:in1
               |vpiFullName:work@case1.in1
               |vpiIndex:
@@ -3671,7 +3672,7 @@ design: (work@dff_async_reset)
               |vpiActual:
               \_logic_net: (work@case1.out2), line:2:25, endln:2:29, parent:work@case1
             |vpiRhs:
-            \_bit_select: (work@case1.in1), line:14:18, endln:14:24
+            \_bit_select: (work@case1.in1), line:14:18, endln:14:24, parent:work@case1.in1
               |vpiName:in1
               |vpiFullName:work@case1.in1
               |vpiIndex:
@@ -3699,7 +3700,7 @@ design: (work@dff_async_reset)
               |vpiActual:
               \_logic_net: (work@case1.out2), line:2:25, endln:2:29, parent:work@case1
             |vpiRhs:
-            \_bit_select: (work@case1.in1), line:15:18, endln:15:24
+            \_bit_select: (work@case1.in1), line:15:18, endln:15:24, parent:work@case1.in1
               |vpiName:in1
               |vpiFullName:work@case1.in1
               |vpiIndex:
@@ -4031,7 +4032,7 @@ design: (work@dff_async_reset)
         |vpiName:in1
         |vpiFullName:work@case2.in1
       |vpiOperand:
-      \_bit_select: (work@case2.select), line:38:27, endln:38:36
+      \_bit_select: (work@case2.select), line:38:27, endln:38:36, parent:work@case2.select
         |vpiName:select
         |vpiFullName:work@case2.select
         |vpiIndex:
@@ -4067,7 +4068,7 @@ design: (work@dff_async_reset)
         |vpiName:in1
         |vpiFullName:work@case2.in1
       |vpiOperand:
-      \_bit_select: (work@case2.select), line:39:27, endln:39:36
+      \_bit_select: (work@case2.select), line:39:27, endln:39:36, parent:work@case2.select
         |vpiName:select
         |vpiFullName:work@case2.select
         |vpiIndex:
@@ -4103,7 +4104,7 @@ design: (work@dff_async_reset)
         |vpiName:in1
         |vpiFullName:work@case2.in1
       |vpiOperand:
-      \_bit_select: (work@case2.select), line:40:27, endln:40:36
+      \_bit_select: (work@case2.select), line:40:27, endln:40:36, parent:work@case2.select
         |vpiName:select
         |vpiFullName:work@case2.select
         |vpiIndex:
@@ -4139,7 +4140,7 @@ design: (work@dff_async_reset)
         |vpiName:in1
         |vpiFullName:work@case2.in1
       |vpiOperand:
-      \_bit_select: (work@case2.select), line:41:27, endln:41:36
+      \_bit_select: (work@case2.select), line:41:27, endln:41:36, parent:work@case2.select
         |vpiName:select
         |vpiFullName:work@case2.select
         |vpiIndex:
@@ -4175,7 +4176,7 @@ design: (work@dff_async_reset)
         |vpiName:in1
         |vpiFullName:work@case2.in1
       |vpiOperand:
-      \_bit_select: (work@case2.select), line:42:27, endln:42:36
+      \_bit_select: (work@case2.select), line:42:27, endln:42:36, parent:work@case2.select
         |vpiName:select
         |vpiFullName:work@case2.select
         |vpiIndex:
@@ -4211,7 +4212,7 @@ design: (work@dff_async_reset)
         |vpiName:in1
         |vpiFullName:work@case2.in1
       |vpiOperand:
-      \_bit_select: (work@case2.select), line:43:29, endln:43:38
+      \_bit_select: (work@case2.select), line:43:29, endln:43:38, parent:work@case2.select
         |vpiName:select
         |vpiFullName:work@case2.select
         |vpiIndex:
@@ -4247,7 +4248,7 @@ design: (work@dff_async_reset)
         |vpiName:in1
         |vpiFullName:work@case2.in1
       |vpiOperand:
-      \_bit_select: (work@case2.select), line:44:29, endln:44:38
+      \_bit_select: (work@case2.select), line:44:29, endln:44:38, parent:work@case2.select
         |vpiName:select
         |vpiFullName:work@case2.select
         |vpiIndex:
@@ -4283,7 +4284,7 @@ design: (work@dff_async_reset)
         |vpiName:in1
         |vpiFullName:work@case2.in1
       |vpiOperand:
-      \_bit_select: (work@case2.select), line:45:29, endln:45:38
+      \_bit_select: (work@case2.select), line:45:29, endln:45:38, parent:work@case2.select
         |vpiName:select
         |vpiFullName:work@case2.select
         |vpiIndex:
@@ -7426,7 +7427,7 @@ design: (work@dff_async_reset)
                               \_assignment: , line:96:15, endln:96:42, parent:work@uart
                                 |vpiOpType:82
                                 |vpiLhs:
-                                \_bit_select: (work@uart.rx_reg), line:96:15, endln:96:21
+                                \_bit_select: (work@uart.rx_reg), line:96:15, endln:96:21, parent:work@uart.rx_reg
                                   |vpiName:rx_reg
                                   |vpiFullName:work@uart.rx_reg
                                   |vpiIndex:
@@ -7993,7 +7994,7 @@ design: (work@dff_async_reset)
                       |vpiActual:
                       \_logic_net: (work@uart.tx_out), line:43:14, endln:43:20, parent:work@uart
                     |vpiRhs:
-                    \_bit_select: (work@uart.tx_reg), line:142:19, endln:142:36
+                    \_bit_select: (work@uart.tx_reg), line:142:19, endln:142:36, parent:work@uart.tx_reg
                       |vpiName:tx_reg
                       |vpiFullName:work@uart.tx_reg
                       |vpiIndex:


### PR DESCRIPTION
The UHDM Elaborator is also modified to bind the vpiActual property of ref_obj used as parents of bit_select and range_select
This new scheme allows to have a parent for bit_select and bind to the proper nodes. 