### PR TITLE
Make MacroInfo fields const (they are only ever set in constructor).

### DIFF
--- a/src/SourceCompile/CompilationUnit.cpp
+++ b/src/SourceCompile/CompilationUnit.cpp
@@ -29,8 +29,6 @@ CompilationUnit::CompilationUnit(bool fileunit)
       m_uniqueIdGenerator(0),
       m_uniqueNodeIdGenerator(0) {}
 
-CompilationUnit::CompilationUnit(const CompilationUnit& orig) {}
-
 CompilationUnit::~CompilationUnit() {}
 
 MacroInfo* CompilationUnit::getMacroInfo(const std::string& macroName) {

--- a/src/SourceCompile/CompilationUnit.h
+++ b/src/SourceCompile/CompilationUnit.h
@@ -33,13 +33,13 @@ namespace SURELOG {
 class CompilationUnit {
  public:
   CompilationUnit(bool fileunit);
-  CompilationUnit(const CompilationUnit& orig);
+  CompilationUnit(const CompilationUnit& orig) = delete;
   virtual ~CompilationUnit();
 
   void setInDesignElement() { m_inDesignElement = true; }
   void unsetInDesignElement() { m_inDesignElement = false; }
-  bool isInDesignElement() { return m_inDesignElement; }
-  bool isFileUnit() { return m_fileunit; }
+  bool isInDesignElement() const { return m_inDesignElement; }
+  bool isFileUnit() const { return m_fileunit; }
 
   void registerMacroInfo(const std::string& macroName, MacroInfo* macro);
   MacroInfo* getMacroInfo(const std::string& macroName);
@@ -64,7 +64,7 @@ class CompilationUnit {
   }
 
  private:
-  bool m_fileunit;
+  const bool m_fileunit;
   bool m_inDesignElement;
 
   MacroStorageRef m_macros;

--- a/src/SourceCompile/MacroInfo.h
+++ b/src/SourceCompile/MacroInfo.h
@@ -26,6 +26,7 @@
 
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "SourceCompile/SymbolTable.h"
@@ -34,7 +35,7 @@ namespace SURELOG {
 
 class MacroInfo {
  public:
-  MacroInfo(std::string name, int type, SymbolId file, unsigned int line,
+  MacroInfo(std::string_view name, int type, SymbolId file, unsigned int line,
             unsigned short int column,
             const std::vector<std::string>& arguments,
             const std::vector<std::string>& tokens)
@@ -49,13 +50,14 @@ class MacroInfo {
     NO_ARGS,
     WITH_ARGS,
   };
-  std::string m_name;
-  int m_type;
-  SymbolId m_file;
-  unsigned int m_line;
-  unsigned short int m_column;
-  std::vector<std::string> m_arguments;
-  std::vector<std::string> m_tokens;
+
+  const std::string m_name;
+  const int m_type;
+  const SymbolId m_file;
+  const unsigned int m_line;
+  const unsigned short int m_column;
+  const std::vector<std::string> m_arguments;
+  const std::vector<std::string> m_tokens;
 };
 
 typedef std::map<std::string, MacroInfo*> MacroStorage;


### PR DESCRIPTION
Also fix missing constness opportunities in CompilationUnit and
delete copy constructor.

Next step for MacroInfo would actually be to add const getters,
but for separate pull request.

Signed-off-by: Henner Zeller <h.zeller@acm.org>