### PR TITLE
Fix delete of design by non-owner.

### DIFF
--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -98,12 +98,12 @@ Compiler::~Compiler() {
   for (itr = m_antlrPpMap.begin(); itr != m_antlrPpMap.end(); itr++) {
     delete (*itr).second;
   }
-  // TODO: the following would need to be deleted but it creates issues
-  // when precompilng ovm. Needs further investigation.
-  // delete m_design;
-  // delete m_configSet;
-  // delete m_librarySet;
+
+  delete m_design;
+  delete m_configSet;
+  delete m_librarySet;
   delete m_commonCompilationUnit;
+
   cleanup_();
 }
 

--- a/src/SourceCompile/Compiler.h
+++ b/src/SourceCompile/Compiler.h
@@ -73,9 +73,15 @@ class Compiler {
                                    PreprocessFile::AntlrParserHandler* pp);
   PreprocessFile::AntlrParserHandler* getAntlrPpHandlerForId(SymbolId);
 
-  LibrarySet* getLibrarySet() { return m_librarySet; }
+  // TODO: this should return a const Design, but can't be because
+  // of Design having a bunch of non-const accessors. Address
+  // these first.
+  // All _modifying_ operations should be calls on the Compiler,
+  // not on the handed out Design object, as the Compiler is owner
+  // of the design.
   Design* getDesign() { return m_design; }
-  vpiHandle getUhdmDesign() { return m_uhdmDesign; }
+
+  const vpiHandle getUhdmDesign() const { return m_uhdmDesign; }
 
   ErrorContainer::Stats getErrorStats() const;
   bool isLibraryFile(SymbolId id) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,8 +71,6 @@ unsigned int executeCompilation(
 
     SURELOG::scompiler* compiler = SURELOG::start_compiler(clp);
     if (!compiler) codedReturn |= 1;
-    SURELOG::Design* design = SURELOG::get_design(compiler);
-    delete design;
     SURELOG::shutdown_compiler(compiler);
   }
   SURELOG::ErrorContainer::Stats stats;


### PR DESCRIPTION
The Design* owned by the Compiler was deleted in main while it
needs to be deleted by Compiler.
Removed the delete there and enable the deletes in the Compiler
destructor.

While at it, add a todo to not hand out writable Design*, but
that will be a larger, long-term effort.

With this change, two more of the unit tests pass without leaks.

Signed-off-by: Henner Zeller <h.zeller@acm.org>