### PR TITLE
Address CompilerHarness memory leaks: own and delete all objects.

### DIFF
--- a/src/DesignCompile/CompilerHarness.h
+++ b/src/DesignCompile/CompilerHarness.h
@@ -32,7 +32,13 @@ namespace SURELOG {
 
 class CompilerHarness {
  public:
-  static std::unique_ptr<CompileDesign> createCompileDesign();
+  std::unique_ptr<CompileDesign> createCompileDesign();
+
+  ~CompilerHarness();
+
+ private:
+  struct Holder;
+  Holder *m_h = nullptr;
 };
 
 };  // namespace SURELOG


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>