### PR TITLE
Unset LC_ALL for building and testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 # Use bash as the default shell
 SHELL := /bin/bash
+undefine LC_ALL
 
 ifeq ($(CPU_CORES),)
 	CPU_CORES := $(shell nproc)


### PR DESCRIPTION
I had situations on some machines where bash (?) stumbled
upon some unsupported setting in LC_ALL.

Signed-off-by: Henner Zeller <h.zeller@acm.org>