### PR TITLE
createErrorMessage should take the error parameter as const.

### DIFF
--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -126,7 +126,7 @@ void ErrorContainer::appendErrors(ErrorContainer& rhs) {
 }
 
 std::tuple<std::string, bool, bool> ErrorContainer::createErrorMessage(
-    Error& msg, bool reentrantPython) {
+    const Error& msg, bool reentrantPython) {
   const std::map<ErrorDefinition::ErrorType, ErrorDefinition::ErrorInfo>&
       infoMap = ErrorDefinition::getErrorInfoMap();
   std::string tmp;
@@ -168,7 +168,7 @@ std::tuple<std::string, bool, bool> ErrorContainer::createErrorMessage(
       }
       std::string category = ErrorDefinition::getCategoryName(info.m_category);
 
-      Location& loc = msg.m_locations[0];
+      const Location& loc = msg.m_locations[0];
       /* Object */
       std::string text = info.m_errorText;
       const std::string& objectName = m_symbolTable->getSymbol(loc.m_object);
@@ -195,7 +195,7 @@ std::tuple<std::string, bool, bool> ErrorContainer::createErrorMessage(
       /* Extra locations */
       unsigned int nbExtraLoc = msg.m_locations.size();
       for (unsigned int i = 1; i < nbExtraLoc; i++) {
-        Location& extraLoc = msg.m_locations[i];
+        const Location& extraLoc = msg.m_locations[i];
         if (extraLoc.m_fileId) {
           std::string extraLocation;
           const std::string& fileName =

--- a/src/ErrorReporting/ErrorContainer.h
+++ b/src/ErrorReporting/ErrorContainer.h
@@ -76,7 +76,7 @@ class ErrorContainer {
   void appendErrors(ErrorContainer&);
   SymbolTable* getSymbolTable() { return m_symbolTable; }
   std::tuple<std::string, bool, bool> createErrorMessage(
-      Error& error, bool reentrantPython = true);
+      const Error& error, bool reentrantPython = true);
   void setPythonInterp(void* interpState) { m_interpState = interpState; }
 
  private:


### PR DESCRIPTION
Mainly since the errors generated from GetErrors are const, so using
those directly requires a const_cast at the moment.