### PR TITLE
Readability: Use container::empty() instead of size().

### DIFF
--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -2144,22 +2144,22 @@ bool CompileHelper::isDecreasingRange(UHDM::typespec* ts,
     range* r = nullptr;
     if (ttps == uhdmlogic_typespec) {
       logic_typespec* lts = (logic_typespec*)ts;
-      if (lts->Ranges() && lts->Ranges()->size() >= 1) {
+      if (lts->Ranges() && !lts->Ranges()->empty()) {
         r = (*lts->Ranges())[0];
       }
     } else if (ttps == uhdmarray_typespec) {
       array_typespec* lts = (array_typespec*)ts;
-      if (lts->Ranges() && lts->Ranges()->size() >= 1) {
+      if (lts->Ranges() && !lts->Ranges()->empty()) {
         r = (*lts->Ranges())[0];
       }
     } else if (ttps == uhdmpacked_array_typespec) {
       packed_array_typespec* lts = (packed_array_typespec*)ts;
-      if (lts->Ranges() && lts->Ranges()->size() >= 1) {
+      if (lts->Ranges() && !lts->Ranges()->empty()) {
         r = (*lts->Ranges())[0];
       }
     } else if (ttps == uhdmbit_typespec) {
       bit_typespec* lts = (bit_typespec*)ts;
-      if (lts->Ranges() && lts->Ranges()->size() >= 1) {
+      if (lts->Ranges() && !lts->Ranges()->empty()) {
         r = (*lts->Ranges())[0];
       }
     }
@@ -3184,28 +3184,28 @@ bool CompileHelper::valueRange(Value* val, UHDM::typespec* ts,
   switch (type) {
     case uhdmlogic_typespec: {
       logic_typespec* lts = (logic_typespec*)ts;
-      if (lts->Ranges() && lts->Ranges()->size() >= 1) {
+      if (lts->Ranges() && !lts->Ranges()->empty()) {
         r = (*lts->Ranges())[0];
       }
       break;
     }
     case uhdmarray_typespec: {
       array_typespec* lts = (array_typespec*)ts;
-      if (lts->Ranges() && lts->Ranges()->size() >= 1) {
+      if (lts->Ranges() && !lts->Ranges()->empty()) {
         r = (*lts->Ranges())[0];
       }
       break;
     }
     case uhdmpacked_array_typespec: {
       packed_array_typespec* lts = (packed_array_typespec*)ts;
-      if (lts->Ranges() && lts->Ranges()->size() >= 1) {
+      if (lts->Ranges() && !lts->Ranges()->empty()) {
         r = (*lts->Ranges())[0];
       }
       break;
     }
     case uhdmbit_typespec: {
       bit_typespec* lts = (bit_typespec*)ts;
-      if (lts->Ranges() && lts->Ranges()->size() >= 1) {
+      if (lts->Ranges() && !lts->Ranges()->empty()) {
         r = (*lts->Ranges())[0];
       }
     }

--- a/src/SourceCompile/ParseFile.cpp
+++ b/src/SourceCompile/ParseFile.cpp
@@ -174,7 +174,7 @@ SymbolId ParseFile::getFileId(unsigned int line) {
   if (!pp) return 0;
   auto& infos = pp->getIncludeFileInfo();
   if (infos.size()) {
-    if (fileInfoCache.size()) {
+    if (!fileInfoCache.empty()) {
       return fileInfoCache[line];
     }
     fileInfoCache.resize(pp->getSumLineCount() + 10);
@@ -232,7 +232,7 @@ unsigned int ParseFile::getLineNb(unsigned int line) {
   if (!pp) return 0;
   auto& infos = pp->getIncludeFileInfo();
   if (infos.size()) {
-    if (lineInfoCache.size()) {
+    if (!lineInfoCache.empty()) {
       return lineInfoCache[line];
     }
     lineInfoCache.resize(pp->getSumLineCount() + 10);


### PR DESCRIPTION
Consider using empty() instead of size() on container for
more intuitive way of expressing that intent.

Also some containers have an easier way to determine
if empty() than its size, so this is a good defensive way
to express it that way

https://clang.llvm.org/extra/clang-tidy/checks/readability-container-size-empty.html

Signed-off-by: Henner Zeller <hzeller@google.com>