### PR TITLE
Issue #1526: Using Surelog as external project dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,9 +207,13 @@ jobs:
         where ninja && ninja --version
 
         make release
+        if %errorlevel% neq 0 exit /b %errorlevel%
         make install
+        if %errorlevel% neq 0 exit /b %errorlevel%
         make test_install
+        if %errorlevel% neq 0 exit /b %errorlevel%
         make test/unittest
+        if %errorlevel% neq 0 exit /b %errorlevel%
         make regression
 
   CodeFormatting:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,19 +52,6 @@ message(STATUS "Python3_INCLUDE_DIRS = ${Python3_INCLUDE_DIRS}")
 message(STATUS "Python3_RUNTIME_LIBRARY_DIRS = ${Python3_RUNTIME_LIBRARY_DIRS}")
 endif()
 
-# Includes
-include_directories("${PROJECT_SOURCE_DIR}/third_party/antlr4/runtime/Cpp/runtime/src/")
-include_directories("${PROJECT_SOURCE_DIR}/third_party/flatbuffers/include/")
-include_directories("${PROJECT_SOURCE_DIR}/third_party/UHDM/include/")
-include_directories("${PROJECT_SOURCE_DIR}/third_party/UHDM/")
-include_directories("${PROJECT_SOURCE_DIR}/third_party/UHDM/headers/")
-include_directories("${PROJECT_SOURCE_DIR}/third_party/googletest/googletest/include/")
-include_directories("${PROJECT_SOURCE_DIR}/third_party/googletest/googlemock/include/")
-
-if (SURELOG_WITH_PYTHON)
-include_directories(${Python3_INCLUDE_DIRS}) # Keep this at the end
-endif()
-
 # Use tcmalloc if installed and not NO_TCMALLOC is on. TODO: don't use negative
 # names, but positive. -DWITH_TCMALLOC=Off is easier to understand than
 # -DNO_TCMALLOC=On
@@ -376,10 +363,17 @@ foreach(gen_src ${surelog_generated_SRC})
   set_source_files_properties(${gen_src} PROPERTIES GENERATED TRUE)
 endforeach()
 
-set(SURELOG_PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/src/surelog.h)
-
 add_library(surelog STATIC ${surelog_SRC} ${surelog_generated_SRC})
-set_target_properties(surelog PROPERTIES PUBLIC_HEADER "${SURELOG_PUBLIC_HEADERS}")
+set_target_properties(surelog PROPERTIES PUBLIC_HEADER src/surelog.h)
+target_include_directories(surelog PRIVATE
+  third_party/antlr4/runtime/Cpp/runtime/src
+  third_party/flatbuffers/include
+  third_party/googletest/googletest/include
+  third_party/googletest/googlemock/include)
+target_include_directories(surelog PUBLIC $<INSTALL_INTERFACE:include/surelog>)
+if (SURELOG_WITH_PYTHON)
+  target_include_directories(surelog PUBLIC ${Python3_INCLUDE_DIRS}) # Keep this at the end
+endif()
 if (SURELOG_WITH_PYTHON)
   target_compile_definitions(surelog PUBLIC SURELOG_WITH_PYTHON)
 endif()
@@ -469,6 +463,9 @@ function(register_gtests)
     # Build binary, link all relevant libs and extract tests
     add_executable(${test_bin} EXCLUDE_FROM_ALL ${gtest_cc_file})
 
+    target_include_directories(${test_bin} PRIVATE
+      ${PROJECT_SOURCE_DIR}/third_party/antlr4/runtime/Cpp/runtime/src
+      ${PROJECT_SOURCE_DIR}/third_party/flatbuffers/include)
     # For simplicity, we link the test with libsurelog, but there is of
     # course a lot unnecessary churn if headers are modified.
     # Often it is sufficient to just have a few depeendencies.
@@ -590,24 +587,31 @@ add_dependencies(hellosureworld PrecompileOVM)
 add_dependencies(hellosureworld PrecompileUVM)
 
 # Installation target
-install(TARGETS surelog-bin RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(
-  TARGETS surelog
+  TARGETS surelog-bin
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(
+  TARGETS surelog antlr4_static flatbuffers
+  EXPORT Surelog
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/surelog
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog)
 install(
-  TARGETS antlr4_static flatbuffers
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/surelog)
+  TARGETS uhdm capnp kj
+  EXPORT Surelog
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/uhdm
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/uhdm)
 install(
   DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/python
             ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sv
             ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/pkg
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/surelog)
-install(FILES ${PROJECT_SOURCE_DIR}/src/CommandLine/CommandLineParser.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/CommandLine)
-install(FILES ${PROJECT_SOURCE_DIR}/src/SourceCompile/SymbolTable.h
-              ${PROJECT_SOURCE_DIR}/src/SourceCompile/VObjectTypes.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/SourceCompile)
+install(
+  FILES ${PROJECT_SOURCE_DIR}/src/CommandLine/CommandLineParser.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/CommandLine)
+install(
+  FILES ${PROJECT_SOURCE_DIR}/src/SourceCompile/SymbolTable.h
+        ${PROJECT_SOURCE_DIR}/src/SourceCompile/VObjectTypes.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/SourceCompile)
 install(
   FILES ${PROJECT_SOURCE_DIR}/src/ErrorReporting/Location.h
         ${PROJECT_SOURCE_DIR}/src/ErrorReporting/Error.h
@@ -622,15 +626,17 @@ install(
         ${PROJECT_SOURCE_DIR}/src/API/SLAPI.h
         ${PROJECT_SOURCE_DIR}/src/API/Surelog.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/API)
-install(FILES ${PROJECT_SOURCE_DIR}/src/Common/ClockingBlockHolder.h
-              ${PROJECT_SOURCE_DIR}/src/Common/PortNetHolder.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/Common)
-install(FILES ${PROJECT_SOURCE_DIR}/src/DesignCompile/CompileHelper.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/DesignCompile)
+install(
+  FILES ${PROJECT_SOURCE_DIR}/src/Common/ClockingBlockHolder.h
+        ${PROJECT_SOURCE_DIR}/src/Common/PortNetHolder.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/Common)
+install(
+  FILES ${PROJECT_SOURCE_DIR}/src/DesignCompile/CompileHelper.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/DesignCompile)
 install(
   FILES ${PROJECT_SOURCE_DIR}/src/Design/ClockingBlock.h
         ${PROJECT_SOURCE_DIR}/src/Design/Design.h
-	${PROJECT_SOURCE_DIR}/src/Design/BindStmt.h
+        ${PROJECT_SOURCE_DIR}/src/Design/BindStmt.h
         ${PROJECT_SOURCE_DIR}/src/Design/Instance.h
         ${PROJECT_SOURCE_DIR}/src/Design/Signal.h
         ${PROJECT_SOURCE_DIR}/src/Design/ValuedComponentI.h
@@ -657,7 +663,7 @@ install(
         ${PROJECT_SOURCE_DIR}/src/Design/ModPort.h
         ${PROJECT_SOURCE_DIR}/src/Design/Union.h
         ${PROJECT_SOURCE_DIR}/src/Design/SimpleType.h
-	${PROJECT_SOURCE_DIR}/src/Design/DummyType.h
+        ${PROJECT_SOURCE_DIR}/src/Design/DummyType.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/Design)
 install(
   FILES ${PROJECT_SOURCE_DIR}/src/Testbench/ClassDefinition.h
@@ -671,14 +677,17 @@ install(
         ${PROJECT_SOURCE_DIR}/src/Testbench/Program.h
         ${PROJECT_SOURCE_DIR}/src/Testbench/TypeDef.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/Testbench)
-install(FILES ${PROJECT_SOURCE_DIR}/src/Package/Package.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/Package)
-install(FILES ${PROJECT_SOURCE_DIR}/src/Library/Library.h
-              ${PROJECT_SOURCE_DIR}/src/Library/LibrarySet.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/Library)
-install(FILES ${PROJECT_SOURCE_DIR}/src/Config/Config.h
-              ${PROJECT_SOURCE_DIR}/src/Config/ConfigSet.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/Config)
+install(
+  FILES ${PROJECT_SOURCE_DIR}/src/Package/Package.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/Package)
+install(
+  FILES ${PROJECT_SOURCE_DIR}/src/Library/Library.h
+        ${PROJECT_SOURCE_DIR}/src/Library/LibrarySet.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/Library)
+install(
+  FILES ${PROJECT_SOURCE_DIR}/src/Config/Config.h
+        ${PROJECT_SOURCE_DIR}/src/Config/ConfigSet.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/surelog/Config)
 install(
   FILES ${PROJECT_SOURCE_DIR}/src/Expression/ExprBuilder.h
         ${PROJECT_SOURCE_DIR}/src/Expression/Value.h
@@ -692,6 +701,11 @@ if (WIN32 AND $<CONFIG:Debug>)
       DESTINATION ${CMAKE_INSTALL_BINDIR})
   endif()
   install(
+    FILES $<TARGET_PDB_FILE:surelog-bin>
+          ${UHDM_BINARY_DIR}/bin/uhdm-dump.pdb
+          ${UHDM_BINARY_DIR}/bin/uhdm-hier.pdb
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install(
     FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/surelog.dir/surelog.pdb
           ${FlatBuffers_BINARY_DIR}/CMakeFiles/flatbuffers.dir/flatbuffers.pdb
           ${LIBANTLR4_BINARY_DIR}/runtime/CMakeFiles/antlr4_static.dir/antlr4_static.pdb
@@ -702,6 +716,25 @@ if (WIN32 AND $<CONFIG:Debug>)
           ${UHDM_BINARY_DIR}/third_party/capnproto/c++/src/kj/CMakeFiles/kj.dir/kj.pdb
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/uhdm)
 endif()
+
+install(
+  EXPORT Surelog
+  FILE Surelog.cmake
+  DESTINATION cmake)
+include(CMakePackageConfigHelpers)
+
+# generate the config file that is includes the exports
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/SurelogConfig.cmake"
+  INSTALL_DESTINATION cmake
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+# install the configuration file
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/SurelogConfig.cmake
+  DESTINATION cmake)
 
 ADD_CUSTOM_TARGET(link_target ALL
                   COMMAND ${CMAKE_COMMAND} -E create_symlink

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/Surelog.cmake" )

--- a/README.md
+++ b/README.md
@@ -50,6 +50,34 @@ make install (/usr/local/bin and /usr/local/lib/surelog by default, use DESTDIR=
 For more build/test options and system requirements for building see
 [`src/README`](src/README.md) file.
 
+## Use Surelog as an external package with CMake
+
+For your project to use Surelog as an external module, you need to tell CMake where to find Surelog. Note that CMake expects the module directory organized a certain way and Surelog's installation step does that so make sure to run that. You can provide the path to CMake in few different ways -
+
+1. By updating `CMAKE_MODULE_PATH` variable in your project's CMakeLists.txt file by adding the following lines -
+
+```
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} <absolute or relative path to surelog installation folder>)
+find_package(Surelog)
+```
+
+2. By providing the location of the surelog installation with the `find_package` command itself, as in the following -
+```
+find_package(Surelog PATHS <absolute or relative path to surelog installation folder>)
+```
+
+3. By providing the location of the surelog installation as a command line parameter when invoking CMake -
+```
+cmake -DSurelog_DIR=<absolute or relative path to surelog installation folder> -S . -B out
+```
+
+For additional help, refer to cmake documentation on external modules.
+
+Once CMake successfully finds Surelog, all you would need is to add the following line after the call to `add_library/add_executable` in your CMakeLists.txt file.
+```
+target_link_libraries(<your project name> surelog)
+```
+
 ## Usage
 
 ### Surelog commands

--- a/src/Utils/StringUtils_test.cpp
+++ b/src/Utils/StringUtils_test.cpp
@@ -230,8 +230,13 @@ TEST(StringUtilsTest, EvaluateEnvironmentVariables) {
             StringUtils::evaluateEnvVars("hello $TESTING_UNKNOWN_VAR/ bar"));
 
   // Variables set via the environment
+#if defined(_MSC_VER)
+  _putenv_s("TESTING_EVAL_FOO", "foo-value");
+  _putenv_s("TESTING_EVAL_BAR", "bar-value");
+#else
   setenv("TESTING_EVAL_FOO", "foo-value", 1);
   setenv("TESTING_EVAL_BAR", "bar-value", 1);
+#endif
 
   EXPECT_EQ("hello foo-value bar",
             StringUtils::evaluateEnvVars("hello ${TESTING_EVAL_FOO} bar"));

--- a/tests/TestInstall/CMakeLists.txt
+++ b/tests/TestInstall/CMakeLists.txt
@@ -105,11 +105,6 @@ if (WIN32)
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
             ${Python3_RUNTIME_LIBRARY_DIRS}/python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}$<$<CONFIG:Debug>:_d>.dll
             $<TARGET_FILE_DIR:test_hellosureworld>)
-    else()
-   add_custom_command(
-      TARGET test_hellosureworld
-      POST_BUILD
-            $<TARGET_FILE_DIR:test_hellosureworld>)    
     endif()
 endif()
 


### PR DESCRIPTION
Issue #1526: Using Surelog as external project dependency

* Updated both UHDM & Surelog to expose relevant/public include paths
  so they get correctly included in the generated output config file.

* Fix the issue where uhdm.h was included twice in the installation.

* Following line in any project's CMakeLists.txt would pull in surelog
  as a dependency including setting up the include paths.

  find_package(surelog PATHS <path to where the lib was installed>)

* Similarly, appending the module path for CMake would also work.

* Updated README.md with instructions on how to include Surelog as
  external module with CMake.

* Windows test builds had been failing with compile errors but the error
  wasn't being propagated up correctly, and so the builds were always
  green on dashboard. Fixed the underlying compiler issue and also
  updated the workflow file so the errors are propagated correctly.