### PR TITLE
Include coverage-build/ in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ slpp_all/
 /out
 /build
 /dbuild
+/coverage-build
 /publish
 /dist
 /install


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>