### PR TITLE
Fix building Surelog using gcc 11.1

### DIFF
--- a/third_party/antlr4_fast/runtime/Cpp/runtime/CMakeLists.txt
+++ b/third_party/antlr4_fast/runtime/Cpp/runtime/CMakeLists.txt
@@ -9,8 +9,8 @@ ExternalProject_Add(
   GIT_TAG               "v3.1.1"
   SOURCE_DIR            ${UTFCPP_DIR}
   UPDATE_DISCONNECTED   1
-  CMAKE_ARGS            -DCMAKE_INSTALL_PREFIX=${UTFCPP_DIR}/install -Dgtest_force_shared_crt=ON
-  TEST_AFTER_INSTALL    1
+  CMAKE_ARGS            -DCMAKE_INSTALL_PREFIX=${UTFCPP_DIR}/install -Dgtest_force_shared_crt=ON -DUTF8_TESTS=OFF
+  TEST_AFTER_INSTALL    0
   STEP_TARGETS          build)
 
 


### PR DESCRIPTION
This fixes building Surelog using gcc 11.1.
Before this build was failing with:
```
In file included from Surelog/build/runtime/thirdparty/utfcpp/extern/gtest/googletest/src/gtest-all.cc:42:
Surelog/build/runtime/thirdparty/utfcpp/extern/gtest/googletest/src/gtest-death-test.cc: In function âbool testing::internal::StackGrowsDown()â:
Surelog/build/runtime/thirdparty/utfcpp/extern/gtest/googletest/src/gtest-death-test.cc:1224:24: error: âdummyâ may be used uninitialized [-Werror=maybe-uninitialize
d]
 1224 |   StackLowerThanAddress(&dummy, &result);
      |   ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
Surelog/build/runtime/thirdparty/utfcpp/extern/gtest/googletest/src/gtest-death-test.cc:1214:13: note: by argument 1 of type âconst void*â to âvoid testing::internal
::StackLowerThanAddress(const void*, bool*)â declared here
 1214 | static void StackLowerThanAddress(const void* ptr, bool* result) {
      |             ^~~~~~~~~~~~~~~~~~~~~
Surelog/build/runtime/thirdparty/utfcpp/extern/gtest/googletest/src/gtest-death-test.cc:1222:7: note: âdummyâ declared here
 1222 |   int dummy;
      |       ^~~~~
```
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>