### PR TITLE
Add TODO for object leackage in preprocess harness.

### DIFF
--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -230,7 +230,7 @@ PreprocessFile::PreprocessFile(SymbolId fileId, PreprocessFile* includedIn,
                                CompileSourceFile* csf,
                                SpecialInstructions& instructions,
                                CompilationUnit* comp_unit, Library* library,
-                               std::string macroBody, MacroInfo* macroInfo,
+                               std::string_view macroBody, MacroInfo* macroInfo,
                                unsigned int embeddedMacroCallLine,
                                SymbolId embeddedMacroCallFile)
     : m_fileId(fileId),

--- a/src/SourceCompile/PreprocessFile.h
+++ b/src/SourceCompile/PreprocessFile.h
@@ -69,7 +69,7 @@ class PreprocessFile {
                  unsigned int includerLine, CompileSourceFile* csf,
                  SpecialInstructions& instructions,
                  CompilationUnit* compilationUnit, Library* library,
-                 std::string macroBody = "", MacroInfo* = NULL,
+                 std::string_view macroBody = "", MacroInfo* = NULL,
                  unsigned int embeddedMacroCallLine = 0,
                  SymbolId embeddedMacroCallFile = 0);
   PreprocessFile(const PreprocessFile& orig);

--- a/src/SourceCompile/PreprocessHarness.cpp
+++ b/src/SourceCompile/PreprocessHarness.cpp
@@ -65,7 +65,7 @@
 
 namespace SURELOG {
 
-std::string PreprocessHarness::preprocess(const std::string& content) {
+std::string PreprocessHarness::preprocess(std::string_view content) {
   std::string result;
   PreprocessFile::SpecialInstructions instructions(
       PreprocessFile::SpecialInstructions::DontMute,
@@ -73,6 +73,7 @@ std::string PreprocessHarness::preprocess(const std::string& content) {
       PreprocessFile::SpecialInstructions::DontFilter,
       PreprocessFile::SpecialInstructions::CheckLoop,
       PreprocessFile::SpecialInstructions::ComplainUndefinedMacro);
+  // TODO: all these objects leak.
   CompilationUnit* unit = new CompilationUnit(false);
   SymbolTable* symbols = new SymbolTable();
   ErrorContainer* errors = new ErrorContainer(symbols);

--- a/src/SourceCompile/PreprocessHarness.h
+++ b/src/SourceCompile/PreprocessHarness.h
@@ -27,6 +27,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <string_view>
 #include <thread>
 
 #include "Config/ConfigSet.h"
@@ -42,10 +43,7 @@ namespace SURELOG {
 
 class PreprocessHarness {
  public:
-  std::string preprocess(const std::string& content);
-
- public:
- private:
+  static std::string preprocess(std::string_view content);
 };
 
 };  // namespace SURELOG


### PR DESCRIPTION
While at it, have preprocess file take a string_view

Signed-off-by: Henner Zeller <h.zeller@acm.org>