### PR TITLE
Issue #1979,  chipsalliance/UHDM#510

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt install -y \
-          g++-7 \
+          g++-9 \
           tclsh \
           default-jre \
           cmake \
@@ -44,9 +44,9 @@ jobs:
           libgoogle-perftools-dev \
           uuid-dev \
           lcov
-        sudo ln -sf /usr/bin/g++-7 /usr/bin/g++
-        sudo ln -sf /usr/bin/gcc-7 /usr/bin/gcc
-        sudo ln -sf /usr/bin/gcov-7 /usr/bin/gcov
+        sudo ln -sf /usr/bin/g++-9 /usr/bin/g++
+        sudo ln -sf /usr/bin/gcc-9 /usr/bin/gcc
+        sudo ln -sf /usr/bin/gcov-9 /usr/bin/gcov
 
     - uses: actions/setup-python@v2
       with:
@@ -65,8 +65,8 @@ jobs:
 
     - name: Configure shell
       run: |
-        echo 'CC=gcc-7' >> $GITHUB_ENV
-        echo 'CXX=g++-7' >> $GITHUB_ENV
+        echo 'CC=gcc-9' >> $GITHUB_ENV
+        echo 'CXX=g++-9' >> $GITHUB_ENV
         echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
         echo 'PREFIX=/tmp/surelog-install' >> $GITHUB_ENV
         echo "ADDITIONAL_CMAKE_OPTIONS='-DMY_CXX_WARNING_FLAGS="-W -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Werror -UNDEBUG"'" >> $GITHUB_ENV
@@ -452,7 +452,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt -qq -y install clang-tidy-12 \
-                                g++-7 tclsh  default-jre cmake \
+                                g++-9 tclsh  default-jre cmake \
                                 uuid-dev build-essential
 
     - name: Use ccache

--- a/.github/workflows/regression_on_demand.yml
+++ b/.github/workflows/regression_on_demand.yml
@@ -5,10 +5,17 @@ on:
 
 jobs:
   linux-gcc:
+    name: ubuntu-linux-${{ matrix.mode }}
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        mode:
+        - pygen
+        - tclgen
 
     steps:
 
@@ -16,7 +23,7 @@ jobs:
       run: |
         sudo apt-get update -qq
         sudo apt install -y \
-          g++-7 \
+          g++-9 \
           tclsh \
           default-jre \
           cmake \
@@ -26,9 +33,9 @@ jobs:
           libgoogle-perftools-dev \
           uuid-dev \
           lcov
-        sudo ln -sf /usr/bin/g++-7 /usr/bin/g++
-        sudo ln -sf /usr/bin/gcc-7 /usr/bin/gcc
-        sudo ln -sf /usr/bin/gcov-7 /usr/bin/gcov
+        sudo ln -sf /usr/bin/g++-9 /usr/bin/g++
+        sudo ln -sf /usr/bin/gcc-9 /usr/bin/gcc
+        sudo ln -sf /usr/bin/gcov-9 /usr/bin/gcov
 
     - uses: actions/setup-python@v2
       with:
@@ -42,10 +49,16 @@ jobs:
 
     - name: Configure shell
       run: |
-        echo 'CC=gcc-7' >> $GITHUB_ENV
-        echo 'CXX=g++-7' >> $GITHUB_ENV
+        echo 'CC=gcc-9' >> $GITHUB_ENV
+        echo 'CXX=g++-9' >> $GITHUB_ENV
         echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
         echo 'PREFIX=/tmp/surelog-install' >> $GITHUB_ENV
+
+        if [[ "${{ matrix.mode }}" = "pygen" ]] ; then
+          echo 'WITH_PYTHON_GENERATOR=ON' >> $GITHUB_ENV
+        else
+          echo 'WITH_PYTHON_GENERATOR=OFF' >> $GITHUB_ENV
+        fi
 
     - name: Run Regression
       run: |
@@ -66,17 +79,24 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: surelog-linux-gcc-regression
+        name: surelog-linux-gcc-regression-${{ matrix.mode }}
         path: |
           ${{ github.workspace }}/build/test/
           ${{ github.workspace }}/build/tests/
 
   windows-msvc:
+    name: windows-msvc-${{ matrix.mode }}
     runs-on: windows-latest
 
     defaults:
       run:
         shell: cmd
+    strategy:
+      fail-fast: false
+      matrix:
+        mode:
+        - pygen
+        - tclgen
 
     steps:
     - name: Install Core Dependencies
@@ -121,6 +141,12 @@ jobs:
         set SWIG_DIR=%PROGRMDATA%\chocolatey\lib\swig\tools\install\swigwin-3.0.12
         set PATH=%pythonLocation%;%SWIG_DIR%;%JAVA_HOME%\bin;%MAKE_DIR%;%TCL_DIR%;%PATH%
 
+        if "${{ matrix.mode }}" == "pygen" (
+          set WITH_PYTHON_GENERATOR=ON
+        ) else (
+          set WITH_PYTHON_GENERATOR=OFF
+        )
+
         set
         where cmake && cmake --version
         where make && make --version
@@ -135,7 +161,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: surelog-windows-msvc-regression
+        name: surelog-windows-msvc-regression-${{ matrix.mode }}
         path: |
           ${{ github.workspace }}/build/test/
           ${{ github.workspace }}/build/tests/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ project(SURELOG)
 cmake_policy(SET CMP0091 NEW)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "Skip flatbuffers' tests")
 add_subdirectory(third_party/flatbuffers EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/antlr4_fast/runtime/Cpp EXCLUDE_FROM_ALL)
@@ -32,15 +36,10 @@ set(UHDM_BUILD_TESTS OFF CACHE BOOL "Skip UHDM tests")
 add_subdirectory(third_party/UHDM)
 add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
 # NOTE: Set the global output directories after the subprojects have had their go at it
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
-
 
 set(GENDIR ${CMAKE_CURRENT_BINARY_DIR}/generated)
 
@@ -444,6 +443,20 @@ endif()
 # Unit tests
 enable_testing()
 include(GoogleTest)
+
+if(MSVC)
+  # Microsoft reports the value of __cplusplus wrong and gmock/gtest pulls in the
+  # string_view implementation based on it's value. Microsoft's solution is to
+  # provide additional flags to make the value correct. More info can be found here -
+  #
+  #   https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-160
+  #   https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+  target_compile_options(gmock PRIVATE /Zc:__cplusplus)
+  target_compile_options(gmock_main PRIVATE /Zc:__cplusplus)
+  target_compile_options(gtest PRIVATE /Zc:__cplusplus)
+  target_compile_options(gtest_main PRIVATE /Zc:__cplusplus)
+endif()
+
 # All unit-tests are registered with this custom target as dependency, so
 # just `make UnitTests` will build them all.
 add_custom_target(UnitTests)


### PR DESCRIPTION
Issue #1979,  chipsalliance/UHDM#510

* Upgrade CI to use gcc9 instead of gcc7
* Also, updated the regression_on_demand to run the regression
  using both pygen and tclgen.
* Moved the setting to use specific version of C++ before adding
  subprojects to ensure all dependent projects use the same C++
  version.
* Windows specific - MSVC-cl has a bug where the value of
  __cplusplus is wrong unless a specific compile flag is included.
  gtest requires the value to be correct to enable inclusion of
  string_view specific matchers. Forcing the compile flag from
  Surelog to avoid having to clone/fork gtest. More information on
  this bug can be found here -
  https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-160
  https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/