### PR TITLE
generate_parser_listener python implementation & few other fixes

### DIFF
--- a/.github/workflows/pymain.yml
+++ b/.github/workflows/pymain.yml
@@ -36,11 +36,9 @@ jobs:
         sudo apt-get update -qq
         sudo apt install -y \
           g++-9 \
-          tclsh \
           default-jre \
           cmake \
           build-essential \
-          swig \
           google-perftools \
           libgoogle-perftools-dev \
           uuid-dev \
@@ -57,7 +55,9 @@ jobs:
         architecture: x64
 
     - name: Setup Python Packages
-      run: pip3 install psutil
+      run: |
+        pip3 install orderedmultidict
+        pip3 install psutil
 
     - name: Checkout code
       uses: actions/checkout@v2
@@ -85,11 +85,9 @@ jobs:
         env
         which cmake && cmake --version
         which make && make --version
-        which swig && swig -version
         which java && java -version
         which python && python --version
         which ninja && ninja --version
-        which tclsh && echo 'puts [info patchlevel];exit 0' | tclsh
         which $CC && $CC --version
         which $CXX && $CXX --version
 
@@ -101,7 +99,7 @@ jobs:
     - name: Regression
       if: matrix.mode == 'regression'
       run: |
-        make pytest/regression || true
+        make pytest/regression
 
     - name: Coverage
       if: matrix.mode == 'coverage'
@@ -170,10 +168,6 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    - name: Install core dependencies
-      run: choco install -y swig --side-by-side --version=3.0.12
-      shell: powershell
-
     - name: Setup Java
       uses: actions/setup-java@v1
       with:
@@ -189,7 +183,9 @@ jobs:
 
     - name: Setup Python Packages
       shell: cmd
-      run: pip3 install psutil
+      run: |
+        pip3 install orderedmultidict
+        pip3 install psutil
 
     - name: Setup Msys2
       uses: msys2/setup-msys2@v2
@@ -220,12 +216,10 @@ jobs:
 
     - name: Configure shell environment variables
       run: |
-        export SWIG_DIR=/c/ProgramData/chocolatey/lib/swig/tools/install/swigwin-3.0.12
         export JAVA_HOME=`cygpath -u $JAVA_HOME_8_0_275_X64`
         export CWD=`pwd`
         export Py3_ROOT_DIR=`cygpath -u $pythonLocation`
 
-        echo "SWIG_DIR=$SWIG_DIR" >> $GITHUB_ENV
         echo "JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
         echo 'CMAKE_GENERATOR=Ninja' >> $GITHUB_ENV
         echo 'CC=gcc' >> $GITHUB_ENV
@@ -236,37 +230,34 @@ jobs:
         echo "Py3_ROOT_DIR=$Py3_ROOT_DIR" >> $GITHUB_ENV
         echo "ADDITIONAL_CMAKE_OPTIONS=-DPython3_ROOT_DIR=$Py3_ROOT_DIR" >> $GITHUB_ENV
 
-        echo "$SWIG_DIR" >> $GITHUB_PATH
         echo "$JAVA_HOME/bin" >> $GITHUB_PATH
         echo "$Py3_ROOT_DIR" >> $GITHUB_PATH
 
     - name: Show shell configuration
       run: |
-        export PATH=$SWIG_DIR:$JAVA_HOME/bin:$Py3_ROOT_DIR:$PATH
+        export PATH=$JAVA_HOME/bin:$Py3_ROOT_DIR:$PATH
         env
         where git && git --version
         where cmake && cmake --version
         where make && make --version
-        where swig && swig -version
         where java && java -version
         where python && python --version
         where ninja && ninja --version
-        where tclsh && echo 'puts [info patchlevel];exit 0' | tclsh
         where $CC && $CC --version
         where $CXX && $CXX --version
 
     - name: Build
       run: |
-        export PATH=$SWIG_DIR:$JAVA_HOME/bin:$Py3_ROOT_DIR:$PATH
+        export PATH=$JAVA_HOME/bin:$Py3_ROOT_DIR:$PATH
         make release
         make install
 
     - name: Test
       run: |
-        export PATH=$SWIG_DIR:$JAVA_HOME/bin:$Py3_ROOT_DIR:$PATH
+        export PATH=$JAVA_HOME/bin:$Py3_ROOT_DIR:$PATH
         make test_install
         make test/unittest
-        make pytest/regression || true
+        make pytest/regression
 
     - name: Prepare build artifacts
       run: |
@@ -310,7 +301,6 @@ jobs:
     - name: Install Core Dependencies
       run: |
         choco install -y make
-        choco install -y swig --side-by-side --version=3.0.12
 
     - name: Setup Python
       uses: actions/setup-python@v2
@@ -319,7 +309,9 @@ jobs:
         architecture: x64
 
     - name: Setup Python Packages
-      run: pip3 install psutil
+      run: |
+        pip3 install orderedmultidict
+        pip3 install psutil
 
     - name: Setup Java
       uses: actions/setup-java@v1
@@ -357,15 +349,13 @@ jobs:
 
         set MAKE_DIR=C:\make\bin
         set TCL_DIR=%PROGRAMFILES%\Git\mingw64\bin
-        set SWIG_DIR=%PROGRMDATA%\chocolatey\lib\swig\tools\install\swigwin-3.0.12
-        set PATH=%pythonLocation%;%SWIG_DIR%;%JAVA_HOME%\bin;%MAKE_DIR%;%TCL_DIR%;%PATH%
+        set PATH=%pythonLocation%;%JAVA_HOME%\bin;%MAKE_DIR%;%TCL_DIR%;%PATH%
         set WITH_PYTHON_GENERATOR=ON
         set ADDITIONAL_CMAKE_OPTIONS=-DPython3_ROOT_DIR=%pythonLocation%
 
         set
         where cmake && cmake --version
         where make && make --version
-        where swig && swig -version
         where java && java -version
         where python && python --version
         where ninja && ninja --version
@@ -378,7 +368,7 @@ jobs:
         if %errorlevel% neq 0 exit /b %errorlevel%
         make test/unittest
         if %errorlevel% neq 0 exit /b %errorlevel%
-        make pytest/regression || true
+        make pytest/regression
 
     - name: Prepare build artifacts
       shell: bash
@@ -424,7 +414,9 @@ jobs:
         architecture: x64
 
     - name: Setup Python Packages
-      run: pip3 install psutil
+      run: |
+        pip3 install orderedmultidict
+        pip3 install psutil
 
     - uses: actions/checkout@v2
       with:
@@ -450,10 +442,8 @@ jobs:
         env
         which cmake && cmake --version
         which make && make --version
-        which swig && swig -version
         which java && java -version
         which python && python --version
-        which tclsh && echo 'puts [info patchlevel];exit 0' | tclsh
         which $CC && $CC --version
         which $CXX && $CXX --version
 
@@ -469,7 +459,7 @@ jobs:
 
     - name: Regression tests
       run: |
-        make pytest/regression || true
+        make pytest/regression
 
     - name: Prepare build artifacts
       run: |
@@ -513,7 +503,9 @@ jobs:
         architecture: x64
 
     - name: Setup Python Packages
-      run: pip3 install psutil
+      run: |
+        pip3 install orderedmultidict
+        pip3 install psutil
 
     - uses: actions/checkout@v2
       with:
@@ -537,10 +529,8 @@ jobs:
         env
         which cmake && cmake --version
         which make && make --version
-        which swig && swig -version
         which java && java -version
         which python && python --version
-        which tclsh && echo 'puts [info patchlevel];exit 0' | tclsh
 
     - name: Build
       run: |
@@ -554,7 +544,7 @@ jobs:
 
     - name: Regression tests
       run: |
-        make pytest/regression || true
+        make pytest/regression
 
     - name: Prepare build artifacts
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # -*- mode:cmake -*-
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 # Detect build type, fallback to release and throw a warning if use didn't
 # specify any
@@ -17,6 +17,12 @@ option(
   WITH_LIBCXX
   "Building with clang++ and libc++(in Linux). To enable with: -DWITH_LIBCXX=On"
   On)
+
+option(WITH_PYTHON_GENERATOR "Use Python generator instead of TCL." OFF)
+
+if (DEFINED ENV{WITH_PYTHON_GENERATOR})
+  set(WITH_PYTHON_GENERATOR $ENV{WITH_PYTHON_GENERATOR})
+endif()
 
 project(SURELOG)
 
@@ -45,12 +51,15 @@ set(GENDIR ${CMAKE_CURRENT_BINARY_DIR}/generated)
 
 # Python
 if (SURELOG_WITH_PYTHON)
-find_package(Python3 3.3 REQUIRED COMPONENTS Interpreter Development)
-find_package(SWIG 3.0 REQUIRED)
-message(STATUS "Python3_LIBRARIES = ${Python3_LIBRARIES}")
-message(STATUS "Python3_EXECUTABLE = ${Python3_EXECUTABLE}")
-message(STATUS "Python3_INCLUDE_DIRS = ${Python3_INCLUDE_DIRS}")
-message(STATUS "Python3_RUNTIME_LIBRARY_DIRS = ${Python3_RUNTIME_LIBRARY_DIRS}")
+  find_package(Python3 3.3 REQUIRED COMPONENTS Interpreter Development)
+  find_package(SWIG 3.0 REQUIRED)
+  message(STATUS "Python3_LIBRARIES = ${Python3_LIBRARIES}")
+  message(STATUS "Python3_EXECUTABLE = ${Python3_EXECUTABLE}")
+  message(STATUS "Python3_INCLUDE_DIRS = ${Python3_INCLUDE_DIRS}")
+  message(STATUS "Python3_RUNTIME_LIBRARY_DIRS = ${Python3_RUNTIME_LIBRARY_DIRS}")
+elseif (WITH_PYTHON_GENERATOR)
+  find_package(Python3 3.3 REQUIRED Interpreter)
+  message(STATUS "Python3_EXECUTABLE = ${Python3_EXECUTABLE}")
 endif()
 
 # Use tcmalloc if installed and not NO_TCMALLOC is on. TODO: don't use negative
@@ -178,21 +187,37 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E touch ${GENDIR}/src/parser/generated-parsers.tstamp
 )
 
-add_custom_command(
-  OUTPUT ${GENDIR}/src/SourceCompile/VObjectTypes.h
-         ${GENDIR}/src/SourceCompile/VObjectTypes.cpp
-         ${GENDIR}/src/API/vobjecttypes_py.h
-         ${GENDIR}/src/SourceCompile/SV3_1aTreeShapeListener.h
-         ${GENDIR}/src/SourceCompile/SV3_1aPpTreeShapeListener.h
-  DEPENDS ${GENDIR}/src/parser/generated-parsers.tstamp
-          ${PROJECT_SOURCE_DIR}/src/SourceCompile/generate_parser_listener.tcl
+if (WITH_PYTHON_GENERATOR)
+  add_custom_command(
+    OUTPUT ${GENDIR}/src/SourceCompile/VObjectTypes.h
+           ${GENDIR}/src/SourceCompile/VObjectTypes.cpp
+           ${GENDIR}/src/API/VObjectTypes_py.h
+           ${GENDIR}/src/SourceCompile/SV3_1aTreeShapeListener.h
+           ${GENDIR}/src/SourceCompile/SV3_1aPpTreeShapeListener.h
+    DEPENDS ${GENDIR}/src/parser/generated-parsers.tstamp
+            ${PROJECT_SOURCE_DIR}/scripts/generate_parser_listener.py
 
-  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/src/"
-  COMMAND echo "---------- VObjectTypes, Listener generation"
-  COMMAND ${CMAKE_COMMAND} -E make_directory ${GENDIR}/src/SourceCompile
-  COMMAND ${CMAKE_COMMAND} -E make_directory ${GENDIR}/src/API
-  COMMAND tclsh SourceCompile/generate_parser_listener.tcl input_dir=${PROJECT_SOURCE_DIR}/src input_gen_dir=${GENDIR}/src out_dir=${GENDIR}/src
-)
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMAND echo "---------- VObjectTypes, Listener generation"
+    COMMAND ${Python3_EXECUTABLE} scripts/generate_parser_listener.py --output-dirpath ${GENDIR}
+  )
+else()
+  add_custom_command(
+    OUTPUT ${GENDIR}/src/SourceCompile/VObjectTypes.h
+           ${GENDIR}/src/SourceCompile/VObjectTypes.cpp
+           ${GENDIR}/src/API/VObjectTypes_py.h
+           ${GENDIR}/src/SourceCompile/SV3_1aTreeShapeListener.h
+           ${GENDIR}/src/SourceCompile/SV3_1aPpTreeShapeListener.h
+    DEPENDS ${GENDIR}/src/parser/generated-parsers.tstamp
+            ${PROJECT_SOURCE_DIR}/src/SourceCompile/generate_parser_listener.tcl
+
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/src/"
+    COMMAND echo "---------- VObjectTypes, Listener generation"
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${GENDIR}/src/SourceCompile
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${GENDIR}/src/API
+    COMMAND tclsh SourceCompile/generate_parser_listener.tcl input_dir=${PROJECT_SOURCE_DIR}/src input_gen_dir=${GENDIR}/src out_dir=${GENDIR}/src
+  )
+endif()
 
 if (SURELOG_WITH_PYTHON)
 set(surelog_python-GENERATED_SRC
@@ -209,7 +234,7 @@ add_custom_command(
   DEPENDS ${PROJECT_SOURCE_DIR}/src/API/slapi_scripts.i
           ${PROJECT_SOURCE_DIR}/src/API/generate_python_listener_api.tcl
           ${PROJECT_SOURCE_DIR}/src/API/embed_python_api.tcl
-          ${GENDIR}/src/API/vobjecttypes_py.h
+          ${GENDIR}/src/API/VObjectTypes_py.h
           ${GENDIR}/src/parser/generated-parsers.tstamp
 
   WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/src/"
@@ -722,8 +747,8 @@ if (WIN32 AND $<CONFIG:Debug>)
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/surelog)
   install(
     FILES ${UHDM_BINARY_DIR}/CMakeFiles/uhdm.dir/uhdm.pdb
-          ${UHDM_BINARY_DIR}/third_party/capnproto/c++/src/capnp/CMakeFiles/capnp.dir/capnp.pdb
-          ${UHDM_BINARY_DIR}/third_party/capnproto/c++/src/kj/CMakeFiles/kj.dir/kj.pdb
+          ${Cap\'n\ Proto_BINARY_DIR}/src/capnp/CMakeFiles/capnp.dir/capnp.pdb
+          ${Cap\'n\ Proto_BINARY_DIR}/src/kj/CMakeFiles/kj.dir/kj.pdb
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/uhdm)
 endif()
 
@@ -746,6 +771,7 @@ install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/SurelogConfig.cmake
   DESTINATION cmake)
 
-ADD_CUSTOM_TARGET(link_target ALL
-                  COMMAND ${CMAKE_COMMAND} -E create_symlink
-                  build/compile_commands.json ../compile_commands.json)
+ADD_CUSTOM_TARGET(
+  link_target ALL
+  COMMAND ${CMAKE_COMMAND} -E create_symlink
+  build/compile_commands.json ${PROJECT_SOURCE_DIR}/compile_commands.json)

--- a/scripts/generate_parser_listener.py
+++ b/scripts/generate_parser_listener.py
@@ -1,0 +1,592 @@
+import argparse
+import os
+import re
+import sys
+
+_this_filepath = os.path.realpath(__file__)
+_default_workspace_dirpath = os.path.dirname(os.path.dirname(_this_filepath))
+
+_type_names = set([
+  'slNoType',
+  'slComments',
+  'slModule',
+  # both Module_declaration and Interface_declaration enter and exit rules are in SV3_1aTreeShapeListener.cpp file
+  'slModule_declaration',
+  'slInterface_declaration',
+  # Class_type exit is in SV3_1aTreeShapeListener.cpp file
+  'slClass_type',
+  'slHierarchical_identifier',
+  'slModuleInstance',
+  'slPrimitive',
+  'slPrimitiveInstance',
+  'slInterface',
+  'slProgram',
+  'slPackage',
+  'slChecker',
+  'slClass',
+  'slPortInst',
+  'slConstSelect',
+  'slIntConst',
+  'slRealConst',
+  'slStringConst',
+  'slStringLiteral',
+  'slConstantSelect',
+  'slThis',
+  'slGenericElementType',
+  'sl0',
+  'sl1',
+  'slX',
+  'slZ',
+  'slNumber',
+  'slText_blob',
+  'slCR',
+  'slSpaces',
+  'slEscapedCR',
+
+  'slVirtual',
+  'slExtends',
+  'slImplements',
+
+  'slEndfunction',
+  'slEndmodule',
+  'slEndclass',
+  'slEndtask',
+  'slEndchecker',
+  'slEndinterface',
+  'slEndprogram',
+  'slEndpackage',
+  'slEndcase',
+  'slEndsequence',
+  'slEnd',
+  'slEndspecify',
+  'slEndconfig',
+  'slEndproperty',
+  'slEndgroup',
+  'slEndgenerate',
+  'slEndprimitive',
+  'slEndtable',
+  'slEndclocking',
+  'slUnique',
+  'slUnique0',
+  'slPriority',
+  'slCase',
+  'slCaseX',
+  'slCaseZ',
+  'slIncPartSelectOp',
+  'slDecPartSelectOp',
+  'slColumnPartSelectOp',
+  'slReturnStmt',
+  'slBreakStmt',
+  'slContinueStmt',
+  'slAssign',
+  'slDeassign',
+  'slForce',
+  'slRelease',
+  'slForever',
+  'slRepeat',
+  'slWhile',
+  'slFor',
+  'slDo',
+  'slForeach',
+  'slElse',
+  'slInterface_instantiation',
+  'slProgram_instantiation',
+
+  'slSupply0',
+  'slStrong0',
+  'slPull0',
+  'slWeak0',
+  'slSupply1',
+  'slStrong1',
+  'slPull1',
+  'slWeak1',
+  'slHighZ1',
+  'slHighZ0',
+  'slSmall',
+  'slMedium',
+  'slLarge',
+  'slDot',
+  'slDotStar',
+  'slNonBlockingTriggerEvent',
+  'slPound_Pound_delay',
+
+  'slPortDir_Inp',
+  'slPortDir_Out',
+  'slPortDir_Inout',
+  'slPortDir_Ref',
+
+  'slAlwaysKeywd_Always',
+  'slAlwaysKeywd_Comb',
+  'slAlwaysKeywd_Latch',
+  'slAlwaysKeywd_FF',
+
+  'slEdge_Posedge',
+  'slEdge_Negedge',
+  'slEdge_Edge',
+
+  'slNumber_Integral',
+  'slNumber_Real',
+  'slNumber_1Tickb0',
+  'slNumber_1Tickb1',
+  'slNumber_1TickB0',
+  'slNumber_1TickB1',
+  'slNumber_Tickb0',
+  'slNumber_Tickb1',
+  'slNumber_TickB0',
+  'slNumber_TickB1',
+  'slNumber_Tick0',
+  'slNumber_Tick1',
+  'slNumber_1Tickbx',
+  'slNumber_1TickbX',
+  'slNumber_1TickBx',
+  'slNumber_1TickBX',
+
+  'slSigning_Signed',
+  'slSigning_Unsigned',
+
+  'slTfPortDir_Inp',
+  'slTfPortDir_Out',
+  'slTfPortDir_Inout',
+  'slTfPortDir_Ref',
+  'slTfPortDir_ConstRef',
+
+  'slIntegerAtomType_Byte',
+  'slIntegerAtomType_Shortint',
+  'slIntegerAtomType_Int',
+  'slIntegerAtomType_LongInt',
+  'slIntegerAtomType_Int',
+  'slIntegerAtomType_Time',
+  'slIntVec_TypeBit',
+  'slIntVec_TypeLogic',
+  'slIntVec_TypeReg',
+  'slNonIntType_ShortReal',
+  'slNonIntType_Real',
+  'slNonIntType_RealTime',
+
+  'slUnary_Plus',
+  'slUnary_Minus',
+  'slUnary_Not',
+  'slUnary_Tilda',
+  'slUnary_BitwAnd',
+  'slUnary_BitwOr',
+  'slUnary_BitwXor',
+  'slUnary_ReductNand',
+  'slUnary_ReductNor',
+  'slUnary_ReductXnor1',
+  'slUnary_ReductXnor2',
+  'slBinOp_MultMult',
+  'slBinOp_Mult',
+  'slBinOp_Div',
+  'slBinOp_Percent',
+  'slBinOp_Plus',
+  'slBinOp_Minus',
+  'slBinOp_ShiftRight',
+  'slBinOp_ShiftLeft',
+  'slBinOp_ArithShiftRight',
+  'slBinOp_ArithShiftLeft',
+  'slBinOp_Less',
+  'slBinOp_LessEqual',
+  'slBinOp_Great',
+  'slBinOp_GreatEqual',
+  'slInsideOp',
+  'slBinOp_Equiv',
+  'slBinOp_Not',
+  'slBinOp_WildcardEqual',
+  'slBinOp_WildcardNotEqual',
+  'slBinOp_FourStateLogicEqual',
+  'slBinOp_FourStateLogicNotEqual',
+  'slBinOp_WildEqual',
+  'slBinOp_WildNotEqual',
+  'slBinOp_BitwAnd',
+  'slBinOp_ReductXnor1',
+  'slBinOp_ReductXnor2',
+  'slBinOp_ReductNand',
+  'slBinOp_ReductNor',
+  'slBinOp_BitwXor',
+  'slBinOp_BitwOr',
+  'slBinOp_LogicAnd',
+  'slBinOp_LogicOr',
+  'slBinOp_Imply',
+  'slBinOp_Equivalence',
+  'slIncDec_PlusPlus',
+  'slIncDec_MinusMinus',
+  'slTagged',
+  'slQmark',
+  'slMatches',
+  'slIff',
+  'slNull',
+  'slWith',
+  'slImport',
+  'slExport',
+  'slPure',
+
+  'slOpenParens',
+  'slCloseParens',
+
+  'slAssignOp_Assign',
+  'slAssignOp_Add',
+  'slAssignOp_Sub',
+  'slAssignOp_Mult',
+  'slAssignOp_Div',
+  'slAssignOp_Modulo',
+  'slAssignOp_BitwAnd',
+  'slAssignOp_BitwOr',
+  'slAssignOp_BitwXor',
+  'slAssignOp_BitwLeftShift',
+  'slAssignOp_BitwRightShift',
+  'slAssignOp_ArithShiftLeft',
+  'slAssignOp_ArithShiftRight',
+
+  'slIncDec_PlusPlus',
+  'slIncDec_MinusMinus',
+
+  'slNetType_Supply0',
+  'slNetType_Supply1',
+  'slNetType_Tri',
+  'slNetType_TriAnd',
+  'slNetType_TriOr',
+  'slNetType_TriReg',
+  'slNetType_Tri0',
+  'slNetType_Tri1',
+  'slNetType_Uwire',
+  'slNetType_Wire',
+  'slNetType_Wand',
+  'slNetType_Wor',
+  'slPulldown',
+  'slPullup',
+
+  'slWithin',
+  'slThroughout',
+  'slFirstMatch',
+  'slIntersect',
+
+  'slDefault',
+  'slGlobal',
+
+  # Properties
+  'slOR',
+  'slAND',
+  'slIF',
+  'slSTRONG',
+  'slWEAK',
+  'slNOT',
+  'slOVERLAP_IMPLY',
+  'slNON_OVERLAP_IMPLY',
+  'slOVERLAPPED',
+  'slNONOVERLAPPED',
+  'slS_NEXTTIME',
+  'slALWAYS',
+  'slS_ALWAYS',
+  'slS_EVENTUALLY',
+  'slEVENTUALLY',
+  'slUNTIL',
+  'slS_UNTIL',
+  'slUNTIL_WITH',
+  'slS_UNTIL_WITH',
+  'slIMPLIES',
+  'slIFF',
+  'slACCEPT_ON',
+  'slREJECT_ON',
+  'slSYNC_ACCEPT_ON',
+  'slSYNC_REJECT_ON',
+
+  'slType',
+])
+
+
+def _write_output(filename, content):
+  if os.path.exists(filename):
+    with open(filename, 'rt') as strm:
+      orig_content = strm.read()
+
+    if orig_content == content:
+      return False
+
+  dirpath = os.path.dirname(filename)
+  if not os.path.isdir(dirpath):
+    os.makedirs(dirpath)
+
+  with open(filename, 'wt') as strm:
+    strm.write(content)
+    strm.flush()
+
+  return True
+
+
+def _get_implemented_methods(filepath):
+  parse_method_name_regex = re.compile('.+::(?P<method_name>(enter|exit|visit)\w+)\s*\(.*')
+
+  methods = set()
+  with open(filepath, 'rt') as strm:
+    for line in strm:
+      m = parse_method_name_regex.match(line)
+      if m:
+        methods.add(m.group('method_name'))
+
+  return methods
+
+
+def _generate_header(listener, antlr_definition_filepath, cpp_input_filepath, output_header_filepath):
+  content = [
+    '// This file is auto-generated by generate_parser_listener.py',
+    '// DO NOT EDIT',
+    '',
+    '/*',
+    ' Copyright 2019 Alain Dargelas',
+    ' Licensed under the Apache License, Version 2.0 (the \"License\");',
+    ' you may not use this file except in compliance with the License.',
+    ' You may obtain a copy of the License at',
+    '',
+    '    http://www.apache.org/licenses/LICENSE-2.0',
+    '',
+    ' Unless required by applicable law or agreed to in writing, software',
+    ' distributed under the License is distributed on an \"AS IS\" BASIS,',
+    ' WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.',
+    ' See the License for the specific language governing permissions and',
+    ' limitations under the License.',
+    ' */',
+    '',
+    '/*',
+   f' * If a method needs custom operator, write the method in {os.path.basename(cpp_input_filepath)}',
+    ' *',
+   f' * File:   {os.path.basename(output_header_filepath)}',
+    ' * Author: alain',
+    ' *',
+    ' * Created on April 16, 2017, 8:28 PM',
+    ' */',
+    ''
+  ]
+
+  if listener == 'Parser':
+    content.extend([
+      '#ifndef SV3_1ATREESHAPELISTENER_H',
+      '#define SV3_1ATREESHAPELISTENER_H',
+      '#pragma once',
+      '',
+      '',
+      '#include <stack>',
+      '#include <map>',
+      '#include <unordered_map>',
+      '',
+      '#include "Utils/ParseUtils.h"',
+      '#include "SourceCompile/SymbolTable.h"',
+      '#include "Design/TimeInfo.h"',
+      '#include "Design/DesignElement.h"',
+      '#include "Design/FileContent.h"',
+      '#include "SourceCompile/ParseFile.h"',
+      '#include "SourceCompile/CompilationUnit.h"',
+      '#include "SourceCompile/CompileSourceFile.h"',
+      '#include "SourceCompile/SV3_1aTreeShapeHelper.h"',
+      '#include "parser/SV3_1aParserBaseListener.h"',
+      '',
+      'namespace SURELOG {',
+      '',
+      '  class SV3_1aTreeShapeListener : public SV3_1aParserBaseListener, public SV3_1aTreeShapeHelper {',
+      '  private:',
+      '',
+      '  public:',
+      '    SV3_1aTreeShapeListener(ParseFile* pf, antlr4::CommonTokenStream* tokens, unsigned int lineOffset);',
+      '    virtual ~SV3_1aTreeShapeListener() override;',
+      ''
+    ])
+  else:
+    content.extend([
+      '#ifndef SV3_1APPTREESHAPELISTENER_H',
+      '#define SV3_1APPTREESHAPELISTENER_H',
+      '#pragma once',
+      '',
+      '',
+      '#include <regex>',
+      '',
+      '#include "SourceCompile/PreprocessFile.h"',
+      '#include "SourceCompile/CompileSourceFile.h"',
+      '#include "SourceCompile/Compiler.h"',
+      '#include "SourceCompile/SymbolTable.h"',
+      '#include "SourceCompile/CompilationUnit.h"',
+      '#include "Design/TimeInfo.h"',
+      '#include "SourceCompile/SV3_1aPpTreeListenerHelper.h"',
+      '#include "parser/SV3_1aPpParserBaseListener.h"',
+      '',
+      'namespace SURELOG {',
+      '',
+      '  class SV3_1aPpTreeShapeListener : public SV3_1aPpParserBaseListener , public SV3_1aPpTreeListenerHelper {',
+      '',
+      '  public:',
+      '    SV3_1aPpTreeShapeListener(PreprocessFile* pp, antlr4::CommonTokenStream* tokens, PreprocessFile::SpecialInstructions& instructions);',
+      ''
+    ])
+
+  parse_method_name_regex = re.compile('\s*virtual\s+void\s+(?P<method_name>(enter|exit|visit)\w+)\s*\(.*')
+  sub_regex1 = re.compile('\s*virtual\s+(?P<declaration>void\s+(?P<method>(enter|exit|visit)\w+).+)\s+override\s+\{\s+\}')
+  sub_regex2 = re.compile('(.+)(/\*ctx\*/)(.+)')
+
+  implemented_methods = _get_implemented_methods(cpp_input_filepath)
+  with open(antlr_definition_filepath, 'rt') as strm:
+    for line in strm:
+      line = line.strip()
+
+      if line:
+        m = parse_method_name_regex.match(line)
+        if m:
+          method_name = m.group('method_name')
+
+          if 'ErrorNode' in method_name:
+            abc = 0
+
+          if method_name.startswith('exit'):
+            type_name = method_name.replace('enter', '').replace('exit', '').replace('visit', '')
+            _type_names.add(f'sl{type_name}')
+
+          if method_name in implemented_methods:
+            line = sub_regex1.sub('    \g<declaration> final;', line)
+          elif method_name.startswith('exit'):
+            method_name = method_name.replace('exit', '')
+            line = sub_regex1.sub(f'\g<declaration> final {{ addVObject(ctx, VObjectType::sl{method_name}); }}', line)
+            line = sub_regex2.sub('    \g<1>ctx\g<3>', line)
+          else:
+            line = sub_regex1.sub('    \g<declaration> final {}', line)
+
+          content.append(line)
+
+  content.extend([
+    '  };',
+    '} // namespace SURELOG',
+    ''
+  ])
+
+  if listener == 'Parser':
+    content.append('#endif // SV3_1ATREESHAPELISTENER_H')
+  else:
+    content.append('#endif // SV3_1APPTREESHAPELISTENER_H')
+
+  _write_output(output_header_filepath, '\n'.join(content))
+
+
+def _generate_VObjectTypes_h(filepath):
+  content = [
+    '// This file is auto-generated by generate_parser_listener.py',
+    '// DO NOT EDIT',
+    '',
+    '#ifndef VOBJECTTYPES_H',
+    '#define VOBJECTTYPES_H',
+    '#pragma once',
+    '',
+    '',
+    'enum VObjectType {',
+  ]
+
+  index = 0
+  for type_name in sorted(_type_names, key=lambda s: s.lower()):
+    content.append(f'  {type_name} = {index},')
+    index += 1
+
+  content.extend([
+    '};',
+    '',
+    '#endif // VOBJECTTYPES_H',
+    ''
+  ])
+
+  _write_output(filepath, '\n'.join(content))
+
+
+def _generate_VObjectTypes_cpp(filepath):
+  content = [
+    '// This file is auto-generated by generate_parser_listener.py',
+    '// DO NOT EDIT',
+    '',
+    '#include <string>',
+    '#include "Design/VObject.h"',
+    '',
+    '',
+    'using namespace SURELOG;',
+    '',
+    'std::string VObject::getTypeName(unsigned short type) {',
+    '  switch (type) {',
+  ]
+
+  content.extend([f'  case {type_name}: return "{type_name}";' for type_name in sorted(_type_names, key=lambda s: s.lower())])
+  content.extend([
+    '  default: return "";',
+    '  }',
+    '}',
+    ''
+  ])
+
+  _write_output(filepath, '\n'.join(content))
+
+
+def _generate_VObjectTypes_py_h(filepath):
+  content = [
+    '// This file is auto-generated by generate_parser_listener.py',
+    '// DO NOT EDIT',
+    '',
+    '#ifndef VOBJECTTYPES_PY_H',
+    '#define VOBJECTTYPES_PY_H',
+    '#pragma once',
+    '',
+    '',
+    '#include <vector>',
+    '#include <string_view>',
+    '',
+    'std::vector<std::string_view> slapi_types = {',
+    '  "# This file is automatically generated by generate_parser_listener.py\\n",',
+    '  "# DO NOT EDIT\\n",',
+  ]
+
+  index = 0
+  for type_name in sorted(_type_names, key=lambda s: s.lower()):
+    content.append(f'  "{type_name} = {index};\\n",')
+    index += 1
+
+  content.extend([
+    '};',
+    '',
+    '#endif // VOBJECTTYPES_PY_H',
+    ''
+  ])
+
+  _write_output(filepath, '\n'.join(content))
+
+
+def _main():
+  parser = argparse.ArgumentParser()
+
+  parser.add_argument(
+      '--workspace-dirpath', dest='workspace_dirpath', required=False, default=_default_workspace_dirpath, type=str,
+      help='Workspace root, either absolute or relative to current working directory.')
+
+  parser.add_argument(
+      '--output-dirpath', dest='output_dirpath', required=True, type=str,
+      help='Output directory path, either absolute or relative to the workspace directory.')
+
+  args = parser.parse_args()
+
+  if not os.path.isabs(args.workspace_dirpath):
+    args.workspace_dirpath = os.path.abspath(args.workspace_dirpath)
+
+  if not os.path.isabs(args.output_dirpath):
+    args.output_dirpath = os.path.join(args.workspace_dirpath, args.output_dirpath)
+  args.output_dirpath = os.path.abspath(args.output_dirpath)
+
+  _generate_header(
+    'Parser',
+    os.path.join(args.output_dirpath, 'src', 'parser', 'SV3_1aParserBaseListener.h'),
+    os.path.join(args.workspace_dirpath, 'src', 'SourceCompile', 'SV3_1aTreeShapeListener.cpp'),
+    os.path.join(args.output_dirpath, 'src', 'SourceCompile', 'SV3_1aTreeShapeListener.h'))
+
+  _generate_header(
+    'PreProc',
+    os.path.join(args.output_dirpath, 'src', 'parser', 'SV3_1aPpParserBaseListener.h'),
+    os.path.join(args.workspace_dirpath, 'src', 'SourceCompile', 'SV3_1aPpTreeShapeListener.cpp'),
+    os.path.join(args.output_dirpath, 'src', 'SourceCompile', 'SV3_1aPpTreeShapeListener.h'))
+
+  _generate_VObjectTypes_h(os.path.join(args.output_dirpath, 'src', 'SourceCompile', 'VObjectTypes.h'))
+  _generate_VObjectTypes_cpp(os.path.join(args.output_dirpath, 'src', 'SourceCompile', 'VObjectTypes.cpp'))
+  _generate_VObjectTypes_py_h(os.path.join(args.output_dirpath, 'src', 'API', 'VObjectTypes_py.h'))
+
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(_main())

--- a/scripts/scripts.pyproj
+++ b/scripts/scripts.pyproj
@@ -35,6 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="blacklisted.py" />
+    <Compile Include="generate_parser_listener.py" />
     <Compile Include="regression.py" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/API/PythonAPI.cpp
+++ b/src/API/PythonAPI.cpp
@@ -52,9 +52,9 @@
 
 #ifdef SURELOG_WITH_PYTHON
 #include "API/SV3_1aPythonListener.h"
+#include "API/VObjectTypes_py.h"
 #include "API/slapi_scripts.h"
 #include "API/slapi_wrap.cxx"
-#include "API/vobjecttypes_py.h"
 #endif
 
 namespace SURELOG {

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -386,7 +386,7 @@ bool PPCache::save() {
   auto defineList =
       m_pp->getCompileSourceFile()->getCommandLineParser()->getDefineList();
   std::vector<std::string> define_vec;
-  for (auto definePair : defineList) {
+  for (auto& definePair : defineList) {
     std::string spath =
         m_pp->getSymbol(definePair.first) + "=" + definePair.second;
     define_vec.push_back(spath);
@@ -396,7 +396,7 @@ bool PPCache::save() {
   /* Cache the `timescale directives */
   auto timeinfoList = m_pp->getCompilationUnit()->getTimeInfo();
   std::vector<flatbuffers::Offset<CACHE::TimeInfo>> timeinfo_vec;
-  for (auto info : timeinfoList) {
+  for (auto& info : timeinfoList) {
     if (info.m_fileId != m_pp->getFileId(0)) continue;
     auto timeInfo = CACHE::CreateTimeInfo(
         builder, static_cast<uint16_t>(info.m_type),

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -74,7 +74,7 @@ std::string FileContent::printObjects() const {
   std::string fileName = m_symbolTable->getSymbol(m_fileId);
   const std::string separator(1, fs::path::preferred_separator);
   text += "FILE: " + fileName + "\n";
-  for (auto object : m_objects) {
+  for (auto& object : m_objects) {
     text +=
         object.print(m_symbolTable, index, GetDefinitionFile(index), m_fileId);
     text += "\n";

--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -516,8 +516,9 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
         std::string name = fC->SymName(child).c_str();
         m_valueFactory.deleteValue(value);
         value = m_valueFactory.newStValue();
-        if (name.front() == '"' && name.back() == '"')
+        if (name.length() >= 2 && name.front() == '"' && name.back() == '"') {
           name = name.substr(1, name.length() - 2);
+        }
         value->set(name);
         break;
       }

--- a/src/Expression/Value.cpp
+++ b/src/Expression/Value.cpp
@@ -1840,8 +1840,10 @@ std::string StValue::uhdmValue() {
   else if (m_type == Type::Scalar)
     result = "SCAL:";
   // Remove '"' from the string
-  if (result == "STRING:" && m_value.front() == '"' && m_value.back() == '"')
+  if (result == "STRING:" && m_value.length() >= 2 && m_value.front() == '"' &&
+      m_value.back() == '"') {
     m_value = m_value.substr(1, m_value.length() - 2);
+  }
   result += m_value;
   return result;
 }

--- a/src/SourceCompile/CheckCompile.cpp
+++ b/src/SourceCompile/CheckCompile.cpp
@@ -100,7 +100,7 @@ bool CheckCompile::checkTimescale_() {
   std::unordered_set<SymbolId> reportedMissingTimeunit;
   for (auto fitr = all_files.begin(); fitr != all_files.end(); fitr++) {
     auto fileContent = (*fitr).second;
-    for (auto elem : fileContent->getDesignElements()) {
+    for (auto& elem : fileContent->getDesignElements()) {
       if (elem.m_type == DesignElement::Module ||
           elem.m_type == DesignElement::Interface ||
           elem.m_type == DesignElement::Package ||

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -555,7 +555,7 @@ void PreprocessFile::recordMacro(const std::string& name, unsigned int line,
 
 std::string PreprocessFile::reportIncludeInfo() {
   std::string report;
-  for (auto info : m_includeFileInfo) {
+  for (auto& info : m_includeFileInfo) {
     std::string type = (info.m_type == IncludeFileInfo::PUSH) ? "in" : "out";
     report += std::to_string(info.m_originalLine) + " " +
               getSymbol(info.m_sectionFile) + " " +

--- a/src/SourceCompile/generate_parser_listener.tcl
+++ b/src/SourceCompile/generate_parser_listener.tcl
@@ -36,7 +36,7 @@ set CPP_INPUT(PreProc)        "SourceCompile/SV3_1aPpTreeShapeListener.cpp"
 set HEADER_OUTPUT(PreProc)    "SourceCompile/SV3_1aPpTreeShapeListener.h"
 
 set VOBJECTTYPES_CPP_BASENAME "SourceCompile/VObjectTypes"
-set VOBJECTTYPES_PY_H         "API/vobjecttypes_py.h"
+set VOBJECTTYPES_PY_H         "API/VObjectTypes_py.h"
 
 puts "Creating Parser listener $HEADER_OUTPUT(Parser) and object types ${VOBJECTTYPES_CPP_BASENAME}"
 
@@ -528,7 +528,7 @@ puts $oid "\"\# DO NOT EDIT\\n\""
 
 set id 0
 foreach type [lsort -dictionary [array names TYPES]] {
-    puts $oid "\"$type = $id;\\n\""
+    puts $oid "\"$type = $id;\\n\","
     incr id
 }
 puts $oid "};"


### PR DESCRIPTION
Remove use of TCL from CI workflow, few changes from static analyzer,
few bug fixes, and python implementation of generate_parser_listener

IMPORTANT: CI Builds will now report a failure if python CI i.e. pymain.yml
reports a failure.

+ Transition to python
  * Fixed regression script to add support for unicode characters
  * Implemented generate_parser_listener
  * Removed traces of tcl & swift from pymain.yml

+ Command-line parser
  * For fully quoted command-line arguments remove quotes before
    processing it

+ Bug fixes
  * Check the length of the string before attempting to unquote it

+ Tcl scripts bug fixes
  * VObjectTypes_py.h content was being generated wrong. It was missing
    a comma so the vector contained merely one string instead of every
    type as a string. This is potentially unused code since python
    support has been long deprecated.