### PR TITLE
Fix syntax in clang-tidy file: enabled rules don't have a leading plus.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,8 +41,9 @@ Checks: >
   bugprone-*,
   -bugprone-narrowing-conversions,
   -bugprone-branch-clone,
-  +modernize-loop-convert,
-  +modernize-raw-string-literal,
+  modernize-loop-convert,
+  modernize-raw-string-literal,
+  modernize-use-override,
 
 WarningsAsErrors: ''
 HeaderFilterRegex: ''


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>