### PR TITLE
Avoid objects that need allocation in the global static scope

### DIFF
--- a/src/CommandLine/CommandLineParser.h
+++ b/src/CommandLine/CommandLineParser.h
@@ -111,7 +111,7 @@ class CommandLineParser final {
   bool help() { return m_help; }
   void logBanner(int argc, const char** argv);
   void logFooter();
-  static std::string getVersionNumber() { return m_versionNumber; }
+  static const std::string& getVersionNumber();
   /* Core functions options */
   bool parse() { return m_parse; }
   bool parseOnly() { return m_parseOnly; }
@@ -228,7 +228,6 @@ class CommandLineParser final {
   SymbolId m_defaultCacheDirId;
   SymbolId m_cacheDirId;
   SymbolId m_precompiledDirId;
-  static std::string m_versionNumber;
   bool m_note;
   bool m_info;
   bool m_warning;

--- a/src/ErrorReporting/ErrorDefinition.cpp
+++ b/src/ErrorReporting/ErrorDefinition.cpp
@@ -26,23 +26,23 @@
 
 using namespace SURELOG;
 
-std::map<ErrorDefinition::ErrorType, ErrorDefinition::ErrorInfo>
-    ErrorDefinition::m_errorInfoMap;
+ErrorDefinition::ErrorMap* ErrorDefinition::mutableGlobalErrorInfoMap() {
+  static ErrorMap error_info_map;
+  return &error_info_map;
+}
 
 void ErrorDefinition::rec(ErrorType type, ErrorSeverity severity,
-                          ErrorCategory category, std::string text,
-                          std::string extraText) {
-  ErrorInfo info(severity, category, text, extraText);
-  m_errorInfoMap.insert(std::make_pair(type, info));
+                          ErrorCategory category, std::string_view text,
+                          std::string_view extraText) {
+  mutableGlobalErrorInfoMap()->emplace(
+      type, ErrorInfo(severity, category, text, extraText));
 }
 
 void ErrorDefinition::setSeverity(ErrorDefinition::ErrorType type,
                                   ErrorDefinition::ErrorSeverity severity) {
-  std::map<ErrorDefinition::ErrorType, ErrorDefinition::ErrorInfo>::iterator
-      itr = m_errorInfoMap.find(type);
-  if (itr != m_errorInfoMap.end()) {
-    ErrorDefinition::ErrorInfo& info = (*itr).second;
-    info.m_severity = severity;
+  ErrorMap::iterator found = mutableGlobalErrorInfoMap()->find(type);
+  if (found != mutableGlobalErrorInfoMap()->end()) {
+    found->second.m_severity = severity;
   }
 }
 

--- a/src/ErrorReporting/ErrorDefinition.h
+++ b/src/ErrorReporting/ErrorDefinition.h
@@ -212,7 +212,7 @@ class ErrorDefinition {
   class ErrorInfo {
    public:
     ErrorInfo(ErrorSeverity severity, ErrorCategory category,
-              const std::string& s, const std::string& extra)
+              std::string_view s, std::string_view extra)
         : m_severity(severity),
           m_category(category),
           m_errorText(s),
@@ -227,7 +227,7 @@ class ErrorDefinition {
   static bool init();
 
   static const std::map<ErrorType, ErrorInfo>& getErrorInfoMap() {
-    return m_errorInfoMap;
+    return *mutableGlobalErrorInfoMap();
   }
 
   static ErrorType getErrorType(std::string errorId);
@@ -237,14 +237,16 @@ class ErrorDefinition {
 
   static void setSeverity(ErrorType type, ErrorSeverity severity);
   static void rec(ErrorType type, ErrorSeverity severity,
-                  ErrorCategory category, std::string text,
-                  std::string extraText = "");
+                  ErrorCategory category, std::string_view text,
+                  std::string_view extraText = "");
 
  private:
   ErrorDefinition();
   ErrorDefinition(const ErrorDefinition& orig);
   virtual ~ErrorDefinition();
-  static std::map<ErrorType, ErrorInfo> m_errorInfoMap;
+
+  using ErrorMap = std::map<ErrorType, ErrorInfo>;
+  static ErrorMap* mutableGlobalErrorInfoMap();
 };
 
 };  // namespace SURELOG


### PR DESCRIPTION
This creates all kinds of nasty initialization sequence issues. Do this safely by
  * Either avoid allocating a global object that requires a complex set-up in the first-place (global strings for instance are a natural `std::string_view`, std::vector can be an initialzer list or an array.
  * Allocating global object in a function call with a pattern like the following will make sure things are allocated an initialized in the intended sequence.
```
static ComplexObject *GetThing() {
  static ComplexObject instance;
  return &instance;
}
```
 