### PR TITLE
Fix CI builds for macos-gcc & macos-clang

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -355,7 +355,7 @@ jobs:
         echo 'CC=gcc-9' >> $GITHUB_ENV
         echo 'CXX=g++-9' >> $GITHUB_ENV
         echo "PATH=$(brew --prefix)/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
-        echo 'PREFIX=/usr/local' >> $GITHUB_ENV
+        echo 'PREFIX=${GITHUB_WORKSPACE}/install' >> $GITHUB_ENV
 
     - name: Show shell configuration
       run: |
@@ -372,7 +372,7 @@ jobs:
     - name: Build
       run: |
         make release
-        sudo make install
+        make install
 
     - name: Unit tests
       run: |
@@ -409,7 +409,7 @@ jobs:
 
     - name: Configure shell
       run: |
-        echo 'PREFIX=/usr/local' >> $GITHUB_ENV
+        echo 'PREFIX=${GITHUB_WORKSPACE}/install' >> $GITHUB_ENV
         echo "PATH=$(brew --prefix)/opt/ccache/libexec:$PATH" >> $GITHUB_ENV
 
     - name: Show shell configuration
@@ -425,7 +425,7 @@ jobs:
     - name: Build
       run: |
         make release
-        sudo make install
+        make install
 
     - name: Unit tests
       run: |


### PR DESCRIPTION
Fix CI builds for macos-gcc & macos-clang

As per the reported issue here,
https://github.com/Homebrew/brew/issues/385

/usr/local on macos Sierra is a protected location.

Use location relative to the workspace to guarantee we don't
run into permission related issues again.