### PR TITLE
Add more specific dependencies for the nix build.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -22,6 +22,10 @@ pkgs.mkShell {
       antlr4
       pkg-config
       libuuid
+      diffutils
+      time
+      gperftools
+      zlib
     ];
 
 }


### PR DESCRIPTION
gperftools (for tcmalloc) and zlib are also requested
by cmake.

diff and time are used in the regression tests.

Signed-off-by: Henner Zeller <h.zeller@acm.org>