### PR TITLE
Fix some temporary string instances; reduce static global objects.

### DIFF
--- a/src/Cache/PPCache.h
+++ b/src/Cache/PPCache.h
@@ -41,9 +41,9 @@ class PPCache : Cache {
  private:
   PPCache(const PPCache& orig) = delete;
 
-  std::string getCacheFileName_(std::string fileName = "");
-  bool restore_(std::string cacheFileName, bool errorsOnly);
-  bool checkCacheIsValid_(std::string cacheFileName);
+  std::string getCacheFileName_(const std::string& fileName = "");
+  bool restore_(const std::string& cacheFileName, bool errorsOnly);
+  bool checkCacheIsValid_(const std::string& cacheFileName);
 
   PreprocessFile* m_pp;
   bool m_isPrecompiled;

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -52,9 +52,9 @@
 using namespace antlr4;
 
 namespace SURELOG {
-std::string PreprocessFile::MacroNotDefined = "SURELOG_MACRO_NOT_DEFINED";
-std::string PreprocessFile::PP__Line__Marking = "SURELOG__LINE__MARKING";
-std::string PreprocessFile::PP__File__Marking = "SURELOG__FILE__MARKING";
+const char* const PreprocessFile::MacroNotDefined = "SURELOG_MACRO_NOT_DEFINED";
+const char* const PreprocessFile::PP__Line__Marking = "SURELOG__LINE__MARKING";
+const char* const PreprocessFile::PP__File__Marking = "SURELOG__FILE__MARKING";
 
 void PreprocessFile::setDebug(int level) {
   switch (level) {
@@ -263,11 +263,11 @@ void PreprocessFile::addError(Error& error) {
     getCompileSourceFile()->getErrorContainer()->addError(error);
 }
 
-const std::string PreprocessFile::getSymbol(SymbolId id) {
+std::string PreprocessFile::getSymbol(SymbolId id) {
   return getCompileSourceFile()->getSymbolTable()->getSymbol(id);
 }
 
-const std::string PreprocessFile::getFileName(unsigned int line) {
+std::string PreprocessFile::getFileName(unsigned int line) {
   return getSymbol(getFileId(line));
 }
 
@@ -461,7 +461,7 @@ bool PreprocessFile::preprocess() {
   return true;
 }
 
-static unsigned int LinesCount(const std::string& s) {
+static size_t LinesCount(std::string_view s) {
   return std::count(s.begin(), s.end(), '\n');
 }
 
@@ -475,14 +475,14 @@ unsigned int PreprocessFile::getSumLineCount() {
 void PreprocessFile::append(const std::string& s) {
   if (!m_pauseAppend) {
     m_lineCount += LinesCount(s);
-    m_result += s;
+    m_result.append(s);
   }
 }
 
-void PreprocessFile::recordMacro(const std::string name, unsigned int line,
+void PreprocessFile::recordMacro(const std::string& name, unsigned int line,
                                  unsigned short int column,
-                                 const std::string arguments,
-                                 const std::vector<std::string> tokens) {
+                                 const std::string& arguments,
+                                 const std::vector<std::string>& tokens) {
   // *** Argument processing
   std::string arguments_short = arguments;
   // Remove (
@@ -531,10 +531,10 @@ std::string PreprocessFile::reportIncludeInfo() {
   return report;
 }
 
-void PreprocessFile::recordMacro(const std::string name, unsigned int line,
+void PreprocessFile::recordMacro(const std::string& name, unsigned int line,
                                  unsigned short int column,
-                                 const std::vector<std::string> arguments,
-                                 const std::vector<std::string> tokens) {
+                                 const std::vector<std::string>& arguments,
+                                 const std::vector<std::string>& tokens) {
   MacroInfo* macroInfo = new MacroInfo(
       name, arguments.size() ? MacroInfo::WITH_ARGS : MacroInfo::NO_ARGS,
       getFileId(line), line, column, arguments, tokens);
@@ -635,7 +635,7 @@ SymbolId PreprocessFile::getId(const std::string symbol) {
 }
 
 std::string PreprocessFile::evaluateMacroInstance(
-    const std::string macro_instance, PreprocessFile* callingFile,
+    const std::string& macro_instance, PreprocessFile* callingFile,
     unsigned int callingLine,
     SpecialInstructions::CheckLoopInstr checkMacroLoop,
     SpecialInstructions::AsIsUndefinedMacroInstr asisUndefMacro) {
@@ -674,7 +674,7 @@ static bool isKeyword(const std::vector<std::string>& body_tokens) {
 }
 
 std::pair<bool, std::string> PreprocessFile::evaluateMacro_(
-    const std::string name, std::vector<std::string>& actual_args,
+    const std::string& name, std::vector<std::string>& actual_args,
     PreprocessFile* callingFile, unsigned int callingLine,
     LoopCheck& loopChecker, MacroInfo* macroInfo,
     SpecialInstructions& instructions, unsigned int embeddedMacroCallLine,
@@ -936,12 +936,12 @@ std::pair<bool, std::string> PreprocessFile::evaluateMacro_(
   return std::make_pair(found, result);
 }
 
-MacroInfo* PreprocessFile::getMacro(const std::string name) {
+MacroInfo* PreprocessFile::getMacro(const std::string& name) {
   registerSymbol(name);
   return m_compilationUnit->getMacroInfo(name);
 }
 
-bool PreprocessFile::deleteMacro(const std::string name,
+bool PreprocessFile::deleteMacro(const std::string& name,
                                  std::set<PreprocessFile*>& visited) {
   /*SymbolId macroId = */ registerSymbol(name);
   if (m_debugMacro)
@@ -1020,7 +1020,7 @@ void PreprocessFile::undefineAllMacros(std::set<PreprocessFile*>& visited) {
 }
 
 std::string PreprocessFile::getMacro(
-    const std::string name, std::vector<std::string>& arguments,
+    const std::string& name, std::vector<std::string>& arguments,
     PreprocessFile* callingFile, unsigned int callingLine,
     LoopCheck& loopChecker, SpecialInstructions& instructions,
     unsigned int embeddedMacroCallLine, SymbolId embeddedMacroCallFile) {

--- a/src/SourceCompile/PreprocessFile.h
+++ b/src/SourceCompile/PreprocessFile.h
@@ -80,31 +80,31 @@ class PreprocessFile {
   std::string getPreProcessedFileContent();
 
   /* Macro manipulations */
-  void recordMacro(const std::string name, unsigned int line,
+  void recordMacro(const std::string& name, unsigned int line,
                    unsigned short int column,
-                   const std::string formal_arguments,
-                   const std::vector<std::string> body);
-  void recordMacro(const std::string name, unsigned int line,
+                   const std::string& formal_arguments,
+                   const std::vector<std::string>& body);
+  void recordMacro(const std::string& name, unsigned int line,
                    unsigned short int column,
-                   const std::vector<std::string> formal_arguments,
-                   const std::vector<std::string> body);
-  std::string getMacro(const std::string name,
+                   const std::vector<std::string>& formal_arguments,
+                   const std::vector<std::string>& body);
+  std::string getMacro(const std::string& name,
                        std::vector<std::string>& actual_arguments,
                        PreprocessFile* callingFile, unsigned int callingLine,
                        LoopCheck& loopChecker,
                        SpecialInstructions& instructions,
                        unsigned int embeddedMacroCallLine = 0,
                        SymbolId embeddedMacroCallFile = 0);
-  bool deleteMacro(const std::string name, std::set<PreprocessFile*>& visited);
+  bool deleteMacro(const std::string& name, std::set<PreprocessFile*>& visited);
   void undefineAllMacros(std::set<PreprocessFile*>& visited);
-  bool isMacroBody() { return !m_macroBody.empty(); }
-  std::string getMacroBody() { return m_macroBody; }
+  bool isMacroBody() const { return !m_macroBody.empty(); }
+  const std::string& getMacroBody() const { return m_macroBody; }
   MacroInfo* getMacroInfo() { return m_macroInfo; }
   SymbolId getMacroSignature();
   const MacroStorage& getMacros() { return m_macros; }
-  MacroInfo* getMacro(const std::string name);
+  MacroInfo* getMacro(const std::string& name);
 
-  const std::string getFileName(unsigned int line);
+  std::string getFileName(unsigned int line);
 
   std::string reportIncludeInfo();
 
@@ -121,8 +121,8 @@ class PreprocessFile {
   unsigned int getLineNb(unsigned int line);
   PreprocessFile* getIncluder() { return m_includer; }
   unsigned int getIncluderLine() { return m_includerLine; }
-  unsigned int getLineCount() { return m_lineCount; }
-  void setLineCount(unsigned int count) { m_lineCount = count; }
+  size_t getLineCount() { return m_lineCount; }
+  void setLineCount(size_t count) { m_lineCount = count; }
   unsigned int getSumLineCount();
   std::vector<IncludeFileInfo>& getIncludeFileInfo() {
     return m_includeFileInfo;
@@ -137,9 +137,9 @@ class PreprocessFile {
   SymbolId getEmbeddedMacroCallFile() { return m_embeddedMacroCallFile; }
 
   /* Markings */
-  static std::string MacroNotDefined;
-  static std::string PP__Line__Marking;
-  static std::string PP__File__Marking;
+  static const char* const MacroNotDefined;
+  static const char* const PP__Line__Marking;
+  static const char* const PP__File__Marking;
 
  private:
   SymbolId m_fileId;
@@ -150,7 +150,7 @@ class PreprocessFile {
   unsigned int m_includerLine;
   std::vector<PreprocessFile*> m_includes;
   CompileSourceFile* m_compileSourceFile;
-  unsigned int m_lineCount;
+  size_t m_lineCount;
   IncludeFileInfo m_badIncludeFileInfo;
 
  public:
@@ -213,7 +213,7 @@ class PreprocessFile {
   };
 
   std::string evaluateMacroInstance(
-      const std::string macro_instance, PreprocessFile* callingFile,
+      const std::string& macro_instance, PreprocessFile* callingFile,
       unsigned int callingLine,
       SpecialInstructions::CheckLoopInstr checkMacroLoop,
       SpecialInstructions::AsIsUndefinedMacroInstr);
@@ -285,7 +285,7 @@ class PreprocessFile {
   /* Shorthands for symbol manipulations */
   SymbolId registerSymbol(const std::string symbol);
   SymbolId getId(const std::string symbol);
-  const std::string getSymbol(SymbolId id);
+  std::string getSymbol(SymbolId id);
 
   // For recursive macro definition detection
   PreprocessFile* getSourceFile();
@@ -308,7 +308,7 @@ class PreprocessFile {
 
  private:
   std::pair<bool, std::string> evaluateMacro_(
-      const std::string name, std::vector<std::string>& arguments,
+      const std::string& name, std::vector<std::string>& arguments,
       PreprocessFile* callingFile, unsigned int callingLine,
       LoopCheck& loopChecker, MacroInfo* macroInfo,
       SpecialInstructions& instructions, unsigned int embeddedMacroCallLine,


### PR DESCRIPTION
 * Static global objects: reduce to avoid initialization sequence
   issues. For strings, std::string can typically be replaced with
   std::string_view or const char*
 * const string parameters to function calls should never be passed
   by value only by reference to avoid a bunch of copies.

Signed-off-by: Henner Zeller <h.zeller@acm.org>