### PR TITLE
[RFC] init nix-shell development environment

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,9 +13,11 @@ Executable: `surelog`
 
    * `sudo apt-get install build-essential cmake git pkg-config tclsh swig uuid-dev libgoogle-perftools-dev python3 python3-dev`
 
-   * If you don't intent to change the grammar: `sudo apt-get install default-jre`
+   * If you don't intend to change the grammar: `sudo apt-get install default-jre`
 
-   * If you do intent to change the grammar: `sudo apt-get install default-jdk ant`
+   * If you do intend to change the grammar: `sudo apt-get install default-jdk ant`
+
+   * In a [nix environment](https://nixos.org) simply type `nix-shell` to set up the dependencies.
 
 * If you have a version of cmake before 3.13 on your system
   (check with `cmake --version`), you need get a version that is more current.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,43 +1,62 @@
-# Surelog Install instructions
+# Surelog Install and Build Instructions
 
 Executable: `surelog`
 
-# Development Environment Required
+## Clone and Initialize Submodules
 
-* Linux (Ubuntu or Centos)
+```
+git clone https://github.com/alainmarcel/Surelog.git
+cd Surelog
+git submodule update --init --recursive
+```
 
-* Unlimit all limits, in your .cshrc or .bashrc put "ulimit -s"
-  that will enable gcc to compile the very large Antlr generated C++ files
+## Build Dependencies
 
-* Please install the following package updates:
+* cmake >= 3.13
 
-   * `sudo apt-get install build-essential cmake git pkg-config tclsh swig uuid-dev libgoogle-perftools-dev python3 python3-dev`
+### Ubuntu/Debian 
 
-   * If you don't intend to change the grammar: `sudo apt-get install default-jre`
+`sudo apt-get install build-essential cmake git pkg-config tclsh swig uuid-dev libgoogle-perftools-dev python3 python3-dev default-jre`
 
-   * If you do intend to change the grammar: `sudo apt-get install default-jdk ant`
+*Note:* If you intend to change the grammar, add: `sudo apt-get install ant`
 
-   * In a [nix environment](https://nixos.org) simply type `nix-shell` to set up the dependencies.
+*Note:* If you have a version of cmake before 3.13 on your system
+(check with `cmake --version`), you need get a version that is more current.
+On Debian-like systems (includes Ubuntu), that would be
+```
+wget -q -O- https://apt.kitware.com/keys/kitware-archive-latest.asc | sudo apt-key add -
+sudo add-apt-repository 'deb https://apt.kitware.com/ubuntu/ xenial main'
+sudo apt-get remove -y cmake
+sudo apt-get install -y cmake
+```
 
-* If you have a version of cmake before 3.13 on your system
-  (check with `cmake --version`), you need get a version that is more current.
-  On Debian-like systems (includes Ubuntu), that would be
-  ```
-  wget -q -O- https://apt.kitware.com/keys/kitware-archive-latest.asc | sudo apt-key add -
-  sudo add-apt-repository 'deb https://apt.kitware.com/ubuntu/ xenial main'
-  sudo apt-get remove -y cmake
-  sudo apt-get install -y cmake
-  ```
 
-* Download the Surelog source code
-  ```
-  git clone https://github.com/alainmarcel/Surelog.git
-  cd Surelog
-  git submodule update --init --recursive
-  ```
+### Nix Package Manager
 
-* Build
-  * `make`
-  * `make debug`
-  * make install (/usr/local/bin and /usr/local/lib/surelog by default, use PREFIX=<path> for alternative locations)
+In a [nix environment](https://nixos.org) simply type `nix-shell` to set up the dependencies.
+
+
+## Build Instructions
+
+```
+make
+```
+
+For debug builds:
+```
+make debug
+```
+
+Installation:
+```
+make install
+```
+
+The installation path may be set by specifying a `PREFIX`. The default is `/usr/local`. 
+For example:
+```
+make install PREFIX=~/.local
+```
+
+
   * or see [`src/README`](./src/README.md)

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,27 @@
+# This is a nix-shell for use with the nix package manager.
+# If you have nix installed, you may simply run `nix-shell`
+# in this repo, and have all dependencies ready in the new shell. 
+
+{pkgs ? import (builtins.fetchTarball {
+  # Descriptive name to make the store path easier to identify
+  name = "nixos-2021-05";
+  # Commit hash
+  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/21.05.tar.gz";
+  # Hash obtained using `nix-prefetch-url --unpack <url>`
+  sha256 = "1ckzhh24mgz6jd1xhfgx0i9mijk6xjqxwsshnvq789xsavrmsc36";
+}) {}}:
+
+
+pkgs.mkShell {
+  buildInputs = with pkgs;
+    [ 
+      cmake
+      swig
+      tcl
+      jre8
+      antlr4
+      pkg-config
+      libuuid
+    ];
+
+}


### PR DESCRIPTION
This is a nix-shell environment for building Surelog. Nix shells can be helpful for ensuring local development and CI environments match, among other benefits. 

With a nix install you can simply do:
```
nix-shell
make 
make install
```

There are some tweaks that are required for fully hermetic and reproducible builds (ANTLR4 is the main suspect). I am working on those fixes [here](https://github.com/RAPcores/rapcores/blob/sjk/sv-ng1/nix/surelog.nix), with the objective of eventual upstreaming in nixpkgs.

I'm labeling this RFC since Nix is somewhat niche, and totally get not wanting some weird package manager you don't use polluting the repo :).