### PR TITLE
Make uhdm includes qualified within uhdm-directory.

### DIFF
--- a/src/API/Surelog.h
+++ b/src/API/Surelog.h
@@ -25,7 +25,7 @@
 
 #include "CommandLine/CommandLineParser.h"
 #include "Design/Design.h"
-#include "sv_vpi_user.h"
+#include "include/sv_vpi_user.h"
 
 namespace SURELOG {
 struct scompiler;

--- a/src/DesignCompile/CompileDesign.h
+++ b/src/DesignCompile/CompileDesign.h
@@ -28,7 +28,7 @@
 
 #include "Serializer.h"
 #include "SourceCompile/Compiler.h"
-#include "sv_vpi_user.h"
+#include "include/sv_vpi_user.h"
 
 namespace SURELOG {
 

--- a/src/SourceCompile/Compiler.h
+++ b/src/SourceCompile/Compiler.h
@@ -36,7 +36,7 @@ limitations under the License.
 #include "SourceCompile/CompileSourceFile.h"
 #include "SourceCompile/PreprocessFile.h"
 #include "SourceCompile/SymbolTable.h"
-#include "sv_vpi_user.h"
+#include "include/sv_vpi_user.h"
 
 #ifdef USETBB
 #include <tbb/task.h>

--- a/src/SourceCompile/PreprocessHarness.h
+++ b/src/SourceCompile/PreprocessHarness.h
@@ -37,7 +37,7 @@
 #include "SourceCompile/CompileSourceFile.h"
 #include "SourceCompile/PreprocessFile.h"
 #include "SourceCompile/SymbolTable.h"
-#include "sv_vpi_user.h"
+#include "include/sv_vpi_user.h"
 
 namespace SURELOG {
 


### PR DESCRIPTION
As preparation to switch to latest UHDM head.

Signed-off-by: Henner Zeller <h.zeller@acm.org>