### PR TITLE
Update PP test to test for expected error message.

### DIFF
--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -130,23 +130,21 @@ Cache::cacheErrors(flatbuffers::FlatBufferBuilder& builder,
                    SymbolTable& canonicalSymbols,
                    ErrorContainer* errorContainer, SymbolTable* symbols,
                    SymbolId subjectId) {
-  std::vector<Error>& errors = errorContainer->getErrors();
+  const std::vector<Error>& errors = errorContainer->getErrors();
   std::vector<flatbuffers::Offset<SURELOG::CACHE::Error>> error_vec;
-  for (unsigned int i = 0; i < errors.size(); i++) {
-    Error& error = errors[i];
-    std::vector<Location>& locs = error.getLocations();
-    if (locs.size()) {
+  for (const Error& error : errors) {
+    const std::vector<Location>& locs = error.getLocations();
+    if (!locs.empty()) {
       bool matchSubject = false;
-      for (unsigned int j = 0; j < locs.size(); j++) {
-        if (locs[j].m_fileId == subjectId) {
+      for (const Location& loc : locs) {
+        if (loc.m_fileId == subjectId) {
           matchSubject = true;
           break;
         }
       }
       if (matchSubject) {
         std::vector<flatbuffers::Offset<SURELOG::CACHE::Location>> location_vec;
-        for (unsigned int j = 0; j < locs.size(); j++) {
-          Location& loc = locs[j];
+        for (const Location& loc : locs) {
           SymbolId canonicalFileId =
               canonicalSymbols.registerSymbol(symbols->getSymbol(loc.m_fileId));
           SymbolId canonicalObjectId =

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -333,7 +333,7 @@ CommandLineParser::CommandLineParser(ErrorContainer* errors,
       m_uhdmStats(false),
       m_lowMem(false),
       m_writeUhdm(true) {
-  m_errors->regiterCmdLine(this);
+  m_errors->registerCmdLine(this);
   m_logFileId = m_symbolTable->registerSymbol(defaultLogFileName);
   m_compileUnitDirectory = m_symbolTable->registerSymbol("slpp_unit/");
   m_compileAllDirectory = m_symbolTable->registerSymbol("slpp_all/");

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -88,7 +88,7 @@ bool CompileClass::compile() {
 
   Error err1(ErrorDefinition::COMP_COMPILE_CLASS, loc);
   ErrorContainer* errors = new ErrorContainer(m_symbols);
-  errors->regiterCmdLine(
+  errors->registerCmdLine(
       m_compileDesign->getCompiler()->getCommandLineParser());
   errors->addError(err1);
   errors->printMessage(

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -88,7 +88,7 @@ bool CompileDesign::compile() {
   Location loc(0);
   Error err1(ErrorDefinition::COMP_COMPILE, loc);
   ErrorContainer* errors = new ErrorContainer(getCompiler()->getSymbolTable());
-  errors->regiterCmdLine(getCompiler()->getCommandLineParser());
+  errors->registerCmdLine(getCompiler()->getCommandLineParser());
   errors->addError(err1);
   errors->printMessage(err1,
                        getCompiler()->getCommandLineParser()->muteStdout());
@@ -256,7 +256,7 @@ bool CompileDesign::elaborate() {
   Location loc(0);
   Error err2(ErrorDefinition::ELAB_ELABORATING_DESIGN, loc);
   ErrorContainer* errors = new ErrorContainer(getCompiler()->getSymbolTable());
-  errors->regiterCmdLine(getCompiler()->getCommandLineParser());
+  errors->registerCmdLine(getCompiler()->getCommandLineParser());
   errors->addError(err2);
   errors->printMessage(err2,
                        getCompiler()->getCommandLineParser()->muteStdout());
@@ -281,7 +281,7 @@ bool CompileDesign::compilation_() {
         new SymbolTable(m_compiler->getCommandLineParser()->getSymbolTable());
     m_symbolTables.push_back(symbols);
     ErrorContainer* errors = new ErrorContainer(symbols);
-    errors->regiterCmdLine(m_compiler->getCommandLineParser());
+    errors->registerCmdLine(m_compiler->getCommandLineParser());
     m_errorContainers.push_back(errors);
     index++;
   } while (index < maxThreadCount);

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -93,7 +93,7 @@ bool CompileModule::compile() {
 
   Error err(errType, loc);
   ErrorContainer* errors = new ErrorContainer(m_symbols);
-  errors->regiterCmdLine(
+  errors->registerCmdLine(
       m_compileDesign->getCompiler()->getCommandLineParser());
   errors->addError(err);
   errors->printMessage(

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -68,7 +68,7 @@ bool CompilePackage::compile() {
   Error err(ErrorDefinition::COMP_COMPILE_PACKAGE, loc);
 
   ErrorContainer* errors = new ErrorContainer(m_symbols);
-  errors->regiterCmdLine(
+  errors->registerCmdLine(
       m_compileDesign->getCompiler()->getCommandLineParser());
   errors->addError(err);
   errors->printMessage(

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -64,7 +64,7 @@ bool CompileProgram::compile() {
 
   Error err1(ErrorDefinition::COMP_COMPILE_PROGRAM, loc);
   ErrorContainer* errors = new ErrorContainer(m_symbols);
-  errors->regiterCmdLine(
+  errors->registerCmdLine(
       m_compileDesign->getCompiler()->getCommandLineParser());
   errors->addError(err1);
   errors->printMessage(

--- a/src/ErrorReporting/Error.h
+++ b/src/ErrorReporting/Error.h
@@ -49,8 +49,8 @@ class Error {
   /* Do not create Copy constructor, use default*/
   // Error(const Error& orig);
   virtual ~Error();
-  std::vector<Location>& getLocations() { return m_locations; }
-  ErrorDefinition::ErrorType getType() { return m_errorId; }
+  const std::vector<Location>& getLocations() const { return m_locations; }
+  const ErrorDefinition::ErrorType getType() const { return m_errorId; }
 
  private:
   std::vector<Location> m_locations;

--- a/src/ErrorReporting/ErrorContainer.h
+++ b/src/ErrorReporting/ErrorContainer.h
@@ -61,12 +61,12 @@ class ErrorContainer {
                  LogListener* const logListener = nullptr);
   virtual ~ErrorContainer();
 
-  void regiterCmdLine(CommandLineParser* clp) { m_clp = clp; }
+  void registerCmdLine(CommandLineParser* clp) { m_clp = clp; }
   void init();
   Error& addError(Error& error, bool showDuplicates = false,
                   bool reentrantPython = true);
 
-  std::vector<Error>& getErrors() { return m_errors; }
+  const std::vector<Error>& getErrors() const { return m_errors; }
   bool printMessages(bool muteStdout = false);
   bool printMessage(Error& error, bool muteStdout = false);
   bool printStats(Stats stats, bool muteStdout = false);

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -159,7 +159,7 @@ bool Compiler::ppinit_() {
     }
     ErrorContainer* errors = new ErrorContainer(symbols);
     m_errorContainers.push_back(errors);
-    errors->regiterCmdLine(m_commandLineParser);
+    errors->registerCmdLine(m_commandLineParser);
 
     const std::string fileName =
         m_commandLineParser->getSymbolTable().getSymbol(source_file_id);
@@ -211,7 +211,7 @@ bool Compiler::ppinit_() {
     }
     ErrorContainer* errors = new ErrorContainer(symbols);
     m_errorContainers.push_back(errors);
-    errors->regiterCmdLine(m_commandLineParser);
+    errors->registerCmdLine(m_commandLineParser);
 
     std::string fullPath = FileUtils::getFullPath(
         m_commandLineParser->getSymbolTable().getSymbol(id));
@@ -254,7 +254,7 @@ bool Compiler::ppinit_() {
       }
       ErrorContainer* errors = new ErrorContainer(symbols);
       m_errorContainers.push_back(errors);
-      errors->regiterCmdLine(m_commandLineParser);
+      errors->registerCmdLine(m_commandLineParser);
 
       CompileSourceFile* compiler = new CompileSourceFile(
           id, m_commandLineParser, errors, this, symbols, comp_unit, &lib);
@@ -636,7 +636,7 @@ bool Compiler::parseinit_() {
         // fileContent->setSymbolTable(symbols);
         ErrorContainer* errors = new ErrorContainer(symbols);
         m_errorContainers.push_back(errors);
-        errors->regiterCmdLine(m_commandLineParser);
+        errors->registerCmdLine(m_commandLineParser);
         compiler->setErrorContainer(errors);
       }
 
@@ -660,7 +660,7 @@ bool Compiler::parseinit_() {
         chunkCompiler->setSymbolTable(symbols);
         ErrorContainer* errors = new ErrorContainer(symbols);
         m_errorContainers.push_back(errors);
-        errors->regiterCmdLine(m_commandLineParser);
+        errors->registerCmdLine(m_commandLineParser);
         chunkCompiler->setErrorContainer(errors);
         // chunkCompiler->getParser ()->setFileContent (fileContent);
 
@@ -681,7 +681,7 @@ bool Compiler::parseinit_() {
         compiler->setSymbolTable(symbols);
         ErrorContainer* errors = new ErrorContainer(symbols);
         m_errorContainers.push_back(errors);
-        errors->regiterCmdLine(m_commandLineParser);
+        errors->registerCmdLine(m_commandLineParser);
         compiler->setErrorContainer(errors);
       }
 

--- a/src/SourceCompile/PreprocessHarness.cpp
+++ b/src/SourceCompile/PreprocessHarness.cpp
@@ -65,6 +65,8 @@
 
 namespace SURELOG {
 
+PreprocessHarness::PreprocessHarness() : m_errors(&m_symbols) {}
+
 std::string PreprocessHarness::preprocess(std::string_view content) {
   std::string result;
   PreprocessFile::SpecialInstructions instructions(
@@ -74,23 +76,20 @@ std::string PreprocessHarness::preprocess(std::string_view content) {
       PreprocessFile::SpecialInstructions::CheckLoop,
       PreprocessFile::SpecialInstructions::ComplainUndefinedMacro);
   CompilationUnit unit(false);
-  SymbolTable symbols;
-  ErrorContainer errors(&symbols);
-  CommandLineParser clp(&errors, &symbols, false, false);
-  Library lib("work", &symbols);
-  Compiler compiler(&clp, &errors, &symbols);
-  CompileSourceFile csf(0, &clp, &errors, &compiler, &symbols, &unit, &lib);
+  CommandLineParser clp(&m_errors, &m_symbols, false, false);
+  Library lib("work", &m_symbols);
+  Compiler compiler(&clp, &m_errors, &m_symbols);
+  CompileSourceFile csf(0, &clp, &m_errors, &compiler, &m_symbols, &unit, &lib);
   PreprocessFile pp(0, nullptr, 0, &csf, instructions, &unit, &lib, content,
                     nullptr, 0, 0);
 
   if (!pp.preprocess()) {
     result = "ERROR_PP";
   }
-  bool fatalErrors = errors.hasFatalErrors();
-  if (fatalErrors) {
+  if (m_errors.hasFatalErrors()) {
     result = "ERROR_PP";
   }
-  errors.printMessages();
+  m_errors.printMessages();
   if (result.empty()) result = pp.getPreProcessedFileContent();
   return result;
 }

--- a/src/SourceCompile/PreprocessHarness.h
+++ b/src/SourceCompile/PreprocessHarness.h
@@ -43,7 +43,14 @@ namespace SURELOG {
 
 class PreprocessHarness {
  public:
-  static std::string preprocess(std::string_view content);
+  PreprocessHarness();
+  std::string preprocess(std::string_view content);
+
+  const ErrorContainer &collected_errors() const { return m_errors; }
+
+ private:
+  SymbolTable m_symbols;
+  ErrorContainer m_errors;
 };
 
 };  // namespace SURELOG


### PR DESCRIPTION
  * Test that errors in the input of the PP result in expected
    error message.
  * Document Issue #1724 (just the test, no solution yet)
  * While at it: make relevant functions in ErrorContainer
    const, to be able to read them without handing out a
    writable context.
  * Fix a typo in regiterCmdLine() -> registerCmdLine()

Signed-off-by: Henner Zeller <hzeller@google.com>