### PR TITLE
Removing leading backslash from array instances

### DIFF
--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -667,7 +667,6 @@ void DesignElaboration::recurseInstanceLoop_(
         if (instanceName[instanceName.size() - 1] == ' ') {
           instanceName.erase(instanceName.end() - 1);
         }
-        if (instanceName[0] != '\\') instanceName = "\\" + instanceName;
       }
       instanceName = instanceName + "[" + std::to_string(indexes[i]) + "] ";
     }

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -668,7 +668,7 @@ void DesignElaboration::recurseInstanceLoop_(
           instanceName.erase(instanceName.end() - 1);
         }
       }
-      instanceName = instanceName + "[" + std::to_string(indexes[i]) + "] ";
+      instanceName = instanceName + "[" + std::to_string(indexes[i]) + "]";
     }
     ModuleInstance* child = factory->newModuleInstance(
         def, fC, subInstanceId, parent, instanceName, modName);

--- a/tests/ArrayInst/ArrayInst.log
+++ b/tests/ArrayInst/ArrayInst.log
@@ -125,111 +125,111 @@ design: (work@top)
   |vpiDefName:work@top
   |vpiName:work@top
   |vpiModule:
-  \_module: work@flop (work@top.flop_instances[0] ) dut.sv:9:3: , endln:9:31, parent:work@top
+  \_module: work@flop (work@top.flop_instances[0]) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiDefName:work@flop
     |vpiDefFile:dut.sv
     |vpiDefLineNo:4
-    |vpiName:flop_instances[0] 
-    |vpiFullName:work@top.flop_instances[0] 
+    |vpiName:flop_instances[0]
+    |vpiFullName:work@top.flop_instances[0]
     |vpiModule:
-    \_module: work@qq (work@top.flop_instances[0] .q[0] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[0] 
+    \_module: work@qq (work@top.flop_instances[0].q[0]) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[0]
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:q[0] 
-      |vpiFullName:work@top.flop_instances[0] .q[0] 
+      |vpiName:q[0]
+      |vpiFullName:work@top.flop_instances[0].q[0]
       |vpiInstance:
-      \_module: work@flop (work@top.flop_instances[0] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[0]) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiModule:
-    \_module: work@qq (work@top.flop_instances[0] .q[1] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[0] 
+    \_module: work@qq (work@top.flop_instances[0].q[1]) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[0]
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:q[1] 
-      |vpiFullName:work@top.flop_instances[0] .q[1] 
+      |vpiName:q[1]
+      |vpiFullName:work@top.flop_instances[0].q[1]
       |vpiInstance:
-      \_module: work@flop (work@top.flop_instances[0] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[0]) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:8:1: , endln:10:10
   |vpiModule:
-  \_module: work@flop (work@top.flop_instances[1] ) dut.sv:9:3: , endln:9:31, parent:work@top
+  \_module: work@flop (work@top.flop_instances[1]) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiDefName:work@flop
     |vpiDefFile:dut.sv
     |vpiDefLineNo:4
-    |vpiName:flop_instances[1] 
-    |vpiFullName:work@top.flop_instances[1] 
+    |vpiName:flop_instances[1]
+    |vpiFullName:work@top.flop_instances[1]
     |vpiModule:
-    \_module: work@qq (work@top.flop_instances[1] .q[0] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[1] 
+    \_module: work@qq (work@top.flop_instances[1].q[0]) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[1]
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:q[0] 
-      |vpiFullName:work@top.flop_instances[1] .q[0] 
+      |vpiName:q[0]
+      |vpiFullName:work@top.flop_instances[1].q[0]
       |vpiInstance:
-      \_module: work@flop (work@top.flop_instances[1] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[1]) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiModule:
-    \_module: work@qq (work@top.flop_instances[1] .q[1] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[1] 
+    \_module: work@qq (work@top.flop_instances[1].q[1]) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[1]
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:q[1] 
-      |vpiFullName:work@top.flop_instances[1] .q[1] 
+      |vpiName:q[1]
+      |vpiFullName:work@top.flop_instances[1].q[1]
       |vpiInstance:
-      \_module: work@flop (work@top.flop_instances[1] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[1]) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:8:1: , endln:10:10
   |vpiModule:
-  \_module: work@flop (work@top.flop_instances[2] ) dut.sv:9:3: , endln:9:31, parent:work@top
+  \_module: work@flop (work@top.flop_instances[2]) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiDefName:work@flop
     |vpiDefFile:dut.sv
     |vpiDefLineNo:4
-    |vpiName:flop_instances[2] 
-    |vpiFullName:work@top.flop_instances[2] 
+    |vpiName:flop_instances[2]
+    |vpiFullName:work@top.flop_instances[2]
     |vpiModule:
-    \_module: work@qq (work@top.flop_instances[2] .q[0] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[2] 
+    \_module: work@qq (work@top.flop_instances[2].q[0]) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[2]
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:q[0] 
-      |vpiFullName:work@top.flop_instances[2] .q[0] 
+      |vpiName:q[0]
+      |vpiFullName:work@top.flop_instances[2].q[0]
       |vpiInstance:
-      \_module: work@flop (work@top.flop_instances[2] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[2]) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiModule:
-    \_module: work@qq (work@top.flop_instances[2] .q[1] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[2] 
+    \_module: work@qq (work@top.flop_instances[2].q[1]) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[2]
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:q[1] 
-      |vpiFullName:work@top.flop_instances[2] .q[1] 
+      |vpiName:q[1]
+      |vpiFullName:work@top.flop_instances[2].q[1]
       |vpiInstance:
-      \_module: work@flop (work@top.flop_instances[2] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[2]) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:8:1: , endln:10:10
   |vpiModule:
-  \_module: work@flop (work@top.flop_instances[3] ) dut.sv:9:3: , endln:9:31, parent:work@top
+  \_module: work@flop (work@top.flop_instances[3]) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiDefName:work@flop
     |vpiDefFile:dut.sv
     |vpiDefLineNo:4
-    |vpiName:flop_instances[3] 
-    |vpiFullName:work@top.flop_instances[3] 
+    |vpiName:flop_instances[3]
+    |vpiFullName:work@top.flop_instances[3]
     |vpiModule:
-    \_module: work@qq (work@top.flop_instances[3] .q[0] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[3] 
+    \_module: work@qq (work@top.flop_instances[3].q[0]) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[3]
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:q[0] 
-      |vpiFullName:work@top.flop_instances[3] .q[0] 
+      |vpiName:q[0]
+      |vpiFullName:work@top.flop_instances[3].q[0]
       |vpiInstance:
-      \_module: work@flop (work@top.flop_instances[3] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[3]) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiModule:
-    \_module: work@qq (work@top.flop_instances[3] .q[1] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[3] 
+    \_module: work@qq (work@top.flop_instances[3].q[1]) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[3]
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:q[1] 
-      |vpiFullName:work@top.flop_instances[3] .q[1] 
+      |vpiName:q[1]
+      |vpiFullName:work@top.flop_instances[3].q[1]
       |vpiInstance:
-      \_module: work@flop (work@top.flop_instances[3] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[3]) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:8:1: , endln:10:10
 ===================

--- a/tests/ArrayInst/ArrayInst.log
+++ b/tests/ArrayInst/ArrayInst.log
@@ -125,111 +125,111 @@ design: (work@top)
   |vpiDefName:work@top
   |vpiName:work@top
   |vpiModule:
-  \_module: work@flop (work@top.\flop_instances[0] ) dut.sv:9:3: , endln:9:31, parent:work@top
+  \_module: work@flop (work@top.flop_instances[0] ) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiDefName:work@flop
     |vpiDefFile:dut.sv
     |vpiDefLineNo:4
-    |vpiName:\flop_instances[0] 
-    |vpiFullName:work@top.\flop_instances[0] 
+    |vpiName:flop_instances[0] 
+    |vpiFullName:work@top.flop_instances[0] 
     |vpiModule:
-    \_module: work@qq (work@top.\flop_instances[0] .\q[0] ) dut.sv:5:3: , endln:5:15, parent:work@top.\flop_instances[0] 
+    \_module: work@qq (work@top.flop_instances[0] .q[0] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[0] 
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:\q[0] 
-      |vpiFullName:work@top.\flop_instances[0] .\q[0] 
+      |vpiName:q[0] 
+      |vpiFullName:work@top.flop_instances[0] .q[0] 
       |vpiInstance:
-      \_module: work@flop (work@top.\flop_instances[0] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[0] ) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiModule:
-    \_module: work@qq (work@top.\flop_instances[0] .\q[1] ) dut.sv:5:3: , endln:5:15, parent:work@top.\flop_instances[0] 
+    \_module: work@qq (work@top.flop_instances[0] .q[1] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[0] 
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:\q[1] 
-      |vpiFullName:work@top.\flop_instances[0] .\q[1] 
+      |vpiName:q[1] 
+      |vpiFullName:work@top.flop_instances[0] .q[1] 
       |vpiInstance:
-      \_module: work@flop (work@top.\flop_instances[0] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[0] ) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:8:1: , endln:10:10
   |vpiModule:
-  \_module: work@flop (work@top.\flop_instances[1] ) dut.sv:9:3: , endln:9:31, parent:work@top
+  \_module: work@flop (work@top.flop_instances[1] ) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiDefName:work@flop
     |vpiDefFile:dut.sv
     |vpiDefLineNo:4
-    |vpiName:\flop_instances[1] 
-    |vpiFullName:work@top.\flop_instances[1] 
+    |vpiName:flop_instances[1] 
+    |vpiFullName:work@top.flop_instances[1] 
     |vpiModule:
-    \_module: work@qq (work@top.\flop_instances[1] .\q[0] ) dut.sv:5:3: , endln:5:15, parent:work@top.\flop_instances[1] 
+    \_module: work@qq (work@top.flop_instances[1] .q[0] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[1] 
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:\q[0] 
-      |vpiFullName:work@top.\flop_instances[1] .\q[0] 
+      |vpiName:q[0] 
+      |vpiFullName:work@top.flop_instances[1] .q[0] 
       |vpiInstance:
-      \_module: work@flop (work@top.\flop_instances[1] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[1] ) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiModule:
-    \_module: work@qq (work@top.\flop_instances[1] .\q[1] ) dut.sv:5:3: , endln:5:15, parent:work@top.\flop_instances[1] 
+    \_module: work@qq (work@top.flop_instances[1] .q[1] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[1] 
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:\q[1] 
-      |vpiFullName:work@top.\flop_instances[1] .\q[1] 
+      |vpiName:q[1] 
+      |vpiFullName:work@top.flop_instances[1] .q[1] 
       |vpiInstance:
-      \_module: work@flop (work@top.\flop_instances[1] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[1] ) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:8:1: , endln:10:10
   |vpiModule:
-  \_module: work@flop (work@top.\flop_instances[2] ) dut.sv:9:3: , endln:9:31, parent:work@top
+  \_module: work@flop (work@top.flop_instances[2] ) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiDefName:work@flop
     |vpiDefFile:dut.sv
     |vpiDefLineNo:4
-    |vpiName:\flop_instances[2] 
-    |vpiFullName:work@top.\flop_instances[2] 
+    |vpiName:flop_instances[2] 
+    |vpiFullName:work@top.flop_instances[2] 
     |vpiModule:
-    \_module: work@qq (work@top.\flop_instances[2] .\q[0] ) dut.sv:5:3: , endln:5:15, parent:work@top.\flop_instances[2] 
+    \_module: work@qq (work@top.flop_instances[2] .q[0] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[2] 
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:\q[0] 
-      |vpiFullName:work@top.\flop_instances[2] .\q[0] 
+      |vpiName:q[0] 
+      |vpiFullName:work@top.flop_instances[2] .q[0] 
       |vpiInstance:
-      \_module: work@flop (work@top.\flop_instances[2] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[2] ) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiModule:
-    \_module: work@qq (work@top.\flop_instances[2] .\q[1] ) dut.sv:5:3: , endln:5:15, parent:work@top.\flop_instances[2] 
+    \_module: work@qq (work@top.flop_instances[2] .q[1] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[2] 
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:\q[1] 
-      |vpiFullName:work@top.\flop_instances[2] .\q[1] 
+      |vpiName:q[1] 
+      |vpiFullName:work@top.flop_instances[2] .q[1] 
       |vpiInstance:
-      \_module: work@flop (work@top.\flop_instances[2] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[2] ) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:8:1: , endln:10:10
   |vpiModule:
-  \_module: work@flop (work@top.\flop_instances[3] ) dut.sv:9:3: , endln:9:31, parent:work@top
+  \_module: work@flop (work@top.flop_instances[3] ) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiDefName:work@flop
     |vpiDefFile:dut.sv
     |vpiDefLineNo:4
-    |vpiName:\flop_instances[3] 
-    |vpiFullName:work@top.\flop_instances[3] 
+    |vpiName:flop_instances[3] 
+    |vpiFullName:work@top.flop_instances[3] 
     |vpiModule:
-    \_module: work@qq (work@top.\flop_instances[3] .\q[0] ) dut.sv:5:3: , endln:5:15, parent:work@top.\flop_instances[3] 
+    \_module: work@qq (work@top.flop_instances[3] .q[0] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[3] 
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:\q[0] 
-      |vpiFullName:work@top.\flop_instances[3] .\q[0] 
+      |vpiName:q[0] 
+      |vpiFullName:work@top.flop_instances[3] .q[0] 
       |vpiInstance:
-      \_module: work@flop (work@top.\flop_instances[3] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[3] ) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiModule:
-    \_module: work@qq (work@top.\flop_instances[3] .\q[1] ) dut.sv:5:3: , endln:5:15, parent:work@top.\flop_instances[3] 
+    \_module: work@qq (work@top.flop_instances[3] .q[1] ) dut.sv:5:3: , endln:5:15, parent:work@top.flop_instances[3] 
       |vpiDefName:work@qq
       |vpiDefFile:dut.sv
       |vpiDefLineNo:1
-      |vpiName:\q[1] 
-      |vpiFullName:work@top.\flop_instances[3] .\q[1] 
+      |vpiName:q[1] 
+      |vpiFullName:work@top.flop_instances[3] .q[1] 
       |vpiInstance:
-      \_module: work@flop (work@top.\flop_instances[3] ) dut.sv:9:3: , endln:9:31, parent:work@top
+      \_module: work@flop (work@top.flop_instances[3] ) dut.sv:9:3: , endln:9:31, parent:work@top
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:8:1: , endln:10:10
 ===================

--- a/tests/LibraryIntercon/LibraryIntercon.log
+++ b/tests/LibraryIntercon/LibraryIntercon.log
@@ -79,26 +79,26 @@ LIB: logicLib
 
 Instance tree:
 [TOP] logicLib@top logicLib@top
-[MOD] realLib@driver logicLib@top.driverArray[0] 
-[MOD] realLib@driver logicLib@top.driverArray[1] 
-[MOD] realLib@driver logicLib@top.driverArray[2] 
-[MOD] realLib@driver logicLib@top.driverArray[3] 
-[MOD] realLib@cmp logicLib@top.cmpArray[0] 
-[MOD] realLib@cmp logicLib@top.cmpArray[1] 
-[MOD] realLib@cmp logicLib@top.cmpArray[2] 
-[MOD] realLib@cmp logicLib@top.cmpArray[3] 
-[SCO] realLib@driver.UNNAMED logicLib@top.driverArray[0] .UNNAMED
-[SCO] realLib@driver.UNNAMED logicLib@top.driverArray[1] .UNNAMED
-[SCO] realLib@driver.UNNAMED logicLib@top.driverArray[2] .UNNAMED
-[SCO] realLib@driver.UNNAMED logicLib@top.driverArray[3] .UNNAMED
-[SCO] realLib@cmp.UNNAMED logicLib@top.cmpArray[0] .UNNAMED
-[SCO] realLib@cmp.UNNAMED logicLib@top.cmpArray[1] .UNNAMED
-[SCO] realLib@cmp.UNNAMED logicLib@top.cmpArray[2] .UNNAMED
-[SCO] realLib@cmp.UNNAMED logicLib@top.cmpArray[3] .UNNAMED
-[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.driverArray[0] .UNNAMED.UNNAMED
-[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.driverArray[1] .UNNAMED.UNNAMED
-[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.driverArray[2] .UNNAMED.UNNAMED
-[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.driverArray[3] .UNNAMED.UNNAMED
+[MOD] realLib@driver logicLib@top.driverArray[0]
+[MOD] realLib@driver logicLib@top.driverArray[1]
+[MOD] realLib@driver logicLib@top.driverArray[2]
+[MOD] realLib@driver logicLib@top.driverArray[3]
+[MOD] realLib@cmp logicLib@top.cmpArray[0]
+[MOD] realLib@cmp logicLib@top.cmpArray[1]
+[MOD] realLib@cmp logicLib@top.cmpArray[2]
+[MOD] realLib@cmp logicLib@top.cmpArray[3]
+[SCO] realLib@driver.UNNAMED logicLib@top.driverArray[0].UNNAMED
+[SCO] realLib@driver.UNNAMED logicLib@top.driverArray[1].UNNAMED
+[SCO] realLib@driver.UNNAMED logicLib@top.driverArray[2].UNNAMED
+[SCO] realLib@driver.UNNAMED logicLib@top.driverArray[3].UNNAMED
+[SCO] realLib@cmp.UNNAMED logicLib@top.cmpArray[0].UNNAMED
+[SCO] realLib@cmp.UNNAMED logicLib@top.cmpArray[1].UNNAMED
+[SCO] realLib@cmp.UNNAMED logicLib@top.cmpArray[2].UNNAMED
+[SCO] realLib@cmp.UNNAMED logicLib@top.cmpArray[3].UNNAMED
+[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.driverArray[0].UNNAMED.UNNAMED
+[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.driverArray[1].UNNAMED.UNNAMED
+[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.driverArray[2].UNNAMED.UNNAMED
+[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.driverArray[3].UNNAMED.UNNAMED
 
 [NTE:EL0519] lib.map:5: Using configuration "work@cfgReal".
 
@@ -116,45 +116,45 @@ Instance tree:
 
 [NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:1: Instance "logicLib@top".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.driverArray[0] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.driverArray[0]".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.driverArray[1] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.driverArray[1]".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.driverArray[2] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.driverArray[2]".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.driverArray[3] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.driverArray[3]".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.cmpArray[0] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.cmpArray[0]".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.cmpArray[1] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.cmpArray[1]".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.cmpArray[2] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.cmpArray[2]".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.cmpArray[3] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.cmpArray[3]".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.driverArray[0] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.driverArray[0].UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.driverArray[1] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.driverArray[1].UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.driverArray[2] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.driverArray[2].UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.driverArray[3] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.driverArray[3].UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.cmpArray[0] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.cmpArray[0].UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.cmpArray[1] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.cmpArray[1].UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.cmpArray[2] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.cmpArray[2].UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.cmpArray[3] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.cmpArray[3].UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.driverArray[0] .UNNAMED.UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.driverArray[0].UNNAMED.UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.driverArray[1] .UNNAMED.UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.driverArray[1].UNNAMED.UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.driverArray[2] .UNNAMED.UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.driverArray[2].UNNAMED.UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.driverArray[3] .UNNAMED.UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.driverArray[3].UNNAMED.UNNAMED".
 
 [INF:UH0706] Creating UHDM Model...
 

--- a/tests/LibraryIntercon/LibraryIntercon.log
+++ b/tests/LibraryIntercon/LibraryIntercon.log
@@ -10,13 +10,13 @@ LIB: work
      ${SURELOG_DIR}/build/bin/sv/builtin.sv
 
 LIB: realLib
-     ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr
      ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr
+     ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr
 
 LIB: logicLib
-     ${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv
-     ${SURELOG_DIR}/tests/LibraryIntercon/driver.sv
      ${SURELOG_DIR}/tests/LibraryIntercon/top.sv
+     ${SURELOG_DIR}/tests/LibraryIntercon/driver.sv
+     ${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv
 
 
 [INF:PP0122] Preprocessing source file "builtin.sv".
@@ -25,35 +25,35 @@ LIB: logicLib
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/nets.pkg".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.svr".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/top.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/top.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv".
 
 [INF:PA0201] Parsing source file "builtin.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/nets.pkg".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.svr".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/top.sv".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv".
+
 [WRN:PA0205] ${SURELOG_DIR}/tests/LibraryIntercon/nets.pkg:1: No timescale set for "NetsPkg".
 
-[WRN:PA0205] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv:2: No timescale set for "cmp".
-
 [WRN:PA0205] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:1: No timescale set for "top".
+
+[WRN:PA0205] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv:2: No timescale set for "cmp".
 
 [INF:CP0300] Compilation...
 
@@ -79,26 +79,26 @@ LIB: logicLib
 
 Instance tree:
 [TOP] logicLib@top logicLib@top
-[MOD] realLib@driver logicLib@top.\driverArray[0] 
-[MOD] realLib@driver logicLib@top.\driverArray[1] 
-[MOD] realLib@driver logicLib@top.\driverArray[2] 
-[MOD] realLib@driver logicLib@top.\driverArray[3] 
-[MOD] realLib@cmp logicLib@top.\cmpArray[0] 
-[MOD] realLib@cmp logicLib@top.\cmpArray[1] 
-[MOD] realLib@cmp logicLib@top.\cmpArray[2] 
-[MOD] realLib@cmp logicLib@top.\cmpArray[3] 
-[SCO] realLib@driver.UNNAMED logicLib@top.\driverArray[0] .UNNAMED
-[SCO] realLib@driver.UNNAMED logicLib@top.\driverArray[1] .UNNAMED
-[SCO] realLib@driver.UNNAMED logicLib@top.\driverArray[2] .UNNAMED
-[SCO] realLib@driver.UNNAMED logicLib@top.\driverArray[3] .UNNAMED
-[SCO] realLib@cmp.UNNAMED logicLib@top.\cmpArray[0] .UNNAMED
-[SCO] realLib@cmp.UNNAMED logicLib@top.\cmpArray[1] .UNNAMED
-[SCO] realLib@cmp.UNNAMED logicLib@top.\cmpArray[2] .UNNAMED
-[SCO] realLib@cmp.UNNAMED logicLib@top.\cmpArray[3] .UNNAMED
-[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.\driverArray[0] .UNNAMED.UNNAMED
-[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.\driverArray[1] .UNNAMED.UNNAMED
-[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.\driverArray[2] .UNNAMED.UNNAMED
-[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.\driverArray[3] .UNNAMED.UNNAMED
+[MOD] realLib@driver logicLib@top.driverArray[0] 
+[MOD] realLib@driver logicLib@top.driverArray[1] 
+[MOD] realLib@driver logicLib@top.driverArray[2] 
+[MOD] realLib@driver logicLib@top.driverArray[3] 
+[MOD] realLib@cmp logicLib@top.cmpArray[0] 
+[MOD] realLib@cmp logicLib@top.cmpArray[1] 
+[MOD] realLib@cmp logicLib@top.cmpArray[2] 
+[MOD] realLib@cmp logicLib@top.cmpArray[3] 
+[SCO] realLib@driver.UNNAMED logicLib@top.driverArray[0] .UNNAMED
+[SCO] realLib@driver.UNNAMED logicLib@top.driverArray[1] .UNNAMED
+[SCO] realLib@driver.UNNAMED logicLib@top.driverArray[2] .UNNAMED
+[SCO] realLib@driver.UNNAMED logicLib@top.driverArray[3] .UNNAMED
+[SCO] realLib@cmp.UNNAMED logicLib@top.cmpArray[0] .UNNAMED
+[SCO] realLib@cmp.UNNAMED logicLib@top.cmpArray[1] .UNNAMED
+[SCO] realLib@cmp.UNNAMED logicLib@top.cmpArray[2] .UNNAMED
+[SCO] realLib@cmp.UNNAMED logicLib@top.cmpArray[3] .UNNAMED
+[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.driverArray[0] .UNNAMED.UNNAMED
+[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.driverArray[1] .UNNAMED.UNNAMED
+[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.driverArray[2] .UNNAMED.UNNAMED
+[SCO] realLib@driver.UNNAMED.UNNAMED logicLib@top.driverArray[3] .UNNAMED.UNNAMED
 
 [NTE:EL0519] lib.map:5: Using configuration "work@cfgReal".
 
@@ -116,45 +116,45 @@ Instance tree:
 
 [NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:1: Instance "logicLib@top".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.\driverArray[0] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.driverArray[0] ".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.\driverArray[1] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.driverArray[1] ".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.\driverArray[2] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.driverArray[2] ".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.\driverArray[3] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:5: Instance "logicLib@top.driverArray[3] ".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.\cmpArray[0] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.cmpArray[0] ".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.\cmpArray[1] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.cmpArray[1] ".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.\cmpArray[2] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.cmpArray[2] ".
 
-[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.\cmpArray[3] ".
+[NTE:EL0523] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:7: Instance "logicLib@top.cmpArray[3] ".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.\driverArray[0] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.driverArray[0] .UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.\driverArray[1] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.driverArray[1] .UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.\driverArray[2] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.driverArray[2] .UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.\driverArray[3] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:11: Scope "logicLib@top.driverArray[3] .UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.\cmpArray[0] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.cmpArray[0] .UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.\cmpArray[1] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.cmpArray[1] .UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.\cmpArray[2] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.cmpArray[2] .UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.\cmpArray[3] .UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr:25: Scope "logicLib@top.cmpArray[3] .UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.\driverArray[0] .UNNAMED.UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.driverArray[0] .UNNAMED.UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.\driverArray[1] .UNNAMED.UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.driverArray[1] .UNNAMED.UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.\driverArray[2] .UNNAMED.UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.driverArray[2] .UNNAMED.UNNAMED".
 
-[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.\driverArray[3] .UNNAMED.UNNAMED".
+[NTE:EL0522] ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr:15: Scope "logicLib@top.driverArray[3] .UNNAMED.UNNAMED".
 
 [INF:UH0706] Creating UHDM Model...
 

--- a/tests/OldLibrary/OldLibrary.log
+++ b/tests/OldLibrary/OldLibrary.log
@@ -4,29 +4,29 @@
 
 [INF:PP0122] Preprocessing source file "top.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL3.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL2.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL1.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL2.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL3.v".
 
 [INF:PA0201] Parsing source file "builtin.sv".
 
 [INF:PA0201] Parsing source file "top.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL3.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL2.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL1.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL2.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL3.v".
 
 [WRN:PA0205] top.v:1: No timescale set for "top".
 
-[WRN:PA0205] ${SURELOG_DIR}/tests/OldLibrary/lib/CELL3.v:1: No timescale set for "CELL3".
+[WRN:PA0205] ${SURELOG_DIR}/tests/OldLibrary/lib/CELL2.v:1: No timescale set for "CELL2".
 
 [WRN:PA0205] ${SURELOG_DIR}/tests/OldLibrary/lib/CELL1.v:1: No timescale set for "CELL1".
 
-[WRN:PA0205] ${SURELOG_DIR}/tests/OldLibrary/lib/CELL2.v:1: No timescale set for "CELL2".
+[WRN:PA0205] ${SURELOG_DIR}/tests/OldLibrary/lib/CELL3.v:1: No timescale set for "CELL3".
 
 [INF:CP0300] Compilation...
 

--- a/tests/SimpleConstraint/SimpleConstraint.log
+++ b/tests/SimpleConstraint/SimpleConstraint.log
@@ -746,7 +746,7 @@ n<> u<723> t<Source_text> p<724> c<17> l<2:1> el<80:11>
 n<> u<724> t<Top_level_rule> l<2:1> el<81:1>
 Cache saving: t.ttts
 Parsing took t.ttts
-SLL Parsing: t.ttts ../../build/tests/SimpleConstraint/slpp_all/work/sv_6956721045759131781/builtin.sv
+SLL Parsing: t.ttts ../../build/tests/SimpleConstraint/slpp_all/work/sv_2076548932596474082/builtin.sv
 Cache saving: t.ttts
 SLL Parsing: t.ttts ../../build/tests/SimpleConstraint/slpp_all/work/_6142509188972423790/top.sv
 Cache saving: t.ttts
@@ -793,7 +793,7 @@ Preprocessing took t.ttts
 PP SSL Parsing: t.ttts ${SURELOG_DIR}/build/bin/sv/builtin.sv
 PP SSL Parsing: t.ttts top.sv
 Parsing took t.ttts
-SLL Parsing: t.ttts ../../build/tests/SimpleConstraint/slpp_all/work/sv_6956721045759131781/builtin.sv
+SLL Parsing: t.ttts ../../build/tests/SimpleConstraint/slpp_all/work/sv_2076548932596474082/builtin.sv
 Cache saving: t.ttts
 SLL Parsing: t.ttts ../../build/tests/SimpleConstraint/slpp_all/work/_6142509188972423790/top.sv
 Cache saving: t.ttts

--- a/tests/TestFileSplit/TestFileSplit.log
+++ b/tests/TestFileSplit/TestFileSplit.log
@@ -21,56 +21,56 @@ LIB:  work
 FILE: top.v
 n<> u<0> t<Null_rule> p<85> s<84> l<1:1>
 n<top1_1> u<1> t<StringConst> p<33> s<6> l<1:9> el<1:15>
-n<middle_17> u<2> t<StringConst> p<4> s<3> f<67> l<17:7> el<17:16>
-n<> u<3> t<Endclass> p<4> f<67> l<18:1> el<18:9>
-n<> u<4> t<Class_declaration> p<5> c<2> f<67> l<17:1> el<18:9>
-n<> u<5> t<Package_or_generate_item_declaration> p<6> c<4> f<67> l<17:1> el<18:9>
-n<> u<6> t<Package_item> p<33> c<5> s<11> f<67> l<17:1> el<18:9>
-n<leaf_13> u<7> t<StringConst> p<9> s<8> f<72> l<13:7> el<13:14>
-n<> u<8> t<Endclass> p<9> f<72> l<14:1> el<14:9>
-n<> u<9> t<Class_declaration> p<10> c<7> f<72> l<13:1> el<14:9>
-n<> u<10> t<Package_or_generate_item_declaration> p<11> c<9> f<72> l<13:1> el<14:9>
-n<> u<11> t<Package_item> p<33> c<10> s<16> f<72> l<13:1> el<14:9>
-n<middle_25> u<12> t<StringConst> p<14> s<13> f<67> l<25:7> el<25:16>
-n<> u<13> t<Endclass> p<14> f<67> l<26:1> el<26:9>
-n<> u<14> t<Class_declaration> p<15> c<12> f<67> l<25:1> el<26:9>
-n<> u<15> t<Package_or_generate_item_declaration> p<16> c<14> f<67> l<25:1> el<26:9>
-n<> u<16> t<Package_item> p<33> c<15> s<21> f<67> l<25:1> el<26:9>
-n<middle_17> u<17> t<StringConst> p<19> s<18> f<67> l<17:7> el<17:16>
-n<> u<18> t<Endclass> p<19> f<67> l<18:1> el<18:9>
-n<> u<19> t<Class_declaration> p<20> c<17> f<67> l<17:1> el<18:9>
-n<> u<20> t<Package_or_generate_item_declaration> p<21> c<19> f<67> l<17:1> el<18:9>
-n<> u<21> t<Package_item> p<33> c<20> s<26> f<67> l<17:1> el<18:9>
-n<leaf_13> u<22> t<StringConst> p<24> s<23> f<72> l<13:7> el<13:14>
-n<> u<23> t<Endclass> p<24> f<72> l<14:1> el<14:9>
-n<> u<24> t<Class_declaration> p<25> c<22> f<72> l<13:1> el<14:9>
-n<> u<25> t<Package_or_generate_item_declaration> p<26> c<24> f<72> l<13:1> el<14:9>
-n<> u<26> t<Package_item> p<33> c<25> s<31> f<72> l<13:1> el<14:9>
-n<middle_25> u<27> t<StringConst> p<29> s<28> f<67> l<25:7> el<25:16>
-n<> u<28> t<Endclass> p<29> f<67> l<26:1> el<26:9>
-n<> u<29> t<Class_declaration> p<30> c<27> f<67> l<25:1> el<26:9>
-n<> u<30> t<Package_or_generate_item_declaration> p<31> c<29> f<67> l<25:1> el<26:9>
-n<> u<31> t<Package_item> p<33> c<30> s<32> f<67> l<25:1> el<26:9>
+n<middle_17> u<2> t<StringConst> p<4> s<3> f<68> l<17:7> el<17:16>
+n<> u<3> t<Endclass> p<4> f<68> l<18:1> el<18:9>
+n<> u<4> t<Class_declaration> p<5> c<2> f<68> l<17:1> el<18:9>
+n<> u<5> t<Package_or_generate_item_declaration> p<6> c<4> f<68> l<17:1> el<18:9>
+n<> u<6> t<Package_item> p<33> c<5> s<11> f<68> l<17:1> el<18:9>
+n<leaf_13> u<7> t<StringConst> p<9> s<8> f<73> l<13:7> el<13:14>
+n<> u<8> t<Endclass> p<9> f<73> l<14:1> el<14:9>
+n<> u<9> t<Class_declaration> p<10> c<7> f<73> l<13:1> el<14:9>
+n<> u<10> t<Package_or_generate_item_declaration> p<11> c<9> f<73> l<13:1> el<14:9>
+n<> u<11> t<Package_item> p<33> c<10> s<16> f<73> l<13:1> el<14:9>
+n<middle_25> u<12> t<StringConst> p<14> s<13> f<68> l<25:7> el<25:16>
+n<> u<13> t<Endclass> p<14> f<68> l<26:1> el<26:9>
+n<> u<14> t<Class_declaration> p<15> c<12> f<68> l<25:1> el<26:9>
+n<> u<15> t<Package_or_generate_item_declaration> p<16> c<14> f<68> l<25:1> el<26:9>
+n<> u<16> t<Package_item> p<33> c<15> s<21> f<68> l<25:1> el<26:9>
+n<middle_17> u<17> t<StringConst> p<19> s<18> f<68> l<17:7> el<17:16>
+n<> u<18> t<Endclass> p<19> f<68> l<18:1> el<18:9>
+n<> u<19> t<Class_declaration> p<20> c<17> f<68> l<17:1> el<18:9>
+n<> u<20> t<Package_or_generate_item_declaration> p<21> c<19> f<68> l<17:1> el<18:9>
+n<> u<21> t<Package_item> p<33> c<20> s<26> f<68> l<17:1> el<18:9>
+n<leaf_13> u<22> t<StringConst> p<24> s<23> f<73> l<13:7> el<13:14>
+n<> u<23> t<Endclass> p<24> f<73> l<14:1> el<14:9>
+n<> u<24> t<Class_declaration> p<25> c<22> f<73> l<13:1> el<14:9>
+n<> u<25> t<Package_or_generate_item_declaration> p<26> c<24> f<73> l<13:1> el<14:9>
+n<> u<26> t<Package_item> p<33> c<25> s<31> f<73> l<13:1> el<14:9>
+n<middle_25> u<27> t<StringConst> p<29> s<28> f<68> l<25:7> el<25:16>
+n<> u<28> t<Endclass> p<29> f<68> l<26:1> el<26:9>
+n<> u<29> t<Class_declaration> p<30> c<27> f<68> l<25:1> el<26:9>
+n<> u<30> t<Package_or_generate_item_declaration> p<31> c<29> f<68> l<25:1> el<26:9>
+n<> u<31> t<Package_item> p<33> c<30> s<32> f<68> l<25:1> el<26:9>
 n<> u<32> t<Endpackage> p<33> l<33:1> el<33:11>
 n<> u<33> t<Package_declaration> p<34> c<1> l<1:1> el<33:11>
 n<> u<34> t<Description> p<84> c<33> s<51> l<1:1> el<33:11>
-n<> u<35> t<Module_keyword> p<39> s<36> f<81> l<3:1> el<3:7>
-n<mod_3> u<36> t<StringConst> p<39> s<38> f<81> l<3:8> el<3:13>
-n<> u<37> t<Port> p<38> f<81> l<3:15> el<3:15>
-n<> u<38> t<List_of_ports> p<39> c<37> f<81> l<3:14> el<3:16>
-n<> u<39> t<Module_nonansi_header> p<50> c<35> s<49> f<81> l<3:1> el<3:17>
-n<NO_DEF5> u<40> t<StringConst> p<46> s<45> f<81> l<5:1> el<5:8>
-n<nodef_5> u<41> t<StringConst> p<42> f<81> l<5:9> el<5:16>
-n<> u<42> t<Name_of_instance> p<45> c<41> s<44> f<81> l<5:9> el<5:16>
-n<> u<43> t<Ordered_port_connection> p<44> f<81> l<5:17> el<5:17>
-n<> u<44> t<List_of_port_connections> p<45> c<43> f<81> l<5:17> el<5:17>
-n<> u<45> t<Hierarchical_instance> p<46> c<42> f<81> l<5:9> el<5:18>
-n<> u<46> t<Module_instantiation> p<47> c<40> f<81> l<5:1> el<5:19>
-n<> u<47> t<Module_or_generate_item> p<48> c<46> f<81> l<5:1> el<5:19>
-n<> u<48> t<Non_port_module_item> p<49> c<47> f<81> l<5:1> el<5:19>
-n<> u<49> t<Module_item> p<50> c<48> f<81> l<5:1> el<5:19>
-n<> u<50> t<Module_declaration> p<51> c<39> f<81> l<3:1> el<7:10>
-n<> u<51> t<Description> p<84> c<50> s<58> f<81> l<3:1> el<7:10>
+n<> u<35> t<Module_keyword> p<39> s<36> f<82> l<3:1> el<3:7>
+n<mod_3> u<36> t<StringConst> p<39> s<38> f<82> l<3:8> el<3:13>
+n<> u<37> t<Port> p<38> f<82> l<3:15> el<3:15>
+n<> u<38> t<List_of_ports> p<39> c<37> f<82> l<3:14> el<3:16>
+n<> u<39> t<Module_nonansi_header> p<50> c<35> s<49> f<82> l<3:1> el<3:17>
+n<NO_DEF5> u<40> t<StringConst> p<46> s<45> f<82> l<5:1> el<5:8>
+n<nodef_5> u<41> t<StringConst> p<42> f<82> l<5:9> el<5:16>
+n<> u<42> t<Name_of_instance> p<45> c<41> s<44> f<82> l<5:9> el<5:16>
+n<> u<43> t<Ordered_port_connection> p<44> f<82> l<5:17> el<5:17>
+n<> u<44> t<List_of_port_connections> p<45> c<43> f<82> l<5:17> el<5:17>
+n<> u<45> t<Hierarchical_instance> p<46> c<42> f<82> l<5:9> el<5:18>
+n<> u<46> t<Module_instantiation> p<47> c<40> f<82> l<5:1> el<5:19>
+n<> u<47> t<Module_or_generate_item> p<48> c<46> f<82> l<5:1> el<5:19>
+n<> u<48> t<Non_port_module_item> p<49> c<47> f<82> l<5:1> el<5:19>
+n<> u<49> t<Module_item> p<50> c<48> f<82> l<5:1> el<5:19>
+n<> u<50> t<Module_declaration> p<51> c<39> f<82> l<3:1> el<7:10>
+n<> u<51> t<Description> p<84> c<50> s<58> f<82> l<3:1> el<7:10>
 n<> u<52> t<Module_keyword> p<56> s<53> l<43:1> el<43:7>
 n<top_43> u<53> t<StringConst> p<56> s<55> l<43:8> el<43:14>
 n<> u<54> t<Port> p<55> l<43:16> el<43:16>
@@ -78,24 +78,24 @@ n<> u<55> t<List_of_ports> p<56> c<54> l<43:15> el<43:17>
 n<> u<56> t<Module_nonansi_header> p<57> c<52> l<43:1> el<43:18>
 n<> u<57> t<Module_declaration> p<58> c<56> l<43:1> el<44:10>
 n<> u<58> t<Description> p<84> c<57> s<64> l<43:1> el<44:10>
-n<middle_17> u<59> t<StringConst> p<61> s<60> f<67> l<17:7> el<17:16>
-n<> u<60> t<Endclass> p<61> f<67> l<18:1> el<18:9>
-n<> u<61> t<Class_declaration> p<62> c<59> f<67> l<17:1> el<18:9>
-n<> u<62> t<Package_or_generate_item_declaration> p<63> c<61> f<67> l<17:1> el<18:9>
-n<> u<63> t<Package_item> p<64> c<62> f<67> l<17:1> el<18:9>
-n<> u<64> t<Description> p<84> c<63> s<70> f<67> l<17:1> el<18:9>
-n<leaf_13> u<65> t<StringConst> p<67> s<66> f<72> l<13:7> el<13:14>
-n<> u<66> t<Endclass> p<67> f<72> l<14:1> el<14:9>
-n<> u<67> t<Class_declaration> p<68> c<65> f<72> l<13:1> el<14:9>
-n<> u<68> t<Package_or_generate_item_declaration> p<69> c<67> f<72> l<13:1> el<14:9>
-n<> u<69> t<Package_item> p<70> c<68> f<72> l<13:1> el<14:9>
-n<> u<70> t<Description> p<84> c<69> s<76> f<72> l<13:1> el<14:9>
-n<middle_25> u<71> t<StringConst> p<73> s<72> f<67> l<25:7> el<25:16>
-n<> u<72> t<Endclass> p<73> f<67> l<26:1> el<26:9>
-n<> u<73> t<Class_declaration> p<74> c<71> f<67> l<25:1> el<26:9>
-n<> u<74> t<Package_or_generate_item_declaration> p<75> c<73> f<67> l<25:1> el<26:9>
-n<> u<75> t<Package_item> p<76> c<74> f<67> l<25:1> el<26:9>
-n<> u<76> t<Description> p<84> c<75> s<83> f<67> l<25:1> el<26:9>
+n<middle_17> u<59> t<StringConst> p<61> s<60> f<68> l<17:7> el<17:16>
+n<> u<60> t<Endclass> p<61> f<68> l<18:1> el<18:9>
+n<> u<61> t<Class_declaration> p<62> c<59> f<68> l<17:1> el<18:9>
+n<> u<62> t<Package_or_generate_item_declaration> p<63> c<61> f<68> l<17:1> el<18:9>
+n<> u<63> t<Package_item> p<64> c<62> f<68> l<17:1> el<18:9>
+n<> u<64> t<Description> p<84> c<63> s<70> f<68> l<17:1> el<18:9>
+n<leaf_13> u<65> t<StringConst> p<67> s<66> f<73> l<13:7> el<13:14>
+n<> u<66> t<Endclass> p<67> f<73> l<14:1> el<14:9>
+n<> u<67> t<Class_declaration> p<68> c<65> f<73> l<13:1> el<14:9>
+n<> u<68> t<Package_or_generate_item_declaration> p<69> c<67> f<73> l<13:1> el<14:9>
+n<> u<69> t<Package_item> p<70> c<68> f<73> l<13:1> el<14:9>
+n<> u<70> t<Description> p<84> c<69> s<76> f<73> l<13:1> el<14:9>
+n<middle_25> u<71> t<StringConst> p<73> s<72> f<68> l<25:7> el<25:16>
+n<> u<72> t<Endclass> p<73> f<68> l<26:1> el<26:9>
+n<> u<73> t<Class_declaration> p<74> c<71> f<68> l<25:1> el<26:9>
+n<> u<74> t<Package_or_generate_item_declaration> p<75> c<73> f<68> l<25:1> el<26:9>
+n<> u<75> t<Package_item> p<76> c<74> f<68> l<25:1> el<26:9>
+n<> u<76> t<Description> p<84> c<75> s<83> f<68> l<25:1> el<26:9>
 n<> u<77> t<Module_keyword> p<81> s<78> l<49:1> el<49:7>
 n<bottom_49> u<78> t<StringConst> p<81> s<80> l<49:8> el<49:17>
 n<> u<79> t<Port> p<80> l<49:19> el<49:19>

--- a/tests/UnitElab/UnitElab.log
+++ b/tests/UnitElab/UnitElab.log
@@ -3481,30 +3481,30 @@ Instance tree:
 [TOP] work@small_top work@small_top
 [MOD] work@bottom2 work@bottom1.u1
 [UDP] work@bottom1::bottom3 [U] work@bottom1.u2
-[MOD] work@my_module work@top.inst[0][0][0] 
-[MOD] work@my_module work@top.inst[0][0][1] 
-[MOD] work@my_module work@top.inst[0][1][0] 
-[MOD] work@my_module work@top.inst[0][1][1] 
-[MOD] work@my_module work@top.inst[0][2][0] 
-[MOD] work@my_module work@top.inst[0][2][1] 
-[MOD] work@my_module work@top.inst[1][0][0] 
-[MOD] work@my_module work@top.inst[1][0][1] 
-[MOD] work@my_module work@top.inst[1][1][0] 
-[MOD] work@my_module work@top.inst[1][1][1] 
-[MOD] work@my_module work@top.inst[1][2][0] 
-[MOD] work@my_module work@top.inst[1][2][1] 
-[MOD] work@my_module work@top.inst[2][0][0] 
-[MOD] work@my_module work@top.inst[2][0][1] 
-[MOD] work@my_module work@top.inst[2][1][0] 
-[MOD] work@my_module work@top.inst[2][1][1] 
-[MOD] work@my_module work@top.inst[2][2][0] 
-[MOD] work@my_module work@top.inst[2][2][1] 
-[MOD] work@my_module work@top.inst[3][0][0] 
-[MOD] work@my_module work@top.inst[3][0][1] 
-[MOD] work@my_module work@top.inst[3][1][0] 
-[MOD] work@my_module work@top.inst[3][1][1] 
-[MOD] work@my_module work@top.inst[3][2][0] 
-[MOD] work@my_module work@top.inst[3][2][1] 
+[MOD] work@my_module work@top.inst[0][0][0]
+[MOD] work@my_module work@top.inst[0][0][1]
+[MOD] work@my_module work@top.inst[0][1][0]
+[MOD] work@my_module work@top.inst[0][1][1]
+[MOD] work@my_module work@top.inst[0][2][0]
+[MOD] work@my_module work@top.inst[0][2][1]
+[MOD] work@my_module work@top.inst[1][0][0]
+[MOD] work@my_module work@top.inst[1][0][1]
+[MOD] work@my_module work@top.inst[1][1][0]
+[MOD] work@my_module work@top.inst[1][1][1]
+[MOD] work@my_module work@top.inst[1][2][0]
+[MOD] work@my_module work@top.inst[1][2][1]
+[MOD] work@my_module work@top.inst[2][0][0]
+[MOD] work@my_module work@top.inst[2][0][1]
+[MOD] work@my_module work@top.inst[2][1][0]
+[MOD] work@my_module work@top.inst[2][1][1]
+[MOD] work@my_module work@top.inst[2][2][0]
+[MOD] work@my_module work@top.inst[2][2][1]
+[MOD] work@my_module work@top.inst[3][0][0]
+[MOD] work@my_module work@top.inst[3][0][1]
+[MOD] work@my_module work@top.inst[3][1][0]
+[MOD] work@my_module work@top.inst[3][1][1]
+[MOD] work@my_module work@top.inst[3][2][0]
+[MOD] work@my_module work@top.inst[3][2][1]
 [MOD] work@my_module work@top.inst1
 [GAT] work@and work@test.u0
 [SCO] work@test.g1 work@test.g1
@@ -8371,53 +8371,53 @@ Instance tree:
 
 [NTE:EL0523] top.v:3: Instance "work@bottom1.u2".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[0][0][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[0][0][0]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[0][0][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[0][0][1]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[0][1][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[0][1][0]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[0][1][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[0][1][1]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[0][2][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[0][2][0]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[0][2][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[0][2][1]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[1][0][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[1][0][0]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[1][0][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[1][0][1]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[1][1][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[1][1][0]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[1][1][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[1][1][1]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[1][2][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[1][2][0]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[1][2][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[1][2][1]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[2][0][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[2][0][0]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[2][0][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[2][0][1]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[2][1][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[2][1][0]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[2][1][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[2][1][1]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[2][2][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[2][2][0]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[2][2][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[2][2][1]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[3][0][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[3][0][0]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[3][0][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[3][0][1]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[3][1][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[3][1][0]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[3][1][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[3][1][1]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[3][2][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[3][2][0]".
 
-[NTE:EL0523] top.v:29: Instance "work@top.inst[3][2][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[3][2][1]".
 
 [NTE:EL0523] top.v:30: Instance "work@top.inst1".
 
@@ -13729,9 +13729,9 @@ design: (work@bottom1)
         |vpiName:b
         |vpiFullName:work@my_module.b
         |vpiActual:
-        \_logic_net: (work@top.inst[0][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][0][0] 
+        \_logic_net: (work@top.inst[0][0][0].b), line:20:22, endln:20:23, parent:work@top.inst[0][0][0]
           |vpiName:b
-          |vpiFullName:work@top.inst[0][0][0] .b
+          |vpiFullName:work@top.inst[0][0][0].b
     |vpiLhs:
     \_ref_obj: (work@my_module.c), line:23:10, endln:23:11
       |vpiName:c
@@ -14128,14 +14128,14 @@ design: (work@bottom1)
             |vpiSize:64
             |UINT:0
   |vpiModule:
-  \_module: work@my_module (work@top.inst[0][0][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[0][0][0]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[0][0][0] 
-    |vpiFullName:work@top.inst[0][0][0] 
+    |vpiName:inst[0][0][0]
+    |vpiFullName:work@top.inst[0][0][0]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][0][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][0][0]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14146,11 +14146,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[0][0][0] 
+        \_logic_net: (work@top.inst[0][0][0].a), line:20:19, endln:20:20, parent:work@top.inst[0][0][0]
           |vpiName:a
-          |vpiFullName:work@top.inst[0][0][0] .a
+          |vpiFullName:work@top.inst[0][0][0].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][0][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][0][0]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14161,11 +14161,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][0][0] 
+        \_logic_net: (work@top.inst[0][0][0].b), line:20:22, endln:20:23, parent:work@top.inst[0][0][0]
           |vpiName:b
-          |vpiFullName:work@top.inst[0][0][0] .b
+          |vpiFullName:work@top.inst[0][0][0].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][0][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][0][0]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14176,26 +14176,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[0][0][0] 
+        \_logic_net: (work@top.inst[0][0][0].c), line:20:25, endln:20:26, parent:work@top.inst[0][0][0]
           |vpiName:c
-          |vpiFullName:work@top.inst[0][0][0] .c
+          |vpiFullName:work@top.inst[0][0][0].c
     |vpiNet:
-    \_logic_net: (work@top.inst[0][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[0][0][0] 
+    \_logic_net: (work@top.inst[0][0][0].a), line:20:19, endln:20:20, parent:work@top.inst[0][0][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[0][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][0][0] 
+    \_logic_net: (work@top.inst[0][0][0].b), line:20:22, endln:20:23, parent:work@top.inst[0][0][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[0][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[0][0][0] 
+    \_logic_net: (work@top.inst[0][0][0].c), line:20:25, endln:20:26, parent:work@top.inst[0][0][0]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[0][0][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[0][0][1]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[0][0][1] 
-    |vpiFullName:work@top.inst[0][0][1] 
+    |vpiName:inst[0][0][1]
+    |vpiFullName:work@top.inst[0][0][1]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][0][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][0][1]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14206,11 +14206,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[0][0][1] 
+        \_logic_net: (work@top.inst[0][0][1].a), line:20:19, endln:20:20, parent:work@top.inst[0][0][1]
           |vpiName:a
-          |vpiFullName:work@top.inst[0][0][1] .a
+          |vpiFullName:work@top.inst[0][0][1].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][0][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][0][1]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14221,11 +14221,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[0][0][1] 
+        \_logic_net: (work@top.inst[0][0][1].b), line:20:22, endln:20:23, parent:work@top.inst[0][0][1]
           |vpiName:b
-          |vpiFullName:work@top.inst[0][0][1] .b
+          |vpiFullName:work@top.inst[0][0][1].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][0][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][0][1]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14236,26 +14236,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[0][0][1] 
+        \_logic_net: (work@top.inst[0][0][1].c), line:20:25, endln:20:26, parent:work@top.inst[0][0][1]
           |vpiName:c
-          |vpiFullName:work@top.inst[0][0][1] .c
+          |vpiFullName:work@top.inst[0][0][1].c
     |vpiNet:
-    \_logic_net: (work@top.inst[0][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[0][0][1] 
+    \_logic_net: (work@top.inst[0][0][1].a), line:20:19, endln:20:20, parent:work@top.inst[0][0][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[0][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[0][0][1] 
+    \_logic_net: (work@top.inst[0][0][1].b), line:20:22, endln:20:23, parent:work@top.inst[0][0][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[0][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[0][0][1] 
+    \_logic_net: (work@top.inst[0][0][1].c), line:20:25, endln:20:26, parent:work@top.inst[0][0][1]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[0][1][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[0][1][0]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[0][1][0] 
-    |vpiFullName:work@top.inst[0][1][0] 
+    |vpiName:inst[0][1][0]
+    |vpiFullName:work@top.inst[0][1][0]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][1][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][1][0]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14266,11 +14266,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[0][1][0] 
+        \_logic_net: (work@top.inst[0][1][0].a), line:20:19, endln:20:20, parent:work@top.inst[0][1][0]
           |vpiName:a
-          |vpiFullName:work@top.inst[0][1][0] .a
+          |vpiFullName:work@top.inst[0][1][0].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][1][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][1][0]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14281,11 +14281,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][1][0] 
+        \_logic_net: (work@top.inst[0][1][0].b), line:20:22, endln:20:23, parent:work@top.inst[0][1][0]
           |vpiName:b
-          |vpiFullName:work@top.inst[0][1][0] .b
+          |vpiFullName:work@top.inst[0][1][0].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][1][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][1][0]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14296,26 +14296,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[0][1][0] 
+        \_logic_net: (work@top.inst[0][1][0].c), line:20:25, endln:20:26, parent:work@top.inst[0][1][0]
           |vpiName:c
-          |vpiFullName:work@top.inst[0][1][0] .c
+          |vpiFullName:work@top.inst[0][1][0].c
     |vpiNet:
-    \_logic_net: (work@top.inst[0][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[0][1][0] 
+    \_logic_net: (work@top.inst[0][1][0].a), line:20:19, endln:20:20, parent:work@top.inst[0][1][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[0][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][1][0] 
+    \_logic_net: (work@top.inst[0][1][0].b), line:20:22, endln:20:23, parent:work@top.inst[0][1][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[0][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[0][1][0] 
+    \_logic_net: (work@top.inst[0][1][0].c), line:20:25, endln:20:26, parent:work@top.inst[0][1][0]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[0][1][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[0][1][1]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[0][1][1] 
-    |vpiFullName:work@top.inst[0][1][1] 
+    |vpiName:inst[0][1][1]
+    |vpiFullName:work@top.inst[0][1][1]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][1][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][1][1]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14326,11 +14326,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[0][1][1] 
+        \_logic_net: (work@top.inst[0][1][1].a), line:20:19, endln:20:20, parent:work@top.inst[0][1][1]
           |vpiName:a
-          |vpiFullName:work@top.inst[0][1][1] .a
+          |vpiFullName:work@top.inst[0][1][1].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][1][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][1][1]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14341,11 +14341,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[0][1][1] 
+        \_logic_net: (work@top.inst[0][1][1].b), line:20:22, endln:20:23, parent:work@top.inst[0][1][1]
           |vpiName:b
-          |vpiFullName:work@top.inst[0][1][1] .b
+          |vpiFullName:work@top.inst[0][1][1].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][1][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][1][1]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14356,26 +14356,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[0][1][1] 
+        \_logic_net: (work@top.inst[0][1][1].c), line:20:25, endln:20:26, parent:work@top.inst[0][1][1]
           |vpiName:c
-          |vpiFullName:work@top.inst[0][1][1] .c
+          |vpiFullName:work@top.inst[0][1][1].c
     |vpiNet:
-    \_logic_net: (work@top.inst[0][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[0][1][1] 
+    \_logic_net: (work@top.inst[0][1][1].a), line:20:19, endln:20:20, parent:work@top.inst[0][1][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[0][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[0][1][1] 
+    \_logic_net: (work@top.inst[0][1][1].b), line:20:22, endln:20:23, parent:work@top.inst[0][1][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[0][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[0][1][1] 
+    \_logic_net: (work@top.inst[0][1][1].c), line:20:25, endln:20:26, parent:work@top.inst[0][1][1]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[0][2][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[0][2][0]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[0][2][0] 
-    |vpiFullName:work@top.inst[0][2][0] 
+    |vpiName:inst[0][2][0]
+    |vpiFullName:work@top.inst[0][2][0]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][2][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][2][0]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14386,11 +14386,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[0][2][0] 
+        \_logic_net: (work@top.inst[0][2][0].a), line:20:19, endln:20:20, parent:work@top.inst[0][2][0]
           |vpiName:a
-          |vpiFullName:work@top.inst[0][2][0] .a
+          |vpiFullName:work@top.inst[0][2][0].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][2][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][2][0]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14401,11 +14401,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][2][0] 
+        \_logic_net: (work@top.inst[0][2][0].b), line:20:22, endln:20:23, parent:work@top.inst[0][2][0]
           |vpiName:b
-          |vpiFullName:work@top.inst[0][2][0] .b
+          |vpiFullName:work@top.inst[0][2][0].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][2][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][2][0]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14416,26 +14416,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[0][2][0] 
+        \_logic_net: (work@top.inst[0][2][0].c), line:20:25, endln:20:26, parent:work@top.inst[0][2][0]
           |vpiName:c
-          |vpiFullName:work@top.inst[0][2][0] .c
+          |vpiFullName:work@top.inst[0][2][0].c
     |vpiNet:
-    \_logic_net: (work@top.inst[0][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[0][2][0] 
+    \_logic_net: (work@top.inst[0][2][0].a), line:20:19, endln:20:20, parent:work@top.inst[0][2][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[0][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][2][0] 
+    \_logic_net: (work@top.inst[0][2][0].b), line:20:22, endln:20:23, parent:work@top.inst[0][2][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[0][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[0][2][0] 
+    \_logic_net: (work@top.inst[0][2][0].c), line:20:25, endln:20:26, parent:work@top.inst[0][2][0]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[0][2][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[0][2][1]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[0][2][1] 
-    |vpiFullName:work@top.inst[0][2][1] 
+    |vpiName:inst[0][2][1]
+    |vpiFullName:work@top.inst[0][2][1]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][2][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][2][1]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14446,11 +14446,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[0][2][1] 
+        \_logic_net: (work@top.inst[0][2][1].a), line:20:19, endln:20:20, parent:work@top.inst[0][2][1]
           |vpiName:a
-          |vpiFullName:work@top.inst[0][2][1] .a
+          |vpiFullName:work@top.inst[0][2][1].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][2][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][2][1]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14461,11 +14461,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[0][2][1] 
+        \_logic_net: (work@top.inst[0][2][1].b), line:20:22, endln:20:23, parent:work@top.inst[0][2][1]
           |vpiName:b
-          |vpiFullName:work@top.inst[0][2][1] .b
+          |vpiFullName:work@top.inst[0][2][1].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][2][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][2][1]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14476,26 +14476,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[0][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[0][2][1] 
+        \_logic_net: (work@top.inst[0][2][1].c), line:20:25, endln:20:26, parent:work@top.inst[0][2][1]
           |vpiName:c
-          |vpiFullName:work@top.inst[0][2][1] .c
+          |vpiFullName:work@top.inst[0][2][1].c
     |vpiNet:
-    \_logic_net: (work@top.inst[0][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[0][2][1] 
+    \_logic_net: (work@top.inst[0][2][1].a), line:20:19, endln:20:20, parent:work@top.inst[0][2][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[0][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[0][2][1] 
+    \_logic_net: (work@top.inst[0][2][1].b), line:20:22, endln:20:23, parent:work@top.inst[0][2][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[0][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[0][2][1] 
+    \_logic_net: (work@top.inst[0][2][1].c), line:20:25, endln:20:26, parent:work@top.inst[0][2][1]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[1][0][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[1][0][0]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[1][0][0] 
-    |vpiFullName:work@top.inst[1][0][0] 
+    |vpiName:inst[1][0][0]
+    |vpiFullName:work@top.inst[1][0][0]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][0][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][0][0]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14506,11 +14506,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[1][0][0] 
+        \_logic_net: (work@top.inst[1][0][0].a), line:20:19, endln:20:20, parent:work@top.inst[1][0][0]
           |vpiName:a
-          |vpiFullName:work@top.inst[1][0][0] .a
+          |vpiFullName:work@top.inst[1][0][0].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][0][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][0][0]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14521,11 +14521,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[1][0][0] 
+        \_logic_net: (work@top.inst[1][0][0].b), line:20:22, endln:20:23, parent:work@top.inst[1][0][0]
           |vpiName:b
-          |vpiFullName:work@top.inst[1][0][0] .b
+          |vpiFullName:work@top.inst[1][0][0].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][0][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][0][0]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14536,26 +14536,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[1][0][0] 
+        \_logic_net: (work@top.inst[1][0][0].c), line:20:25, endln:20:26, parent:work@top.inst[1][0][0]
           |vpiName:c
-          |vpiFullName:work@top.inst[1][0][0] .c
+          |vpiFullName:work@top.inst[1][0][0].c
     |vpiNet:
-    \_logic_net: (work@top.inst[1][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[1][0][0] 
+    \_logic_net: (work@top.inst[1][0][0].a), line:20:19, endln:20:20, parent:work@top.inst[1][0][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[1][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[1][0][0] 
+    \_logic_net: (work@top.inst[1][0][0].b), line:20:22, endln:20:23, parent:work@top.inst[1][0][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[1][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[1][0][0] 
+    \_logic_net: (work@top.inst[1][0][0].c), line:20:25, endln:20:26, parent:work@top.inst[1][0][0]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[1][0][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[1][0][1]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[1][0][1] 
-    |vpiFullName:work@top.inst[1][0][1] 
+    |vpiName:inst[1][0][1]
+    |vpiFullName:work@top.inst[1][0][1]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][0][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][0][1]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14566,11 +14566,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[1][0][1] 
+        \_logic_net: (work@top.inst[1][0][1].a), line:20:19, endln:20:20, parent:work@top.inst[1][0][1]
           |vpiName:a
-          |vpiFullName:work@top.inst[1][0][1] .a
+          |vpiFullName:work@top.inst[1][0][1].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][0][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][0][1]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14581,11 +14581,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[1][0][1] 
+        \_logic_net: (work@top.inst[1][0][1].b), line:20:22, endln:20:23, parent:work@top.inst[1][0][1]
           |vpiName:b
-          |vpiFullName:work@top.inst[1][0][1] .b
+          |vpiFullName:work@top.inst[1][0][1].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][0][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][0][1]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14596,26 +14596,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[1][0][1] 
+        \_logic_net: (work@top.inst[1][0][1].c), line:20:25, endln:20:26, parent:work@top.inst[1][0][1]
           |vpiName:c
-          |vpiFullName:work@top.inst[1][0][1] .c
+          |vpiFullName:work@top.inst[1][0][1].c
     |vpiNet:
-    \_logic_net: (work@top.inst[1][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[1][0][1] 
+    \_logic_net: (work@top.inst[1][0][1].a), line:20:19, endln:20:20, parent:work@top.inst[1][0][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[1][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[1][0][1] 
+    \_logic_net: (work@top.inst[1][0][1].b), line:20:22, endln:20:23, parent:work@top.inst[1][0][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[1][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[1][0][1] 
+    \_logic_net: (work@top.inst[1][0][1].c), line:20:25, endln:20:26, parent:work@top.inst[1][0][1]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[1][1][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[1][1][0]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[1][1][0] 
-    |vpiFullName:work@top.inst[1][1][0] 
+    |vpiName:inst[1][1][0]
+    |vpiFullName:work@top.inst[1][1][0]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][1][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][1][0]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14626,11 +14626,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[1][1][0] 
+        \_logic_net: (work@top.inst[1][1][0].a), line:20:19, endln:20:20, parent:work@top.inst[1][1][0]
           |vpiName:a
-          |vpiFullName:work@top.inst[1][1][0] .a
+          |vpiFullName:work@top.inst[1][1][0].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][1][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][1][0]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14641,11 +14641,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[1][1][0] 
+        \_logic_net: (work@top.inst[1][1][0].b), line:20:22, endln:20:23, parent:work@top.inst[1][1][0]
           |vpiName:b
-          |vpiFullName:work@top.inst[1][1][0] .b
+          |vpiFullName:work@top.inst[1][1][0].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][1][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][1][0]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14656,26 +14656,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[1][1][0] 
+        \_logic_net: (work@top.inst[1][1][0].c), line:20:25, endln:20:26, parent:work@top.inst[1][1][0]
           |vpiName:c
-          |vpiFullName:work@top.inst[1][1][0] .c
+          |vpiFullName:work@top.inst[1][1][0].c
     |vpiNet:
-    \_logic_net: (work@top.inst[1][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[1][1][0] 
+    \_logic_net: (work@top.inst[1][1][0].a), line:20:19, endln:20:20, parent:work@top.inst[1][1][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[1][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[1][1][0] 
+    \_logic_net: (work@top.inst[1][1][0].b), line:20:22, endln:20:23, parent:work@top.inst[1][1][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[1][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[1][1][0] 
+    \_logic_net: (work@top.inst[1][1][0].c), line:20:25, endln:20:26, parent:work@top.inst[1][1][0]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[1][1][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[1][1][1]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[1][1][1] 
-    |vpiFullName:work@top.inst[1][1][1] 
+    |vpiName:inst[1][1][1]
+    |vpiFullName:work@top.inst[1][1][1]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][1][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][1][1]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14686,11 +14686,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[1][1][1] 
+        \_logic_net: (work@top.inst[1][1][1].a), line:20:19, endln:20:20, parent:work@top.inst[1][1][1]
           |vpiName:a
-          |vpiFullName:work@top.inst[1][1][1] .a
+          |vpiFullName:work@top.inst[1][1][1].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][1][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][1][1]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14701,11 +14701,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[1][1][1] 
+        \_logic_net: (work@top.inst[1][1][1].b), line:20:22, endln:20:23, parent:work@top.inst[1][1][1]
           |vpiName:b
-          |vpiFullName:work@top.inst[1][1][1] .b
+          |vpiFullName:work@top.inst[1][1][1].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][1][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][1][1]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14716,26 +14716,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[1][1][1] 
+        \_logic_net: (work@top.inst[1][1][1].c), line:20:25, endln:20:26, parent:work@top.inst[1][1][1]
           |vpiName:c
-          |vpiFullName:work@top.inst[1][1][1] .c
+          |vpiFullName:work@top.inst[1][1][1].c
     |vpiNet:
-    \_logic_net: (work@top.inst[1][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[1][1][1] 
+    \_logic_net: (work@top.inst[1][1][1].a), line:20:19, endln:20:20, parent:work@top.inst[1][1][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[1][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[1][1][1] 
+    \_logic_net: (work@top.inst[1][1][1].b), line:20:22, endln:20:23, parent:work@top.inst[1][1][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[1][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[1][1][1] 
+    \_logic_net: (work@top.inst[1][1][1].c), line:20:25, endln:20:26, parent:work@top.inst[1][1][1]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[1][2][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[1][2][0]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[1][2][0] 
-    |vpiFullName:work@top.inst[1][2][0] 
+    |vpiName:inst[1][2][0]
+    |vpiFullName:work@top.inst[1][2][0]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][2][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][2][0]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14746,11 +14746,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[1][2][0] 
+        \_logic_net: (work@top.inst[1][2][0].a), line:20:19, endln:20:20, parent:work@top.inst[1][2][0]
           |vpiName:a
-          |vpiFullName:work@top.inst[1][2][0] .a
+          |vpiFullName:work@top.inst[1][2][0].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][2][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][2][0]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14761,11 +14761,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[1][2][0] 
+        \_logic_net: (work@top.inst[1][2][0].b), line:20:22, endln:20:23, parent:work@top.inst[1][2][0]
           |vpiName:b
-          |vpiFullName:work@top.inst[1][2][0] .b
+          |vpiFullName:work@top.inst[1][2][0].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][2][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][2][0]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14776,26 +14776,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[1][2][0] 
+        \_logic_net: (work@top.inst[1][2][0].c), line:20:25, endln:20:26, parent:work@top.inst[1][2][0]
           |vpiName:c
-          |vpiFullName:work@top.inst[1][2][0] .c
+          |vpiFullName:work@top.inst[1][2][0].c
     |vpiNet:
-    \_logic_net: (work@top.inst[1][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[1][2][0] 
+    \_logic_net: (work@top.inst[1][2][0].a), line:20:19, endln:20:20, parent:work@top.inst[1][2][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[1][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[1][2][0] 
+    \_logic_net: (work@top.inst[1][2][0].b), line:20:22, endln:20:23, parent:work@top.inst[1][2][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[1][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[1][2][0] 
+    \_logic_net: (work@top.inst[1][2][0].c), line:20:25, endln:20:26, parent:work@top.inst[1][2][0]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[1][2][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[1][2][1]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[1][2][1] 
-    |vpiFullName:work@top.inst[1][2][1] 
+    |vpiName:inst[1][2][1]
+    |vpiFullName:work@top.inst[1][2][1]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][2][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][2][1]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14806,11 +14806,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[1][2][1] 
+        \_logic_net: (work@top.inst[1][2][1].a), line:20:19, endln:20:20, parent:work@top.inst[1][2][1]
           |vpiName:a
-          |vpiFullName:work@top.inst[1][2][1] .a
+          |vpiFullName:work@top.inst[1][2][1].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][2][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][2][1]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14821,11 +14821,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[1][2][1] 
+        \_logic_net: (work@top.inst[1][2][1].b), line:20:22, endln:20:23, parent:work@top.inst[1][2][1]
           |vpiName:b
-          |vpiFullName:work@top.inst[1][2][1] .b
+          |vpiFullName:work@top.inst[1][2][1].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][2][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][2][1]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14836,26 +14836,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[1][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[1][2][1] 
+        \_logic_net: (work@top.inst[1][2][1].c), line:20:25, endln:20:26, parent:work@top.inst[1][2][1]
           |vpiName:c
-          |vpiFullName:work@top.inst[1][2][1] .c
+          |vpiFullName:work@top.inst[1][2][1].c
     |vpiNet:
-    \_logic_net: (work@top.inst[1][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[1][2][1] 
+    \_logic_net: (work@top.inst[1][2][1].a), line:20:19, endln:20:20, parent:work@top.inst[1][2][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[1][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[1][2][1] 
+    \_logic_net: (work@top.inst[1][2][1].b), line:20:22, endln:20:23, parent:work@top.inst[1][2][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[1][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[1][2][1] 
+    \_logic_net: (work@top.inst[1][2][1].c), line:20:25, endln:20:26, parent:work@top.inst[1][2][1]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[2][0][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[2][0][0]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[2][0][0] 
-    |vpiFullName:work@top.inst[2][0][0] 
+    |vpiName:inst[2][0][0]
+    |vpiFullName:work@top.inst[2][0][0]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][0][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][0][0]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14866,11 +14866,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[2][0][0] 
+        \_logic_net: (work@top.inst[2][0][0].a), line:20:19, endln:20:20, parent:work@top.inst[2][0][0]
           |vpiName:a
-          |vpiFullName:work@top.inst[2][0][0] .a
+          |vpiFullName:work@top.inst[2][0][0].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][0][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][0][0]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14881,11 +14881,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[2][0][0] 
+        \_logic_net: (work@top.inst[2][0][0].b), line:20:22, endln:20:23, parent:work@top.inst[2][0][0]
           |vpiName:b
-          |vpiFullName:work@top.inst[2][0][0] .b
+          |vpiFullName:work@top.inst[2][0][0].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][0][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][0][0]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14896,26 +14896,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[2][0][0] 
+        \_logic_net: (work@top.inst[2][0][0].c), line:20:25, endln:20:26, parent:work@top.inst[2][0][0]
           |vpiName:c
-          |vpiFullName:work@top.inst[2][0][0] .c
+          |vpiFullName:work@top.inst[2][0][0].c
     |vpiNet:
-    \_logic_net: (work@top.inst[2][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[2][0][0] 
+    \_logic_net: (work@top.inst[2][0][0].a), line:20:19, endln:20:20, parent:work@top.inst[2][0][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[2][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[2][0][0] 
+    \_logic_net: (work@top.inst[2][0][0].b), line:20:22, endln:20:23, parent:work@top.inst[2][0][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[2][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[2][0][0] 
+    \_logic_net: (work@top.inst[2][0][0].c), line:20:25, endln:20:26, parent:work@top.inst[2][0][0]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[2][0][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[2][0][1]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[2][0][1] 
-    |vpiFullName:work@top.inst[2][0][1] 
+    |vpiName:inst[2][0][1]
+    |vpiFullName:work@top.inst[2][0][1]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][0][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][0][1]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14926,11 +14926,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[2][0][1] 
+        \_logic_net: (work@top.inst[2][0][1].a), line:20:19, endln:20:20, parent:work@top.inst[2][0][1]
           |vpiName:a
-          |vpiFullName:work@top.inst[2][0][1] .a
+          |vpiFullName:work@top.inst[2][0][1].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][0][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][0][1]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14941,11 +14941,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[2][0][1] 
+        \_logic_net: (work@top.inst[2][0][1].b), line:20:22, endln:20:23, parent:work@top.inst[2][0][1]
           |vpiName:b
-          |vpiFullName:work@top.inst[2][0][1] .b
+          |vpiFullName:work@top.inst[2][0][1].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][0][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][0][1]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14956,26 +14956,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[2][0][1] 
+        \_logic_net: (work@top.inst[2][0][1].c), line:20:25, endln:20:26, parent:work@top.inst[2][0][1]
           |vpiName:c
-          |vpiFullName:work@top.inst[2][0][1] .c
+          |vpiFullName:work@top.inst[2][0][1].c
     |vpiNet:
-    \_logic_net: (work@top.inst[2][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[2][0][1] 
+    \_logic_net: (work@top.inst[2][0][1].a), line:20:19, endln:20:20, parent:work@top.inst[2][0][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[2][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[2][0][1] 
+    \_logic_net: (work@top.inst[2][0][1].b), line:20:22, endln:20:23, parent:work@top.inst[2][0][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[2][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[2][0][1] 
+    \_logic_net: (work@top.inst[2][0][1].c), line:20:25, endln:20:26, parent:work@top.inst[2][0][1]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[2][1][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[2][1][0]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[2][1][0] 
-    |vpiFullName:work@top.inst[2][1][0] 
+    |vpiName:inst[2][1][0]
+    |vpiFullName:work@top.inst[2][1][0]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][1][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][1][0]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14986,11 +14986,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[2][1][0] 
+        \_logic_net: (work@top.inst[2][1][0].a), line:20:19, endln:20:20, parent:work@top.inst[2][1][0]
           |vpiName:a
-          |vpiFullName:work@top.inst[2][1][0] .a
+          |vpiFullName:work@top.inst[2][1][0].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][1][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][1][0]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15001,11 +15001,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[2][1][0] 
+        \_logic_net: (work@top.inst[2][1][0].b), line:20:22, endln:20:23, parent:work@top.inst[2][1][0]
           |vpiName:b
-          |vpiFullName:work@top.inst[2][1][0] .b
+          |vpiFullName:work@top.inst[2][1][0].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][1][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][1][0]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15016,26 +15016,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[2][1][0] 
+        \_logic_net: (work@top.inst[2][1][0].c), line:20:25, endln:20:26, parent:work@top.inst[2][1][0]
           |vpiName:c
-          |vpiFullName:work@top.inst[2][1][0] .c
+          |vpiFullName:work@top.inst[2][1][0].c
     |vpiNet:
-    \_logic_net: (work@top.inst[2][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[2][1][0] 
+    \_logic_net: (work@top.inst[2][1][0].a), line:20:19, endln:20:20, parent:work@top.inst[2][1][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[2][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[2][1][0] 
+    \_logic_net: (work@top.inst[2][1][0].b), line:20:22, endln:20:23, parent:work@top.inst[2][1][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[2][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[2][1][0] 
+    \_logic_net: (work@top.inst[2][1][0].c), line:20:25, endln:20:26, parent:work@top.inst[2][1][0]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[2][1][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[2][1][1]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[2][1][1] 
-    |vpiFullName:work@top.inst[2][1][1] 
+    |vpiName:inst[2][1][1]
+    |vpiFullName:work@top.inst[2][1][1]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][1][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][1][1]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15046,11 +15046,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[2][1][1] 
+        \_logic_net: (work@top.inst[2][1][1].a), line:20:19, endln:20:20, parent:work@top.inst[2][1][1]
           |vpiName:a
-          |vpiFullName:work@top.inst[2][1][1] .a
+          |vpiFullName:work@top.inst[2][1][1].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][1][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][1][1]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15061,11 +15061,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[2][1][1] 
+        \_logic_net: (work@top.inst[2][1][1].b), line:20:22, endln:20:23, parent:work@top.inst[2][1][1]
           |vpiName:b
-          |vpiFullName:work@top.inst[2][1][1] .b
+          |vpiFullName:work@top.inst[2][1][1].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][1][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][1][1]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15076,26 +15076,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[2][1][1] 
+        \_logic_net: (work@top.inst[2][1][1].c), line:20:25, endln:20:26, parent:work@top.inst[2][1][1]
           |vpiName:c
-          |vpiFullName:work@top.inst[2][1][1] .c
+          |vpiFullName:work@top.inst[2][1][1].c
     |vpiNet:
-    \_logic_net: (work@top.inst[2][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[2][1][1] 
+    \_logic_net: (work@top.inst[2][1][1].a), line:20:19, endln:20:20, parent:work@top.inst[2][1][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[2][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[2][1][1] 
+    \_logic_net: (work@top.inst[2][1][1].b), line:20:22, endln:20:23, parent:work@top.inst[2][1][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[2][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[2][1][1] 
+    \_logic_net: (work@top.inst[2][1][1].c), line:20:25, endln:20:26, parent:work@top.inst[2][1][1]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[2][2][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[2][2][0]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[2][2][0] 
-    |vpiFullName:work@top.inst[2][2][0] 
+    |vpiName:inst[2][2][0]
+    |vpiFullName:work@top.inst[2][2][0]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][2][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][2][0]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15106,11 +15106,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[2][2][0] 
+        \_logic_net: (work@top.inst[2][2][0].a), line:20:19, endln:20:20, parent:work@top.inst[2][2][0]
           |vpiName:a
-          |vpiFullName:work@top.inst[2][2][0] .a
+          |vpiFullName:work@top.inst[2][2][0].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][2][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][2][0]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15121,11 +15121,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[2][2][0] 
+        \_logic_net: (work@top.inst[2][2][0].b), line:20:22, endln:20:23, parent:work@top.inst[2][2][0]
           |vpiName:b
-          |vpiFullName:work@top.inst[2][2][0] .b
+          |vpiFullName:work@top.inst[2][2][0].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][2][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][2][0]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15136,26 +15136,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[2][2][0] 
+        \_logic_net: (work@top.inst[2][2][0].c), line:20:25, endln:20:26, parent:work@top.inst[2][2][0]
           |vpiName:c
-          |vpiFullName:work@top.inst[2][2][0] .c
+          |vpiFullName:work@top.inst[2][2][0].c
     |vpiNet:
-    \_logic_net: (work@top.inst[2][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[2][2][0] 
+    \_logic_net: (work@top.inst[2][2][0].a), line:20:19, endln:20:20, parent:work@top.inst[2][2][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[2][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[2][2][0] 
+    \_logic_net: (work@top.inst[2][2][0].b), line:20:22, endln:20:23, parent:work@top.inst[2][2][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[2][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[2][2][0] 
+    \_logic_net: (work@top.inst[2][2][0].c), line:20:25, endln:20:26, parent:work@top.inst[2][2][0]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[2][2][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[2][2][1]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[2][2][1] 
-    |vpiFullName:work@top.inst[2][2][1] 
+    |vpiName:inst[2][2][1]
+    |vpiFullName:work@top.inst[2][2][1]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][2][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][2][1]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15166,11 +15166,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[2][2][1] 
+        \_logic_net: (work@top.inst[2][2][1].a), line:20:19, endln:20:20, parent:work@top.inst[2][2][1]
           |vpiName:a
-          |vpiFullName:work@top.inst[2][2][1] .a
+          |vpiFullName:work@top.inst[2][2][1].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][2][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][2][1]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15181,11 +15181,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[2][2][1] 
+        \_logic_net: (work@top.inst[2][2][1].b), line:20:22, endln:20:23, parent:work@top.inst[2][2][1]
           |vpiName:b
-          |vpiFullName:work@top.inst[2][2][1] .b
+          |vpiFullName:work@top.inst[2][2][1].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][2][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][2][1]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15196,26 +15196,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[2][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[2][2][1] 
+        \_logic_net: (work@top.inst[2][2][1].c), line:20:25, endln:20:26, parent:work@top.inst[2][2][1]
           |vpiName:c
-          |vpiFullName:work@top.inst[2][2][1] .c
+          |vpiFullName:work@top.inst[2][2][1].c
     |vpiNet:
-    \_logic_net: (work@top.inst[2][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[2][2][1] 
+    \_logic_net: (work@top.inst[2][2][1].a), line:20:19, endln:20:20, parent:work@top.inst[2][2][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[2][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[2][2][1] 
+    \_logic_net: (work@top.inst[2][2][1].b), line:20:22, endln:20:23, parent:work@top.inst[2][2][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[2][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[2][2][1] 
+    \_logic_net: (work@top.inst[2][2][1].c), line:20:25, endln:20:26, parent:work@top.inst[2][2][1]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[3][0][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[3][0][0]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[3][0][0] 
-    |vpiFullName:work@top.inst[3][0][0] 
+    |vpiName:inst[3][0][0]
+    |vpiFullName:work@top.inst[3][0][0]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][0][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][0][0]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15226,11 +15226,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[3][0][0] 
+        \_logic_net: (work@top.inst[3][0][0].a), line:20:19, endln:20:20, parent:work@top.inst[3][0][0]
           |vpiName:a
-          |vpiFullName:work@top.inst[3][0][0] .a
+          |vpiFullName:work@top.inst[3][0][0].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][0][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][0][0]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15241,11 +15241,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[3][0][0] 
+        \_logic_net: (work@top.inst[3][0][0].b), line:20:22, endln:20:23, parent:work@top.inst[3][0][0]
           |vpiName:b
-          |vpiFullName:work@top.inst[3][0][0] .b
+          |vpiFullName:work@top.inst[3][0][0].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][0][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][0][0]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15256,26 +15256,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[3][0][0] 
+        \_logic_net: (work@top.inst[3][0][0].c), line:20:25, endln:20:26, parent:work@top.inst[3][0][0]
           |vpiName:c
-          |vpiFullName:work@top.inst[3][0][0] .c
+          |vpiFullName:work@top.inst[3][0][0].c
     |vpiNet:
-    \_logic_net: (work@top.inst[3][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[3][0][0] 
+    \_logic_net: (work@top.inst[3][0][0].a), line:20:19, endln:20:20, parent:work@top.inst[3][0][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[3][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[3][0][0] 
+    \_logic_net: (work@top.inst[3][0][0].b), line:20:22, endln:20:23, parent:work@top.inst[3][0][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[3][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[3][0][0] 
+    \_logic_net: (work@top.inst[3][0][0].c), line:20:25, endln:20:26, parent:work@top.inst[3][0][0]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[3][0][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[3][0][1]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[3][0][1] 
-    |vpiFullName:work@top.inst[3][0][1] 
+    |vpiName:inst[3][0][1]
+    |vpiFullName:work@top.inst[3][0][1]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][0][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][0][1]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15286,11 +15286,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[3][0][1] 
+        \_logic_net: (work@top.inst[3][0][1].a), line:20:19, endln:20:20, parent:work@top.inst[3][0][1]
           |vpiName:a
-          |vpiFullName:work@top.inst[3][0][1] .a
+          |vpiFullName:work@top.inst[3][0][1].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][0][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][0][1]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15301,11 +15301,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[3][0][1] 
+        \_logic_net: (work@top.inst[3][0][1].b), line:20:22, endln:20:23, parent:work@top.inst[3][0][1]
           |vpiName:b
-          |vpiFullName:work@top.inst[3][0][1] .b
+          |vpiFullName:work@top.inst[3][0][1].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][0][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][0][1]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15316,26 +15316,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[3][0][1] 
+        \_logic_net: (work@top.inst[3][0][1].c), line:20:25, endln:20:26, parent:work@top.inst[3][0][1]
           |vpiName:c
-          |vpiFullName:work@top.inst[3][0][1] .c
+          |vpiFullName:work@top.inst[3][0][1].c
     |vpiNet:
-    \_logic_net: (work@top.inst[3][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[3][0][1] 
+    \_logic_net: (work@top.inst[3][0][1].a), line:20:19, endln:20:20, parent:work@top.inst[3][0][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[3][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[3][0][1] 
+    \_logic_net: (work@top.inst[3][0][1].b), line:20:22, endln:20:23, parent:work@top.inst[3][0][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[3][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[3][0][1] 
+    \_logic_net: (work@top.inst[3][0][1].c), line:20:25, endln:20:26, parent:work@top.inst[3][0][1]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[3][1][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[3][1][0]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[3][1][0] 
-    |vpiFullName:work@top.inst[3][1][0] 
+    |vpiName:inst[3][1][0]
+    |vpiFullName:work@top.inst[3][1][0]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][1][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][1][0]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15346,11 +15346,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[3][1][0] 
+        \_logic_net: (work@top.inst[3][1][0].a), line:20:19, endln:20:20, parent:work@top.inst[3][1][0]
           |vpiName:a
-          |vpiFullName:work@top.inst[3][1][0] .a
+          |vpiFullName:work@top.inst[3][1][0].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][1][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][1][0]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15361,11 +15361,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[3][1][0] 
+        \_logic_net: (work@top.inst[3][1][0].b), line:20:22, endln:20:23, parent:work@top.inst[3][1][0]
           |vpiName:b
-          |vpiFullName:work@top.inst[3][1][0] .b
+          |vpiFullName:work@top.inst[3][1][0].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][1][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][1][0]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15376,26 +15376,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[3][1][0] 
+        \_logic_net: (work@top.inst[3][1][0].c), line:20:25, endln:20:26, parent:work@top.inst[3][1][0]
           |vpiName:c
-          |vpiFullName:work@top.inst[3][1][0] .c
+          |vpiFullName:work@top.inst[3][1][0].c
     |vpiNet:
-    \_logic_net: (work@top.inst[3][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[3][1][0] 
+    \_logic_net: (work@top.inst[3][1][0].a), line:20:19, endln:20:20, parent:work@top.inst[3][1][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[3][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[3][1][0] 
+    \_logic_net: (work@top.inst[3][1][0].b), line:20:22, endln:20:23, parent:work@top.inst[3][1][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[3][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[3][1][0] 
+    \_logic_net: (work@top.inst[3][1][0].c), line:20:25, endln:20:26, parent:work@top.inst[3][1][0]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[3][1][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[3][1][1]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[3][1][1] 
-    |vpiFullName:work@top.inst[3][1][1] 
+    |vpiName:inst[3][1][1]
+    |vpiFullName:work@top.inst[3][1][1]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][1][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][1][1]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15406,11 +15406,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[3][1][1] 
+        \_logic_net: (work@top.inst[3][1][1].a), line:20:19, endln:20:20, parent:work@top.inst[3][1][1]
           |vpiName:a
-          |vpiFullName:work@top.inst[3][1][1] .a
+          |vpiFullName:work@top.inst[3][1][1].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][1][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][1][1]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15421,11 +15421,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[3][1][1] 
+        \_logic_net: (work@top.inst[3][1][1].b), line:20:22, endln:20:23, parent:work@top.inst[3][1][1]
           |vpiName:b
-          |vpiFullName:work@top.inst[3][1][1] .b
+          |vpiFullName:work@top.inst[3][1][1].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][1][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][1][1]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15436,26 +15436,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[3][1][1] 
+        \_logic_net: (work@top.inst[3][1][1].c), line:20:25, endln:20:26, parent:work@top.inst[3][1][1]
           |vpiName:c
-          |vpiFullName:work@top.inst[3][1][1] .c
+          |vpiFullName:work@top.inst[3][1][1].c
     |vpiNet:
-    \_logic_net: (work@top.inst[3][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[3][1][1] 
+    \_logic_net: (work@top.inst[3][1][1].a), line:20:19, endln:20:20, parent:work@top.inst[3][1][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[3][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[3][1][1] 
+    \_logic_net: (work@top.inst[3][1][1].b), line:20:22, endln:20:23, parent:work@top.inst[3][1][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[3][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[3][1][1] 
+    \_logic_net: (work@top.inst[3][1][1].c), line:20:25, endln:20:26, parent:work@top.inst[3][1][1]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[3][2][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[3][2][0]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[3][2][0] 
-    |vpiFullName:work@top.inst[3][2][0] 
+    |vpiName:inst[3][2][0]
+    |vpiFullName:work@top.inst[3][2][0]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][2][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][2][0]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15466,11 +15466,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[3][2][0] 
+        \_logic_net: (work@top.inst[3][2][0].a), line:20:19, endln:20:20, parent:work@top.inst[3][2][0]
           |vpiName:a
-          |vpiFullName:work@top.inst[3][2][0] .a
+          |vpiFullName:work@top.inst[3][2][0].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][2][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][2][0]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15481,11 +15481,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[3][2][0] 
+        \_logic_net: (work@top.inst[3][2][0].b), line:20:22, endln:20:23, parent:work@top.inst[3][2][0]
           |vpiName:b
-          |vpiFullName:work@top.inst[3][2][0] .b
+          |vpiFullName:work@top.inst[3][2][0].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][2][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][2][0]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15496,26 +15496,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[3][2][0] 
+        \_logic_net: (work@top.inst[3][2][0].c), line:20:25, endln:20:26, parent:work@top.inst[3][2][0]
           |vpiName:c
-          |vpiFullName:work@top.inst[3][2][0] .c
+          |vpiFullName:work@top.inst[3][2][0].c
     |vpiNet:
-    \_logic_net: (work@top.inst[3][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[3][2][0] 
+    \_logic_net: (work@top.inst[3][2][0].a), line:20:19, endln:20:20, parent:work@top.inst[3][2][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[3][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[3][2][0] 
+    \_logic_net: (work@top.inst[3][2][0].b), line:20:22, endln:20:23, parent:work@top.inst[3][2][0]
     |vpiNet:
-    \_logic_net: (work@top.inst[3][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[3][2][0] 
+    \_logic_net: (work@top.inst[3][2][0].c), line:20:25, endln:20:26, parent:work@top.inst[3][2][0]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.inst[3][2][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[3][2][1]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:inst[3][2][1] 
-    |vpiFullName:work@top.inst[3][2][1] 
+    |vpiName:inst[3][2][1]
+    |vpiFullName:work@top.inst[3][2][1]
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][2][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][2][1]
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15526,11 +15526,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[3][2][1] 
+        \_logic_net: (work@top.inst[3][2][1].a), line:20:19, endln:20:20, parent:work@top.inst[3][2][1]
           |vpiName:a
-          |vpiFullName:work@top.inst[3][2][1] .a
+          |vpiFullName:work@top.inst[3][2][1].a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][2][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][2][1]
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15541,11 +15541,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[3][2][1] 
+        \_logic_net: (work@top.inst[3][2][1].b), line:20:22, endln:20:23, parent:work@top.inst[3][2][1]
           |vpiName:b
-          |vpiFullName:work@top.inst[3][2][1] .b
+          |vpiFullName:work@top.inst[3][2][1].b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][2][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][2][1]
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15556,15 +15556,15 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.inst[3][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[3][2][1] 
+        \_logic_net: (work@top.inst[3][2][1].c), line:20:25, endln:20:26, parent:work@top.inst[3][2][1]
           |vpiName:c
-          |vpiFullName:work@top.inst[3][2][1] .c
+          |vpiFullName:work@top.inst[3][2][1].c
     |vpiNet:
-    \_logic_net: (work@top.inst[3][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[3][2][1] 
+    \_logic_net: (work@top.inst[3][2][1].a), line:20:19, endln:20:20, parent:work@top.inst[3][2][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[3][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[3][2][1] 
+    \_logic_net: (work@top.inst[3][2][1].b), line:20:22, endln:20:23, parent:work@top.inst[3][2][1]
     |vpiNet:
-    \_logic_net: (work@top.inst[3][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[3][2][1] 
+    \_logic_net: (work@top.inst[3][2][1].c), line:20:25, endln:20:26, parent:work@top.inst[3][2][1]
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:

--- a/tests/UnitElab/UnitElab.log
+++ b/tests/UnitElab/UnitElab.log
@@ -3481,30 +3481,30 @@ Instance tree:
 [TOP] work@small_top work@small_top
 [MOD] work@bottom2 work@bottom1.u1
 [UDP] work@bottom1::bottom3 [U] work@bottom1.u2
-[MOD] work@my_module work@top.\inst[0][0][0] 
-[MOD] work@my_module work@top.\inst[0][0][1] 
-[MOD] work@my_module work@top.\inst[0][1][0] 
-[MOD] work@my_module work@top.\inst[0][1][1] 
-[MOD] work@my_module work@top.\inst[0][2][0] 
-[MOD] work@my_module work@top.\inst[0][2][1] 
-[MOD] work@my_module work@top.\inst[1][0][0] 
-[MOD] work@my_module work@top.\inst[1][0][1] 
-[MOD] work@my_module work@top.\inst[1][1][0] 
-[MOD] work@my_module work@top.\inst[1][1][1] 
-[MOD] work@my_module work@top.\inst[1][2][0] 
-[MOD] work@my_module work@top.\inst[1][2][1] 
-[MOD] work@my_module work@top.\inst[2][0][0] 
-[MOD] work@my_module work@top.\inst[2][0][1] 
-[MOD] work@my_module work@top.\inst[2][1][0] 
-[MOD] work@my_module work@top.\inst[2][1][1] 
-[MOD] work@my_module work@top.\inst[2][2][0] 
-[MOD] work@my_module work@top.\inst[2][2][1] 
-[MOD] work@my_module work@top.\inst[3][0][0] 
-[MOD] work@my_module work@top.\inst[3][0][1] 
-[MOD] work@my_module work@top.\inst[3][1][0] 
-[MOD] work@my_module work@top.\inst[3][1][1] 
-[MOD] work@my_module work@top.\inst[3][2][0] 
-[MOD] work@my_module work@top.\inst[3][2][1] 
+[MOD] work@my_module work@top.inst[0][0][0] 
+[MOD] work@my_module work@top.inst[0][0][1] 
+[MOD] work@my_module work@top.inst[0][1][0] 
+[MOD] work@my_module work@top.inst[0][1][1] 
+[MOD] work@my_module work@top.inst[0][2][0] 
+[MOD] work@my_module work@top.inst[0][2][1] 
+[MOD] work@my_module work@top.inst[1][0][0] 
+[MOD] work@my_module work@top.inst[1][0][1] 
+[MOD] work@my_module work@top.inst[1][1][0] 
+[MOD] work@my_module work@top.inst[1][1][1] 
+[MOD] work@my_module work@top.inst[1][2][0] 
+[MOD] work@my_module work@top.inst[1][2][1] 
+[MOD] work@my_module work@top.inst[2][0][0] 
+[MOD] work@my_module work@top.inst[2][0][1] 
+[MOD] work@my_module work@top.inst[2][1][0] 
+[MOD] work@my_module work@top.inst[2][1][1] 
+[MOD] work@my_module work@top.inst[2][2][0] 
+[MOD] work@my_module work@top.inst[2][2][1] 
+[MOD] work@my_module work@top.inst[3][0][0] 
+[MOD] work@my_module work@top.inst[3][0][1] 
+[MOD] work@my_module work@top.inst[3][1][0] 
+[MOD] work@my_module work@top.inst[3][1][1] 
+[MOD] work@my_module work@top.inst[3][2][0] 
+[MOD] work@my_module work@top.inst[3][2][1] 
 [MOD] work@my_module work@top.inst1
 [GAT] work@and work@test.u0
 [SCO] work@test.g1 work@test.g1
@@ -8371,53 +8371,53 @@ Instance tree:
 
 [NTE:EL0523] top.v:3: Instance "work@bottom1.u2".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[0][0][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[0][0][0] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[0][0][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[0][0][1] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[0][1][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[0][1][0] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[0][1][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[0][1][1] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[0][2][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[0][2][0] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[0][2][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[0][2][1] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[1][0][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[1][0][0] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[1][0][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[1][0][1] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[1][1][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[1][1][0] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[1][1][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[1][1][1] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[1][2][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[1][2][0] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[1][2][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[1][2][1] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[2][0][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[2][0][0] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[2][0][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[2][0][1] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[2][1][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[2][1][0] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[2][1][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[2][1][1] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[2][2][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[2][2][0] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[2][2][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[2][2][1] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[3][0][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[3][0][0] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[3][0][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[3][0][1] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[3][1][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[3][1][0] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[3][1][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[3][1][1] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[3][2][0] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[3][2][0] ".
 
-[NTE:EL0523] top.v:29: Instance "work@top.\inst[3][2][1] ".
+[NTE:EL0523] top.v:29: Instance "work@top.inst[3][2][1] ".
 
 [NTE:EL0523] top.v:30: Instance "work@top.inst1".
 
@@ -13729,9 +13729,9 @@ design: (work@bottom1)
         |vpiName:b
         |vpiFullName:work@my_module.b
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][0][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[0][0][0] 
+        \_logic_net: (work@top.inst[0][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][0][0] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[0][0][0] .b
+          |vpiFullName:work@top.inst[0][0][0] .b
     |vpiLhs:
     \_ref_obj: (work@my_module.c), line:23:10, endln:23:11
       |vpiName:c
@@ -14128,14 +14128,14 @@ design: (work@bottom1)
             |vpiSize:64
             |UINT:0
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[0][0][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[0][0][0] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[0][0][0] 
-    |vpiFullName:work@top.\inst[0][0][0] 
+    |vpiName:inst[0][0][0] 
+    |vpiFullName:work@top.inst[0][0][0] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[0][0][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][0][0] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14146,11 +14146,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][0][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[0][0][0] 
+        \_logic_net: (work@top.inst[0][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[0][0][0] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[0][0][0] .a
+          |vpiFullName:work@top.inst[0][0][0] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[0][0][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][0][0] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14161,11 +14161,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][0][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[0][0][0] 
+        \_logic_net: (work@top.inst[0][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][0][0] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[0][0][0] .b
+          |vpiFullName:work@top.inst[0][0][0] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[0][0][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][0][0] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14176,26 +14176,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][0][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[0][0][0] 
+        \_logic_net: (work@top.inst[0][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[0][0][0] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[0][0][0] .c
+          |vpiFullName:work@top.inst[0][0][0] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][0][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[0][0][0] 
+    \_logic_net: (work@top.inst[0][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[0][0][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][0][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[0][0][0] 
+    \_logic_net: (work@top.inst[0][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][0][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][0][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[0][0][0] 
+    \_logic_net: (work@top.inst[0][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[0][0][0] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[0][0][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[0][0][1] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[0][0][1] 
-    |vpiFullName:work@top.\inst[0][0][1] 
+    |vpiName:inst[0][0][1] 
+    |vpiFullName:work@top.inst[0][0][1] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[0][0][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][0][1] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14206,11 +14206,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][0][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[0][0][1] 
+        \_logic_net: (work@top.inst[0][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[0][0][1] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[0][0][1] .a
+          |vpiFullName:work@top.inst[0][0][1] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[0][0][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][0][1] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14221,11 +14221,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][0][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[0][0][1] 
+        \_logic_net: (work@top.inst[0][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[0][0][1] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[0][0][1] .b
+          |vpiFullName:work@top.inst[0][0][1] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[0][0][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][0][1] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14236,26 +14236,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][0][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[0][0][1] 
+        \_logic_net: (work@top.inst[0][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[0][0][1] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[0][0][1] .c
+          |vpiFullName:work@top.inst[0][0][1] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][0][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[0][0][1] 
+    \_logic_net: (work@top.inst[0][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[0][0][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][0][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[0][0][1] 
+    \_logic_net: (work@top.inst[0][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[0][0][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][0][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[0][0][1] 
+    \_logic_net: (work@top.inst[0][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[0][0][1] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[0][1][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[0][1][0] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[0][1][0] 
-    |vpiFullName:work@top.\inst[0][1][0] 
+    |vpiName:inst[0][1][0] 
+    |vpiFullName:work@top.inst[0][1][0] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[0][1][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][1][0] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14266,11 +14266,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][1][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[0][1][0] 
+        \_logic_net: (work@top.inst[0][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[0][1][0] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[0][1][0] .a
+          |vpiFullName:work@top.inst[0][1][0] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[0][1][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][1][0] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14281,11 +14281,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][1][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[0][1][0] 
+        \_logic_net: (work@top.inst[0][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][1][0] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[0][1][0] .b
+          |vpiFullName:work@top.inst[0][1][0] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[0][1][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][1][0] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14296,26 +14296,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][1][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[0][1][0] 
+        \_logic_net: (work@top.inst[0][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[0][1][0] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[0][1][0] .c
+          |vpiFullName:work@top.inst[0][1][0] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][1][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[0][1][0] 
+    \_logic_net: (work@top.inst[0][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[0][1][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][1][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[0][1][0] 
+    \_logic_net: (work@top.inst[0][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][1][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][1][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[0][1][0] 
+    \_logic_net: (work@top.inst[0][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[0][1][0] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[0][1][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[0][1][1] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[0][1][1] 
-    |vpiFullName:work@top.\inst[0][1][1] 
+    |vpiName:inst[0][1][1] 
+    |vpiFullName:work@top.inst[0][1][1] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[0][1][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][1][1] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14326,11 +14326,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][1][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[0][1][1] 
+        \_logic_net: (work@top.inst[0][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[0][1][1] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[0][1][1] .a
+          |vpiFullName:work@top.inst[0][1][1] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[0][1][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][1][1] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14341,11 +14341,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][1][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[0][1][1] 
+        \_logic_net: (work@top.inst[0][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[0][1][1] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[0][1][1] .b
+          |vpiFullName:work@top.inst[0][1][1] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[0][1][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][1][1] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14356,26 +14356,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][1][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[0][1][1] 
+        \_logic_net: (work@top.inst[0][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[0][1][1] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[0][1][1] .c
+          |vpiFullName:work@top.inst[0][1][1] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][1][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[0][1][1] 
+    \_logic_net: (work@top.inst[0][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[0][1][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][1][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[0][1][1] 
+    \_logic_net: (work@top.inst[0][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[0][1][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][1][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[0][1][1] 
+    \_logic_net: (work@top.inst[0][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[0][1][1] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[0][2][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[0][2][0] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[0][2][0] 
-    |vpiFullName:work@top.\inst[0][2][0] 
+    |vpiName:inst[0][2][0] 
+    |vpiFullName:work@top.inst[0][2][0] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[0][2][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][2][0] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14386,11 +14386,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][2][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[0][2][0] 
+        \_logic_net: (work@top.inst[0][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[0][2][0] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[0][2][0] .a
+          |vpiFullName:work@top.inst[0][2][0] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[0][2][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][2][0] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14401,11 +14401,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][2][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[0][2][0] 
+        \_logic_net: (work@top.inst[0][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][2][0] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[0][2][0] .b
+          |vpiFullName:work@top.inst[0][2][0] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[0][2][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][2][0] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14416,26 +14416,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][2][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[0][2][0] 
+        \_logic_net: (work@top.inst[0][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[0][2][0] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[0][2][0] .c
+          |vpiFullName:work@top.inst[0][2][0] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][2][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[0][2][0] 
+    \_logic_net: (work@top.inst[0][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[0][2][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][2][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[0][2][0] 
+    \_logic_net: (work@top.inst[0][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[0][2][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][2][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[0][2][0] 
+    \_logic_net: (work@top.inst[0][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[0][2][0] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[0][2][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[0][2][1] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[0][2][1] 
-    |vpiFullName:work@top.\inst[0][2][1] 
+    |vpiName:inst[0][2][1] 
+    |vpiFullName:work@top.inst[0][2][1] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[0][2][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[0][2][1] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14446,11 +14446,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][2][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[0][2][1] 
+        \_logic_net: (work@top.inst[0][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[0][2][1] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[0][2][1] .a
+          |vpiFullName:work@top.inst[0][2][1] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[0][2][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[0][2][1] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14461,11 +14461,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][2][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[0][2][1] 
+        \_logic_net: (work@top.inst[0][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[0][2][1] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[0][2][1] .b
+          |vpiFullName:work@top.inst[0][2][1] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[0][2][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[0][2][1] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14476,26 +14476,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[0][2][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[0][2][1] 
+        \_logic_net: (work@top.inst[0][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[0][2][1] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[0][2][1] .c
+          |vpiFullName:work@top.inst[0][2][1] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][2][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[0][2][1] 
+    \_logic_net: (work@top.inst[0][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[0][2][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][2][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[0][2][1] 
+    \_logic_net: (work@top.inst[0][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[0][2][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[0][2][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[0][2][1] 
+    \_logic_net: (work@top.inst[0][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[0][2][1] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[1][0][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[1][0][0] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[1][0][0] 
-    |vpiFullName:work@top.\inst[1][0][0] 
+    |vpiName:inst[1][0][0] 
+    |vpiFullName:work@top.inst[1][0][0] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[1][0][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][0][0] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14506,11 +14506,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][0][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[1][0][0] 
+        \_logic_net: (work@top.inst[1][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[1][0][0] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[1][0][0] .a
+          |vpiFullName:work@top.inst[1][0][0] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[1][0][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][0][0] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14521,11 +14521,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][0][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[1][0][0] 
+        \_logic_net: (work@top.inst[1][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[1][0][0] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[1][0][0] .b
+          |vpiFullName:work@top.inst[1][0][0] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[1][0][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][0][0] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14536,26 +14536,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][0][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[1][0][0] 
+        \_logic_net: (work@top.inst[1][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[1][0][0] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[1][0][0] .c
+          |vpiFullName:work@top.inst[1][0][0] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][0][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[1][0][0] 
+    \_logic_net: (work@top.inst[1][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[1][0][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][0][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[1][0][0] 
+    \_logic_net: (work@top.inst[1][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[1][0][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][0][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[1][0][0] 
+    \_logic_net: (work@top.inst[1][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[1][0][0] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[1][0][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[1][0][1] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[1][0][1] 
-    |vpiFullName:work@top.\inst[1][0][1] 
+    |vpiName:inst[1][0][1] 
+    |vpiFullName:work@top.inst[1][0][1] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[1][0][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][0][1] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14566,11 +14566,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][0][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[1][0][1] 
+        \_logic_net: (work@top.inst[1][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[1][0][1] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[1][0][1] .a
+          |vpiFullName:work@top.inst[1][0][1] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[1][0][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][0][1] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14581,11 +14581,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][0][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[1][0][1] 
+        \_logic_net: (work@top.inst[1][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[1][0][1] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[1][0][1] .b
+          |vpiFullName:work@top.inst[1][0][1] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[1][0][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][0][1] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14596,26 +14596,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][0][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[1][0][1] 
+        \_logic_net: (work@top.inst[1][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[1][0][1] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[1][0][1] .c
+          |vpiFullName:work@top.inst[1][0][1] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][0][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[1][0][1] 
+    \_logic_net: (work@top.inst[1][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[1][0][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][0][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[1][0][1] 
+    \_logic_net: (work@top.inst[1][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[1][0][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][0][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[1][0][1] 
+    \_logic_net: (work@top.inst[1][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[1][0][1] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[1][1][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[1][1][0] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[1][1][0] 
-    |vpiFullName:work@top.\inst[1][1][0] 
+    |vpiName:inst[1][1][0] 
+    |vpiFullName:work@top.inst[1][1][0] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[1][1][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][1][0] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14626,11 +14626,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][1][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[1][1][0] 
+        \_logic_net: (work@top.inst[1][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[1][1][0] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[1][1][0] .a
+          |vpiFullName:work@top.inst[1][1][0] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[1][1][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][1][0] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14641,11 +14641,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][1][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[1][1][0] 
+        \_logic_net: (work@top.inst[1][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[1][1][0] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[1][1][0] .b
+          |vpiFullName:work@top.inst[1][1][0] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[1][1][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][1][0] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14656,26 +14656,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][1][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[1][1][0] 
+        \_logic_net: (work@top.inst[1][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[1][1][0] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[1][1][0] .c
+          |vpiFullName:work@top.inst[1][1][0] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][1][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[1][1][0] 
+    \_logic_net: (work@top.inst[1][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[1][1][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][1][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[1][1][0] 
+    \_logic_net: (work@top.inst[1][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[1][1][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][1][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[1][1][0] 
+    \_logic_net: (work@top.inst[1][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[1][1][0] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[1][1][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[1][1][1] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[1][1][1] 
-    |vpiFullName:work@top.\inst[1][1][1] 
+    |vpiName:inst[1][1][1] 
+    |vpiFullName:work@top.inst[1][1][1] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[1][1][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][1][1] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14686,11 +14686,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][1][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[1][1][1] 
+        \_logic_net: (work@top.inst[1][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[1][1][1] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[1][1][1] .a
+          |vpiFullName:work@top.inst[1][1][1] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[1][1][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][1][1] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14701,11 +14701,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][1][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[1][1][1] 
+        \_logic_net: (work@top.inst[1][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[1][1][1] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[1][1][1] .b
+          |vpiFullName:work@top.inst[1][1][1] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[1][1][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][1][1] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14716,26 +14716,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][1][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[1][1][1] 
+        \_logic_net: (work@top.inst[1][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[1][1][1] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[1][1][1] .c
+          |vpiFullName:work@top.inst[1][1][1] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][1][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[1][1][1] 
+    \_logic_net: (work@top.inst[1][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[1][1][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][1][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[1][1][1] 
+    \_logic_net: (work@top.inst[1][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[1][1][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][1][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[1][1][1] 
+    \_logic_net: (work@top.inst[1][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[1][1][1] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[1][2][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[1][2][0] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[1][2][0] 
-    |vpiFullName:work@top.\inst[1][2][0] 
+    |vpiName:inst[1][2][0] 
+    |vpiFullName:work@top.inst[1][2][0] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[1][2][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][2][0] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14746,11 +14746,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][2][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[1][2][0] 
+        \_logic_net: (work@top.inst[1][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[1][2][0] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[1][2][0] .a
+          |vpiFullName:work@top.inst[1][2][0] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[1][2][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][2][0] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14761,11 +14761,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][2][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[1][2][0] 
+        \_logic_net: (work@top.inst[1][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[1][2][0] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[1][2][0] .b
+          |vpiFullName:work@top.inst[1][2][0] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[1][2][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][2][0] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14776,26 +14776,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][2][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[1][2][0] 
+        \_logic_net: (work@top.inst[1][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[1][2][0] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[1][2][0] .c
+          |vpiFullName:work@top.inst[1][2][0] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][2][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[1][2][0] 
+    \_logic_net: (work@top.inst[1][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[1][2][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][2][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[1][2][0] 
+    \_logic_net: (work@top.inst[1][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[1][2][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][2][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[1][2][0] 
+    \_logic_net: (work@top.inst[1][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[1][2][0] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[1][2][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[1][2][1] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[1][2][1] 
-    |vpiFullName:work@top.\inst[1][2][1] 
+    |vpiName:inst[1][2][1] 
+    |vpiFullName:work@top.inst[1][2][1] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[1][2][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[1][2][1] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14806,11 +14806,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][2][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[1][2][1] 
+        \_logic_net: (work@top.inst[1][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[1][2][1] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[1][2][1] .a
+          |vpiFullName:work@top.inst[1][2][1] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[1][2][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[1][2][1] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14821,11 +14821,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][2][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[1][2][1] 
+        \_logic_net: (work@top.inst[1][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[1][2][1] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[1][2][1] .b
+          |vpiFullName:work@top.inst[1][2][1] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[1][2][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[1][2][1] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14836,26 +14836,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[1][2][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[1][2][1] 
+        \_logic_net: (work@top.inst[1][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[1][2][1] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[1][2][1] .c
+          |vpiFullName:work@top.inst[1][2][1] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][2][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[1][2][1] 
+    \_logic_net: (work@top.inst[1][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[1][2][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][2][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[1][2][1] 
+    \_logic_net: (work@top.inst[1][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[1][2][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[1][2][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[1][2][1] 
+    \_logic_net: (work@top.inst[1][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[1][2][1] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[2][0][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[2][0][0] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[2][0][0] 
-    |vpiFullName:work@top.\inst[2][0][0] 
+    |vpiName:inst[2][0][0] 
+    |vpiFullName:work@top.inst[2][0][0] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[2][0][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][0][0] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14866,11 +14866,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][0][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[2][0][0] 
+        \_logic_net: (work@top.inst[2][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[2][0][0] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[2][0][0] .a
+          |vpiFullName:work@top.inst[2][0][0] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[2][0][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][0][0] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14881,11 +14881,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][0][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[2][0][0] 
+        \_logic_net: (work@top.inst[2][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[2][0][0] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[2][0][0] .b
+          |vpiFullName:work@top.inst[2][0][0] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[2][0][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][0][0] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14896,26 +14896,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][0][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[2][0][0] 
+        \_logic_net: (work@top.inst[2][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[2][0][0] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[2][0][0] .c
+          |vpiFullName:work@top.inst[2][0][0] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][0][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[2][0][0] 
+    \_logic_net: (work@top.inst[2][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[2][0][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][0][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[2][0][0] 
+    \_logic_net: (work@top.inst[2][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[2][0][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][0][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[2][0][0] 
+    \_logic_net: (work@top.inst[2][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[2][0][0] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[2][0][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[2][0][1] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[2][0][1] 
-    |vpiFullName:work@top.\inst[2][0][1] 
+    |vpiName:inst[2][0][1] 
+    |vpiFullName:work@top.inst[2][0][1] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[2][0][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][0][1] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14926,11 +14926,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][0][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[2][0][1] 
+        \_logic_net: (work@top.inst[2][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[2][0][1] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[2][0][1] .a
+          |vpiFullName:work@top.inst[2][0][1] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[2][0][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][0][1] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -14941,11 +14941,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][0][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[2][0][1] 
+        \_logic_net: (work@top.inst[2][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[2][0][1] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[2][0][1] .b
+          |vpiFullName:work@top.inst[2][0][1] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[2][0][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][0][1] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -14956,26 +14956,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][0][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[2][0][1] 
+        \_logic_net: (work@top.inst[2][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[2][0][1] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[2][0][1] .c
+          |vpiFullName:work@top.inst[2][0][1] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][0][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[2][0][1] 
+    \_logic_net: (work@top.inst[2][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[2][0][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][0][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[2][0][1] 
+    \_logic_net: (work@top.inst[2][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[2][0][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][0][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[2][0][1] 
+    \_logic_net: (work@top.inst[2][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[2][0][1] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[2][1][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[2][1][0] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[2][1][0] 
-    |vpiFullName:work@top.\inst[2][1][0] 
+    |vpiName:inst[2][1][0] 
+    |vpiFullName:work@top.inst[2][1][0] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[2][1][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][1][0] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -14986,11 +14986,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][1][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[2][1][0] 
+        \_logic_net: (work@top.inst[2][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[2][1][0] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[2][1][0] .a
+          |vpiFullName:work@top.inst[2][1][0] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[2][1][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][1][0] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15001,11 +15001,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][1][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[2][1][0] 
+        \_logic_net: (work@top.inst[2][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[2][1][0] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[2][1][0] .b
+          |vpiFullName:work@top.inst[2][1][0] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[2][1][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][1][0] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15016,26 +15016,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][1][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[2][1][0] 
+        \_logic_net: (work@top.inst[2][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[2][1][0] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[2][1][0] .c
+          |vpiFullName:work@top.inst[2][1][0] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][1][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[2][1][0] 
+    \_logic_net: (work@top.inst[2][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[2][1][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][1][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[2][1][0] 
+    \_logic_net: (work@top.inst[2][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[2][1][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][1][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[2][1][0] 
+    \_logic_net: (work@top.inst[2][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[2][1][0] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[2][1][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[2][1][1] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[2][1][1] 
-    |vpiFullName:work@top.\inst[2][1][1] 
+    |vpiName:inst[2][1][1] 
+    |vpiFullName:work@top.inst[2][1][1] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[2][1][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][1][1] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15046,11 +15046,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][1][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[2][1][1] 
+        \_logic_net: (work@top.inst[2][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[2][1][1] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[2][1][1] .a
+          |vpiFullName:work@top.inst[2][1][1] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[2][1][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][1][1] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15061,11 +15061,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][1][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[2][1][1] 
+        \_logic_net: (work@top.inst[2][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[2][1][1] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[2][1][1] .b
+          |vpiFullName:work@top.inst[2][1][1] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[2][1][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][1][1] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15076,26 +15076,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][1][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[2][1][1] 
+        \_logic_net: (work@top.inst[2][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[2][1][1] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[2][1][1] .c
+          |vpiFullName:work@top.inst[2][1][1] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][1][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[2][1][1] 
+    \_logic_net: (work@top.inst[2][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[2][1][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][1][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[2][1][1] 
+    \_logic_net: (work@top.inst[2][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[2][1][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][1][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[2][1][1] 
+    \_logic_net: (work@top.inst[2][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[2][1][1] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[2][2][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[2][2][0] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[2][2][0] 
-    |vpiFullName:work@top.\inst[2][2][0] 
+    |vpiName:inst[2][2][0] 
+    |vpiFullName:work@top.inst[2][2][0] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[2][2][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][2][0] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15106,11 +15106,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][2][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[2][2][0] 
+        \_logic_net: (work@top.inst[2][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[2][2][0] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[2][2][0] .a
+          |vpiFullName:work@top.inst[2][2][0] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[2][2][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][2][0] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15121,11 +15121,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][2][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[2][2][0] 
+        \_logic_net: (work@top.inst[2][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[2][2][0] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[2][2][0] .b
+          |vpiFullName:work@top.inst[2][2][0] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[2][2][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][2][0] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15136,26 +15136,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][2][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[2][2][0] 
+        \_logic_net: (work@top.inst[2][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[2][2][0] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[2][2][0] .c
+          |vpiFullName:work@top.inst[2][2][0] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][2][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[2][2][0] 
+    \_logic_net: (work@top.inst[2][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[2][2][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][2][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[2][2][0] 
+    \_logic_net: (work@top.inst[2][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[2][2][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][2][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[2][2][0] 
+    \_logic_net: (work@top.inst[2][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[2][2][0] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[2][2][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[2][2][1] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[2][2][1] 
-    |vpiFullName:work@top.\inst[2][2][1] 
+    |vpiName:inst[2][2][1] 
+    |vpiFullName:work@top.inst[2][2][1] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[2][2][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[2][2][1] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15166,11 +15166,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][2][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[2][2][1] 
+        \_logic_net: (work@top.inst[2][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[2][2][1] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[2][2][1] .a
+          |vpiFullName:work@top.inst[2][2][1] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[2][2][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[2][2][1] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15181,11 +15181,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][2][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[2][2][1] 
+        \_logic_net: (work@top.inst[2][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[2][2][1] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[2][2][1] .b
+          |vpiFullName:work@top.inst[2][2][1] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[2][2][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[2][2][1] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15196,26 +15196,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[2][2][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[2][2][1] 
+        \_logic_net: (work@top.inst[2][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[2][2][1] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[2][2][1] .c
+          |vpiFullName:work@top.inst[2][2][1] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][2][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[2][2][1] 
+    \_logic_net: (work@top.inst[2][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[2][2][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][2][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[2][2][1] 
+    \_logic_net: (work@top.inst[2][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[2][2][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[2][2][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[2][2][1] 
+    \_logic_net: (work@top.inst[2][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[2][2][1] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[3][0][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[3][0][0] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[3][0][0] 
-    |vpiFullName:work@top.\inst[3][0][0] 
+    |vpiName:inst[3][0][0] 
+    |vpiFullName:work@top.inst[3][0][0] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[3][0][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][0][0] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15226,11 +15226,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][0][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[3][0][0] 
+        \_logic_net: (work@top.inst[3][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[3][0][0] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[3][0][0] .a
+          |vpiFullName:work@top.inst[3][0][0] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[3][0][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][0][0] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15241,11 +15241,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][0][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[3][0][0] 
+        \_logic_net: (work@top.inst[3][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[3][0][0] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[3][0][0] .b
+          |vpiFullName:work@top.inst[3][0][0] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[3][0][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][0][0] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15256,26 +15256,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][0][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[3][0][0] 
+        \_logic_net: (work@top.inst[3][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[3][0][0] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[3][0][0] .c
+          |vpiFullName:work@top.inst[3][0][0] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][0][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[3][0][0] 
+    \_logic_net: (work@top.inst[3][0][0] .a), line:20:19, endln:20:20, parent:work@top.inst[3][0][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][0][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[3][0][0] 
+    \_logic_net: (work@top.inst[3][0][0] .b), line:20:22, endln:20:23, parent:work@top.inst[3][0][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][0][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[3][0][0] 
+    \_logic_net: (work@top.inst[3][0][0] .c), line:20:25, endln:20:26, parent:work@top.inst[3][0][0] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[3][0][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[3][0][1] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[3][0][1] 
-    |vpiFullName:work@top.\inst[3][0][1] 
+    |vpiName:inst[3][0][1] 
+    |vpiFullName:work@top.inst[3][0][1] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[3][0][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][0][1] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15286,11 +15286,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][0][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[3][0][1] 
+        \_logic_net: (work@top.inst[3][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[3][0][1] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[3][0][1] .a
+          |vpiFullName:work@top.inst[3][0][1] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[3][0][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][0][1] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15301,11 +15301,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][0][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[3][0][1] 
+        \_logic_net: (work@top.inst[3][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[3][0][1] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[3][0][1] .b
+          |vpiFullName:work@top.inst[3][0][1] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[3][0][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][0][1] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15316,26 +15316,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][0][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[3][0][1] 
+        \_logic_net: (work@top.inst[3][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[3][0][1] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[3][0][1] .c
+          |vpiFullName:work@top.inst[3][0][1] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][0][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[3][0][1] 
+    \_logic_net: (work@top.inst[3][0][1] .a), line:20:19, endln:20:20, parent:work@top.inst[3][0][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][0][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[3][0][1] 
+    \_logic_net: (work@top.inst[3][0][1] .b), line:20:22, endln:20:23, parent:work@top.inst[3][0][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][0][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[3][0][1] 
+    \_logic_net: (work@top.inst[3][0][1] .c), line:20:25, endln:20:26, parent:work@top.inst[3][0][1] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[3][1][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[3][1][0] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[3][1][0] 
-    |vpiFullName:work@top.\inst[3][1][0] 
+    |vpiName:inst[3][1][0] 
+    |vpiFullName:work@top.inst[3][1][0] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[3][1][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][1][0] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15346,11 +15346,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][1][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[3][1][0] 
+        \_logic_net: (work@top.inst[3][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[3][1][0] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[3][1][0] .a
+          |vpiFullName:work@top.inst[3][1][0] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[3][1][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][1][0] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15361,11 +15361,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][1][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[3][1][0] 
+        \_logic_net: (work@top.inst[3][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[3][1][0] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[3][1][0] .b
+          |vpiFullName:work@top.inst[3][1][0] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[3][1][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][1][0] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15376,26 +15376,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][1][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[3][1][0] 
+        \_logic_net: (work@top.inst[3][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[3][1][0] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[3][1][0] .c
+          |vpiFullName:work@top.inst[3][1][0] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][1][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[3][1][0] 
+    \_logic_net: (work@top.inst[3][1][0] .a), line:20:19, endln:20:20, parent:work@top.inst[3][1][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][1][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[3][1][0] 
+    \_logic_net: (work@top.inst[3][1][0] .b), line:20:22, endln:20:23, parent:work@top.inst[3][1][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][1][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[3][1][0] 
+    \_logic_net: (work@top.inst[3][1][0] .c), line:20:25, endln:20:26, parent:work@top.inst[3][1][0] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[3][1][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[3][1][1] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[3][1][1] 
-    |vpiFullName:work@top.\inst[3][1][1] 
+    |vpiName:inst[3][1][1] 
+    |vpiFullName:work@top.inst[3][1][1] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[3][1][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][1][1] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15406,11 +15406,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][1][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[3][1][1] 
+        \_logic_net: (work@top.inst[3][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[3][1][1] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[3][1][1] .a
+          |vpiFullName:work@top.inst[3][1][1] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[3][1][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][1][1] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15421,11 +15421,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][1][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[3][1][1] 
+        \_logic_net: (work@top.inst[3][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[3][1][1] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[3][1][1] .b
+          |vpiFullName:work@top.inst[3][1][1] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[3][1][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][1][1] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15436,26 +15436,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][1][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[3][1][1] 
+        \_logic_net: (work@top.inst[3][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[3][1][1] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[3][1][1] .c
+          |vpiFullName:work@top.inst[3][1][1] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][1][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[3][1][1] 
+    \_logic_net: (work@top.inst[3][1][1] .a), line:20:19, endln:20:20, parent:work@top.inst[3][1][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][1][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[3][1][1] 
+    \_logic_net: (work@top.inst[3][1][1] .b), line:20:22, endln:20:23, parent:work@top.inst[3][1][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][1][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[3][1][1] 
+    \_logic_net: (work@top.inst[3][1][1] .c), line:20:25, endln:20:26, parent:work@top.inst[3][1][1] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[3][2][0] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[3][2][0] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[3][2][0] 
-    |vpiFullName:work@top.\inst[3][2][0] 
+    |vpiName:inst[3][2][0] 
+    |vpiFullName:work@top.inst[3][2][0] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[3][2][0] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][2][0] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15466,11 +15466,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][2][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[3][2][0] 
+        \_logic_net: (work@top.inst[3][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[3][2][0] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[3][2][0] .a
+          |vpiFullName:work@top.inst[3][2][0] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[3][2][0] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][2][0] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15481,11 +15481,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][2][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[3][2][0] 
+        \_logic_net: (work@top.inst[3][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[3][2][0] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[3][2][0] .b
+          |vpiFullName:work@top.inst[3][2][0] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[3][2][0] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][2][0] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15496,26 +15496,26 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][2][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[3][2][0] 
+        \_logic_net: (work@top.inst[3][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[3][2][0] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[3][2][0] .c
+          |vpiFullName:work@top.inst[3][2][0] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][2][0] .a), line:20:19, endln:20:20, parent:work@top.\inst[3][2][0] 
+    \_logic_net: (work@top.inst[3][2][0] .a), line:20:19, endln:20:20, parent:work@top.inst[3][2][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][2][0] .b), line:20:22, endln:20:23, parent:work@top.\inst[3][2][0] 
+    \_logic_net: (work@top.inst[3][2][0] .b), line:20:22, endln:20:23, parent:work@top.inst[3][2][0] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][2][0] .c), line:20:25, endln:20:26, parent:work@top.\inst[3][2][0] 
+    \_logic_net: (work@top.inst[3][2][0] .c), line:20:25, endln:20:26, parent:work@top.inst[3][2][0] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:
-  \_module: work@my_module (work@top.\inst[3][2][1] ) top.v:29:3: , endln:29:44, parent:work@top
+  \_module: work@my_module (work@top.inst[3][2][1] ) top.v:29:3: , endln:29:44, parent:work@top
     |vpiDefName:work@my_module
     |vpiDefFile:top.v
     |vpiDefLineNo:20
-    |vpiName:\inst[3][2][1] 
-    |vpiFullName:work@top.\inst[3][2][1] 
+    |vpiName:inst[3][2][1] 
+    |vpiFullName:work@top.inst[3][2][1] 
     |vpiPort:
-    \_port: (a), line:20:19, endln:20:20, parent:work@top.\inst[3][2][1] 
+    \_port: (a), line:20:19, endln:20:20, parent:work@top.inst[3][2][1] 
       |vpiName:a
       |vpiDirection:1
       |vpiHighConn:
@@ -15526,11 +15526,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][2][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[3][2][1] 
+        \_logic_net: (work@top.inst[3][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[3][2][1] 
           |vpiName:a
-          |vpiFullName:work@top.\inst[3][2][1] .a
+          |vpiFullName:work@top.inst[3][2][1] .a
     |vpiPort:
-    \_port: (b), line:20:22, endln:20:23, parent:work@top.\inst[3][2][1] 
+    \_port: (b), line:20:22, endln:20:23, parent:work@top.inst[3][2][1] 
       |vpiName:b
       |vpiDirection:1
       |vpiHighConn:
@@ -15541,11 +15541,11 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][2][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[3][2][1] 
+        \_logic_net: (work@top.inst[3][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[3][2][1] 
           |vpiName:b
-          |vpiFullName:work@top.\inst[3][2][1] .b
+          |vpiFullName:work@top.inst[3][2][1] .b
     |vpiPort:
-    \_port: (c), line:20:25, endln:20:26, parent:work@top.\inst[3][2][1] 
+    \_port: (c), line:20:25, endln:20:26, parent:work@top.inst[3][2][1] 
       |vpiName:c
       |vpiDirection:2
       |vpiHighConn:
@@ -15556,15 +15556,15 @@ design: (work@bottom1)
       |vpiLowConn:
       \_ref_obj: 
         |vpiActual:
-        \_logic_net: (work@top.\inst[3][2][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[3][2][1] 
+        \_logic_net: (work@top.inst[3][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[3][2][1] 
           |vpiName:c
-          |vpiFullName:work@top.\inst[3][2][1] .c
+          |vpiFullName:work@top.inst[3][2][1] .c
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][2][1] .a), line:20:19, endln:20:20, parent:work@top.\inst[3][2][1] 
+    \_logic_net: (work@top.inst[3][2][1] .a), line:20:19, endln:20:20, parent:work@top.inst[3][2][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][2][1] .b), line:20:22, endln:20:23, parent:work@top.\inst[3][2][1] 
+    \_logic_net: (work@top.inst[3][2][1] .b), line:20:22, endln:20:23, parent:work@top.inst[3][2][1] 
     |vpiNet:
-    \_logic_net: (work@top.\inst[3][2][1] .c), line:20:25, endln:20:26, parent:work@top.\inst[3][2][1] 
+    \_logic_net: (work@top.inst[3][2][1] .c), line:20:25, endln:20:26, parent:work@top.inst[3][2][1] 
     |vpiInstance:
     \_module: work@top (work@top) top.v:26:1: , endln:31:10
   |vpiModule:

--- a/tests/UnitLibrary/UnitLibrary.log
+++ b/tests/UnitLibrary/UnitLibrary.log
@@ -30,8 +30,8 @@ LIB: lib1
      ${SURELOG_DIR}/tests/UnitLibrary/lib1/bot.sv
 
 LIB: lib2
-     ${SURELOG_DIR}/tests/UnitLibrary/lib2/sub.v
      ${SURELOG_DIR}/tests/UnitLibrary/lib2/bot.sv
+     ${SURELOG_DIR}/tests/UnitLibrary/lib2/sub.v
 
 LIB: lib3
      ${SURELOG_DIR}/tests/UnitLibrary/lib3/sub.v
@@ -69,9 +69,9 @@ LIB: libw
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/UnitLibrary/lib1/bot.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/UnitLibrary/lib2/sub.v".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/UnitLibrary/lib2/bot.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/UnitLibrary/lib2/sub.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/UnitLibrary/lib3/sub.v".
 
@@ -95,9 +95,9 @@ LIB: libw
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/UnitLibrary/lib1/bot.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/UnitLibrary/lib2/sub.v".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/UnitLibrary/lib2/bot.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/UnitLibrary/lib2/sub.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/UnitLibrary/lib3/sub.v".
 

--- a/third_party/tests/BuildOVMPkg/BuildOVMPkg.log
+++ b/third_party/tests/BuildOVMPkg/BuildOVMPkg.log
@@ -248,7 +248,7 @@ Cache saving: t.ttts
 
 Cache saving: t.ttts
 Parsing took t.ttts
-SLL Parsing: t.ttts ../../../build/tests/BuildOVMPkg/slpp_all/work/sv_6956721045759131781/builtin.sv
+SLL Parsing: t.ttts ../../../build/tests/BuildOVMPkg/slpp_all/work/sv_2076548932596474082/builtin.sv
 Cache saving: t.ttts
 LL  Parsing: t.ttts ../../../build/tests/BuildOVMPkg/slpp_all/work/src_3277136984355752457/ovm_pkg.sv
 Cache saving: t.ttts
@@ -843,7 +843,7 @@ Preprocessing took t.ttts
 PP SSL Parsing: t.ttts ${SURELOG_DIR}/build/bin/sv/builtin.sv
 PP SSL Parsing: t.ttts ../../UVM/ovm-2.1.2/src/ovm_pkg.sv
 Parsing took t.ttts
-SLL Parsing: t.ttts ../../../build/tests/BuildOVMPkg/slpp_all/work/sv_6956721045759131781/builtin.sv
+SLL Parsing: t.ttts ../../../build/tests/BuildOVMPkg/slpp_all/work/sv_2076548932596474082/builtin.sv
 Cache saving: t.ttts
 LL  Parsing: t.ttts ../../../build/tests/BuildOVMPkg/slpp_all/work/src_3277136984355752457/ovm_pkg.sv
 Cache saving: t.ttts

--- a/third_party/tests/Google/Google.log
+++ b/third_party/tests/Google/Google.log
@@ -2667,6 +2667,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-prec-uvm.sv -l 16.12--property-prec-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -2676,12 +2682,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2699,6 +2699,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.9--sequence-fell-uvm.sv -l 16.9--sequence-fell-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -2708,12 +2714,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2741,6 +2741,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assert-uvm.sv -l 16.2--assert-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -2750,12 +2756,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2793,6 +2793,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-uvm.sv -l 16.7--sequence-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -2802,12 +2808,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2827,6 +2827,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.15--property-iff-uvm-fail.sv -l 16.15--property-iff-uvm-fail.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -2836,12 +2842,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2867,6 +2867,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.17--expect-uvm.sv -l 16.17--expect-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -2876,12 +2882,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2893,13 +2893,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:8: Unused macro argument "OPER".
 
-[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1125> t<Expect_property_statement> p<1126> c<1053> f<12> l<152:9> el<156:7>> ".
+[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1125> t<Expect_property_statement> p<1126> c<1053> f<13> l<152:9> el<156:7>> ".
 
-[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1126> t<Statement_item> p<1127> c<1125> f<12> l<152:9> el<156:7>> ".
+[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1126> t<Statement_item> p<1127> c<1125> f<13> l<152:9> el<156:7>> ".
 
-[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1127> t<Statement> p<1128> c<1126> f<12> l<152:9> el<156:7>> ".
+[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1127> t<Statement> p<1128> c<1126> f<13> l<152:9> el<156:7>> ".
 
-[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1128> t<Statement_or_null> p<1131> c<1127> s<1129> f<12> l<152:9> el<156:7>> ".
+[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1128> t<Statement_or_null> p<1131> c<1127> s<1129> f<13> l<152:9> el<156:7>> ".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -2915,6 +2915,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-and-range-uvm.sv -l 16.7--sequence-and-range-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -2924,12 +2930,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2955,6 +2955,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-uvm.sv -l 16.12--property-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -2964,12 +2970,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3007,6 +3007,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assert-final-uvm.sv -l 16.2--assert-final-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3016,12 +3022,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3055,6 +3055,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.10--property-local-var-uvm.sv -l 16.10--property-local-var-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3064,12 +3070,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3089,6 +3089,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.14--assume-property-uvm-fail.sv -l 16.14--assume-property-uvm-fail.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3098,12 +3104,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3121,6 +3121,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.10--sequence-local-var-uvm.sv -l 16.10--sequence-local-var-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3130,12 +3136,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3181,6 +3181,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.9--sequence-stable-uvm.sv -l 16.9--sequence-stable-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3190,12 +3196,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3215,6 +3215,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.11--sequence-subroutine-uvm.sv -l 16.11--sequence-subroutine-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3224,12 +3230,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3267,6 +3267,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-interface-uvm-fail.sv -l 16.12--property-interface-uvm-fail.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3276,12 +3282,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3307,6 +3307,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-uvm-fail.sv -l 16.7--sequence-uvm-fail.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3316,12 +3322,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3341,6 +3341,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.10--property-local-var-uvm-fail.sv -l 16.10--property-local-var-uvm-fail.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3350,12 +3356,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3375,6 +3375,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.17--expect-uvm-fail.sv -l 16.17--expect-uvm-fail.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3384,12 +3390,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3401,13 +3401,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:8: Unused macro argument "OPER".
 
-[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1125> t<Expect_property_statement> p<1126> c<1053> f<12> l<152:9> el<156:7>> ".
+[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1125> t<Expect_property_statement> p<1126> c<1053> f<13> l<152:9> el<156:7>> ".
 
-[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1126> t<Statement_item> p<1127> c<1125> f<12> l<152:9> el<156:7>> ".
+[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1126> t<Statement_item> p<1127> c<1125> f<13> l<152:9> el<156:7>> ".
 
-[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1127> t<Statement> p<1128> c<1126> f<12> l<152:9> el<156:7>> ".
+[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1127> t<Statement> p<1128> c<1126> f<13> l<152:9> el<156:7>> ".
 
-[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1128> t<Statement_or_null> p<1131> c<1127> s<1129> f<12> l<152:9> el<156:7>> ".
+[ERR:UH0701] ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv:152: Unsupported statement "<n<> u<1128> t<Statement_or_null> p<1131> c<1127> s<1129> f<13> l<152:9> el<156:7>> ".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -3415,6 +3415,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.15--property-iff-uvm.sv -l 16.15--property-iff-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3424,12 +3430,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3455,6 +3455,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.13--sequence-multiclock-uvm.sv -l 16.13--sequence-multiclock-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3464,12 +3470,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3495,6 +3495,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-intersect-uvm.sv -l 16.7--sequence-intersect-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3504,12 +3510,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3529,6 +3529,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-or-uvm.sv -l 16.7--sequence-or-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3538,12 +3544,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3563,6 +3563,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.9--sequence-past-uvm.sv -l 16.9--sequence-past-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3572,12 +3578,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3597,6 +3597,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assume-uvm-fail.sv -l 16.2--assume-uvm-fail.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3606,12 +3612,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3629,6 +3629,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-throughout-uvm-fail.sv -l 16.7--sequence-throughout-uvm-fail.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3638,12 +3644,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3663,6 +3663,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.9--sequence-changed-uvm.sv -l 16.9--sequence-changed-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3672,12 +3678,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3697,6 +3697,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-uvm-fail.sv -l 16.12--property-uvm-fail.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3706,12 +3712,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3729,6 +3729,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.14--assume-property-uvm.sv -l 16.14--assume-property-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3738,12 +3744,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3761,6 +3761,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-prec-uvm-fail.sv -l 16.12--property-prec-uvm-fail.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3770,12 +3776,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3793,6 +3793,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-and-uvm.sv -l 16.7--sequence-and-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3802,12 +3808,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3847,6 +3847,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-interface-uvm.sv -l 16.12--property-interface-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3856,12 +3862,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3885,6 +3885,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assume-uvm.sv -l 16.2--assume-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3894,12 +3900,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3917,6 +3917,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-intersect-uvm-fail.sv -l 16.7--sequence-intersect-uvm-fail.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3926,12 +3932,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3965,6 +3965,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-throughout-uvm.sv -l 16.7--sequence-throughout-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -3974,12 +3980,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3999,6 +3999,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-interface-prec-uvm.sv -l 16.12--property-interface-prec-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -4008,12 +4014,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -4031,6 +4031,12 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assert0-uvm.sv -l 16.2--assert0-uvm.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -4040,12 +4046,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -7548,6 +7548,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.15--manually-seeding-randomize_1.sv -l 18.15--manually-seeding-randomize_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -7557,12 +7563,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -7604,6 +7604,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.1--urandom_1.sv -l 18.13.1--urandom_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -7613,12 +7619,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -7636,6 +7636,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14--soft-constraints_1.sv -l 18.5.14--soft-constraints_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -7645,12 +7651,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -7668,6 +7668,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.11.1--in-line-constraint-checker_1.sv -l 18.11.1--in-line-constraint-checker_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -7677,12 +7683,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -7700,6 +7700,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14.3--object-stability_1.sv -l 18.14.3--object-stability_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -7709,12 +7715,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -7753,6 +7753,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.2--urandom_range_1.sv -l 18.13.2--urandom_range_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -7762,12 +7768,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -7785,6 +7785,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.4--get_randstate_0.sv -l 18.13.4--get_randstate_0.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -7794,12 +7800,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -7817,6 +7817,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.6--aborting-productions-break-and-return_1.sv -l 18.17.6--aborting-productions-break-and-return_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -7826,12 +7832,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -7861,6 +7861,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.11--static-constraint-blocks_1.sv -l 18.5.11--static-constraint-blocks_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -7870,12 +7876,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -7895,6 +7895,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.5--interleaving-productions-rand-join_1.sv -l 18.17.5--interleaving-productions-rand-join_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -7904,12 +7910,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -7945,6 +7945,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14.2--thread-stability_1.sv -l 18.14.2--thread-stability_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -7954,12 +7960,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -7989,6 +7989,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14--random-stability_1.sv -l 18.14--random-stability_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -7998,12 +8004,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8021,6 +8021,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.4--distribution_1.sv -l 18.5.4--distribution_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8030,12 +8036,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8053,6 +8053,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14.2--discarding-soft-constraints_5.sv -l 18.5.14.2--discarding-soft-constraints_5.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8062,12 +8068,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8085,6 +8085,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.7--in-line-constraints--randomize_4.sv -l 18.7--in-line-constraints--randomize_4.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8094,12 +8100,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8141,6 +8141,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.12--functions-in-constraint_1.sv -l 18.5.12--functions-in-constraint_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8150,12 +8156,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8173,6 +8173,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14.2--discarding-soft-constraints_3.sv -l 18.5.14.2--discarding-soft-constraints_3.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8182,12 +8188,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8220,6 +8220,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.9--global-constraints_1.sv -l 18.5.9--global-constraints_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8229,12 +8235,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8267,6 +8267,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.1--random-production-weights_1.sv -l 18.17.1--random-production-weights_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8276,12 +8282,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8317,6 +8317,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.12--randomization-of-scope-variables_1.sv -l 18.12--randomization-of-scope-variables_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8326,12 +8332,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8367,6 +8367,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.8--disabling-random-variables-with-rand_mode_3.sv -l 18.8--disabling-random-variables-with-rand_mode_3.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8376,12 +8382,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8399,6 +8399,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.2--if-else-production-statements_3.sv -l 18.17.2--if-else-production-statements_3.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8408,12 +8414,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8443,6 +8443,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5--constraint-blocks_1.sv -l 18.5--constraint-blocks_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8452,12 +8458,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8490,6 +8490,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.2--if-else-production-statements_1.sv -l 18.17.2--if-else-production-statements_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8499,12 +8505,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8546,6 +8546,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.5--set_randstate_0.sv -l 18.13.5--set_randstate_0.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8555,12 +8561,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8605,6 +8605,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.7--value-passing-between-productions_1.sv -l 18.17.7--value-passing-between-productions_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8614,12 +8620,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8685,6 +8685,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.3--behavior-of-randomization-methods_3.sv -l 18.6.3--behavior-of-randomization-methods_3.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8694,12 +8700,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8717,6 +8717,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.1--urandom_3.sv -l 18.13.1--urandom_3.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8726,12 +8732,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8749,6 +8749,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.13--constraint-guards_1.sv -l 18.5.13--constraint-guards_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8758,12 +8764,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8781,6 +8781,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.8.2--array-reduction-iterative-constraints_1.sv -l 18.5.8.2--array-reduction-iterative-constraints_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8790,12 +8796,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8825,6 +8825,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14--random-stability_0.sv -l 18.14--random-stability_0.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8834,12 +8840,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8857,6 +8857,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.16--random-weighted-case-randcase_3.sv -l 18.16--random-weighted-case-randcase_3.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8866,12 +8872,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8898,6 +8898,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14.1--soft-constraint-priorities_3.sv -l 18.5.14.1--soft-constraint-priorities_3.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8907,12 +8913,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8930,6 +8930,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.2--post-randomize_method_1.sv -l 18.6.2--post-randomize_method_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -8939,12 +8945,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -8995,6 +8995,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.7--in-line-constraints--randomize_0.sv -l 18.7--in-line-constraints--randomize_0.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9004,12 +9010,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9041,6 +9041,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14.2--discarding-soft-constraints_1.sv -l 18.5.14.2--discarding-soft-constraints_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9050,12 +9056,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9073,6 +9073,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.16--random-weighted-case-randcase_1.sv -l 18.16--random-weighted-case-randcase_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9082,12 +9088,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9114,6 +9114,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.8--disabling-random-variables-with-rand_mode_5.sv -l 18.8--disabling-random-variables-with-rand_mode_5.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9123,12 +9129,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9146,6 +9146,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17--random-sequence-generation-randsequence_3.sv -l 18.17--random-sequence-generation-randsequence_3.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9155,12 +9161,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9202,6 +9202,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.2--pure-constraint_1.sv -l 18.5.2--pure-constraint_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9211,12 +9217,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9234,6 +9234,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14.1--soft-constraint-priorities_1.sv -l 18.5.14.1--soft-constraint-priorities_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9243,12 +9249,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9266,6 +9266,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.5--uniqueness-constraints_1.sv -l 18.5.5--uniqueness-constraints_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9275,12 +9281,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9298,6 +9298,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.4--repeat-production-statements_1.sv -l 18.17.4--repeat-production-statements_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9307,12 +9313,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9357,6 +9357,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14.2--thread-stability_0.sv -l 18.14.2--thread-stability_0.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9366,12 +9372,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9389,6 +9389,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.1--randomize-method_0.sv -l 18.6.1--randomize-method_0.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9398,12 +9404,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9421,6 +9421,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.10--dynamic-constraint-modification_0.sv -l 18.10--dynamic-constraint-modification_0.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9430,12 +9436,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9459,6 +9459,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14--random-stability_3.sv -l 18.14--random-stability_3.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9468,12 +9474,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9515,6 +9515,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.2--pre-randomize-method_1.sv -l 18.6.2--pre-randomize-method_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9524,12 +9530,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9547,6 +9547,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.6--aborting-productions-break-and-return_3.sv -l 18.17.6--aborting-productions-break-and-return_3.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9556,12 +9562,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9591,6 +9591,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.2--urandom_range_3.sv -l 18.13.2--urandom_range_3.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9600,12 +9606,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9623,6 +9623,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.2--urandom_range_2.sv -l 18.13.2--urandom_range_2.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9632,12 +9638,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9655,6 +9655,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.8--disabling-random-variables-with-rand_mode_2.sv -l 18.8--disabling-random-variables-with-rand_mode_2.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9664,12 +9670,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9708,6 +9708,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.11--in-line-random-variable-control_1.sv -l 18.11--in-line-random-variable-control_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9717,12 +9723,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9740,6 +9740,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.3--srandom_0.sv -l 18.13.3--srandom_0.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9749,12 +9755,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9772,6 +9772,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.9--controlling-constraints-with-constraint_mode_0.sv -l 18.9--controlling-constraints-with-constraint_mode_0.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9781,12 +9787,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9804,6 +9804,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.9--controlling-constraints-with-constraint_mode_2.sv -l 18.9--controlling-constraints-with-constraint_mode_2.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9813,12 +9819,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9838,6 +9838,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14.3--object-stability_0.sv -l 18.14.3--object-stability_0.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9847,12 +9853,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9876,6 +9876,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.11.1--in-line-constraint-checker_0.sv -l 18.11.1--in-line-constraint-checker_0.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9885,12 +9891,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9920,6 +9920,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17--random-sequence-generation-randsequence_1.sv -l 18.17--random-sequence-generation-randsequence_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9929,12 +9935,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -9988,6 +9988,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14.1--soft-constraint-priorities_4.sv -l 18.5.14.1--soft-constraint-priorities_4.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -9997,12 +10003,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10020,6 +10020,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.3--set-membership_1.sv -l 18.5.3--set-membership_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10029,12 +10035,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10070,6 +10070,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.12.1--adding-constraints-to-scope-variables_1.sv -l 18.12.1--adding-constraints-to-scope-variables_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10079,12 +10085,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10102,6 +10102,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.11--in-line-random-variable-control_0.sv -l 18.11--in-line-random-variable-control_0.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10111,12 +10117,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10134,6 +10134,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.1--implicit-external-constraint_2.sv -l 18.5.1--implicit-external-constraint_2.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10143,12 +10149,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10178,6 +10178,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.6--implication_1.sv -l 18.5.6--implication_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10187,12 +10193,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10216,6 +10216,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.1--explicit-external-constraint_2.sv -l 18.5.1--explicit-external-constraint_2.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10225,12 +10231,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10254,6 +10254,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.2--constraint-inheritance_1.sv -l 18.5.2--constraint-inheritance_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10263,12 +10269,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10286,6 +10286,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.8.1--foreach-iterative-constraints_1.sv -l 18.5.8.1--foreach-iterative-constraints_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10295,12 +10301,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10318,6 +10318,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.3--case-production-statements_1.sv -l 18.17.3--case-production-statements_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10327,12 +10333,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10354,6 +10354,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.3--behavior-of-randomization-methods_2.sv -l 18.6.3--behavior-of-randomization-methods_2.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10363,12 +10369,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10386,6 +10386,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.7--in-line-constraints--randomize_6.sv -l 18.7--in-line-constraints--randomize_6.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10395,12 +10401,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10441,6 +10441,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14--random-stability_2.sv -l 18.14--random-stability_2.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10450,12 +10456,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10485,6 +10485,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.8--disabling-random-variables-with-rand_mode_0.sv -l 18.8--disabling-random-variables-with-rand_mode_0.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10494,12 +10500,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10517,6 +10517,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.8--disabling-random-variables-with-rand_mode_1.sv -l 18.8--disabling-random-variables-with-rand_mode_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10526,12 +10532,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10555,6 +10555,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.7.1--local-scope-resolution_1.sv -l 18.7.1--local-scope-resolution_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10564,12 +10570,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10599,6 +10599,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.7--in-line-constraints--randomize_2.sv -l 18.7--in-line-constraints--randomize_2.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10608,12 +10614,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10631,6 +10631,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.3--behavior-of-randomization-methods_5.sv -l 18.6.3--behavior-of-randomization-methods_5.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10640,12 +10646,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10671,6 +10671,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.7--if-else-constraints_4.sv -l 18.5.7--if-else-constraints_4.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10680,12 +10686,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -10713,6 +10713,12 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.3--behavior-of-randomization-methods_1.sv -l 18.6.3--behavior-of-randomization-methods_1.sv.log
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
+
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
@@ -10722,12 +10728,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:8: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 

--- a/third_party/tests/IbexGoogle/IbexGoogle.log
+++ b/third_party/tests/IbexGoogle/IbexGoogle.log
@@ -902,7 +902,7 @@
 
 [INF:CP0302] builtin.sv:58: Compile class "work@semaphore".
 
-[ERR:UH0700] ./src/riscv_page_table_list.sv:224: Unsupported expression "<n<> u<70306> t<Class_scope> p<70310> c<70305> s<70307> f<5852> l<224:12> el<224:43>>     LWU,
+[ERR:UH0700] ./src/riscv_page_table_list.sv:224: Unsupported expression "<n<> u<70306> t<Class_scope> p<70310> c<70305> s<70307> f<5853> l<224:12> el<224:43>>     LWU,
 ".
 
 [INF:EL0526] Design Elaboration...

--- a/third_party/tests/NyuziProcessor/NyuziProcessor.log
+++ b/third_party/tests/NyuziProcessor/NyuziProcessor.log
@@ -22,125 +22,125 @@
 
 [INF:PP0122] Preprocessing source file "hardware/testbench/sim_sdram.sv".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_1r1w.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/idx_to_oh.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/oh_to_idx.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/int_execute_stage.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_load_miss_queue.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/reciprocal_rom.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_interconnect.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/synchronizer.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage1.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/rr_arbiter.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/thread_select_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_load_miss_queue.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_2r1w.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/writeback_stage.sv".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_2r1w.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage4.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/oh_to_idx.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage1.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/thread_select_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/int_execute_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/performance_counters.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/reciprocal_rom.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_sequencer.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_1r1w.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_sram.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/rr_arbiter.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/spi_controller.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_async_bridge.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/logic_analyzer.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_controller.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_transmit.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_interconnect.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_rom.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_async_bridge.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_receive.sv".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/spi_controller.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_controller.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/logic_analyzer.sv".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/async_fifo.sv".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_transmit.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_sequencer.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/timer.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_sram.sv".
 
 [INF:PA0201] Parsing source file "builtin.sv".
 
@@ -160,125 +160,125 @@
 
 [INF:PA0201] Parsing source file "hardware/testbench/sim_sdram.sv".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_1r1w.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/idx_to_oh.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/oh_to_idx.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/int_execute_stage.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_load_miss_queue.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/reciprocal_rom.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_interconnect.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/synchronizer.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage1.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/rr_arbiter.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/thread_select_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_load_miss_queue.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_2r1w.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/writeback_stage.sv".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_2r1w.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage4.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/oh_to_idx.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage1.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/thread_select_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/int_execute_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/performance_counters.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/reciprocal_rom.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_sequencer.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_1r1w.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_sram.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/rr_arbiter.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/spi_controller.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_async_bridge.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/logic_analyzer.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_controller.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_transmit.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_interconnect.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_rom.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_async_bridge.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_receive.sv".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/spi_controller.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_controller.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/logic_analyzer.sv".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/async_fifo.sv".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_transmit.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_sequencer.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/timer.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_sram.sv".
 
 [INF:CM0029] Using global timescale: "10ps/10ps".
 

--- a/third_party/tests/SVSwitch/SVSwitch.log
+++ b/third_party/tests/SVSwitch/SVSwitch.log
@@ -99,11 +99,11 @@ Instance tree:
 [TOP] work@top work@top
 [I/F] work@mem_interface work@top.mem_intf
 [I/F] work@input_interface work@top.input_intf
-[I/F] work@output_interface work@top.\output_intf[0] 
-[I/F] work@output_interface work@top.\output_intf[1] 
-[I/F] work@output_interface work@top.\output_intf[2] 
-[I/F] work@output_interface work@top.\output_intf[3] 
-[I/F] work@output_interface work@top.\output_intf[4] 
+[I/F] work@output_interface work@top.output_intf[0] 
+[I/F] work@output_interface work@top.output_intf[1] 
+[I/F] work@output_interface work@top.output_intf[2] 
+[I/F] work@output_interface work@top.output_intf[3] 
+[I/F] work@output_interface work@top.output_intf[4] 
 [PRG] work@testcase work@top.TC
 [MOD] work@switch work@top.DUT
 [SCO] work@testcase.UNNAMED work@top.TC.UNNAMED
@@ -184,15 +184,15 @@ Instance tree:
 
 [NTE:EL0524] top.sv:32: Interface Instance "work@top.input_intf".
 
-[NTE:EL0524] top.sv:38: Interface Instance "work@top.\output_intf[0] ".
+[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[0] ".
 
-[NTE:EL0524] top.sv:38: Interface Instance "work@top.\output_intf[1] ".
+[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[1] ".
 
-[NTE:EL0524] top.sv:38: Interface Instance "work@top.\output_intf[2] ".
+[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[2] ".
 
-[NTE:EL0524] top.sv:38: Interface Instance "work@top.\output_intf[3] ".
+[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[3] ".
 
-[NTE:EL0524] top.sv:38: Interface Instance "work@top.\output_intf[4] ".
+[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[4] ".
 
 [NTE:EL0525] top.sv:44: Program Instance "work@top.TC".
 

--- a/third_party/tests/SVSwitch/SVSwitch.log
+++ b/third_party/tests/SVSwitch/SVSwitch.log
@@ -99,11 +99,11 @@ Instance tree:
 [TOP] work@top work@top
 [I/F] work@mem_interface work@top.mem_intf
 [I/F] work@input_interface work@top.input_intf
-[I/F] work@output_interface work@top.output_intf[0] 
-[I/F] work@output_interface work@top.output_intf[1] 
-[I/F] work@output_interface work@top.output_intf[2] 
-[I/F] work@output_interface work@top.output_intf[3] 
-[I/F] work@output_interface work@top.output_intf[4] 
+[I/F] work@output_interface work@top.output_intf[0]
+[I/F] work@output_interface work@top.output_intf[1]
+[I/F] work@output_interface work@top.output_intf[2]
+[I/F] work@output_interface work@top.output_intf[3]
+[I/F] work@output_interface work@top.output_intf[4]
 [PRG] work@testcase work@top.TC
 [MOD] work@switch work@top.DUT
 [SCO] work@testcase.UNNAMED work@top.TC.UNNAMED
@@ -184,15 +184,15 @@ Instance tree:
 
 [NTE:EL0524] top.sv:32: Interface Instance "work@top.input_intf".
 
-[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[0] ".
+[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[0]".
 
-[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[1] ".
+[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[1]".
 
-[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[2] ".
+[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[2]".
 
-[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[3] ".
+[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[3]".
 
-[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[4] ".
+[NTE:EL0524] top.sv:38: Interface Instance "work@top.output_intf[4]".
 
 [NTE:EL0525] top.sv:44: Program Instance "work@top.TC".
 

--- a/third_party/tests/Scr1/Scr1.log
+++ b/third_party/tests/Scr1/Scr1.log
@@ -225,7 +225,7 @@ Cache saving: t.ttts
 
 Cache saving: t.ttts
 Parsing took t.ttts
-SLL Parsing: t.ttts ../../../build/tests/Scr1/slpp_all/work/sv_6956721045759131781/builtin.sv
+SLL Parsing: t.ttts ../../../build/tests/Scr1/slpp_all/work/sv_2076548932596474082/builtin.sv
 Cache saving: t.ttts
 SLL Parsing: t.ttts ../../../build/tests/Scr1/slpp_all/work/pipeline_11658576320160345921/scr1_pipe_hdu.sv
 Cache saving: t.ttts
@@ -630,7 +630,7 @@ PP SSL Parsing: t.ttts src/pipeline/scr1_tracelog.sv
 PP SSL Parsing: t.ttts src/tb/scr1_memory_tb_axi.sv
 PP SSL Parsing: t.ttts src/tb/scr1_top_tb_axi.sv
 Parsing took t.ttts
-SLL Parsing: t.ttts ../../../build/tests/Scr1/slpp_all/work/sv_6956721045759131781/builtin.sv
+SLL Parsing: t.ttts ../../../build/tests/Scr1/slpp_all/work/sv_2076548932596474082/builtin.sv
 Cache saving: t.ttts
 SLL Parsing: t.ttts ../../../build/tests/Scr1/slpp_all/work/pipeline_11658576320160345921/scr1_pipe_hdu.sv
 Cache saving: t.ttts

--- a/third_party/tests/UVMSwitch/UVMSwitch.log
+++ b/third_party/tests/UVMSwitch/UVMSwitch.log
@@ -6287,11 +6287,11 @@ Instance tree:
 [SCO] work@top.UNNAMED work@top.UNNAMED
 [I/F] work@mem_interface work@top.mem_intf
 [I/F] work@input_interface work@top.input_intf
-[I/F] work@output_interface work@top.\output_intf[0] 
-[I/F] work@output_interface work@top.\output_intf[1] 
-[I/F] work@output_interface work@top.\output_intf[2] 
-[I/F] work@output_interface work@top.\output_intf[3] 
-[I/F] work@output_interface work@top.\output_intf[4] 
+[I/F] work@output_interface work@top.output_intf[0] 
+[I/F] work@output_interface work@top.output_intf[1] 
+[I/F] work@output_interface work@top.output_intf[2] 
+[I/F] work@output_interface work@top.output_intf[3] 
+[I/F] work@output_interface work@top.output_intf[4] 
 [SCO] work@top.UNNAMED work@top.UNNAMED
 [MOD] work@switch work@top.DUT
 [SCO] work@top.UNNAMED.UNNAMED work@top.UNNAMED.UNNAMED
@@ -6522,15 +6522,15 @@ Instance tree:
 
 [NTE:EL0524] top.sv:51: Interface Instance "work@top.input_intf".
 
-[NTE:EL0524] top.sv:57: Interface Instance "work@top.\output_intf[0] ".
+[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[0] ".
 
-[NTE:EL0524] top.sv:57: Interface Instance "work@top.\output_intf[1] ".
+[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[1] ".
 
-[NTE:EL0524] top.sv:57: Interface Instance "work@top.\output_intf[2] ".
+[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[2] ".
 
-[NTE:EL0524] top.sv:57: Interface Instance "work@top.\output_intf[3] ".
+[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[3] ".
 
-[NTE:EL0524] top.sv:57: Interface Instance "work@top.\output_intf[4] ".
+[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[4] ".
 
 [NTE:EL0522] top.sv:66: Scope "work@top.UNNAMED".
 

--- a/third_party/tests/UVMSwitch/UVMSwitch.log
+++ b/third_party/tests/UVMSwitch/UVMSwitch.log
@@ -6287,11 +6287,11 @@ Instance tree:
 [SCO] work@top.UNNAMED work@top.UNNAMED
 [I/F] work@mem_interface work@top.mem_intf
 [I/F] work@input_interface work@top.input_intf
-[I/F] work@output_interface work@top.output_intf[0] 
-[I/F] work@output_interface work@top.output_intf[1] 
-[I/F] work@output_interface work@top.output_intf[2] 
-[I/F] work@output_interface work@top.output_intf[3] 
-[I/F] work@output_interface work@top.output_intf[4] 
+[I/F] work@output_interface work@top.output_intf[0]
+[I/F] work@output_interface work@top.output_intf[1]
+[I/F] work@output_interface work@top.output_intf[2]
+[I/F] work@output_interface work@top.output_intf[3]
+[I/F] work@output_interface work@top.output_intf[4]
 [SCO] work@top.UNNAMED work@top.UNNAMED
 [MOD] work@switch work@top.DUT
 [SCO] work@top.UNNAMED.UNNAMED work@top.UNNAMED.UNNAMED
@@ -6522,15 +6522,15 @@ Instance tree:
 
 [NTE:EL0524] top.sv:51: Interface Instance "work@top.input_intf".
 
-[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[0] ".
+[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[0]".
 
-[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[1] ".
+[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[1]".
 
-[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[2] ".
+[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[2]".
 
-[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[3] ".
+[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[3]".
 
-[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[4] ".
+[NTE:EL0524] top.sv:57: Interface Instance "work@top.output_intf[4]".
 
 [NTE:EL0522] top.sv:66: Scope "work@top.UNNAMED".
 

--- a/third_party/tests/YosysBigSim/amber23/YosysBigSimAmber23.log
+++ b/third_party/tests/YosysBigSim/amber23/YosysBigSimAmber23.log
@@ -2,39 +2,39 @@
 
 [INF:CM0020] Separate compilation-unit mode is on.
 
-[WRN:PA0205] sim/bench.v:2: No timescale set for "testbench".
-
-[WRN:PA0205] rtl/a23_cache.v:48: No timescale set for "a23_cache".
-
-[WRN:PA0205] rtl/a23_alu.v:43: No timescale set for "a23_alu".
-
-[WRN:PA0205] rtl/a23_register_bank.v:44: No timescale set for "a23_register_bank".
-
-[WRN:PA0205] rtl/a23_coprocessor.v:41: No timescale set for "a23_coprocessor".
-
-[WRN:PA0205] rtl/a23_decode.v:44: No timescale set for "a23_decode".
-
 [WRN:PA0205] rtl/a23_barrel_shift.v:42: No timescale set for "a23_barrel_shift".
-
-[WRN:PA0205] rtl/a23_execute.v:46: No timescale set for "a23_execute".
-
-[WRN:PA0205] rtl/generic_sram_byte_en.v:43: No timescale set for "generic_sram_byte_en".
-
-[WRN:PA0205] rtl/a23_barrel_shift_fpga.v:46: No timescale set for "a23_barrel_shift_fpga".
-
-[WRN:PA0205] rtl/a23_ram_register_bank.v:44: No timescale set for "a23_ram_register_bank".
-
-[WRN:PA0205] rtl/a23_core.v:43: No timescale set for "a23_core".
-
-[WRN:PA0205] rtl/a23_fetch.v:45: No timescale set for "a23_fetch".
 
 [WRN:PA0205] rtl/a23_decompile.v:45: No timescale set for "a23_decompile".
 
-[WRN:PA0205] rtl/generic_sram_line_en.v:42: No timescale set for "generic_sram_line_en".
+[WRN:PA0205] rtl/a23_multiply.v:56: No timescale set for "a23_multiply".
 
 [WRN:PA0205] rtl/a23_wishbone.v:58: No timescale set for "a23_wishbone".
 
-[WRN:PA0205] rtl/a23_multiply.v:56: No timescale set for "a23_multiply".
+[WRN:PA0205] rtl/a23_core.v:43: No timescale set for "a23_core".
+
+[WRN:PA0205] rtl/a23_cache.v:48: No timescale set for "a23_cache".
+
+[WRN:PA0205] rtl/a23_execute.v:46: No timescale set for "a23_execute".
+
+[WRN:PA0205] rtl/a23_decode.v:44: No timescale set for "a23_decode".
+
+[WRN:PA0205] rtl/a23_ram_register_bank.v:44: No timescale set for "a23_ram_register_bank".
+
+[WRN:PA0205] rtl/generic_sram_byte_en.v:43: No timescale set for "generic_sram_byte_en".
+
+[WRN:PA0205] rtl/a23_coprocessor.v:41: No timescale set for "a23_coprocessor".
+
+[WRN:PA0205] rtl/a23_register_bank.v:44: No timescale set for "a23_register_bank".
+
+[WRN:PA0205] rtl/a23_barrel_shift_fpga.v:46: No timescale set for "a23_barrel_shift_fpga".
+
+[WRN:PA0205] rtl/a23_alu.v:43: No timescale set for "a23_alu".
+
+[WRN:PA0205] rtl/generic_sram_line_en.v:42: No timescale set for "generic_sram_line_en".
+
+[WRN:PA0205] rtl/a23_fetch.v:45: No timescale set for "a23_fetch".
+
+[WRN:PA0205] sim/bench.v:2: No timescale set for "testbench".
 
 [INF:CP0300] Compilation...
 
@@ -111,30 +111,6 @@ there are 2 more instances of this message.
 [NTE:CP0309] rtl/a23_wishbone.v:70: Implicit port type (wire) for "o_stall".
 
 [INF:EL0526] Design Elaboration...
-
-[INF:CP0335] rtl/a23_cache.v:513: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[0]".
-
-[INF:CP0335] rtl/generic_sram_line_en.v:60: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[0].u_tag.init0".
-
-[INF:CP0335] rtl/a23_cache.v:513: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[1]".
-
-[INF:CP0335] rtl/generic_sram_line_en.v:60: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[1].u_tag.init0".
-
-[INF:CP0335] rtl/a23_cache.v:513: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[2]".
-
-[INF:CP0335] rtl/generic_sram_line_en.v:60: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[2].u_tag.init0".
-
-[INF:CP0335] rtl/a23_cache.v:513: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[3]".
-
-[INF:CP0335] rtl/generic_sram_line_en.v:60: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[3].u_tag.init0".
-
-[INF:CP0335] rtl/a23_cache.v:595: Compile generate block "work@testbench.UUT.u_fetch.u_cache.valid_bits_3ways".
-
-[INF:CP0335] rtl/a23_cache.v:642: Compile generate block "work@testbench.UUT.u_fetch.u_cache.read_data_3ways".
-
-[INF:CP0335] rtl/a23_cache.v:707: Compile generate block "work@testbench.UUT.u_fetch.u_cache.pick_way_3ways".
-
-[INF:CP0335] rtl/a23_cache.v:861: Compile generate block "work@testbench.UUT.u_fetch.u_cache.check_hit_3ways".
 
 [INF:CP0335] rtl/a23_barrel_shift_fpga.v:165: Compile generate block "work@a23_barrel_shift_fpga.netgen[0]".
 
@@ -474,13 +450,37 @@ there are 2 more instances of this message.
 
 [INF:CP0335] rtl/a23_barrel_shift_fpga.v:179: Compile generate block "work@a23_barrel_shift_fpga.router[4]".
 
-[NTE:EL0503] sim/bench.v:2: Top level module "work@testbench".
+[INF:CP0335] rtl/a23_cache.v:513: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[0]".
 
-[NTE:EL0503] rtl/a23_barrel_shift_fpga.v:46: Top level module "work@a23_barrel_shift_fpga".
+[INF:CP0335] rtl/generic_sram_line_en.v:60: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[0].u_tag.init0".
+
+[INF:CP0335] rtl/a23_cache.v:513: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[1]".
+
+[INF:CP0335] rtl/generic_sram_line_en.v:60: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[1].u_tag.init0".
+
+[INF:CP0335] rtl/a23_cache.v:513: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[2]".
+
+[INF:CP0335] rtl/generic_sram_line_en.v:60: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[2].u_tag.init0".
+
+[INF:CP0335] rtl/a23_cache.v:513: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[3]".
+
+[INF:CP0335] rtl/generic_sram_line_en.v:60: Compile generate block "work@testbench.UUT.u_fetch.u_cache.rams[3].u_tag.init0".
+
+[INF:CP0335] rtl/a23_cache.v:595: Compile generate block "work@testbench.UUT.u_fetch.u_cache.valid_bits_3ways".
+
+[INF:CP0335] rtl/a23_cache.v:642: Compile generate block "work@testbench.UUT.u_fetch.u_cache.read_data_3ways".
+
+[INF:CP0335] rtl/a23_cache.v:707: Compile generate block "work@testbench.UUT.u_fetch.u_cache.pick_way_3ways".
+
+[INF:CP0335] rtl/a23_cache.v:861: Compile generate block "work@testbench.UUT.u_fetch.u_cache.check_hit_3ways".
+
+[NTE:EL0503] rtl/a23_decompile.v:45: Top level module "work@a23_decompile".
 
 [NTE:EL0503] rtl/a23_ram_register_bank.v:44: Top level module "work@a23_ram_register_bank".
 
-[NTE:EL0503] rtl/a23_decompile.v:45: Top level module "work@a23_decompile".
+[NTE:EL0503] rtl/a23_barrel_shift_fpga.v:46: Top level module "work@a23_barrel_shift_fpga".
+
+[NTE:EL0503] sim/bench.v:2: Top level module "work@testbench".
 
 [NTE:EL0504] Multiple top level modules in design.
 

--- a/third_party/tests/YosysBigSim/lm32/YosysBigSimLm32.log
+++ b/third_party/tests/YosysBigSim/lm32/YosysBigSimLm32.log
@@ -2,45 +2,45 @@
 
 [INF:CM0020] Separate compilation-unit mode is on.
 
-[WRN:PA0205] sim/tb_lm32_system.v:34: No timescale set for "testbench".
+[WRN:PA0205] rtl/lm32_dcache.v:80: No timescale set for "lm32_dcache".
+
+[WRN:PA0205] rtl/lm32_adder.v:56: No timescale set for "lm32_adder".
+
+[WRN:PA0205] rtl/lm32_interrupt.v:56: No timescale set for "lm32_interrupt".
 
 [WRN:PA0205] rtl/lm32_logic_op.v:56: No timescale set for "lm32_logic_op".
+
+[WRN:PA0205] rtl/lm32_addsub.v:55: No timescale set for "lm32_addsub".
+
+[WRN:PA0205] rtl/lm32_top.v:56: No timescale set for "lm32_top".
+
+[WRN:PA0205] rtl/lm32_ram.v:61: No timescale set for "lm32_ram".
+
+[WRN:PA0205] rtl/lm32_dtlb.v:53: No timescale set for "lm32_dtlb".
+
+[WRN:PA0205] rtl/lm32_instruction_unit.v:77: No timescale set for "lm32_instruction_unit".
+
+[WRN:PA0205] rtl/lm32_decoder.v:113: No timescale set for "lm32_decoder".
+
+[WRN:PA0205] rtl/lm32_shifter.v:56: No timescale set for "lm32_shifter".
+
+[WRN:PA0205] rtl/lm32_mc_arithmetic.v:64: No timescale set for "lm32_mc_arithmetic".
+
+[WRN:PA0205] rtl/lm32_debug.v:69: No timescale set for "lm32_debug".
+
+[WRN:PA0205] rtl/lm32_itlb.v:55: No timescale set for "lm32_itlb".
 
 [WRN:PA0205] rtl/lm32_icache.v:86: No timescale set for "lm32_icache".
 
 [WRN:PA0205] rtl/lm32_cpu.v:99: No timescale set for "lm32_cpu".
 
-[WRN:PA0205] rtl/lm32_dp_ram.v:37: No timescale set for "lm32_dp_ram".
-
-[WRN:PA0205] rtl/lm32_itlb.v:55: No timescale set for "lm32_itlb".
-
-[WRN:PA0205] rtl/lm32_dcache.v:80: No timescale set for "lm32_dcache".
-
-[WRN:PA0205] rtl/lm32_decoder.v:113: No timescale set for "lm32_decoder".
-
-[WRN:PA0205] rtl/lm32_mc_arithmetic.v:64: No timescale set for "lm32_mc_arithmetic".
-
 [WRN:PA0205] rtl/lm32_multiplier.v:56: No timescale set for "lm32_multiplier".
 
-[WRN:PA0205] rtl/lm32_shifter.v:56: No timescale set for "lm32_shifter".
-
-[WRN:PA0205] rtl/lm32_debug.v:69: No timescale set for "lm32_debug".
-
-[WRN:PA0205] rtl/lm32_instruction_unit.v:77: No timescale set for "lm32_instruction_unit".
-
-[WRN:PA0205] rtl/lm32_dtlb.v:53: No timescale set for "lm32_dtlb".
+[WRN:PA0205] rtl/lm32_dp_ram.v:37: No timescale set for "lm32_dp_ram".
 
 [WRN:PA0205] rtl/lm32_load_store_unit.v:69: No timescale set for "lm32_load_store_unit".
 
-[WRN:PA0205] rtl/lm32_interrupt.v:56: No timescale set for "lm32_interrupt".
-
-[WRN:PA0205] rtl/lm32_top.v:56: No timescale set for "lm32_top".
-
-[WRN:PA0205] rtl/lm32_addsub.v:55: No timescale set for "lm32_addsub".
-
-[WRN:PA0205] rtl/lm32_ram.v:61: No timescale set for "lm32_ram".
-
-[WRN:PA0205] rtl/lm32_adder.v:56: No timescale set for "lm32_adder".
+[WRN:PA0205] sim/tb_lm32_system.v:34: No timescale set for "testbench".
 
 [INF:CP0300] Compilation...
 
@@ -166,9 +166,9 @@
 
 [INF:CP0335] rtl/lm32_debug.v:265: Compile generate block "work@testbench.lm32.cpu.hw_debug.wp_seq[3]".
 
-[NTE:EL0503] sim/tb_lm32_system.v:34: Top level module "work@testbench".
-
 [NTE:EL0503] rtl/lm32_dp_ram.v:37: Top level module "work@lm32_dp_ram".
+
+[NTE:EL0503] sim/tb_lm32_system.v:34: Top level module "work@testbench".
 
 [NTE:EL0504] Multiple top level modules in design.
 

--- a/third_party/tests/YosysBigSim/reed_solomon_decoder/YosysBigSimReed.log
+++ b/third_party/tests/YosysBigSim/reed_solomon_decoder/YosysBigSimReed.log
@@ -2,31 +2,31 @@
 
 [INF:CM0020] Separate compilation-unit mode is on.
 
-[WRN:PA0205] sim/RS_dec_tb.v:3: No timescale set for "testbench".
-
-[WRN:PA0205] rtl/lamda_roots.v:21: No timescale set for "lamda_roots".
-
 [WRN:PA0205] rtl/error_correction.v:20: No timescale set for "error_correction".
-
-[WRN:PA0205] rtl/GF_matrix_ascending_binary.v:20: No timescale set for "GF_matrix_ascending_binary".
-
-[WRN:PA0205] rtl/DP_RAM.v:18: No timescale set for "DP_RAM".
-
-[WRN:PA0205] rtl/RS_dec.v:21: No timescale set for "RS_dec".
-
-[WRN:PA0205] rtl/GF_matrix_dec.v:21: No timescale set for "GF_matrix_dec".
-
-[WRN:PA0205] rtl/GF_mult_add_syndromes.v:28: No timescale set for "GF_mult_add_syndromes".
 
 [WRN:PA0205] rtl/BM_lamda.v:20: No timescale set for "BM_lamda".
 
+[WRN:PA0205] rtl/GF_matrix_ascending_binary.v:20: No timescale set for "GF_matrix_ascending_binary".
+
 [WRN:PA0205] rtl/Omega_Phy.v:21: No timescale set for "Omega_Phy".
+
+[WRN:PA0205] rtl/GF_mult_add_syndromes.v:28: No timescale set for "GF_mult_add_syndromes".
+
+[WRN:PA0205] rtl/GF_matrix_dec.v:21: No timescale set for "GF_matrix_dec".
+
+[WRN:PA0205] rtl/lamda_roots.v:21: No timescale set for "lamda_roots".
+
+[WRN:PA0205] rtl/transport_in2out.v:22: No timescale set for "transport_in2out".
+
+[WRN:PA0205] rtl/RS_dec.v:21: No timescale set for "RS_dec".
 
 [WRN:PA0205] rtl/out_stage.v:21: No timescale set for "out_stage".
 
 [WRN:PA0205] rtl/input_syndromes.v:24: No timescale set for "input_syndromes".
 
-[WRN:PA0205] rtl/transport_in2out.v:22: No timescale set for "transport_in2out".
+[WRN:PA0205] rtl/DP_RAM.v:18: No timescale set for "DP_RAM".
+
+[WRN:PA0205] sim/RS_dec_tb.v:3: No timescale set for "testbench".
 
 [INF:CP0300] Compilation...
 

--- a/third_party/tests/YosysBigSim/softusb_navre/YosysBigSimSoft.log
+++ b/third_party/tests/YosysBigSim/softusb_navre/YosysBigSimSoft.log
@@ -2,9 +2,9 @@
 
 [INF:CM0020] Separate compilation-unit mode is on.
 
-[WRN:PA0205] sim/bench.v:2: No timescale set for "testbench".
-
 [WRN:PA0205] rtl/softusb_navre.v:18: No timescale set for "softusb_navre".
+
+[WRN:PA0205] sim/bench.v:2: No timescale set for "testbench".
 
 [INF:CP0300] Compilation...
 

--- a/third_party/tests/YosysBigSim/verilog-pong/YosysBigSimPong.log
+++ b/third_party/tests/YosysBigSim/verilog-pong/YosysBigSimPong.log
@@ -4,13 +4,13 @@
 
 [WRN:PP0103] sim/bench.v:5: Undefining an unknown macro "WRITE_FRAMES_PPM".
 
-[WRN:PA0205] sim/bench.v:8: No timescale set for "testbench".
-
-[WRN:PA0205] rtl/text_graph.v:1: No timescale set for "text_graph".
+[WRN:PA0205] rtl/front_rom.v:1: No timescale set for "font_rom".
 
 [WRN:PA0205] rtl/vga_sync.v:1: No timescale set for "vga_sync".
 
-[WRN:PA0205] rtl/front_rom.v:1: No timescale set for "font_rom".
+[WRN:PA0205] rtl/text_graph.v:1: No timescale set for "text_graph".
+
+[WRN:PA0205] sim/bench.v:8: No timescale set for "testbench".
 
 [INF:CP0300] Compilation...
 

--- a/third_party/tests/YosysOldTests/sasc/YosysOldSasc.log
+++ b/third_party/tests/YosysOldTests/sasc/YosysOldSasc.log
@@ -10,27 +10,26 @@
 
 [INF:CP0303] rtl/sasc_brg.v:88: Compile module "work@sasc_brg".
 
-[INF:CP0303] cache/synth.v:1: Compile module "work@sasc_fifo4".
+[INF:CP0303] rtl/sasc_fifo4.v:63: Compile module "work@sasc_fifo4".
 
-[INF:CP0303] cache/synth.v:282: Compile module "work@sasc_top".
+[INF:CP0303] rtl/sasc_top.v:73: Compile module "work@sasc_top".
 
-[NTE:CP0309] cache/synth.v:1: Implicit port type (wire) for "dout",
-there are 2 more instances of this message.
+[NTE:CP0309] rtl/sasc_fifo4.v:63: Implicit port type (wire) for "dout".
 
-[NTE:CP0309] cache/synth.v:282: Implicit port type (wire) for "dout_o",
+[NTE:CP0309] rtl/sasc_top.v:82: Implicit port type (wire) for "dout_o",
 there are 2 more instances of this message.
 
 [INF:EL0526] Design Elaboration...
 
-[NTE:EL0503] cache/synth.v:282: Top level module "work@sasc_top".
-
 [NTE:EL0503] rtl/sasc_brg.v:88: Top level module "work@sasc_brg".
 
-[WRN:EL0505] rtl/sasc_fifo4.v:63: Multiply defined module "work@sasc_fifo4",
-             cache/synth.v:1: previous definition.
+[NTE:EL0503] rtl/sasc_top.v:73: Top level module "work@sasc_top".
 
-[WRN:EL0505] rtl/sasc_top.v:73: Multiply defined module "work@sasc_top",
-             cache/synth.v:282: previous definition.
+[WRN:EL0505] cache/synth.v:1: Multiply defined module "work@sasc_fifo4",
+             rtl/sasc_fifo4.v:63: previous definition.
+
+[WRN:EL0505] cache/synth.v:282: Multiply defined module "work@sasc_top",
+             rtl/sasc_top.v:73: previous definition.
 
 [NTE:EL0504] Multiple top level modules in design.
 

--- a/third_party/tests/ariane/Ariane.log
+++ b/third_party/tests/ariane/Ariane.log
@@ -76,17 +76,19 @@ make[4]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane'
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/serdiv.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ariane_regfile_ff.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/amo_buffer.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/id_stage.sv".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/branch_unit.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/dromajo_ram.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mmu.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/controller.sv".
 
@@ -94,7 +96,7 @@ make[4]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane'
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/re_name.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mult.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/csr_buffer.sv".
 
@@ -106,11 +108,9 @@ make[4]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane'
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/scoreboard.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mmu.sv".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/store_unit.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mult.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/load_store_unit.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/axi_adapter.sv".
 
@@ -118,9 +118,7 @@ make[4]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane'
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/commit_stage.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/load_store_unit.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/alu.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/id_stage.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/multiplier.sv".
 
@@ -129,6 +127,8 @@ make[4]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane'
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/compressed_decoder.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/axi_shim.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/alu.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/ariane/src/instr_realign.sv".
 
@@ -484,17 +484,19 @@ make[4]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane'
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/fpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/serdiv.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ariane_regfile_ff.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/amo_buffer.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/id_stage.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/branch_unit.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/dromajo_ram.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mmu.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/controller.sv".
 
@@ -502,7 +504,7 @@ make[4]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane'
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/re_name.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/ariane.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mult.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/csr_buffer.sv".
 
@@ -514,11 +516,9 @@ make[4]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane'
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/scoreboard.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mmu.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/store_unit.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/mult.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/load_store_unit.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/axi_adapter.sv".
 
@@ -526,9 +526,7 @@ make[4]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane'
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/commit_stage.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/load_store_unit.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/alu.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/id_stage.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/multiplier.sv".
 
@@ -537,6 +535,8 @@ make[4]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane'
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/compressed_decoder.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/axi_shim.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/alu.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/ariane/src/instr_realign.sv".
 
@@ -5457,6 +5457,5 @@ there are 1 more instances of this message.
 [   NOTE] : 19
 make[5]: Entering directory '${SURELOG_DIR}/third_party/tests/ariane/work-ver'
 make[5]: Leaving directory '${SURELOG_DIR}/third_party/tests/ariane/work-ver'
-Makefile:632: recipe for target 'verilate' failed
 make[4]: Leaving directory '${SURELOG_DIR}/third_party/tests/ariane'
 


### PR DESCRIPTION
Rationale: The IEEE1800 doc says that the leading backslash is not part of the identifier, just a way to write the identifier in source code.

Note: I had to hack `regression.tcl` since for some reason it was not stripping my local run directory properly.