### PR TITLE
Make SymbolTable return stable std::string& on query.

### DIFF
--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -162,9 +162,8 @@ Cache::cacheErrors(flatbuffers::FlatBufferBuilder& builder,
   }
 
   /* Cache all the symbols */
-  for (auto itr = symbols->getSymbols().begin();
-       itr != symbols->getSymbols().end(); itr++) {
-    canonicalSymbols.registerSymbol(*itr);
+  for (const auto& s : symbols->getSymbols()) {
+    canonicalSymbols.registerSymbol(s);
   }
 
   auto symbolVec = builder.CreateVectorOfStrings(canonicalSymbols.getSymbols());


### PR DESCRIPTION
There are a few places that take strings coming from the SymbolTable
and then modifying the very SymbolTable that then can make these
string references render invalid due to reallocations within the
table.

Change that, so that we have realloc-safe strings by storing pointers
in the underlying vector instead of string objects. These are the
stable backing of all the string references handed out so we can
guarantee that these are valid as long as the SymbolTable is valid.

As a nice side-effect, we don't have to store strings, just string_views
as keys in the symbol -> ID map.

Due the unfortunate fact that we have copy constructor and we don't
want to re-create all the strings, use a shared_ptr to reference
count these. On the plus side, copies are now cheaper.

More expensive became getSymbols() that expects a std::vector<std::string>
to be returned due to some requirement by flatbuffers. Ideally this
can be changed to a std::vector<std::string_view> at some point.

Signed-off-by: Henner Zeller <h.zeller@acm.org>