### PR TITLE
Reduce leaks in various unit tests.

### DIFF
--- a/src/DesignCompile/CompileExpression_test.cpp
+++ b/src/DesignCompile/CompileExpression_test.cpp
@@ -36,7 +36,7 @@ TEST(CompileExpression, ExprFromParseTree1) {
   std::unique_ptr<CompileDesign> compileDesign = charness.createCompileDesign();
   // Cannot use parameters assignments in next expression, there is no
   // elaboration performed here!
-  FileContent* fC = pharness.parse(
+  auto fC = pharness.parse(
       "module top();"
       "parameter p1 = 1 << 4;"
       "parameter p2 = (1 << 8) >> 4;"
@@ -53,7 +53,8 @@ TEST(CompileExpression, ExprFromParseTree1) {
     NodeId param = fC->Child(param_assign);
     NodeId rhs = fC->Sibling(param);
     UHDM::expr* exp = (UHDM::expr*)helper.compileExpression(
-        nullptr, fC, rhs, compileDesign.get(), nullptr, nullptr, true, true);
+        nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, true,
+        true);
     EXPECT_EQ(exp->UhdmType(), UHDM::uhdmconstant);
     bool invalidValue = false;
     EXPECT_EQ(helper.get_value(invalidValue, exp), 16);
@@ -66,7 +67,7 @@ TEST(CompileExpression, ExprFromParseTree2) {
   std::unique_ptr<CompileDesign> compileDesign = charness.createCompileDesign();
   // Cannot use parameters assignments in next expression, there is no
   // elaboration performed here!
-  FileContent* fC = pharness.parse(
+  auto fC = pharness.parse(
       "module top();"
       "parameter p1 = 1'b1 | 1'b0;"
       "parameter p2 = 1'b1 & 1'b1;"
@@ -80,7 +81,8 @@ TEST(CompileExpression, ExprFromParseTree2) {
     NodeId param = fC->Child(param_assign);
     NodeId rhs = fC->Sibling(param);
     UHDM::expr* exp = (UHDM::expr*)helper.compileExpression(
-        nullptr, fC, rhs, compileDesign.get(), nullptr, nullptr, true, true);
+        nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, true,
+        true);
     EXPECT_EQ(exp->UhdmType(), UHDM::uhdmconstant);
     bool invalidValue = false;
     EXPECT_EQ(helper.get_value(invalidValue, exp), 1);
@@ -93,7 +95,7 @@ TEST(CompileExpression, ExprFromParseTree3) {
   std::unique_ptr<CompileDesign> compileDesign = charness.createCompileDesign();
   // Cannot use parameters assignments in next expression, there is no
   // elaboration performed here!
-  FileContent* fC = pharness.parse(
+  auto fC = pharness.parse(
       "module top();"
       "parameter p1 = {1'b1, 2'b10}"
       "parameter p2 = '{1'b1, 2'b10}"
@@ -106,10 +108,12 @@ TEST(CompileExpression, ExprFromParseTree3) {
     const std::string& name = fC->SymName(param);
     NodeId rhs = fC->Sibling(param);
     UHDM::expr* exp1 = (UHDM::expr*)helper.compileExpression(
-        nullptr, fC, rhs, compileDesign.get(), nullptr, nullptr, false, true);
+        nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, false,
+        true);
     EXPECT_EQ(exp1->UhdmType(), UHDM::uhdmoperation);
     UHDM::expr* exp2 = (UHDM::expr*)helper.compileExpression(
-        nullptr, fC, rhs, compileDesign.get(), nullptr, nullptr, true, true);
+        nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, true,
+        true);
     if (name == "p1") {
       EXPECT_EQ(exp2->UhdmType(), UHDM::uhdmconstant);
       bool invalidValue = false;
@@ -134,7 +138,7 @@ TEST(CompileExpression, ExprFromPpTree) {
       "endmodule\n");
   // Cannot use parameters assignments in next expression, there is no
   // elaboration performed here!
-  FileContent* fC = pharness.parse(text);
+  auto fC = pharness.parse(text);
   NodeId root = fC->getRootNode();
   std::vector<NodeId> assigns = fC->sl_collect_all(root, slParam_assignment);
   EXPECT_EQ(assigns.size(), 2);
@@ -143,10 +147,12 @@ TEST(CompileExpression, ExprFromPpTree) {
     const std::string& name = fC->SymName(param);
     NodeId rhs = fC->Sibling(param);
     UHDM::expr* exp1 = (UHDM::expr*)helper.compileExpression(
-        nullptr, fC, rhs, compileDesign.get(), nullptr, nullptr, false, true);
+        nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, false,
+        true);
     EXPECT_EQ(exp1->UhdmType(), UHDM::uhdmoperation);
     UHDM::expr* exp2 = (UHDM::expr*)helper.compileExpression(
-        nullptr, fC, rhs, compileDesign.get(), nullptr, nullptr, true, true);
+        nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, true,
+        true);
     if (name == "p1") {
       EXPECT_EQ(exp2->UhdmType(), UHDM::uhdmconstant);
       bool invalidValue = false;

--- a/src/SourceCompile/AntlrParserHandler.cpp
+++ b/src/SourceCompile/AntlrParserHandler.cpp
@@ -22,12 +22,15 @@
  */
 #include "SourceCompile/AntlrParserHandler.h"
 
+#include "SourceCompile/AntlrParserErrorListener.h"
 #include "antlr4-runtime.h"
 #include "parser/SV3_1aLexer.h"
 #include "parser/SV3_1aParser.h"
 
 namespace SURELOG {
 AntlrParserHandler::~AntlrParserHandler() {
+  delete m_errorListener;
+  // ParseTree is deleted in antlr4::ParseTreeTracker
   // delete m_tree; // INVALID MEMORY READ can be seen in AdvancedDebug
   delete m_parser;
   delete m_tokens;

--- a/src/SourceCompile/AntlrParserHandler.h
+++ b/src/SourceCompile/AntlrParserHandler.h
@@ -34,20 +34,15 @@ class AntlrParserErrorListener;
 
 class AntlrParserHandler {
  public:
-  AntlrParserHandler()
-      : m_inputStream(NULL),
-        m_lexer(NULL),
-        m_tokens(NULL),
-        m_parser(NULL),
-        m_tree(NULL),
-        m_errorListener(NULL) {}
+  AntlrParserHandler() {}
   ~AntlrParserHandler();
-  antlr4::ANTLRInputStream* m_inputStream;
-  SV3_1aLexer* m_lexer;
-  antlr4::CommonTokenStream* m_tokens;
-  SV3_1aParser* m_parser;
-  antlr4::tree::ParseTree* m_tree;
-  AntlrParserErrorListener* m_errorListener;
+
+  antlr4::ANTLRInputStream* m_inputStream = nullptr;
+  SV3_1aLexer* m_lexer = nullptr;
+  antlr4::CommonTokenStream* m_tokens = nullptr;
+  SV3_1aParser* m_parser = nullptr;
+  antlr4::tree::ParseTree* m_tree = nullptr;
+  AntlrParserErrorListener* m_errorListener = nullptr;
 };
 
 };  // namespace SURELOG

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -69,11 +69,11 @@ Compiler::Compiler(CommandLineParser* commandLineParser, ErrorContainer* errors,
     : m_commandLineParser(commandLineParser),
       m_errors(errors),
       m_symbolTable(symbolTable),
-      m_commonCompilationUnit(NULL) {
-  m_uhdmDesign = 0;
-  m_librarySet = new LibrarySet();
-  m_configSet = new ConfigSet();
-  m_design = new Design(getErrorContainer(), m_librarySet, m_configSet);
+      m_commonCompilationUnit(nullptr),
+      m_librarySet(new LibrarySet()),
+      m_configSet(new ConfigSet()),
+      m_design(new Design(getErrorContainer(), m_librarySet, m_configSet)),
+      m_uhdmDesign(0) {
 #ifdef USETBB
   if (getCommandLineParser()->useTbb() &&
       (getCommandLineParser()->getNbMaxTreads() > 0))
@@ -86,19 +86,23 @@ Compiler::Compiler(CommandLineParser* commandLineParser, ErrorContainer* errors,
     : m_commandLineParser(commandLineParser),
       m_errors(errors),
       m_symbolTable(symbolTable),
-      m_commonCompilationUnit(NULL),
-      m_text(text) {
-  m_uhdmDesign = 0;
-  m_librarySet = new LibrarySet();
-  m_configSet = new ConfigSet();
-  m_design = new Design(getErrorContainer(), m_librarySet, m_configSet);
-}
+      m_commonCompilationUnit(nullptr),
+      m_librarySet(new LibrarySet()),
+      m_configSet(new ConfigSet()),
+      m_design(new Design(getErrorContainer(), m_librarySet, m_configSet)),
+      m_uhdmDesign(0),
+      m_text(text) {}
 
 Compiler::~Compiler() {
   std::map<SymbolId, PreprocessFile::AntlrParserHandler*>::iterator itr;
   for (itr = m_antlrPpMap.begin(); itr != m_antlrPpMap.end(); itr++) {
     delete (*itr).second;
   }
+  // TODO: the following would need to be deleted but it creates issues
+  // when precompilng ovm. Needs further investigation.
+  // delete m_design;
+  // delete m_configSet;
+  // delete m_librarySet;
   delete m_commonCompilationUnit;
   cleanup_();
 }

--- a/src/SourceCompile/Compiler.h
+++ b/src/SourceCompile/Compiler.h
@@ -100,9 +100,9 @@ class Compiler {
                        CompileSourceFile::Action action);
   bool cleanup_();
 
-  CommandLineParser* m_commandLineParser;
-  ErrorContainer* m_errors;
-  SymbolTable* m_symbolTable;
+  CommandLineParser* const m_commandLineParser;
+  ErrorContainer* const m_errors;
+  SymbolTable* const m_symbolTable;
   CompilationUnit* m_commonCompilationUnit;
   std::map<SymbolId, PreprocessFile::AntlrParserHandler*> m_antlrPpMap;
   std::vector<CompileSourceFile*> m_compilers;
@@ -111,9 +111,9 @@ class Compiler {
   std::vector<CompilationUnit*> m_compilationUnits;
   std::vector<SymbolTable*> m_symbolTables;
   std::vector<ErrorContainer*> m_errorContainers;
-  LibrarySet* m_librarySet;
-  ConfigSet* m_configSet;
-  Design* m_design;
+  LibrarySet* const m_librarySet;
+  ConfigSet* const m_configSet;
+  Design* const m_design;
   vpiHandle m_uhdmDesign;
   std::set<SymbolId> m_libraryFiles;  // -v <file>
   std::string m_text;                 // unit tests

--- a/src/SourceCompile/ParseFile.cpp
+++ b/src/SourceCompile/ParseFile.cpp
@@ -135,6 +135,7 @@ ParseFile::ParseFile(const std::string& text, CompileSourceFile* csf,
 
 ParseFile::~ParseFile() {
   if (!m_keepParserHandler) delete m_antlrParserHandler;
+  delete m_listener;
 }
 
 SymbolTable* ParseFile::getSymbolTable() {

--- a/src/SourceCompile/ParseFile.h
+++ b/src/SourceCompile/ParseFile.h
@@ -107,25 +107,25 @@ class ParseFile {
  private:
   SymbolId m_fileId;
   SymbolId m_ppFileId;
-  CompileSourceFile* m_compileSourceFile;
-  CompilationUnit* m_compilationUnit;
-  Library* m_library;
-  AntlrParserHandler* m_antlrParserHandler;
-  SV3_1aTreeShapeListener* m_listener;
+  CompileSourceFile* const m_compileSourceFile;
+  CompilationUnit* const m_compilationUnit;
+  Library* m_library = nullptr;
+  AntlrParserHandler* m_antlrParserHandler = nullptr;
+  SV3_1aTreeShapeListener* m_listener = nullptr;
   std::vector<LineTranslationInfo> m_lineTranslationVec;
   bool m_usingCachedVersion;
   bool m_keepParserHandler;
-  FileContent* m_fileContent;
+  FileContent* m_fileContent = nullptr;
   bool debug_AstModel;
 
   bool parseOneFile_(std::string fileName, unsigned int lineOffset);
 
   // For file chunk:
   std::vector<ParseFile*> m_children;
-  ParseFile* m_parent;
+  ParseFile* const m_parent;
   unsigned int m_offsetLine;
-  SymbolTable* m_symbolTable;
-  ErrorContainer* m_errors;
+  SymbolTable* const m_symbolTable;
+  ErrorContainer* const m_errors;
   std::string m_profileInfo;
   std::string m_sourceText;  // For Unit tests
 };

--- a/src/SourceCompile/ParseFile_test.cpp
+++ b/src/SourceCompile/ParseFile_test.cpp
@@ -29,13 +29,13 @@ namespace {
 TEST(ParserTest, BasicParse) {
   ParserHarness harness;
   {
-    FileContent* fC = harness.parse("module top(); assign a = b; endmodule");
+    auto fC = harness.parse("module top(); assign a = b; endmodule");
     NodeId root = fC->getRootNode();
     NodeId assign = fC->sl_collect(root, slContinuous_assign);
     EXPECT_NE(assign, InvalidNodeId);
   }
   {
-    FileContent* fC = harness.parse("module top(); assign a = !b; endmodule");
+    auto fC = harness.parse("module top(); assign a = !b; endmodule");
     NodeId root = fC->getRootNode();
     NodeId assign = fC->sl_collect(root, slContinuous_assign);
     /*

--- a/src/SourceCompile/ParserHarness.h
+++ b/src/SourceCompile/ParserHarness.h
@@ -24,28 +24,24 @@
 #ifndef PARSERHARNESS_H
 #define PARSERHARNESS_H
 
+#include <memory>
 #include <string>
 
 #include "Design/FileContent.h"
-#include "ErrorReporting/Error.h"
-#include "SourceCompile/AntlrParserHandler.h"
-#include "SourceCompile/CompilationUnit.h"
-#include "parser/SV3_1aLexer.h"
-#include "parser/SV3_1aParser.h"
 
 namespace SURELOG {
 
-class SV3_1aTreeShapeListener;
-class SV3_1aPythonListener;
-class AntlrParserErrorListener;
-class CompileSourceFile;
-
 class ParserHarness {
  public:
-  FileContent* parse(const std::string& content);
+  // Parse content and return FileContent or nullptr if it couldn't
+  // be parsed.
+  std::unique_ptr<FileContent> parse(const std::string& content);
 
- public:
+  ~ParserHarness();
+
  private:
+  struct Holder;
+  Holder* m_h = nullptr;
 };
 
 };  // namespace SURELOG


### PR DESCRIPTION
 * Make ParserHarness own and destroy all the objects
   needed for processing. Hand out a unique_ptr<> so that
   ownership is managed properly at call-site.
 * Make reasoning about classes easier by making
   instance variables that are only set at construction
   to const.
 * Initialize values as much as possible RAII-style
 * Add delete where needed.
 * Document delete calls that would be needed (~Compiler)
   but are currently not working in ovm pre-compile
   (due to leaky abstractions where pointers end up in
   places not the original owner. Needs to be investigated
   separately).
 * Once the deletes in ~Compile can be activated, this will
   make two unit-tests leak-free (ExprBuilder_test and
   ParseFile_test).

Signed-off-by: Henner Zeller <h.zeller@acm.org>