### PR TITLE
Fix missing 'break';

### DIFF
--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -1344,6 +1344,7 @@ void DesignElaboration::elaborateInstance_(
                 def = design->getComponentDefinition(modName);
                 if (def) use.setUsed();
               }
+              break;
             }
             default:
               break;


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>