### PR TITLE
Fix return value of mkDir() and rmDir().

### DIFF
--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -69,7 +69,7 @@ std::string PPCache::getCacheFileName_(const std::string& requested_file) {
   Library* lib = m_pp->getLibrary();
   std::string libName = lib->getName() + "/";
   std::string cacheFileName = cacheDirName + libName + svFileName + ".slpp";
-  FileUtils::mkDir(std::string(cacheDirName + libName).c_str());
+  FileUtils::mkDir(cacheDirName + libName);
   return cacheFileName;
 }
 

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -80,7 +80,7 @@ std::string ParseCache::getCacheFileName_(std::string svFileName) {
   Library* lib = m_parse->getLibrary();
   std::string libName = lib->getName() + "/";
   std::string cacheFileName = cacheDirName + libName + svFileName + ".slpa";
-  FileUtils::mkDir(std::string(cacheDirName + libName).c_str());
+  FileUtils::mkDir(cacheDirName + libName);
   return cacheFileName;
 }
 

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -1128,8 +1128,7 @@ bool CommandLineParser::prepareCompilation_(int argc, const char** argv) {
     m_logFileId = m_symbolTable->registerSymbol(full_path);
   }
 
-  int status = FileUtils::mkDir(odir.c_str());
-  if (status != 0) {
+  if (!FileUtils::mkDir(odir)) {
     Location loc(m_fullCompileDir);
     Error err(ErrorDefinition::CMD_PP_CANNOT_CREATE_OUTPUT_DIR, loc);
     m_errors->addError(err);
@@ -1172,15 +1171,14 @@ bool CommandLineParser::setupCache_() {
   }
 
   if (m_cacheAllowed) {
-    int status = FileUtils::mkDir(cachedir.c_str());
-    if (status != 0) {
+    if (!FileUtils::mkDir(cachedir)) {
       Location loc(m_cacheDirId);
       Error err(ErrorDefinition::CMD_PP_CANNOT_CREATE_CACHE_DIR, loc);
       m_errors->addError(err);
       noError = false;
     }
   } else {
-    FileUtils::rmDir(cachedir.c_str());
+    FileUtils::rmDirRecursively(cachedir);
   }
 
   return noError;
@@ -1207,10 +1205,8 @@ bool CommandLineParser::cleanCache() {
   }
 
   if (!m_cacheAllowed) {
-    int status = FileUtils::rmDir(cachedir.c_str());
-    if (status != 0) {
-      std::cout << "ERROR: Cannot delete " << cachedir << " status: " << status
-                << std::endl;
+    if (!FileUtils::rmDirRecursively(cachedir)) {
+      std::cout << "ERROR: Cannot delete " << cachedir << std::endl;
     }
   }
 

--- a/src/SourceCompile/CompileSourceFile.cpp
+++ b/src/SourceCompile/CompileSourceFile.cpp
@@ -289,7 +289,7 @@ bool CompileSourceFile::postPreprocess_() {
     if (m_commandLineParser->lowMem()) {
       return true;
     }
-    if (FileUtils::mkDir(dirPpFile.c_str()) != 0) {
+    if (!FileUtils::mkDir(dirPpFile)) {
       Location loc(ppDirId);
       Error err(ErrorDefinition::PP_CANNOT_CREATE_DIRECTORY, loc);
       m_errors->addError(err);

--- a/src/Utils/FileUtils.cpp
+++ b/src/Utils/FileUtils.cpp
@@ -94,18 +94,19 @@ SymbolId FileUtils::locateFile(SymbolId file, SymbolTable* symbols,
   return SymbolTable::getBadId();
 }
 
-int FileUtils::mkDir(const char* path) {
+bool FileUtils::mkDir(std::string_view path) {
   // CAUTION: There is a known bug in VC compiler where a trailing
   // slash in the path will cause a false return from a call to
   // fs::create_directories.
-  const std::string dirpath(path);
-  fs::create_directories(dirpath);
-  return fs::is_directory(dirpath) ? 0 : -1;
+  std::error_code err;
+  fs::create_directories(path, err);
+  return fs::is_directory(path);
 }
 
-int FileUtils::rmDir(const char* path) {
-  const std::string dirpath(path);
-  return fs::remove_all(dirpath);
+bool FileUtils::rmDirRecursively(std::string_view path) {
+  static constexpr uintmax_t kErrorCondition = static_cast<std::uintmax_t>(-1);
+  std::error_code err;
+  return fs::remove_all(path, err) != kErrorCondition;
 }
 
 std::string FileUtils::getFullPath(const std::string& path) {

--- a/src/Utils/FileUtils.h
+++ b/src/Utils/FileUtils.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace SURELOG {
@@ -40,10 +41,8 @@ class FileUtils final {
   static bool fileIsDirectory(const std::string& name);
   static SymbolId locateFile(SymbolId file, SymbolTable* symbols,
                              const std::vector<SymbolId>& paths);
-  // TODO: mkDir() and rmDir() don't return what one would think they return.
-  // Change to bool
-  static int mkDir(const char* path);
-  static int rmDir(const char* path);
+  static bool mkDir(std::string_view path);
+  static bool rmDirRecursively(std::string_view path);
   static std::string getFullPath(const std::string& path);
   static bool getFullPath(const std::string& path, std::string* result);
   static std::string getPathName(const std::string& path);


### PR DESCRIPTION
 * The return value was meant to return an posix return code
   but wasn't after move to filesystem::. Also, this system call
   value is confusing in other contexts, as zero means 'success'.
   Changed to return boolean instead now to get what is intuitively
   understood correctly.
 * Rename rmDir() rmDirRecursively() because that is what it does.
 * Don't use the filesystem:: functions that throw exceptions, but
   use the noexept variants instead.
 * Parameter: change from const char* to std::string_view.

Signed-off-by: Henner Zeller <h.zeller@acm.org>