### PR TITLE
Add MacOS clang build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -260,14 +260,14 @@ jobs:
         make release
         sudo make install
 
-    - name: Regression tests
-      run: |
-        make regression
-
     - name: Unit tests
       run: |
         make test_install
         make test/unittest
+
+    - name: Regression tests
+      run: |
+        make regression
 
   macos-clang:
     runs-on: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,7 +222,7 @@ jobs:
         name: surelog-windows
         path: ${{ github.workspace }}/install
 
-  macos:
+  macos-gcc:
     runs-on: macos-latest
 
     steps:
@@ -268,6 +268,47 @@ jobs:
       run: |
         make test_install
         make test/unittest
+
+  macos-clang:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Configure shell
+      run: |
+        echo 'PREFIX=/usr/local' >> $GITHUB_ENV
+
+    - name: Show shell configuration
+      run: |
+        env
+        which cmake && cmake --version
+        which make && make --version
+        which swig && swig -version
+        which java && java -version
+        which python && python --version
+        which tclsh && echo 'puts [info patchlevel];exit 0' | tclsh
+
+    - name: Build
+      run: |
+        make release
+        sudo make install
+
+    - name: Unit tests
+      run: |
+        make test_install
+        make test/unittest
+
+    - name: Regression tests
+      run: |
+        make regression
 
   CodeFormatting:
     runs-on: ubuntu-20.04

--- a/tests/TestInstall/CMakeLists.txt
+++ b/tests/TestInstall/CMakeLists.txt
@@ -88,7 +88,6 @@ endif()
 
 if (APPLE)
   target_link_libraries(test_hellosureworld
-      stdc++fs
       dl
       util
       m


### PR DESCRIPTION
This PR renames the previously added macOS build to `macos-gcc` and adds a separate clang build target.