### PR TITLE
Adding support for publishing prebuilt binaries as artifacts.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,6 +216,12 @@ jobs:
         if %errorlevel% neq 0 exit /b %errorlevel%
         make regression
 
+    - name: Archive artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: surelog-windows
+        path: ${{ github.workspace }}/install
+
   CodeFormatting:
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
Adding support for publishing prebuilt binaries as artifacts.

NOTE: Currently this works only for Windows. Generated binaries
on linux are installed in /usr/local wherein we can't be sure
what else might exist that will get included as part of the
artifact. Additional work is needed for linux to support artifact
generation.