### PR TITLE
Document leak of MacroInfo

### DIFF
--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -508,6 +508,8 @@ void PreprocessFile::recordMacro(const std::string name, unsigned int line,
   // std::cout << "PP RECORDING MACRO: " << name  << ", FILE: " <<
   // getSymbol(getFileId(line)) << "" << std::endl;
 
+  // TODO: this macro info is leaking. Ownership unclear: is
+  // this to be deleted from m_macros or from m_compilationUnit ?
   MacroInfo* macroInfo = new MacroInfo(
       name, arguments.size() ? MacroInfo::WITH_ARGS : MacroInfo::NO_ARGS,
       getFileId(line), line, column, args, tokens);


### PR DESCRIPTION
Ownership is a bit fuzzy, so for now just document to address
later.

Signed-off-by: Henner Zeller <h.zeller@acm.org>