### PR TITLE
Use https instead of git to clone utfcpp

### DIFF
--- a/third_party/antlr4_fast/runtime/Cpp/runtime/CMakeLists.txt
+++ b/third_party/antlr4_fast/runtime/Cpp/runtime/CMakeLists.txt
@@ -5,7 +5,7 @@ set(THIRDPARTY_DIR ${CMAKE_BINARY_DIR}/runtime/thirdparty)
 set(UTFCPP_DIR ${THIRDPARTY_DIR}/utfcpp)
 ExternalProject_Add(
   utfcpp
-  GIT_REPOSITORY        "git://github.com/nemtrif/utfcpp"
+  GIT_REPOSITORY        "https://github.com/nemtrif/utfcpp"
   GIT_TAG               "v3.1.1"
   SOURCE_DIR            ${UTFCPP_DIR}
   UPDATE_DISCONNECTED   1


### PR DESCRIPTION
Github recently removed support for using git protocol unauthenticated: https://github.blog/2021-09-01-improving-git-protocol-security-github/.
This PR fixes clone of utfcpp, example error: https://github.com/hdl/conda-eda/runs/4772215688?check_suite_focus=true#step:3:1646
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>