### PR TITLE
Add override/final where needed. Don't redundantly add virtual for ov…

### DIFF
--- a/src/DesignCompile/CompileHelper_test.cpp
+++ b/src/DesignCompile/CompileHelper_test.cpp
@@ -62,9 +62,7 @@ UHDM::Serializer sharedSerializer;
 class MockCompileDesign : public SURELOG::CompileDesign {
  public:
   MockCompileDesign() : CompileDesign(nullptr) {}
-  virtual UHDM::Serializer& getSerializer() override {
-    return sharedSerializer;
-  }
+  UHDM::Serializer& getSerializer() final { return sharedSerializer; }
 };
 // Need this to get serializer for VpiName, VpiValue etc.
 MockCompileDesign cd;

--- a/src/hellodesign.cpp
+++ b/src/hellodesign.cpp
@@ -36,9 +36,9 @@
 #include <uhdm/vpi_listener.h>
 
 class DesignListener final : public UHDM::VpiListener {
-  virtual void enterModule(const UHDM::module *const object,
-                           const UHDM::any *const parent, vpiHandle handle,
-                           vpiHandle parentHandle) override {
+  void enterModule(const UHDM::module *const object,
+                   const UHDM::any *const parent, vpiHandle handle,
+                   vpiHandle parentHandle) final {
     const std::string &instName = object->VpiName();
     m_flatTraversal =
         (instName.empty()) && ((object->VpiParent() == 0) ||
@@ -52,9 +52,9 @@ class DesignListener final : public UHDM::VpiListener {
                 << intptr_t(object) << " " << object->UhdmId() << std::endl;
   }
 
-  virtual void enterCont_assign(const UHDM::cont_assign *object,
-                                const UHDM::BaseClass *parent, vpiHandle handle,
-                                vpiHandle parentHandle) {
+  void enterCont_assign(const UHDM::cont_assign *object,
+                        const UHDM::BaseClass *parent, vpiHandle handle,
+                        vpiHandle parentHandle) final {
     if (m_flatTraversal) {
       std::cout << "  Let's skip the cont assigns in the flat traversal and "
                    "only navigate the ones in the hierarchical tree!"


### PR DESCRIPTION
…errides.

Signed-off-by: Henner Zeller <h.zeller@acm.org>