### PR TITLE
Cleanup: don't spill 'fs' namespace shortcut into global namespace.

### DIFF
--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -33,6 +33,8 @@
 #include "flatbuffers/util.h"
 
 namespace SURELOG {
+namespace fs = std::filesystem;
+
 const std::string& Cache::getExecutableTimeStamp() {
   static const std::string sExecTstamp(__DATE__ "-" __TIME__);
   return sExecTstamp;
@@ -233,18 +235,18 @@ std::vector<CACHE::VObject> Cache::cacheVObjects(FileContent* fcontent,
     uint64_t field4 = 0;
     SymbolId name = canonicalSymbols.getId(fileTable.getSymbol(object.m_name));
     // clang-format off
-    field1 |= 0x0000000000FFFFFF & (name); 
-    field1 |= 0x0000000FFF000000 & (((uint64_t)object.m_type)      << (24));  
-    field1 |= 0x0000FFF000000000 & (((uint64_t)object.m_column)    << (24 + 12)); 
-    field1 |= 0xFFFF000000000000 & (((uint64_t)object.m_parent     << (24 + 12 + 12)));  
-    field2 |= 0x0000000000000FFF & (object.m_parent                >> (16));  
-    field2 |= 0x000000FFFFFFF000 & (((uint64_t)object.m_definition) << (12));  
-    field2 |= 0xFFFFFF0000000000 & (((uint64_t)object.m_child)     << (12 + 28)); 
-    field3 |= 0x000000000000000F & (((uint64_t)object.m_child)     >> (24));  
-    field3 |= 0x00000000FFFFFFF0 & (object.m_sibling               << (4)); 
-    field3 |= 0x00FFFFFF00000000 & (((uint64_t)object.m_fileId)    << (4 + 28)); 
+    field1 |= 0x0000000000FFFFFF & (name);
+    field1 |= 0x0000000FFF000000 & (((uint64_t)object.m_type)      << (24));
+    field1 |= 0x0000FFF000000000 & (((uint64_t)object.m_column)    << (24 + 12));
+    field1 |= 0xFFFF000000000000 & (((uint64_t)object.m_parent     << (24 + 12 + 12)));
+    field2 |= 0x0000000000000FFF & (object.m_parent                >> (16));
+    field2 |= 0x000000FFFFFFF000 & (((uint64_t)object.m_definition) << (12));
+    field2 |= 0xFFFFFF0000000000 & (((uint64_t)object.m_child)     << (12 + 28));
+    field3 |= 0x000000000000000F & (((uint64_t)object.m_child)     >> (24));
+    field3 |= 0x00000000FFFFFFF0 & (object.m_sibling               << (4));
+    field3 |= 0x00FFFFFF00000000 & (((uint64_t)object.m_fileId)    << (4 + 28));
     field3 |= 0xFF00000000000000 & (((uint64_t)object.m_line)      << (4 + 28 + 24));
-    field4 |= 0x000000000000FFFF & (((uint64_t)object.m_line)      >> (8));  
+    field4 |= 0x000000000000FFFF & (((uint64_t)object.m_line)      >> (8));
     field4 |= 0x000000FFFFFF0000 & (((uint64_t)object.m_endLine)   << (16));
     field4 |= 0x000FFF0000000000 & (((uint64_t)object.m_endColumn) << (16 + 24));
     // clang-format on

--- a/src/Cache/Cache.h
+++ b/src/Cache/Cache.h
@@ -46,22 +46,22 @@ class Cache {
 
   Cache() = default;
 
-  time_t get_mtime(const fs::path& path);
+  time_t get_mtime(const std::filesystem::path& path);
 
   const std::string& getExecutableTimeStamp();
 
-  uint8_t* openFlatBuffers(const fs::path& cacheFileName);
+  uint8_t* openFlatBuffers(const std::filesystem::path& cacheFileName);
 
   bool saveFlatbuffers(flatbuffers::FlatBufferBuilder& builder,
-                       const fs::path& cacheFileName);
+                       const std::filesystem::path& cacheFileName);
 
   bool checkIfCacheIsValid(const SURELOG::CACHE::Header* header,
                            std::string schemaVersion,
-                           const fs::path& cacheFileName);
+                           const std::filesystem::path& cacheFileName);
 
   const flatbuffers::Offset<SURELOG::CACHE::Header> createHeader(
       flatbuffers::FlatBufferBuilder& builder, std::string schemaVersion,
-      const fs::path& origFileName);
+      const std::filesystem::path& origFileName);
 
   std::pair<flatbuffers::Offset<VectorOffsetError>,
             flatbuffers::Offset<VectorOffsetString>>

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -43,6 +43,8 @@
 #include "flatbuffers/util.h"
 
 namespace SURELOG {
+namespace fs = std::filesystem;
+
 PPCache::PPCache(PreprocessFile* pp) : m_pp(pp), m_isPrecompiled(false) {}
 
 static const char FlbSchemaVersion[] = "1.0";

--- a/src/Cache/PPCache.h
+++ b/src/Cache/PPCache.h
@@ -41,9 +41,10 @@ class PPCache : Cache {
  private:
   PPCache(const PPCache& orig) = delete;
 
-  fs::path getCacheFileName_(const fs::path& fileName = "");
-  bool restore_(const fs::path& cacheFileName, bool errorsOnly);
-  bool checkCacheIsValid_(const fs::path& cacheFileName);
+  std::filesystem::path getCacheFileName_(
+      const std::filesystem::path& fileName = "");
+  bool restore_(const std::filesystem::path& cacheFileName, bool errorsOnly);
+  bool checkCacheIsValid_(const std::filesystem::path& cacheFileName);
 
   PreprocessFile* m_pp;
   bool m_isPrecompiled;

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -53,6 +53,8 @@
 #include "flatbuffers/util.h"
 
 namespace SURELOG {
+namespace fs = std::filesystem;
+
 ParseCache::ParseCache(ParseFile* parser)
     : m_parse(parser), m_isPrecompiled(false) {}
 

--- a/src/Cache/ParseCache.h
+++ b/src/Cache/ParseCache.h
@@ -40,9 +40,10 @@ class ParseCache : Cache {
  private:
   ParseCache(const ParseCache& orig) = delete;
 
-  fs::path getCacheFileName_(const fs::path& fileName = "");
-  bool restore_(const fs::path& cacheFileName);
-  bool checkCacheIsValid_(const fs::path& cacheFileName);
+  std::filesystem::path getCacheFileName_(
+      const std::filesystem::path& fileName = "");
+  bool restore_(const std::filesystem::path& cacheFileName);
+  bool checkCacheIsValid_(const std::filesystem::path& cacheFileName);
 
   ParseFile* m_parse;
   bool m_isPrecompiled;

--- a/src/Cache/PythonAPICache.cpp
+++ b/src/Cache/PythonAPICache.cpp
@@ -45,6 +45,8 @@
 #include "flatbuffers/util.h"
 
 namespace SURELOG {
+namespace fs = std::filesystem;
+
 static std::string FlbSchemaVersion = "1.0";
 
 PythonAPICache::PythonAPICache(PythonListen* listener) : m_listener(listener) {}

--- a/src/Cache/PythonAPICache.h
+++ b/src/Cache/PythonAPICache.h
@@ -41,9 +41,10 @@ class PythonAPICache : Cache {
  private:
   PythonAPICache(const PythonAPICache& orig) = delete;
 
-  fs::path getCacheFileName_(const fs::path& fileName = "") const;
-  bool restore_(const fs::path& cacheFileName);
-  bool checkCacheIsValid_(const fs::path& cacheFileName);
+  std::filesystem::path getCacheFileName_(
+      const std::filesystem::path& fileName = "") const;
+  bool restore_(const std::filesystem::path& cacheFileName);
+  bool checkCacheIsValid_(const std::filesystem::path& cacheFileName);
 
   PythonListen* m_listener;
 };

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -53,6 +53,8 @@
 #include "antlr4-runtime.h"
 
 namespace SURELOG {
+namespace fs = std::filesystem;
+
 static std::string_view defaultLogFileName = "surelog.log";
 
 // !!! Update this number when the grammar changes !!!

--- a/src/CommandLine/CommandLineParser.h
+++ b/src/CommandLine/CommandLineParser.h
@@ -32,8 +32,6 @@
 #include "ErrorReporting/ErrorContainer.h"
 #include "SourceCompile/SymbolTable.h"
 
-namespace fs = std::filesystem;
-
 namespace SURELOG {
 
 class CommandLineParser final {
@@ -178,12 +176,12 @@ class CommandLineParser final {
   bool createCache() const { return m_createCache; }
   const std::string currentDateTime();
   bool parseBuiltIn();
-  fs::path getBuiltInPath() const { return m_builtinPath; }
-  fs::path getExePath() const { return m_exePath; }
+  std::filesystem::path getBuiltInPath() const { return m_builtinPath; }
+  std::filesystem::path getExePath() const { return m_exePath; }
   std::string getExeCommand() const { return m_exeCommand; }
   std::set<std::string>& getTopLevelModules() { return m_topLevelModules; }
   bool fullSVMode() const { return m_sverilog; }
-  bool isSVFile(const fs::path& fileName) const;
+  bool isSVFile(const std::filesystem::path& fileName) const;
   bool cleanCache();
 
  private:
@@ -200,11 +198,11 @@ class CommandLineParser final {
   bool prepareCompilation_(int argc, const char** argv);
   bool setupCache_();
 
-  std::vector<SymbolId> m_libraryPaths;  // -y
-  std::vector<SymbolId> m_sourceFiles;   // .v .sv
-  std::set<fs::path> m_svSourceFiles;    // user forced sv files
-  std::vector<SymbolId> m_libraryFiles;  // -v
-  std::vector<SymbolId> m_includePaths;  // +incdir+
+  std::vector<SymbolId> m_libraryPaths;             // -y
+  std::vector<SymbolId> m_sourceFiles;              // .v .sv
+  std::set<std::filesystem::path> m_svSourceFiles;  // user forced sv files
+  std::vector<SymbolId> m_libraryFiles;             // -v
+  std::vector<SymbolId> m_includePaths;             // +incdir+
   std::set<SymbolId> m_includePathSet;
   std::vector<SymbolId> m_libraryExtensions;     // +libext+
   std::vector<SymbolId> m_orderedLibraries;      // -L <libName>
@@ -271,8 +269,8 @@ class CommandLineParser final {
   bool m_parseBuiltIn;
   bool m_ppOutputFileLocation;
   bool m_logFileSpecified;
-  fs::path m_builtinPath;
-  fs::path m_exePath;
+  std::filesystem::path m_builtinPath;
+  std::filesystem::path m_exePath;
   std::string m_exeCommand;
   std::set<std::string> m_topLevelModules;
   bool m_sverilog;

--- a/src/Design/DesignComponent.h
+++ b/src/Design/DesignComponent.h
@@ -36,8 +36,6 @@
 #include "SourceCompile/VObjectTypes.h"
 #include "Testbench/TypeDef.h"
 
-namespace fs = std::filesystem;
-
 namespace SURELOG {
 
 class Package;
@@ -50,7 +48,8 @@ class ParamAssign;
 class ExprEval {
  public:
   ExprEval(UHDM::expr* expr, ValuedComponentI* instance,
-           const fs::path& fileName, int lineNumber, UHDM::any* pexpr)
+           const std::filesystem::path& fileName, int lineNumber,
+           UHDM::any* pexpr)
       : m_expr(expr),
         m_instance(instance),
         m_fileName(fileName),
@@ -58,7 +57,7 @@ class ExprEval {
         m_pexpr(pexpr) {}
   UHDM::expr* m_expr;
   ValuedComponentI* m_instance;
-  fs::path m_fileName;
+  std::filesystem::path m_fileName;
   int m_lineNumber;
   UHDM::any* m_pexpr;
 };

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -35,8 +35,8 @@
 #include "Library/Library.h"
 #include "SourceCompile/SymbolTable.h"
 
-using namespace SURELOG;
-
+namespace SURELOG {
+namespace fs = std::filesystem;
 NodeId FileContent::getRootNode() {
   if (m_objects.size() == 0) {
     return 0;
@@ -570,3 +570,4 @@ const DesignElement* FileContent::getDesignElement(
   }
   return nullptr;
 }
+}  // namespace SURELOG

--- a/src/Design/FileContent.h
+++ b/src/Design/FileContent.h
@@ -36,8 +36,6 @@
 #include "Design/ValuedComponentI.h"
 #include "SourceCompile/VObjectTypes.h"
 
-namespace fs = std::filesystem;
-
 namespace SURELOG {
 
 class Library;
@@ -125,8 +123,8 @@ class FileContent : public DesignComponent {
   std::string printSubTree(NodeId parentIndex);  // Print subtree from parent
   std::string printObject(NodeId noedId) const;  // Only print that object
   std::vector<std::string> collectSubTree(NodeId uniqueId);  // Helper function
-  const fs::path getFileName(NodeId id) const;
-  fs::path getChunkFileName() {
+  const std::filesystem::path getFileName(NodeId id) const;
+  std::filesystem::path getChunkFileName() {
     return m_symbolTable->getSymbol(m_fileChunkId);
   }
   SymbolTable* getSymbolTable() { return m_symbolTable; }
@@ -216,7 +214,9 @@ class FileContent : public DesignComponent {
   const FileContent* getParent() const { return m_parentFile; }
   void setParent(FileContent* parent) { m_parentFile = parent; }
 
-  fs::path getFileName() const { return m_symbolTable->getSymbol(m_fileId); }
+  std::filesystem::path getFileName() const {
+    return m_symbolTable->getSymbol(m_fileId);
+  }
 
   bool diffTree(NodeId id, const FileContent* oFc, NodeId oId,
                 std::string* diff_out) const;

--- a/src/Design/ModuleInstance.h
+++ b/src/Design/ModuleInstance.h
@@ -58,7 +58,9 @@ class ModuleInstance : public ValuedComponentI {
   ModuleInstance* getParent() const { return m_parent; }
   const FileContent* getFileContent() const { return m_fileContent; }
   SymbolId getFileId() const { return m_fileContent->getFileId(m_nodeId); }
-  fs::path getFileName() const { return m_fileContent->getFileName(m_nodeId); }
+  std::filesystem::path getFileName() const {
+    return m_fileContent->getFileName(m_nodeId);
+  }
   NodeId getNodeId() const { return m_nodeId; }
   unsigned int getLineNb();
   unsigned short getColumnNb();

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -44,6 +44,7 @@
 #include <uhdm/uhdm.h>
 
 using namespace SURELOG;
+namespace fs = std::filesystem;
 
 int FunctorCompileClass::operator()() const {
   CompileClass* instance =

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -67,7 +67,8 @@
 
 #include <uhdm/vpi_visitor.h>
 
-using namespace SURELOG;
+namespace SURELOG {
+namespace fs = std::filesystem;
 
 CompileDesign::CompileDesign(Compiler* compiler) : m_compiler(compiler) {}
 CompileDesign::~CompileDesign() {
@@ -421,3 +422,4 @@ void decompile(ValuedComponentI* instance) {
     }
   }
 }
+}  // namespace SURELOG

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -63,6 +63,7 @@
 
 namespace SURELOG {
 using namespace UHDM;  // NOLINT (using a bunch of them)
+namespace fs = std::filesystem;
 
 bool CompileHelper::substituteAssignedValue(const UHDM::any* oper,
                                             CompileDesign* compileDesign) {

--- a/src/DesignCompile/CompileHelper.h
+++ b/src/DesignCompile/CompileHelper.h
@@ -422,22 +422,24 @@ class CompileHelper final {
   UHDM::expr* reduceExpr(UHDM::any* expr, bool& invalidValue,
                          DesignComponent* component,
                          CompileDesign* compileDesign,
-                         ValuedComponentI* instance, const fs::path& fileName,
-                         int lineNumber, UHDM::any* pexpr,
-                         bool muteErrors = false);
+                         ValuedComponentI* instance,
+                         const std::filesystem::path& fileName, int lineNumber,
+                         UHDM::any* pexpr, bool muteErrors = false);
 
   UHDM::expr* reduceCompOp(UHDM::operation* op, bool& invalidValue,
                            DesignComponent* component,
                            CompileDesign* compileDesign,
-                           ValuedComponentI* instance, const fs::path& fileName,
+                           ValuedComponentI* instance,
+                           const std::filesystem::path& fileName,
                            int lineNumber, UHDM::any* pexpr, bool muteErrors);
 
   UHDM::expr* reduceBitSelect(UHDM::expr* op, unsigned int index_val,
                               bool& invalidValue, DesignComponent* component,
                               CompileDesign* compileDesign,
                               ValuedComponentI* instance,
-                              const fs::path& fileName, int lineNumber,
-                              UHDM::any* pexpr, bool muteErrors);
+                              const std::filesystem::path& fileName,
+                              int lineNumber, UHDM::any* pexpr,
+                              bool muteErrors);
 
   UHDM::expr* expandPatternAssignment(UHDM::expr* lhs, UHDM::expr* rhs,
                                       DesignComponent* component,
@@ -446,8 +448,9 @@ class CompileHelper final {
 
   uint64_t Bits(const UHDM::any* typespec, bool& invalidValue,
                 DesignComponent* component, CompileDesign* compileDesign,
-                ValuedComponentI* instance, const fs::path& fileName,
-                int lineNumber, bool reduce, bool sizeMode);
+                ValuedComponentI* instance,
+                const std::filesystem::path& fileName, int lineNumber,
+                bool reduce, bool sizeMode);
 
   UHDM::variables* getSimpleVarFromTypespec(
       UHDM::typespec* spec, std::vector<UHDM::range*>* packedDimensions,
@@ -461,21 +464,22 @@ class CompileHelper final {
   UHDM::expr* EvalFunc(UHDM::function* func, std::vector<UHDM::any*>* args,
                        bool& invalidValue, DesignComponent* component,
                        CompileDesign* compileDesign, ValuedComponentI* instance,
-                       const fs::path& fileName, int lineNumber,
+                       const std::filesystem::path& fileName, int lineNumber,
                        UHDM::any* pexpr);
 
   void EvalStmt(const std::string& funcName, Scopes& scopes, bool& invalidValue,
                 bool& continue_flag, bool& break_flag,
                 DesignComponent* component, CompileDesign* compileDesign,
-                ValuedComponentI* instance, const fs::path& fileName,
-                int lineNumber, const UHDM::any* stmt);
+                ValuedComponentI* instance,
+                const std::filesystem::path& fileName, int lineNumber,
+                const UHDM::any* stmt);
 
   void evalScheduledExprs(DesignComponent* component,
                           CompileDesign* compileDesign);
 
   UHDM::any* getValue(const std::string& name, DesignComponent* component,
                       CompileDesign* compileDesign, ValuedComponentI* instance,
-                      const fs::path& fileName, int lineNumber,
+                      const std::filesystem::path& fileName, int lineNumber,
                       UHDM::any* pexpr, bool reduce, bool muteErrors = false);
 
   int64_t getValue(bool& validValue, DesignComponent* component,
@@ -510,24 +514,22 @@ class CompileHelper final {
                                const std::string& value,
                                CompileDesign* compileDesign,
                                ValuedComponentI* instance,
-                               const fs::path& fileName, unsigned int lineNo,
-                               unsigned short columnNo);
+                               const std::filesystem::path& fileName,
+                               unsigned int lineNo, unsigned short columnNo);
 
-  UHDM::any* hierarchicalSelector(std::vector<std::string>& select_path,
-                                  unsigned int level, UHDM::any* object,
-                                  bool& invalidValue,
-                                  DesignComponent* component,
-                                  CompileDesign* compileDesign,
-                                  ValuedComponentI* instance, UHDM::any* pexpr,
-                                  const fs::path& fileName, int lineNumber,
-                                  bool muteErrors, bool returnTypespec);
+  UHDM::any* hierarchicalSelector(
+      std::vector<std::string>& select_path, unsigned int level,
+      UHDM::any* object, bool& invalidValue, DesignComponent* component,
+      CompileDesign* compileDesign, ValuedComponentI* instance,
+      UHDM::any* pexpr, const std::filesystem::path& fileName, int lineNumber,
+      bool muteErrors, bool returnTypespec);
 
   UHDM::any* decodeHierPath(UHDM::hier_path* path, bool& invalidValue,
                             DesignComponent* component,
                             CompileDesign* compileDesign,
                             ValuedComponentI* instance,
-                            const fs::path& fileName, int lineNumber,
-                            UHDM::any* pexpr, bool muteErrors,
+                            const std::filesystem::path& fileName,
+                            int lineNumber, UHDM::any* pexpr, bool muteErrors,
                             bool returnTypespec);
 
   bool valueRange(Value* val, UHDM::typespec* tps, DesignComponent* component,
@@ -558,11 +560,11 @@ class CompileHelper final {
 
   // Caches
   UHDM::int_typespec* buildIntTypespec(
-      CompileDesign* compileDesign, const fs::path& fileName,
+      CompileDesign* compileDesign, const std::filesystem::path& fileName,
       const std::string& name, const std::string& value, unsigned int line,
       unsigned short column, unsigned int eline, unsigned short ecolumn);
   UHDM::typespec_member* buildTypespecMember(
-      CompileDesign* compileDesign, const fs::path& fileName,
+      CompileDesign* compileDesign, const std::filesystem::path& fileName,
       const std::string& name, const std::string& value, unsigned int line,
       unsigned short column, unsigned int eline, unsigned short ecolumn);
   std::unordered_map<std::string, UHDM::int_typespec*> m_cache_int_typespec;

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -56,6 +56,7 @@
 
 namespace SURELOG {
 using namespace UHDM;  // NOLINT (using a bunch of them)
+namespace fs = std::filesystem;
 
 variables* CompileHelper::getSimpleVarFromTypespec(
     UHDM::typespec* spec, std::vector<UHDM::range*>* packedDimensions,

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -60,8 +60,8 @@
 #include <uhdm/clone_tree.h>
 #include <uhdm/vpi_visitor.h>
 
-using namespace SURELOG;
-
+namespace SURELOG {
+namespace fs = std::filesystem;
 DesignElaboration::DesignElaboration(CompileDesign* compileDesign)
     : TestbenchElaboration(compileDesign) {
   m_moduleDefFactory = nullptr;
@@ -2306,3 +2306,4 @@ void DesignElaboration::createFileList_() {
     }
   }
 }
+}  // namespace SURELOG

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -61,7 +61,7 @@
 #include <uhdm/uhdm.h>
 
 namespace SURELOG {
-
+namespace fs = std::filesystem;
 using namespace UHDM;  // NOLINT (using a bunch of these)
 
 ElaborationStep::ElaborationStep(CompileDesign* compileDesign)

--- a/src/DesignCompile/EvalFunc.cpp
+++ b/src/DesignCompile/EvalFunc.cpp
@@ -56,6 +56,7 @@
 #include <uhdm/uhdm.h>
 
 namespace SURELOG {
+namespace fs = std::filesystem;
 using namespace UHDM;  // NOLINT (using a bunch of them)
 
 void CompileHelper::EvalStmt(const std::string& funcName, Scopes& scopes,

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -68,6 +68,7 @@
 #include <uhdm/uhdm.h>
 
 namespace SURELOG {
+namespace fs = std::filesystem;
 
 using namespace UHDM;  // NOLINT (using a bunch of these)
 

--- a/src/DesignCompile/NetlistElaboration.h
+++ b/src/DesignCompile/NetlistElaboration.h
@@ -56,15 +56,13 @@ class NetlistElaboration : public TestbenchElaboration {
   UHDM::interface* elab_interface_(
       ModuleInstance* instance, ModuleInstance* interf_instance,
       const std::string& instName, const std::string& defName,
-      ModuleDefinition* mod, const fs::path& fileName, int lineNb,
+      ModuleDefinition* mod, const std::filesystem::path& fileName, int lineNb,
       UHDM::interface_array* interf_array, const std::string& modPortName);
-  UHDM::modport* elab_modport_(ModuleInstance* instance,
-                               ModuleInstance* interfInstance,
-                               const std::string& instName,
-                               const std::string& defName,
-                               ModuleDefinition* mod, const fs::path& fileName,
-                               int lineNb, const std::string& modPortName,
-                               UHDM::interface_array* interf_array);
+  UHDM::modport* elab_modport_(
+      ModuleInstance* instance, ModuleInstance* interfInstance,
+      const std::string& instName, const std::string& defName,
+      ModuleDefinition* mod, const std::filesystem::path& fileName, int lineNb,
+      const std::string& modPortName, UHDM::interface_array* interf_array);
   bool elab_ports_nets_(ModuleInstance* instance, bool ports);
   bool elab_ports_nets_(ModuleInstance* instance, ModuleInstance* child,
                         Netlist* parentNetlist, Netlist* netlist,

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -38,7 +38,8 @@
 // UHDM
 #include <uhdm/uhdm.h>
 
-using namespace SURELOG;
+namespace SURELOG {
+namespace fs = std::filesystem;
 
 TestbenchElaboration::~TestbenchElaboration() {}
 
@@ -781,3 +782,4 @@ bool TestbenchElaboration::bindProperties_() {
   }
   return true;
 }
+}  // namespace SURELOG

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -64,6 +64,7 @@
 #include <uhdm/vpi_visitor.h>
 
 namespace SURELOG {
+namespace fs = std::filesystem;
 
 using UHDM::BaseClass;
 using UHDM::begin;

--- a/src/DesignCompile/UhdmChecker.h
+++ b/src/DesignCompile/UhdmChecker.h
@@ -45,9 +45,10 @@ class UhdmChecker final {
 
  private:
   bool registerFile(const FileContent* fC, std::set<std::string>& moduleNames);
-  bool reportHtml(CompileDesign* compileDesign, const fs::path& reportFile,
+  bool reportHtml(CompileDesign* compileDesign,
+                  const std::filesystem::path& reportFile,
                   float overallCoverage);
-  float reportCoverage(const fs::path& reportFile);
+  float reportCoverage(const std::filesystem::path& reportFile);
   void annotate(CompileDesign* m_compileDesign);
   void mergeColumnCoverage();
   CompileDesign* const m_compileDesign;
@@ -64,9 +65,9 @@ class UhdmChecker final {
   typedef std::map<LineNb, Ranges> RangesMap;
   typedef std::map<const FileContent*, RangesMap> FileNodeCoverMap;
   FileNodeCoverMap fileNodeCoverMap;
-  std::map<fs::path, const FileContent*> fileMap;
-  std::multimap<float, std::pair<fs::path, float>> coverageMap;
-  std::map<fs::path, float> fileCoverageMap;
+  std::map<std::filesystem::path, const FileContent*> fileMap;
+  std::multimap<float, std::pair<std::filesystem::path, float>> coverageMap;
+  std::map<std::filesystem::path, float> fileCoverageMap;
 };
 
 }  // namespace SURELOG

--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -39,9 +39,9 @@
 #endif
 #include <stdio.h>
 
+namespace SURELOG {
 namespace fs = std::filesystem;
 
-namespace SURELOG {
 ErrorContainer::ErrorContainer(SymbolTable* symbolTable,
                                LogListener* logListener /* = nullptr */)
     : m_clp(nullptr),

--- a/src/ErrorReporting/Report.cpp
+++ b/src/ErrorReporting/Report.cpp
@@ -37,7 +37,7 @@
 
 #include "ErrorReporting/ErrorContainer.h"
 
-using namespace SURELOG;
+namespace SURELOG {
 namespace fs = std::filesystem;
 
 struct Result {
@@ -167,3 +167,4 @@ std::pair<bool, bool> Report::makeDiffCompUnitReport(CommandLineParser* clp,
   // m.unlock();
   return std::make_pair(retval != -1, (!nbFatal) && (!nbSyntax));
 }
+}  // namespace SURELOG

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -41,7 +41,9 @@
 #include "parser/SV3_1aParser.h"
 
 using namespace antlr4;
-using namespace SURELOG;
+
+namespace SURELOG {
+namespace fs = std::filesystem;
 
 ParseLibraryDef::ParseLibraryDef(CommandLineParser* commandLineParser,
                                  ErrorContainer* errors,
@@ -289,3 +291,4 @@ bool ParseLibraryDef::parseConfigDefinition() {
 
   return true;
 }
+}  // namespace SURELOG

--- a/src/Library/SVLibShapeListener.cpp
+++ b/src/Library/SVLibShapeListener.cpp
@@ -37,7 +37,8 @@
 #include "antlr4-runtime.h"
 #include "atn/ParserATNSimulator.h"
 
-using namespace SURELOG;
+namespace SURELOG {
+namespace fs = std::filesystem;
 
 SVLibShapeListener::SVLibShapeListener(ParseLibraryDef *parser,
                                        antlr4::CommonTokenStream *tokens,
@@ -194,3 +195,4 @@ void SVLibShapeListener::exitHierarchical_identifier(
     logError(ErrorDefinition::PA_MAX_LENGTH_IDENTIFIER, ctx, ident);
   }
 }
+}  // namespace SURELOG

--- a/src/Library/SVLibShapeListener.h
+++ b/src/Library/SVLibShapeListener.h
@@ -33,7 +33,7 @@ class SVLibShapeListener : public SV3_1aParserBaseListener,
                            public SV3_1aTreeShapeHelper {
  public:
   SVLibShapeListener(ParseLibraryDef* parser, antlr4::CommonTokenStream* tokens,
-                     const fs::path& relativePath);
+                     const std::filesystem::path& relativePath);
 
   SymbolId registerSymbol(const std::string& symbol) final;
 
@@ -169,7 +169,7 @@ class SVLibShapeListener : public SV3_1aParserBaseListener,
   ParseLibraryDef* m_parser;
   antlr4::CommonTokenStream* m_tokens;
   Config* m_currentConfig;
-  const fs::path m_relativePath;
+  const std::filesystem::path m_relativePath;
 };
 
 };  // namespace SURELOG

--- a/src/Package/Precompiled.cpp
+++ b/src/Package/Precompiled.cpp
@@ -44,7 +44,8 @@ std::string Precompiled::getFileName(const std::string& packageName) const {
   return (found == m_packageMap.end()) ? "" : found->second;
 }
 
-bool Precompiled::isFilePrecompiled(const fs::path& fileName) const {
+bool Precompiled::isFilePrecompiled(
+    const std::filesystem::path& fileName) const {
   auto found = m_packageFileSet.find(fileName);
   return (found != m_packageFileSet.end());
 }

--- a/src/Package/Precompiled.h
+++ b/src/Package/Precompiled.h
@@ -28,8 +28,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-namespace fs = std::filesystem;
-
 class Precompiled final {
  public:
   static Precompiled* getSingleton();
@@ -38,7 +36,7 @@ class Precompiled final {
                       const std::string& fileName);
 
   std::string getFileName(const std::string& packageName) const;
-  bool isFilePrecompiled(const fs::path& fileName) const;
+  bool isFilePrecompiled(const std::filesystem::path& fileName) const;
   bool isPackagePrecompiled(const std::string& package) const;
 
  private:
@@ -46,13 +44,13 @@ class Precompiled final {
   Precompiled(const Precompiled&) = delete;
 
   struct fs_path_hash final {
-    std::size_t operator()(const fs::path& path) const {
-      return fs::hash_value(path);
+    std::size_t operator()(const std::filesystem::path& path) const {
+      return std::filesystem::hash_value(path);
     }
   };
 
   std::unordered_map<std::string, std::string> m_packageMap;
-  std::unordered_set<fs::path, fs_path_hash> m_packageFileSet;
+  std::unordered_set<std::filesystem::path, fs_path_hash> m_packageFileSet;
 };
 
 #endif /* PRECOMPILED_H */

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -46,7 +46,8 @@
 #include "SourceCompile/PreprocessFile.h"
 #include "Utils/StringUtils.h"
 
-using namespace SURELOG;
+namespace SURELOG {
+namespace fs = std::filesystem;
 
 static void saveContent(const fs::path& fileName, const std::string& content) {
   std::ifstream ifs;
@@ -761,3 +762,4 @@ void AnalyzeFile::analyze() {
     }
   }
 }
+}  // namespace SURELOG

--- a/src/SourceCompile/AnalyzeFile.h
+++ b/src/SourceCompile/AnalyzeFile.h
@@ -59,8 +59,9 @@ class AnalyzeFile {
   };
 
   AnalyzeFile(CommandLineParser* clp, Design* design,
-              const fs::path& ppFileName, const fs::path& fileName,
-              int nbChunks, const std::string& text = "")
+              const std::filesystem::path& ppFileName,
+              const std::filesystem::path& fileName, int nbChunks,
+              const std::string& text = "")
       : m_clp(clp),
         m_design(design),
         m_ppFileName(ppFileName),
@@ -69,7 +70,7 @@ class AnalyzeFile {
         m_text(text) {}
 
   void analyze();
-  std::vector<fs::path>& getSplitFiles() { return m_splitFiles; }
+  std::vector<std::filesystem::path>& getSplitFiles() { return m_splitFiles; }
   std::vector<unsigned int>& getLineOffsets() { return m_lineOffsets; }
 
   AnalyzeFile(const AnalyzeFile& orig) = delete;
@@ -79,13 +80,13 @@ class AnalyzeFile {
   void checkSLlineDirective_(std::string line, unsigned int lineNb);
   std::string setSLlineDirective_(unsigned int lineNb,
                                   unsigned int& origFromLine,
-                                  fs::path& origFile);
+                                  std::filesystem::path& origFile);
   CommandLineParser* m_clp;
   Design* m_design;
-  fs::path m_ppFileName;
-  fs::path m_fileName;
+  std::filesystem::path m_ppFileName;
+  std::filesystem::path m_fileName;
   std::vector<FileChunk> m_fileChunks;
-  std::vector<fs::path> m_splitFiles;
+  std::vector<std::filesystem::path> m_splitFiles;
   std::vector<unsigned int> m_lineOffsets;
   int m_nbChunks;
   std::stack<IncludeFileInfo> m_includeFileInfo;

--- a/src/SourceCompile/CompileSourceFile.cpp
+++ b/src/SourceCompile/CompileSourceFile.cpp
@@ -49,7 +49,9 @@
 #include "parser/SV3_1aParser.h"
 
 using namespace antlr4;
-using namespace SURELOG;
+
+namespace SURELOG {
+namespace fs = std::filesystem;
 
 CompileSourceFile::CompileSourceFile(SymbolId fileId, CommandLineParser* clp,
                                      ErrorContainer* errors, Compiler* compiler,
@@ -348,3 +350,4 @@ void CompileSourceFile::shutdownPythonInterp() {
   m_interpState = nullptr;
 }
 #endif
+}  // namespace SURELOG

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -65,6 +65,8 @@
 #include "antlr4-runtime.h"
 
 namespace SURELOG {
+namespace fs = std::filesystem;
+
 Compiler::Compiler(CommandLineParser* commandLineParser, ErrorContainer* errors,
                    SymbolTable* symbolTable)
     : m_commandLineParser(commandLineParser),

--- a/src/SourceCompile/Compiler.h
+++ b/src/SourceCompile/Compiler.h
@@ -87,7 +87,8 @@ class Compiler {
   CompileDesign* getCompileDesign() { return m_compileDesign; }
   ErrorContainer::Stats getErrorStats() const;
   bool isLibraryFile(SymbolId id) const;
-  const std::map<fs::path, std::vector<fs::path>>& getPPFileMap() {
+  const std::map<std::filesystem::path, std::vector<std::filesystem::path>>&
+  getPPFileMap() {
     return ppFileMap;
   }
 #ifdef USETBB
@@ -128,7 +129,7 @@ class Compiler {
   std::set<SymbolId> m_libraryFiles;  // -v <file>
   std::string m_text;                 // unit tests
   CompileDesign* m_compileDesign;
-  std::map<fs::path, std::vector<fs::path>> ppFileMap;
+  std::map<std::filesystem::path, std::vector<std::filesystem::path>> ppFileMap;
 #ifdef USETBB
   tbb::task_group m_taskGroup;
 #endif

--- a/src/SourceCompile/ParseFile.cpp
+++ b/src/SourceCompile/ParseFile.cpp
@@ -50,6 +50,8 @@
 #include "parser/SV3_1aParserBaseListener.h"
 
 namespace SURELOG {
+namespace fs = std::filesystem;
+
 ParseFile::ParseFile(SymbolId fileId, SymbolTable* symbolTable,
                      ErrorContainer* errors)
     : m_fileId(fileId),

--- a/src/SourceCompile/ParseFile.h
+++ b/src/SourceCompile/ParseFile.h
@@ -67,8 +67,8 @@ class ParseFile {
   CompileSourceFile* getCompileSourceFile() { return m_compileSourceFile; }
   CompilationUnit* getCompilationUnit() { return m_compilationUnit; }
   Library* getLibrary() { return m_library; }
-  const fs::path getFileName(unsigned int line);
-  const fs::path getPpFileName() { return getSymbol(m_ppFileId); }
+  const std::filesystem::path getFileName(unsigned int line);
+  const std::filesystem::path getPpFileName() { return getSymbol(m_ppFileId); }
   SymbolTable* getSymbolTable();
   ErrorContainer* getErrorContainer();
   SymbolId getFileId(unsigned int line);

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -55,6 +55,7 @@
 using namespace antlr4;
 
 namespace SURELOG {
+namespace fs = std::filesystem;
 const char* const PreprocessFile::MacroNotDefined = "SURELOG_MACRO_NOT_DEFINED";
 const char* const PreprocessFile::PP__Line__Marking = "SURELOG__LINE__MARKING";
 const char* const PreprocessFile::PP__File__Marking = "SURELOG__FILE__MARKING";

--- a/src/SourceCompile/PreprocessFile.h
+++ b/src/SourceCompile/PreprocessFile.h
@@ -39,8 +39,6 @@
 #include "parser/SV3_1aPpLexer.h"
 #include "parser/SV3_1aPpParser.h"
 
-namespace fs = std::filesystem;
-
 namespace SURELOG {
 
 class SV3_1aPpTreeShapeListener;
@@ -108,7 +106,7 @@ class PreprocessFile {
   const MacroStorage& getMacros() { return m_macros; }
   MacroInfo* getMacro(const std::string& name);
 
-  fs::path getFileName(unsigned int line);
+  std::filesystem::path getFileName(unsigned int line);
 
   std::string reportIncludeInfo();
 

--- a/src/Utils/FileUtils.cpp
+++ b/src/Utils/FileUtils.cpp
@@ -40,6 +40,8 @@
 #include "Utils/StringUtils.h"
 
 namespace SURELOG {
+namespace fs = std::filesystem;
+
 bool FileUtils::fileExists(const fs::path& name) {
   std::error_code ec;
   return fs::exists(name, ec);
@@ -103,11 +105,6 @@ bool FileUtils::getFullPath(const fs::path& path, fs::path* result) {
     *result = found ? fullPath : path;
   }
   return found;
-}
-
-static bool has_suffix(std::string_view s, std::string_view suffix) {
-  return (s.size() >= suffix.size()) &&
-         equal(suffix.rbegin(), suffix.rend(), s.rbegin());
 }
 
 std::vector<SymbolId> FileUtils::collectFiles(SymbolId dirPath, SymbolId ext,
@@ -194,7 +191,7 @@ std::vector<SymbolId> FileUtils::collectFiles(const fs::path& pathSpec,
       fs::directory_options::skip_permission_denied |
       fs::directory_options::follow_directory_symlink;
 
-  for (fs::directory_entry entry :
+  for (const fs::directory_entry& entry :
        fs::recursive_directory_iterator(prefix, options)) {
     if (fs::is_regular_file(entry.path())) {
       const std::string relative =

--- a/src/Utils/FileUtils.h
+++ b/src/Utils/FileUtils.h
@@ -30,8 +30,6 @@
 #include <string_view>
 #include <vector>
 
-namespace fs = std::filesystem;
-
 namespace SURELOG {
 
 typedef uint64_t SymbolId;
@@ -39,34 +37,37 @@ class SymbolTable;
 
 class FileUtils final {
  public:
-  static bool fileExists(const fs::path& name);
-  static bool fileIsRegular(const fs::path& name);
-  static bool fileIsDirectory(const fs::path& name);
+  static bool fileExists(const std::filesystem::path& name);
+  static bool fileIsRegular(const std::filesystem::path& name);
+  static bool fileIsDirectory(const std::filesystem::path& name);
 
   // Find file whose name is available in the SymbolTable either in
   // the current directory or under each of the paths.
   // If found, return the symbolID representing that file.
   static SymbolId locateFile(SymbolId file, SymbolTable* symbols,
                              const std::vector<SymbolId>& paths);
-  static bool mkDirs(const fs::path& path);
-  static bool rmDirRecursively(const fs::path& path);
-  static fs::path getFullPath(const fs::path& path);
-  static bool getFullPath(const fs::path& path, fs::path* result);
-  static fs::path getPathName(const fs::path& path);
-  static fs::path basename(const fs::path& str);
-  static uint64_t fileSize(const fs::path& name);
-  static std::string hashPath(const fs::path& path);
-  static std::vector<SymbolId> collectFiles(const fs::path& dirPath,
-                                            const fs::path& extension,
-                                            SymbolTable* symbols);
+  static bool mkDirs(const std::filesystem::path& path);
+  static bool rmDirRecursively(const std::filesystem::path& path);
+  static std::filesystem::path getFullPath(const std::filesystem::path& path);
+  static bool getFullPath(const std::filesystem::path& path,
+                          std::filesystem::path* result);
+  static std::filesystem::path getPathName(const std::filesystem::path& path);
+  static std::filesystem::path basename(const std::filesystem::path& str);
+  static uint64_t fileSize(const std::filesystem::path& name);
+  static std::string hashPath(const std::filesystem::path& path);
+  static std::vector<SymbolId> collectFiles(
+      const std::filesystem::path& dirPath,
+      const std::filesystem::path& extension, SymbolTable* symbols);
   static std::vector<SymbolId> collectFiles(SymbolId dirPath,
                                             SymbolId extension,
                                             SymbolTable* symbols);
-  static std::vector<SymbolId> collectFiles(const fs::path& pathSpec,
-                                            SymbolTable* symbols);
-  static std::string getFileContent(const fs::path& name);
-  static fs::path makeRelativePath(const fs::path& path);
-  static fs::path getPreferredPath(const fs::path& path);
+  static std::vector<SymbolId> collectFiles(
+      const std::filesystem::path& pathSpec, SymbolTable* symbols);
+  static std::string getFileContent(const std::filesystem::path& name);
+  static std::filesystem::path makeRelativePath(
+      const std::filesystem::path& path);
+  static std::filesystem::path getPreferredPath(
+      const std::filesystem::path& path);
 
  private:
   FileUtils() = delete;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,8 @@
 #include "Utils/StringUtils.h"
 #include "surelog.h"
 
+namespace fs = std::filesystem;
+
 unsigned int executeCompilation(
     int argc, const char** argv, bool diff_comp_mode, bool fileunit,
     SURELOG::ErrorContainer::Stats* overallStats = nullptr) {


### PR DESCRIPTION
We should never put namespace abbreviations in header files in
the global namespace. One alternative would be to put them inside
our namespace (SURELOG::fs::), but the cleanest is to never use
it in the headers, only *.cpp compilation units.

Signed-off-by: Henner Zeller <h.zeller@acm.org>