### PR TITLE
Document and test environment variable expansion function.

### DIFF
--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -313,10 +313,10 @@ std::string StringUtils::removeComments(std::string_view text) {
 
 // Update the input string.
 
-void StringUtils::autoExpandEnvironmentVariables(std::string& text) {
+void StringUtils::autoExpandEnvironmentVariables(std::string* text) {
   static std::regex env("\\$\\{([^}]+)\\}");
   std::smatch match;
-  while (std::regex_search(text, match, env)) {
+  while (std::regex_search(*text, match, env)) {
     std::string var;
     const char* s = getenv(match[1].str().c_str());
     if (s == NULL) {
@@ -324,10 +324,10 @@ void StringUtils::autoExpandEnvironmentVariables(std::string& text) {
       if (itr != envVars.end()) var = (*itr).second;
     }
     if (var.empty() && s) var = s;
-    text.replace(match.position(0), match.length(0), var);
+    text->replace(match.position(0), match.length(0), var);
   }
   static std::regex env2("\\$([a-zA-Z0-9_]+)/");
-  while (std::regex_search(text, match, env2)) {
+  while (std::regex_search(*text, match, env2)) {
     std::string var;
     const char* s = getenv(match[1].str().c_str());
     if (s == NULL) {
@@ -340,13 +340,13 @@ void StringUtils::autoExpandEnvironmentVariables(std::string& text) {
 #else
     if (var.size() && (var[var.size() - 1] != '/')) var += "/";
 #endif
-    text.replace(match.position(0), match.length(0), var);
+    text->replace(match.position(0), match.length(0), var);
   }
 }
 
 // Leave input alone and return new string.
 std::string StringUtils::evaluateEnvVars(std::string_view text) {
   std::string input(text.begin(), text.end());
-  autoExpandEnvironmentVariables(input);
+  autoExpandEnvironmentVariables(&input);
   return input;
 }

--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -102,8 +102,13 @@ class StringUtils {
 
   static std::string removeComments(std::string_view text);
 
+  // Expand environment variables in the form of ${FOO} or $FOO/
+  // (variable followed by slash) in string. Modifies the string.
+  static void autoExpandEnvironmentVariables(std::string* text);
+
+  // Like autoExpandEnvironmentVariables(), but returns modified string.
   static std::string evaluateEnvVars(std::string_view text);
-  static void autoExpandEnvironmentVariables(std::string& text);
+
   static void registerEnvVar(std::string var, std::string value) {
     envVars.insert(std::make_pair(var, value));
   }

--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -109,7 +109,7 @@ class StringUtils {
   // Like autoExpandEnvironmentVariables(), but returns modified string.
   static std::string evaluateEnvVars(std::string_view text);
 
-  static void registerEnvVar(std::string var, std::string value) {
+  static void registerEnvVar(std::string_view var, std::string_view value) {
     envVars.insert(std::make_pair(var, value));
   }
 

--- a/src/Utils/StringUtils_test.cpp
+++ b/src/Utils/StringUtils_test.cpp
@@ -152,5 +152,28 @@ TEST(StringUtilsTest, DoubleStringConversion) {
   EXPECT_EQ("1.9", StringUtils::to_string(1.94, 1));
 }
 
+TEST(StringUtilsTest, EvaluateEnvironmentVariables) {
+  // Variables not set are expanded to an empty string.
+  EXPECT_EQ("hello  bar",
+            StringUtils::evaluateEnvVars("hello ${TESTING_UNKNOWN_VAR} bar"));
+  EXPECT_EQ("hello  bar",
+            StringUtils::evaluateEnvVars("hello $TESTING_UNKNOWN_VAR/ bar"));
+
+  setenv("TESTING_EVAL_FOO", "foo-value", 1);
+  setenv("TESTING_EVAL_BAR", "bar-value", 1);
+
+  EXPECT_EQ("hello foo-value bar",
+            StringUtils::evaluateEnvVars("hello ${TESTING_EVAL_FOO} bar"));
+
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__)
+#define EXPECTED_SEPARATOR "\\"
+#else
+#define EXPECTED_SEPARATOR "/"
+#endif
+
+  EXPECT_EQ("hello bar-value" EXPECTED_SEPARATOR " bar",
+            StringUtils::evaluateEnvVars("hello $TESTING_EVAL_BAR/ bar"));
+}
+
 }  // namespace
 }  // namespace SURELOG

--- a/src/Utils/StringUtils_test.cpp
+++ b/src/Utils/StringUtils_test.cpp
@@ -159,6 +159,7 @@ TEST(StringUtilsTest, EvaluateEnvironmentVariables) {
   EXPECT_EQ("hello  bar",
             StringUtils::evaluateEnvVars("hello $TESTING_UNKNOWN_VAR/ bar"));
 
+  // Variables set via the environment
   setenv("TESTING_EVAL_FOO", "foo-value", 1);
   setenv("TESTING_EVAL_BAR", "bar-value", 1);
 
@@ -173,6 +174,14 @@ TEST(StringUtilsTest, EvaluateEnvironmentVariables) {
 
   EXPECT_EQ("hello bar-value" EXPECTED_SEPARATOR " bar",
             StringUtils::evaluateEnvVars("hello $TESTING_EVAL_BAR/ bar"));
+
+  // Variables set via registerEnvVar()
+  EXPECT_EQ("hello  bar",
+            StringUtils::evaluateEnvVars("hello ${REGISTERED_EVAL_FOO} bar"));
+
+  StringUtils::registerEnvVar("REGISTERED_EVAL_FOO", "foo-reg");
+  EXPECT_EQ("hello foo-reg bar",
+            StringUtils::evaluateEnvVars("hello ${REGISTERED_EVAL_FOO} bar"));
 }
 
 }  // namespace


### PR DESCRIPTION
It was entirely untested. Also, while at it, change the
out parmaeter to be a pointer instead of a non-const reference
(which makes it easier to read code).

Signed-off-by: Henner Zeller <h.zeller@acm.org>