### PR TITLE
Enable clang-tidy for selected findings; fix these findings.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -633,8 +633,8 @@ jobs:
         make run-cmake-release
         make -j2 -C build GenerateParser
         make -j2 -C build GenerateSerializer
-        ln -s build/compile_commands.json .
+        ln -sf build/compile_commands.json .
 
     - name: Run clang tidy
       run: |
-        ./.github/bin/run-clang-tidy.sh
+        ./.github/bin/run-clang-tidy.sh limited

--- a/src/Design/DataType.h
+++ b/src/Design/DataType.h
@@ -72,7 +72,7 @@ class DataType : public RTTI {
     m_type = type;
     m_is_parameter = isParameter;
   }
-  virtual ~DataType() = default;
+  ~DataType() override = default;
 
   const FileContent* getFileContent() const { return m_fileContent; }
 

--- a/src/Design/ModuleInstance.h
+++ b/src/Design/ModuleInstance.h
@@ -94,7 +94,7 @@ class ModuleInstance : public ValuedComponentI {
   bool isOverridenParam(const std::string& name);
 
   // DO NOT change the signature of this method, it is used in gdb for debug.
-  std::string decompile(char* valueName);
+  std::string decompile(char* valueName) final;
 
   ModuleInstance* getChildByName(const std::string& name);
 

--- a/src/Design/Scope.h
+++ b/src/Design/Scope.h
@@ -47,7 +47,7 @@ class Scope : public RTTI {
 
   Scope(const std::string& name, Scope* parent)
       : m_name(name), m_parentScope(parent) {}
-  virtual ~Scope() {}
+  ~Scope() override {}
 
   const std::string& getName() const { return m_name; }
   Scope* getParentScope() { return m_parentScope; }

--- a/src/Design/Statement.h
+++ b/src/Design/Statement.h
@@ -46,7 +46,7 @@ class Statement : public RTTI {
         m_fileContent(fileContent),
         m_nodeId(node),
         m_type(type) {}
-  virtual ~Statement();
+  ~Statement() override;
 
   Scope* getScope() { return m_scope; }
   Statement* getParentStmt() { return m_parent; }

--- a/src/Design/ValuedComponentI.h
+++ b/src/Design/ValuedComponentI.h
@@ -43,7 +43,7 @@ class ValuedComponentI : public RTTI {
                    ValuedComponentI* definition)
       : m_parentScope(parentScope), m_definition(definition){};
 
-  virtual ~ValuedComponentI(){};
+  ~ValuedComponentI() override{};
 
   virtual Value* getValue(const std::string& name) const;
   virtual Value* getValue(const std::string& name,

--- a/src/DesignCompile/NetlistElaboration.h
+++ b/src/DesignCompile/NetlistElaboration.h
@@ -42,7 +42,7 @@ class NetlistElaboration : public TestbenchElaboration {
   bool elaboratePackages();
   bool elaborateInstance(ModuleInstance* instance);
 
-  virtual ~NetlistElaboration() override;
+  ~NetlistElaboration() override;
   void elabSignal(Signal* sig, ModuleInstance* instance, ModuleInstance* child,
                   Netlist* parentNetlist, Netlist* netlist,
                   DesignComponent* comp, const std::string& prefix);

--- a/src/Expression/Value.h
+++ b/src/Expression/Value.h
@@ -56,7 +56,7 @@ class Value : public RTTI {
     Scalar
   };
 
-  virtual ~Value() {}
+  ~Value() override {}
 
   virtual short getSize() const = 0;  // size in bits
   virtual short getSize(
@@ -191,7 +191,7 @@ class SValue : public Value {
 
   short getSize() const final { return m_size; }
   short getSize(unsigned int wordIndex) const final { return m_size; }
-  void setRange(unsigned short lrange, unsigned short rrange) {
+  void setRange(unsigned short lrange, unsigned short rrange) final {
     m_lrange = lrange;
     m_rrange = rrange;
   }
@@ -348,7 +348,7 @@ class LValue : public Value {
     } else
       return 0;
   }
-  void setRange(unsigned short lrange, unsigned short rrange) {
+  void setRange(unsigned short lrange, unsigned short rrange) final {
     m_lrange = lrange;
     m_rrange = rrange;
   }
@@ -444,7 +444,7 @@ class StValue : public Value {
 
   short getSize() const final { return m_size; }
   short getSize(unsigned int wordIndex) const final { return m_size; }
-  void setRange(unsigned short lrange, unsigned short rrange) {}
+  void setRange(unsigned short lrange, unsigned short rrange) final {}
   unsigned short getLRange() const final { return 0; };
   unsigned short getRRange() const final { return 0; };
   unsigned short getNbWords() const final { return 1; }

--- a/src/Testbench/ClassDefinition.h
+++ b/src/Testbench/ClassDefinition.h
@@ -81,7 +81,7 @@ class ClassDefinition : public DesignComponent, public DataType {
 
   const TaskMap& getTaskMap() const { return m_tasks; }
   TaskMap& getMutableTaskMap() { return m_tasks; }
-  TaskMethod* getTask(const std::string& name) const;
+  TaskMethod* getTask(const std::string& name) const override;
   void insertTask(TaskMethod* p);
 
   ConstraintMap& getConstraintMap() { return m_constraints; }


### PR DESCRIPTION
To have the clang-tidy run have any impact, we need to fix the
findings to get the code to improve. Since there are many hundred
findings currently, let's do this one-by-one.

In this round: fix override/final.
Then enable clang-tidy run for just this particular warning and
make this fail in the CI if new findings happen.

That way, we can over time fix one thing at the time and then
enable the corresponding check to keep in check in the future.

To run clang-tidy with all findings, simply run
  .github/bin/run-clang-tidy.sh

.. and to only run with the limnited set of findings run
  .github/bin/run-clang-tidy.sh limited
(this is what the CI is running)

Signed-off-by: Henner Zeller <h.zeller@acm.org>