### PR TITLE
Add test for StringUtils::removeComments()

### DIFF
--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -100,6 +100,7 @@ class StringUtils {
   // Convert double number with given amount of precision.
   static std::string to_string(double a_value, const int n = 3);
 
+  // Remove '//' and '#'-style end-of-line comments
   static std::string removeComments(std::string_view text);
 
   static std::string evaluateEnvVars(std::string_view text);

--- a/src/Utils/StringUtils_test.cpp
+++ b/src/Utils/StringUtils_test.cpp
@@ -142,6 +142,21 @@ TEST(StringUtilsTest, GetLineInString) {
   EXPECT_EQ("", StringUtils::getLineInString(input_text, 5));
 }
 
+TEST(StringUtilsTest, RemoveComments) {
+  EXPECT_EQ("hello ", StringUtils::removeComments("hello // world"));
+  EXPECT_EQ("hello ", StringUtils::removeComments("hello # world"));
+  EXPECT_EQ("hello \nworld",
+            StringUtils::removeComments("hello # world\nworld"));
+
+#if 0
+  // TODO: does not ignore comment-like characters in strings
+  EXPECT_EQ("hello \"#\" world",
+            StringUtils::removeComments("hello \"#\" world # comment"));
+  EXPECT_EQ("hello \"//\" world",
+            StringUtils::removeComments("hello \"//\" world // comment"));
+#endif
+}
+
 TEST(StringUtilsTest, DoubleStringConversion) {
   EXPECT_EQ("3", StringUtils::to_string(3.1415926, 0));
   EXPECT_EQ("3.1", StringUtils::to_string(3.1415926, 1));


### PR DESCRIPTION
It was not tested in the unit-test.
Also, add comment in the StringUtils.h what this function
is doing (as its naming implies removing all comments, but
in actuality it removes certain kind of end-of-line comments).

Document in test the things it does not do yet: ignore comment
characters in string constants.

Signed-off-by: Henner Zeller <h.zeller@acm.org>