### PR TITLE
Run test, install and regression in separate matrix builds.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,29 @@ on:
 
 jobs:
   linux:
+    name: Check · ${{ matrix.mode }}
+
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        mode:
+        - test
+        - regression
+        - install
+    env:
+      MODE: ${{ matrix.mode }}
 
     steps:
+
+    - name: Cancel previous
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
+
     - name: Install dependencies
       run: |
         sudo apt-get update -qq
@@ -30,7 +47,8 @@ jobs:
       with:
         python-version: 3.8
 
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v2
       with:
         submodules: recursive
         fetch-depth: 0
@@ -54,16 +72,22 @@ jobs:
         which $CC && $CC --version
         which $CXX && $CXX --version
 
-    - name: Build
+    - name: ${{ matrix.env.mode }} Surelog
+      if: matrix.mode == 'test'
+      run: |
+        make test/unittest-d
+
+    - name: ${{ matrix.env.mode }} Surelog
+      if: matrix.mode == 'regression'
+      run: |
+        make regression
+
+    - name: ${{ matrix.env.mode }} Surelog
+      if: matrix.mode == 'install'
       run: |
         make release
-        sudo make install
-
-    - name: Test
-      run: |
-        make test_install
-        make test/unittest
-        make regression
+          sudo make install
+          make test_install
 
   msys2-gcc:
     runs-on: windows-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,6 +103,12 @@ jobs:
         shell: msys2 {0}
 
     steps:
+
+    - name: Cancel previous
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ github.token }}
+
     - name: Install core dependencies
       run: choco install -y swig --side-by-side --version=3.0.12
       shell: powershell
@@ -187,6 +193,12 @@ jobs:
         shell: cmd
 
     steps:
+
+    - name: Cancel previous
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ github.token }}
+
     - name: Install Core Dependencies
       run: |
         choco install -y make
@@ -257,6 +269,12 @@ jobs:
     runs-on: macos-latest
 
     steps:
+
+    - name: Cancel previous
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ github.token }}
+
     - uses: actions/setup-python@v2
       with:
         python-version: 3.8
@@ -304,6 +322,12 @@ jobs:
     runs-on: macos-latest
 
     steps:
+
+    - name: Cancel previous
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        access_token: ${{ github.token }}
+
     - uses: actions/setup-python@v2
       with:
         python-version: 3.8
@@ -345,6 +369,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+
     - name: Checkout code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt install -y \
-          g++-7 ccache \
+          g++-7 \
           tclsh \
           default-jre \
           cmake \
@@ -53,12 +53,17 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
+    - name: Use ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: linux-${{ matrix.mode }}
+
     - name: Configure shell
       run: |
         echo 'CC=gcc-7' >> $GITHUB_ENV
         echo 'CXX=g++-7' >> $GITHUB_ENV
-        echo 'PREFIX=/usr/local' >> $GITHUB_ENV
         echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
+        echo 'PREFIX=/usr/local' >> $GITHUB_ENV
 
     - name: Show shell configuration
       run: |
@@ -72,12 +77,6 @@ jobs:
         which tclsh && echo 'puts [info patchlevel];exit 0' | tclsh
         which $CC && $CC --version
         which $CXX && $CXX --version
-
-    - name: Use ccache
-      uses: actions/cache@v1
-      with:
-        path: ~/.ccache
-        key: ccache-${{ matrix.mode }}
 
     - name: Test
       if: matrix.mode == 'test'
@@ -284,10 +283,16 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
+    - name: Use ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: macos-gcc
+
     - name: Configure shell
       run: |
         echo 'CC=gcc-9' >> $GITHUB_ENV
         echo 'CXX=g++-9' >> $GITHUB_ENV
+        echo "PATH=$(brew --prefix)/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
         echo 'PREFIX=/usr/local' >> $GITHUB_ENV
 
     - name: Show shell configuration
@@ -337,9 +342,15 @@ jobs:
         submodules: recursive
         fetch-depth: 0
 
+    - name: Use ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: macos-clang
+
     - name: Configure shell
       run: |
         echo 'PREFIX=/usr/local' >> $GITHUB_ENV
+        echo "PATH=$(brew --prefix)/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
 
     - name: Show shell configuration
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
 
     - name: Cancel previous
-      uses: styfle/cancel-workflow-action@0.8.0
+      uses: styfle/cancel-workflow-action@0.9.1
       with:
         access_token: ${{ github.token }}
 
@@ -33,7 +33,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt install -y \
-          g++-7 \
+          g++-7 ccache \
           tclsh \
           default-jre \
           cmake \
@@ -58,6 +58,7 @@ jobs:
         echo 'CC=gcc-7' >> $GITHUB_ENV
         echo 'CXX=g++-7' >> $GITHUB_ENV
         echo 'PREFIX=/usr/local' >> $GITHUB_ENV
+        echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
 
     - name: Show shell configuration
       run: |
@@ -72,22 +73,28 @@ jobs:
         which $CC && $CC --version
         which $CXX && $CXX --version
 
-    - name: ${{ matrix.env.mode }} Surelog
+    - name: Use ccache
+      uses: actions/cache@v1
+      with:
+        path: ~/.ccache
+        key: ccache-${{ matrix.mode }}
+
+    - name: Test
       if: matrix.mode == 'test'
       run: |
         make test/unittest-d
 
-    - name: ${{ matrix.env.mode }} Surelog
+    - name: Regression
       if: matrix.mode == 'regression'
       run: |
         make regression
 
-    - name: ${{ matrix.env.mode }} Surelog
+    - name: Install Test
       if: matrix.mode == 'install'
       run: |
         make release
-          sudo make install
-          make test_install
+        sudo make install
+        make test_install
 
   msys2-gcc:
     runs-on: windows-latest
@@ -338,7 +345,6 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-
     - name: Checkout code
       uses: actions/checkout@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ endif
 ifeq ($(CPU_CORES),)
 	CPU_CORES := $(shell nproc)
 	ifeq ($(CPU_CORES),)
-		CPU_CORES := 1
+		CPU_CORES := $(shell sysctl -n hw.physicalcpu)
+	endif
+	ifeq ($(CPU_CORES),)
+		CPU_CORES := 2  # Good minimum assumption
 	endif
 endif
 


### PR DESCRIPTION
  * In Linux CI: run tests, regression and install as separate parallel runs.
  * Use ccache on Linux and Mac which speeds up repeated builds in prticular of low-change source dramatically
  * Cancel previous actions when new pushes come in while actions are still running.
  * Get the number of parallel processes on Mac using the system local means; that allows to run with more `CPU_CORES` than 1

Overall, this makes the CI run much faster for Linux and Mac.
 TODO: something equivalent to ccache on the Windows builds (paging @hs-apotell :) )