### PR TITLE
Reduce visual clutter compile messages in CI build.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   linux:
-    name: Check · ${{ matrix.mode }}
+    name: ${{ matrix.mode }} Check
 
     runs-on: ubuntu-latest
     defaults:
@@ -69,6 +69,7 @@ jobs:
         echo 'CXX=g++-7' >> $GITHUB_ENV
         echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
         echo 'PREFIX=/usr/local' >> $GITHUB_ENV
+        echo 'RULE_MESSAGES=off' >> $GITHUB_ENV  # only relevant compile output
 
     - name: Show shell configuration
       run: |

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ install: release
 	cmake --install build
 
 test_install: release
-	cmake -DCMAKE_BUILD_TYPE=Release -DINSTALL_DIR=$(PREFIX) -S tests/TestInstall -B tests/TestInstall/build
+	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_RULE_MESSAGES=$(RULE_MESSAGES) -DINSTALL_DIR=$(PREFIX) -S tests/TestInstall -B tests/TestInstall/build
 	cmake --build tests/TestInstall/build -j $(CPU_CORES)
 
 uninstall:


### PR DESCRIPTION
Don't show the percentage and each file that is compiled,
just output warnings and errors.

Signed-off-by: Henner Zeller <hzeller@google.com>