### PR TITLE
Add a clang-tidy run to the CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,50 @@
+---
+# readability-make-member-function-const is great, but it also suggests that
+#    in cases where we return a non-const pointer.
+#    So good for a regular cleanup-sweep but not as default.
+# Some of the rules below that are disabled should be re-considered once we
+# have a somewhat clean baseline (runtime-int, readability-casting,
+# narrowing conversion come to mind)
+# In particular the disabled clang-analyzer-* messages should all be
+# enabled as they uncover real bugs, but once we have the other noise reduced.
+# performance-inefficient-string-concatenation is good, but until we use
+# absl in this project with absl::StrCat(), the alternatives are not improving
+# readability.
+Checks: >
+  clang-diagnostic-*,clang-analyzer-*,
+  -clang-analyzer-core.CallAndMessage,
+  -clang-analyzer-core.NullDereference,
+  -clang-analyzer-cplusplus.NewDeleteLeaks,
+  readability-*,
+  -readability-braces-around-statements,
+  -readability-named-parameter,
+  -readability-isolate-declaration,
+  -readability-redundant-access-specifiers,
+  -readability-implicit-bool-conversion,
+  -readability-magic-numbers,
+  -readability-else-after-return,
+  -readability-qualified-auto,
+  -readability-make-member-function-const,
+  -readability-function-cognitive-complexity,
+  -readability-uppercase-literal-suffix,
+  -readability-inconsistent-declaration-parameter-name,
+  -readability-simplify-boolean-expr,
+  google-*,
+  -google-readability-braces-around-statements,
+  -google-readability-todo,
+  -google-readability-casting,
+  -google-runtime-int,
+  -google-build-using-namespace,
+  -google-readability-avoid-underscore-in-googletest-name,
+  performance-*,
+  -performance-inefficient-string-concatenation,
+  bugprone-*,
+  -bugprone-narrowing-conversions,
+  -bugprone-branch-clone,
+  +modernize-loop-convert,
+  +modernize-raw-string-literal,
+
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+...

--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2021 The Surelog Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TIDY_OUT=${TMPDIR:-/tmp}/clang-tidy-surelog.out
+
+CLANG_TIDY=clang-tidy-12
+
+hash ${CLANG_TIDY} || exit 2  # make sure it is installed.
+
+if [ ! -r compile_commands.json ]; then
+    echo "To get compile_commands.json, run in root of project and "
+    echo "  make run-cmake-release"
+    exit 1
+fi
+
+find src/ -name "*.cpp" -or -name "*.h" \
+  | xargs -P$(nproc) -n 5 -- \
+          ${CLANG_TIDY} --quiet 2>/dev/null \
+  > ${TIDY_OUT}
+
+
+cat ${TIDY_OUT}
+
+sed 's|\(.*\)\(\[[a-z-]*\]$\)|\2|p;d' < ${TIDY_OUT} | sort | uniq -c | sort -n
+
+if [ -s ${TIDY_OUT} ]; then
+    echo "There were clang-tidy warnings. Please fix"
+    echo "For now, this is not an error yet"
+    # For now, we don't fail-exit as there is a lot of fixing needed, so
+    # we just have the messages above as FYI.
+    exit 0
+    #exit 1
+fi
+
+echo "No clang-tidy complaints.😎"
+exit 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -428,3 +428,47 @@ jobs:
 
     - name: Run formatting style check
       run: ./.github/bin/run-clang-format.sh
+
+  ClangTidy:
+    runs-on: ubuntu-20.04
+    if: ${{github.event_name == 'pull_request'}}
+
+    steps:
+
+    - name: Cancel previous
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update -qq
+        sudo apt -qq -y install clang-tidy-12 \
+                                g++-7 tclsh  default-jre cmake \
+                                uuid-dev build-essential
+
+    - name: Use ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: clang-tidy-codegen
+
+    - name: Configure shell
+      run: |
+        echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
+
+    - name: Prepare source
+      run: |
+        make run-cmake-release
+        make -j2 -C build GenerateParser
+        make -j2 -C build GenerateSerializer
+        ln -s build/compile_commands.json .
+
+    - name: Run clang tidy
+      run: |
+        ./.github/bin/run-clang-tidy.sh


### PR DESCRIPTION
Using a baseline of useful clang-tidy warnings, but with
some disabled that would be too noisy right now.

For now, this is just generating an FYI output as
a starting point to get these adressed. Once the baseline
is clean, we can change this to result in an CI error if
new warnings show up in a pull request.

Signed-off-by: Henner Zeller <h.zeller@acm.org>