### PR TITLE
Add a macOS build target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,6 +222,51 @@ jobs:
         name: surelog-windows
         path: ${{ github.workspace }}/install
 
+  macos:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Configure shell
+      run: |
+        echo 'CC=gcc-9' >> $GITHUB_ENV
+        echo 'CXX=g++-9' >> $GITHUB_ENV
+        echo 'PREFIX=/usr/local' >> $GITHUB_ENV
+
+    - name: Show shell configuration
+      run: |
+        env
+        which cmake && cmake --version
+        which make && make --version
+        which swig && swig -version
+        which java && java -version
+        which python && python --version
+        which tclsh && echo 'puts [info patchlevel];exit 0' | tclsh
+        which $CC && $CC --version
+        which $CXX && $CXX --version
+
+    - name: Build
+      run: |
+        make release
+        sudo make install
+
+    - name: Regression tests
+      run: |
+        make regression
+
+    - name: Unit tests
+      run: |
+        make test_install
+        make test/unittest
+
   CodeFormatting:
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -255,6 +255,8 @@ jobs:
 
     - name: Build
       run: |
+        # Apply Flatbuffers patch to use gcc
+        cd third_party/flatbuffers && git apply ../flatbuffers_macos.patch && cd ../..
         make release
         sudo make install
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 
 # Use bash as the default shell
 SHELL := /bin/bash
-undefine LC_ALL
+
+ifdef $(LC_ALL)
+	undefine LC_ALL
+endif
 
 ifeq ($(CPU_CORES),)
 	CPU_CORES := $(shell nproc)

--- a/tests/TestInstall/CMakeLists.txt
+++ b/tests/TestInstall/CMakeLists.txt
@@ -86,7 +86,15 @@ else()
 )
 endif()
 
-if (UNIX)
+if (APPLE)
+  target_link_libraries(test_hellosureworld
+      stdc++fs
+      dl
+      util
+      m
+      pthread
+  )
+elseif (UNIX)
   target_link_libraries(test_hellosureworld
       stdc++fs
       dl

--- a/third_party/flatbuffers_macos.patch
+++ b/third_party/flatbuffers_macos.patch
@@ -1,0 +1,33 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2f0a0fc0..34b5f09f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -220,10 +220,6 @@ if(EXISTS "${CMAKE_TOOLCHAIN_FILE}")
+   # do not apply any global settings if the toolchain
+   # is being configured externally
+   message(STATUS "Using toolchain file: ${CMAKE_TOOLCHAIN_FILE}.")
+-elseif(APPLE)
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror -Wextra -Wno-unused-parameter")
+-  set(FLATBUFFERS_PRIVATE_CXX_FLAGS "-Wold-style-cast")
+ elseif(CMAKE_COMPILER_IS_GNUCXX)
+   if(CYGWIN)
+     set(CMAKE_CXX_FLAGS
+@@ -250,9 +246,15 @@ elseif(CMAKE_COMPILER_IS_GNUCXX)
+     "${CMAKE_CXX_FLAGS} -fsigned-char")
+ 
+ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+-  set(CMAKE_CXX_FLAGS
+-      "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -pedantic -Werror -Wextra -Wno-unused-parameter")
++  if(APPLE)
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
++  else()
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
++  endif()
++
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Werror -Wextra -Wno-unused-parameter")
+   set(FLATBUFFERS_PRIVATE_CXX_FLAGS "-Wold-style-cast")
++
+   if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.8)
+     list(APPEND FLATBUFFERS_PRIVATE_CXX_FLAGS "-Wimplicit-fallthrough" "-Wextra-semi" "-Werror=unused-private-field") # enable warning
+   endif()


### PR DESCRIPTION
This PR adds a CI target to build Surelog on macOS 10. The flow was also locally tested to work on macOS 11 (M1).

I've also opened https://github.com/google/flatbuffers/pull/6802 to not rely on a patch for FlatBuffers.