### PR TITLE
Fixed hardcoded output folder for tests

### DIFF
--- a/tests/TestBatchMode/batch.txt
+++ b/tests/TestBatchMode/batch.txt
@@ -1,2 +1,2 @@
--cd ../SimpleClass1 +incdir+.+../../third_party/UVM/uvm-1.2/src/ ../../third_party/UVM/uvm-1.2/src/uvm_pkg.sv -sverilog -writepp -parse -d inst top.v -l batch.log  -exe ../TestBatchMode/fake_command.exe  -o ../../build/tests/TestBatchMode/slpp_all/class1 
--cd ../SimpleClass2 +incdir+.+../../third_party/UVM/uvm-1.2/src/ ../../third_party/UVM/uvm-1.2/src/uvm_pkg.sv -sverilog -writepp -parse -d inst top.v -l batch.log -o ../../build/tests/TestBatchMode/slpp_all/class2 
+-cd ../SimpleClass1 +incdir+.+../../third_party/UVM/uvm-1.2/src/ ../../third_party/UVM/uvm-1.2/src/uvm_pkg.sv -sverilog -writepp -parse -d inst top.v -l batch.log -exe ../TestBatchMode/fake_command.exe -o ../../build/regression/TestBatchMode/slpp_all/class1
+-cd ../SimpleClass2 +incdir+.+../../third_party/UVM/uvm-1.2/src/ ../../third_party/UVM/uvm-1.2/src/uvm_pkg.sv -sverilog -writepp -parse -d inst top.v -l batch.log -o ../../build/regression/TestBatchMode/slpp_all/class2

--- a/third_party/antlr4_fast/runtime/Cpp/runtime/CMakeLists.txt
+++ b/third_party/antlr4_fast/runtime/Cpp/runtime/CMakeLists.txt
@@ -42,16 +42,16 @@ file(GLOB libantlrcpp_SRC
 add_library(antlr4_shared SHARED ${libantlrcpp_SRC})
 add_library(antlr4_static STATIC ${libantlrcpp_SRC})
 
-set(LIB_OUTPUT_DIR "${CMAKE_HOME_DIRECTORY}/dist") # put generated libraries here.
-message(STATUS "Output libraries to ${LIB_OUTPUT_DIR}")
-
-# make sure 'make' works fine even if ${LIB_OUTPUT_DIR} is deleted.
-add_custom_target(make_lib_output_dir ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${LIB_OUTPUT_DIR}
-    )
-
-add_dependencies(antlr4_shared make_lib_output_dir utfcpp)
-add_dependencies(antlr4_static make_lib_output_dir utfcpp)
+# set(LIB_OUTPUT_DIR "${CMAKE_HOME_DIRECTORY}/dist") # put generated libraries here.
+# message(STATUS "Output libraries to ${LIB_OUTPUT_DIR}")
+#
+# # make sure 'make' works fine even if ${LIB_OUTPUT_DIR} is deleted.
+# add_custom_target(make_lib_output_dir ALL
+#     COMMAND ${CMAKE_COMMAND} -E make_directory ${LIB_OUTPUT_DIR}
+#     )
+# 
+# add_dependencies(antlr4_shared make_lib_output_dir utfcpp)
+# add_dependencies(antlr4_static make_lib_output_dir utfcpp)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   target_link_libraries(antlr4_shared ${UUID_LIBRARIES})
@@ -104,18 +104,18 @@ set_target_properties(antlr4_shared
                       PROPERTIES VERSION   ${ANTLR_VERSION}
                                  SOVERSION ${ANTLR_VERSION}
                                  OUTPUT_NAME antlr4-runtime
-                                 LIBRARY_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
-                                 # TODO: test in windows. DLL is treated as runtime.
-                                 # see https://cmake.org/cmake/help/v3.0/prop_tgt/LIBRARY_OUTPUT_DIRECTORY.html
-                                 RUNTIME_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
-                                 ARCHIVE_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
+#                                  LIBRARY_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
+#                                  # TODO: test in windows. DLL is treated as runtime.
+#                                  # see https://cmake.org/cmake/help/v3.0/prop_tgt/LIBRARY_OUTPUT_DIRECTORY.html
+#                                  RUNTIME_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
+#                                  ARCHIVE_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
                                  COMPILE_FLAGS "${disabled_compile_warnings} ${extra_share_compile_flags}")
 
 set_target_properties(antlr4_static
                       PROPERTIES VERSION   ${ANTLR_VERSION}
                                  SOVERSION ${ANTLR_VERSION}
                                  OUTPUT_NAME "antlr4-runtime${static_lib_suffix}"
-                                 ARCHIVE_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
+#                                  ARCHIVE_OUTPUT_DIRECTORY ${LIB_OUTPUT_DIR}
                                  COMPILE_FLAGS "${disabled_compile_warnings} ${extra_static_compile_flags}")
 
 install(TARGETS antlr4_shared

--- a/third_party/tests/YosysOldTests/i2c/YosysOldI2c.sl
+++ b/third_party/tests/YosysOldTests/i2c/YosysOldI2c.sl
@@ -1,1 +1,1 @@
--parse -fileunit rtl/i2c_master_bit_ctrl.v rtl/i2c_master_byte_ctrl.v rtl/	i2c_master_top.v  +incdir+rtl/+. 
+-parse -fileunit rtl/i2c_master_bit_ctrl.v rtl/i2c_master_byte_ctrl.v rtl/i2c_master_top.v +incdir+rtl/+.


### PR DESCRIPTION
Antlr - Don't create the library in the dist folder. This creates problems for multi-configuration build systems.
Tests - Fixing two tests where the inputs provided had typos.