### PR TITLE
Recent changes require git (for utfcpp) and python3 (UHDM).

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -27,6 +27,9 @@ pkgs.mkShell {
       gperftools
       zlib
       lcov
+      git
+      cacert
+      python3
     ];
 
 }


### PR DESCRIPTION
Add these to the build requirements for the hermetic nix shell.