### PR TITLE
Add a Makefile target to generate a coverage report.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,9 +14,9 @@ git submodule update --init --recursive
 
 * cmake >= 3.13
 
-### Ubuntu/Debian 
+### Ubuntu/Debian
 
-`sudo apt-get install build-essential cmake git pkg-config tclsh swig uuid-dev libgoogle-perftools-dev python3 python3-dev default-jre`
+`sudo apt-get install build-essential cmake git pkg-config tclsh swig uuid-dev libgoogle-perftools-dev python3 python3-dev default-jre lcov`
 
 *Note:* If you intend to change the grammar, add: `sudo apt-get install ant`
 
@@ -47,12 +47,26 @@ For debug builds:
 make debug
 ```
 
+As a guide where unit tests are not covering code yet (we're using [gtest]),
+run
+
+```
+make coverage-build/html
+```
+
+This creates an HTML output allowing to drill down to each line indicating
+if it was covered in a unit test.
+
+Helping out here would be in particular useful to the project, as most code
+is only covered by regression tests currently but not by targeted unittests
+explicitly probing the correctness of the implemented functionality.
+
 Installation:
 ```
 make install
 ```
 
-The installation path may be set by specifying a `PREFIX`. The default is `/usr/local`. 
+The installation path may be set by specifying a `PREFIX`. The default is `/usr/local`.
 For example:
 ```
 make install PREFIX=~/.local
@@ -60,3 +74,5 @@ make install PREFIX=~/.local
 
 
   * or see [`src/README`](./src/README.md)
+
+[gtest]: https://github.com/google/googletest

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 # This is a nix-shell for use with the nix package manager.
 # If you have nix installed, you may simply run `nix-shell`
-# in this repo, and have all dependencies ready in the new shell. 
+# in this repo, and have all dependencies ready in the new shell.
 
 {pkgs ? import (builtins.fetchTarball {
   # Descriptive name to make the store path easier to identify
@@ -14,7 +14,7 @@
 
 pkgs.mkShell {
   buildInputs = with pkgs;
-    [ 
+    [
       cmake
       swig
       tcl
@@ -26,6 +26,7 @@ pkgs.mkShell {
       time
       gperftools
       zlib
+      lcov
     ];
 
 }


### PR DESCRIPTION
This will help us find what is missing in unit tests.

Signed-off-by: Henner Zeller <hzeller@google.com>