### PR TITLE
Don't use blanked 'using namespace' if possible.

### DIFF
--- a/src/Design/ModuleInstance.cpp
+++ b/src/Design/ModuleInstance.cpp
@@ -34,9 +34,12 @@
 #include <uhdm/clone_tree.h>
 #include <uhdm/uhdm.h>
 
-using namespace SURELOG;
-using namespace UHDM;
+using UHDM::any;
+using UHDM::constant;
+using UHDM::param_assign;
+using UHDM::uhdmconstant;
 
+namespace SURELOG {
 ModuleInstance::ModuleInstance(DesignComponent* moduleDefinition,
                                const FileContent* fileContent, NodeId nodeId,
                                ModuleInstance* parent, std::string instName,
@@ -235,3 +238,4 @@ void ModuleInstance::overrideParentChild(ModuleInstance* parent,
 
   m_allSubInstances = children;
 }
+}  // namespace SURELOG

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -60,8 +60,8 @@
 #include <uhdm/uhdm.h>
 #include <uhdm/vpi_visitor.h>
 
-using namespace SURELOG;
-using namespace UHDM;
+namespace SURELOG {
+using namespace UHDM;  // NOLINT (using a bunch of them)
 
 bool CompileHelper::substituteAssignedValue(const UHDM::any* oper,
                                             CompileDesign* compileDesign) {
@@ -6248,3 +6248,4 @@ void CompileHelper::reorderAssignmentPattern(DesignComponent* mod,
     }
   }
 }
+}  // namespace SURELOG

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -54,8 +54,9 @@
 #include <uhdm/expr.h>
 #include <uhdm/uhdm.h>
 
-using namespace SURELOG;
-using namespace UHDM;
+namespace SURELOG {
+
+using namespace UHDM;  // NOLINT (we use a good chunk of these here)
 
 bool CompileHelper::importPackage(DesignComponent* scope, Design* design,
                                   const FileContent* fC, NodeId id,
@@ -3298,3 +3299,4 @@ void CompileHelper::setRange(UHDM::constant* c, Value* val,
     r->Right_expr(rc);
   }
 }
+}  // namespace SURELOG

--- a/src/DesignCompile/CompileHelper.h
+++ b/src/DesignCompile/CompileHelper.h
@@ -444,7 +444,7 @@ class CompileHelper final {
                        const std::string& fileName, int lineNumber,
                        UHDM::any* pexpr);
 
-  void EvalStmt(const std::string funcName, Scopes& scopes, bool& invalidValue,
+  void EvalStmt(const std::string& funcName, Scopes& scopes, bool& invalidValue,
                 bool& continue_flag, bool& break_flag,
                 DesignComponent* component, CompileDesign* compileDesign,
                 ValuedComponentI* instance, const std::string& fileName,

--- a/src/DesignCompile/CompileHelper_test.cpp
+++ b/src/DesignCompile/CompileHelper_test.cpp
@@ -50,7 +50,16 @@
 // UHDM
 #include <uhdm/vpi_visitor.h>
 
-using namespace UHDM;
+using UHDM::begin;
+using UHDM::design;
+using UHDM::initial;
+using UHDM::module;
+using UHDM::package;
+using UHDM::VectorOfany;
+using UHDM::VectorOfmodule;
+using UHDM::VectorOfpackage;
+using UHDM::VectorOfprocess_stmt;
+using UHDM::visit_designs;
 
 class MockFileContent : public SURELOG::FileContent {
  public:

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -48,8 +48,8 @@
 #include <uhdm/expr.h>
 #include <uhdm/uhdm.h>
 
-using namespace SURELOG;
-using namespace UHDM;
+namespace SURELOG {
+using namespace UHDM;  // NOLINT (using a bunch of these)
 
 VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
                                         const FileContent* fC, NodeId the_stmt,
@@ -2536,3 +2536,4 @@ void CompileHelper::compileBindStmt(DesignComponent* component,
                                 Instance_target, Source_scope, Instance_name);
   compileDesign->getCompiler()->getDesign()->addBindStmt(fullName, bind);
 }
+}  // namespace SURELOG

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -53,8 +53,8 @@
 #include <uhdm/expr.h>
 #include <uhdm/uhdm.h>
 
-using namespace SURELOG;
-using namespace UHDM;
+namespace SURELOG {
+using namespace UHDM;  // NOLINT (using a bunch of them)
 
 variables* CompileHelper::getSimpleVarFromTypespec(
     UHDM::typespec* spec, std::vector<UHDM::range*>* packedDimensions,
@@ -1362,3 +1362,4 @@ UHDM::typespec* CompileHelper::elabTypespec(DesignComponent* component,
   }
   return result;
 }
+}  // namespace SURELOG

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -58,8 +58,9 @@
 #include <uhdm/clone_tree.h>
 #include <uhdm/uhdm.h>
 
-using namespace SURELOG;
-using namespace UHDM;
+namespace SURELOG {
+
+using namespace UHDM;  // NOLINT (using a bunch of these)
 
 ElaborationStep::ElaborationStep(CompileDesign* compileDesign)
     : m_compileDesign(compileDesign) {
@@ -1460,3 +1461,4 @@ any* ElaborationStep::makeVar_(DesignComponent* component, Signal* sig,
   }
   return obj;
 }
+}  // namespace SURELOG

--- a/src/DesignCompile/EvalFunc.cpp
+++ b/src/DesignCompile/EvalFunc.cpp
@@ -55,10 +55,10 @@
 #include <uhdm/expr.h>
 #include <uhdm/uhdm.h>
 
-using namespace SURELOG;
-using namespace UHDM;
+namespace SURELOG {
+using namespace UHDM;  // NOLINT (using a bunch of them)
 
-void CompileHelper::EvalStmt(const std::string funcName, Scopes& scopes,
+void CompileHelper::EvalStmt(const std::string& funcName, Scopes& scopes,
                              bool& invalidValue, bool& continue_flag,
                              bool& break_flag, DesignComponent* component,
                              CompileDesign* compileDesign,
@@ -561,3 +561,4 @@ void CompileHelper::evalScheduledExprs(DesignComponent* component,
     }
   }
 }
+}  // namespace SURELOG

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -66,8 +66,9 @@
 #include <uhdm/clone_tree.h>
 #include <uhdm/uhdm.h>
 
-using namespace SURELOG;
-using namespace UHDM;
+namespace SURELOG {
+
+using namespace UHDM;  // NOLINT (using a bunch of these)
 
 NetlistElaboration::NetlistElaboration(CompileDesign* compileDesign)
     : TestbenchElaboration(compileDesign) {
@@ -2099,3 +2100,4 @@ any* NetlistElaboration::bind_net_(ModuleInstance* instance,
   }
   return result;
 }
+}  // namespace SURELOG

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -63,8 +63,15 @@
 #include <uhdm/uhdm.h>
 #include <uhdm/vpi_visitor.h>
 
-using namespace SURELOG;
-using namespace UHDM;
+namespace SURELOG {
+
+using UHDM::BaseClass;
+using UHDM::begin;
+using UHDM::Serializer;
+using UHDM::UHDM_OBJECT_TYPE;
+using UHDM::uhdmunsupported_expr;
+using UHDM::uhdmunsupported_stmt;
+using UHDM::uhdmunsupported_typespec;
 
 bool UhdmChecker::registerFile(const FileContent* fC,
                                std::set<std::string>& moduleNames) {
@@ -670,3 +677,4 @@ bool UhdmChecker::check(const std::string& reportFile) {
   reportHtml(m_compileDesign, reportFile, overallCoverage);
   return true;
 }
+}  // namespace SURELOG

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -68,8 +68,9 @@
 #include <uhdm/vpi_uhdm.h>
 #include <uhdm/vpi_visitor.h>
 
-using namespace SURELOG;
-using namespace UHDM;
+namespace SURELOG {
+
+using namespace UHDM;  // NOLINT (we're using a whole bunch of these)
 
 typedef std::map<ModPort*, modport*> ModPortMap;
 typedef std::map<const DesignComponent*, BaseClass*> ComponentMap;
@@ -2224,3 +2225,4 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) const {
       m_compileDesign->getCompiler()->getCommandLineParser()->muteStdout());
   return designHandle;
 }
+}  // namespace SURELOG


### PR DESCRIPTION
Be explicit what types/functions are imported from the
namespace or document explicitly with NOLINT that we
want a general import (here for 'using namespace UHDM').

Signed-off-by: Henner Zeller <h.zeller@acm.org>