### PR TITLE
generate stmt grammar

### DIFF
--- a/tests/Checker/Checker.log
+++ b/tests/Checker/Checker.log
@@ -2,8 +2,8 @@
 
 LIB:  work
 FILE: dut.sv
-n<> u<0> t<Null_rule> p<601> s<600> l<1:1> el<1:0>
-n<assert_window1> u<1> t<StringConst> p<433> s<83> l<1:9> el<1:23>
+n<> u<0> t<Null_rule> p<600> s<599> l<1:1> el<1:0>
+n<assert_window1> u<1> t<StringConst> p<432> s<83> l<1:9> el<1:23>
 n<> u<2> t<IntVec_TypeLogic> p<3> l<2:3> el<2:8>
 n<> u<3> t<Data_type> p<4> c<2> l<2:3> el<2:8>
 n<> u<4> t<Data_type_or_implicit> p<5> c<3> l<2:3> el<2:8>
@@ -85,21 +85,21 @@ n<> u<79> t<Sequence_expr> p<80> c<78> l<10:27> el<10:36>
 n<> u<80> t<Property_expr> p<81> c<79> l<10:27> el<10:36>
 n<> u<81> t<Property_actual_arg> p<82> c<80> l<10:27> el<10:36>
 n<> u<82> t<Checker_port_item> p<83> c<72> l<10:3> el<10:36>
-n<> u<83> t<Checker_port_list> p<433> c<8> s<90> l<2:3> el<10:36>
+n<> u<83> t<Checker_port_list> p<432> c<8> s<90> l<2:3> el<10:36>
 n<clock> u<84> t<StringConst> p<85> l<14:21> el<14:26>
 n<> u<85> t<Clocking_event> p<88> c<84> s<87> l<14:20> el<14:26>
 n<> u<86> t<Default> p<88> s<85> l<14:3> el<14:10>
 n<> u<87> t<Endclocking> p<88> l<14:28> el<14:39>
 n<> u<88> t<Clocking_declaration> p<89> c<86> l<14:3> el<14:39>
 n<> u<89> t<Checker_or_generate_item_declaration> p<90> c<88> l<14:3> el<14:39>
-n<> u<90> t<Checker_or_generate_item> p<433> c<89> s<97> l<14:3> el<14:39>
+n<> u<90> t<Checker_or_generate_item> p<432> c<89> s<97> l<14:3> el<14:39>
 n<reset> u<91> t<StringConst> p<92> l<15:23> el<15:28>
 n<> u<92> t<Primary_literal> p<93> c<91> l<15:23> el<15:28>
 n<> u<93> t<Primary> p<94> c<92> l<15:23> el<15:28>
 n<> u<94> t<Expression> p<95> c<93> l<15:23> el<15:28>
 n<> u<95> t<Expression_or_dist> p<96> c<94> l<15:23> el<15:28>
 n<> u<96> t<Checker_or_generate_item_declaration> p<97> c<95> l<15:3> el<15:29>
-n<> u<97> t<Checker_or_generate_item> p<433> c<96> s<116> l<15:3> el<15:29>
+n<> u<97> t<Checker_or_generate_item> p<432> c<96> s<116> l<15:3> el<15:29>
 n<> u<98> t<IntVec_TypeBit> p<99> l<16:3> el<16:6>
 n<> u<99> t<Data_type> p<113> c<98> s<112> l<16:3> el<16:6>
 n<window> u<100> t<StringConst> p<105> s<104> l<16:7> el<16:13>
@@ -118,7 +118,7 @@ n<> u<112> t<List_of_variable_decl_assignments> p<113> c<105> l<16:7> el<16:40>
 n<> u<113> t<Variable_declaration> p<114> c<99> l<16:3> el<16:41>
 n<> u<114> t<Data_declaration> p<115> c<113> l<16:3> el<16:41>
 n<> u<115> t<Checker_or_generate_item_declaration> p<116> c<114> l<16:3> el<16:41>
-n<> u<116> t<Checker_or_generate_item> p<433> c<115> s<208> l<16:3> el<16:41>
+n<> u<116> t<Checker_or_generate_item> p<432> c<115> s<208> l<16:3> el<16:41>
 n<> u<117> t<AlwaysKeywd_Comb> p<207> s<206> l<18:3> el<18:14>
 n<reset> u<118> t<StringConst> p<119> l<19:9> el<19:14>
 n<> u<119> t<Primary_literal> p<120> c<118> l<19:9> el<19:14>
@@ -210,7 +210,7 @@ n<> u<204> t<Seq_block> p<205> c<202> l<18:15> el<25:8>
 n<> u<205> t<Statement_item> p<206> c<204> l<18:15> el<25:8>
 n<> u<206> t<Statement> p<207> c<205> l<18:15> el<25:8>
 n<> u<207> t<Always_construct> p<208> c<117> l<18:3> el<25:8>
-n<> u<208> t<Checker_or_generate_item> p<433> c<207> s<231> l<18:3> el<25:8>
+n<> u<208> t<Checker_or_generate_item> p<432> c<207> s<231> l<18:3> el<25:8>
 n<> u<209> t<AlwaysKeywd_FF> p<230> s<229> l<27:3> el<27:12>
 n<clock> u<210> t<StringConst> p<211> l<27:14> el<27:19>
 n<> u<211> t<Ps_or_hierarchical_identifier> p<212> c<210> l<27:14> el<27:19>
@@ -233,7 +233,7 @@ n<> u<227> t<Procedural_timing_control_statement> p<228> c<213> l<27:13> el<28:2
 n<> u<228> t<Statement_item> p<229> c<227> l<27:13> el<28:27>
 n<> u<229> t<Statement> p<230> c<228> l<27:13> el<28:27>
 n<> u<230> t<Always_construct> p<231> c<209> l<27:3> el<28:27>
-n<> u<231> t<Checker_or_generate_item> p<433> c<230> s<272> l<27:3> el<28:27>
+n<> u<231> t<Checker_or_generate_item> p<432> c<230> s<272> l<27:3> el<28:27>
 n<p_window> u<232> t<StringConst> p<269> s<267> l<30:12> el<30:20>
 n<start_event> u<233> t<StringConst> p<234> l<31:5> el<31:16>
 n<> u<234> t<Primary_literal> p<235> c<233> l<31:5> el<31:16>
@@ -274,7 +274,7 @@ n<> u<268> t<Endproperty> p<269> l<32:3> el<32:14>
 n<> u<269> t<Property_declaration> p<270> c<232> l<30:3> el<32:14>
 n<> u<270> t<Assertion_item_declaration> p<271> c<269> l<30:3> el<32:14>
 n<> u<271> t<Checker_or_generate_item_declaration> p<272> c<270> l<30:3> el<32:14>
-n<> u<272> t<Checker_or_generate_item> p<433> c<271> s<300> l<30:3> el<32:14>
+n<> u<272> t<Checker_or_generate_item> p<432> c<271> s<300> l<30:3> el<32:14>
 n<a_window> u<273> t<StringConst> p<298> s<297> l<34:3> el<34:11>
 n<p_window> u<274> t<StringConst> p<275> l<34:30> el<34:38>
 n<> u<275> t<Primary_literal> p<276> c<274> l<34:30> el<34:38>
@@ -302,7 +302,7 @@ n<> u<296> t<Assert_property_statement> p<297> c<281> l<34:13> el<34:63>
 n<> u<297> t<Concurrent_assertion_statement> p<298> c<296> l<34:13> el<34:63>
 n<> u<298> t<Concurrent_assertion_item> p<299> c<273> l<34:3> el<34:63>
 n<> u<299> t<Assertion_item> p<300> c<298> l<34:3> el<34:63>
-n<> u<300> t<Checker_or_generate_item> p<433> c<299> s<430> l<34:3> el<34:63>
+n<> u<300> t<Checker_or_generate_item> p<432> c<299> s<429> l<34:3> el<34:63>
 n<clevel> u<301> t<StringConst> p<302> l<36:16> el<36:22>
 n<> u<302> t<Primary_literal> p<303> c<301> l<36:16> el<36:22>
 n<> u<303> t<Constant_primary> p<304> c<302> l<36:16> el<36:22>
@@ -312,8 +312,8 @@ n<> u<306> t<Primary_literal> p<307> c<305> l<36:26> el<36:36>
 n<> u<307> t<Constant_primary> p<308> c<306> l<36:26> el<36:36>
 n<> u<308> t<Constant_expression> p<310> c<307> l<36:26> el<36:36>
 n<> u<309> t<BinOp_Not> p<310> s<308> l<36:23> el<36:25>
-n<> u<310> t<Constant_expression> p<422> c<304> s<421> l<36:16> el<36:36>
-n<cover_b> u<311> t<StringConst> p<421> s<347> l<36:46> el<36:53>
+n<> u<310> t<Constant_expression> p<420> c<304> s<419> l<36:16> el<36:36>
+n<cover_b> u<311> t<StringConst> p<419> s<346> l<36:46> el<36:53>
 n<cover_window_open> u<312> t<StringConst> p<343> s<342> l<37:5> el<37:22>
 n<start_event> u<313> t<StringConst> p<314> l<37:40> el<37:51>
 n<> u<314> t<Primary_literal> p<315> c<313> l<37:40> el<37:51>
@@ -347,263 +347,262 @@ n<> u<341> t<Cover_property_statement> p<342> c<328> l<37:24> el<37:96>
 n<> u<342> t<Concurrent_assertion_statement> p<343> c<341> l<37:24> el<37:96>
 n<> u<343> t<Concurrent_assertion_item> p<344> c<312> l<37:5> el<37:96>
 n<> u<344> t<Assertion_item> p<345> c<343> l<37:5> el<37:96>
-n<> u<345> t<Module_common_item> p<346> c<344> l<37:5> el<37:96>
-n<> u<346> t<Module_or_generate_item> p<347> c<345> l<37:5> el<37:96>
-n<> u<347> t<Generate_item> p<421> c<346> s<418> l<37:5> el<37:96>
-n<cover_window> u<348> t<StringConst> p<414> s<413> l<39:5> el<39:17>
-n<start_event> u<349> t<StringConst> p<350> l<40:7> el<40:18>
-n<> u<350> t<Primary_literal> p<351> c<349> l<40:7> el<40:18>
-n<> u<351> t<Primary> p<352> c<350> l<40:7> el<40:18>
-n<> u<352> t<Expression> p<360> c<351> s<359> l<40:7> el<40:18>
-n<window> u<353> t<StringConst> p<354> l<40:23> el<40:29>
-n<> u<354> t<Primary_literal> p<355> c<353> l<40:23> el<40:29>
-n<> u<355> t<Primary> p<356> c<354> l<40:23> el<40:29>
-n<> u<356> t<Expression> p<358> c<355> l<40:23> el<40:29>
-n<> u<357> t<Unary_Not> p<358> s<356> l<40:22> el<40:23>
-n<> u<358> t<Expression> p<360> c<357> l<40:22> el<40:29>
-n<> u<359> t<BinOp_LogicAnd> p<360> s<358> l<40:19> el<40:21>
-n<> u<360> t<Expression> p<361> c<352> l<40:7> el<40:29>
-n<> u<361> t<Expression_or_dist> p<362> c<360> l<40:7> el<40:29>
-n<> u<362> t<Sequence_expr> p<397> c<361> s<364> l<40:7> el<40:29>
-n<##1> u<363> t<Pound_Pound_delay> p<364> l<41:7> el<41:10>
-n<> u<364> t<Cycle_delay_range> p<397> c<363> s<396> l<41:7> el<41:10>
-n<end_event> u<365> t<StringConst> p<366> l<41:13> el<41:22>
-n<> u<366> t<Primary_literal> p<367> c<365> l<41:13> el<41:22>
-n<> u<367> t<Primary> p<368> c<366> l<41:13> el<41:22>
-n<> u<368> t<Expression> p<370> c<367> l<41:13> el<41:22>
-n<> u<369> t<Unary_Not> p<370> s<368> l<41:12> el<41:13>
-n<> u<370> t<Expression> p<376> c<369> s<375> l<41:12> el<41:22>
-n<window> u<371> t<StringConst> p<372> l<41:26> el<41:32>
-n<> u<372> t<Primary_literal> p<373> c<371> l<41:26> el<41:32>
-n<> u<373> t<Primary> p<374> c<372> l<41:26> el<41:32>
-n<> u<374> t<Expression> p<376> c<373> l<41:26> el<41:32>
-n<> u<375> t<BinOp_LogicAnd> p<376> s<374> l<41:23> el<41:25>
-n<> u<376> t<Expression> p<377> c<370> l<41:12> el<41:32>
-n<> u<377> t<Expression> p<378> c<376> l<41:11> el<41:33>
-n<> u<378> t<Expression_or_dist> p<381> c<377> s<380> l<41:11> el<41:33>
-n<> u<379> t<Consecutive_repetition> p<380> l<41:34> el<41:37>
-n<> u<380> t<Boolean_abbrev> p<381> c<379> l<41:34> el<41:37>
-n<> u<381> t<Sequence_expr> p<396> c<378> s<383> l<41:11> el<41:37>
-n<##1> u<382> t<Pound_Pound_delay> p<383> l<42:7> el<42:10>
-n<> u<383> t<Cycle_delay_range> p<396> c<382> s<395> l<42:7> el<42:10>
-n<end_event> u<384> t<StringConst> p<385> l<42:11> el<42:20>
-n<> u<385> t<Primary_literal> p<386> c<384> l<42:11> el<42:20>
-n<> u<386> t<Primary> p<387> c<385> l<42:11> el<42:20>
-n<> u<387> t<Expression> p<393> c<386> s<392> l<42:11> el<42:20>
-n<window> u<388> t<StringConst> p<389> l<42:24> el<42:30>
-n<> u<389> t<Primary_literal> p<390> c<388> l<42:24> el<42:30>
-n<> u<390> t<Primary> p<391> c<389> l<42:24> el<42:30>
-n<> u<391> t<Expression> p<393> c<390> l<42:24> el<42:30>
-n<> u<392> t<BinOp_LogicAnd> p<393> s<391> l<42:21> el<42:23>
-n<> u<393> t<Expression> p<394> c<387> l<42:11> el<42:30>
-n<> u<394> t<Expression_or_dist> p<395> c<393> l<42:11> el<42:30>
-n<> u<395> t<Sequence_expr> p<396> c<394> l<42:11> el<42:30>
-n<> u<396> t<Sequence_expr> p<397> c<381> l<41:11> el<42:30>
-n<> u<397> t<Sequence_expr> p<398> c<362> l<40:7> el<42:30>
-n<> u<398> t<Property_expr> p<399> c<397> l<40:7> el<42:30>
-n<> u<399> t<Property_spec> p<412> c<398> s<411> l<40:7> el<42:30>
-n<> u<400> t<Dollar_keyword> p<407> s<401> l<43:9> el<43:10>
-n<display> u<401> t<StringConst> p<407> s<406> l<43:10> el<43:17>
-n<"window covered"> u<402> t<StringLiteral> p<403> l<43:18> el<43:34>
-n<> u<403> t<Primary_literal> p<404> c<402> l<43:18> el<43:34>
-n<> u<404> t<Primary> p<405> c<403> l<43:18> el<43:34>
-n<> u<405> t<Expression> p<406> c<404> l<43:18> el<43:34>
-n<> u<406> t<List_of_arguments> p<407> c<405> l<43:18> el<43:34>
-n<> u<407> t<Subroutine_call> p<408> c<400> l<43:9> el<43:35>
-n<> u<408> t<Subroutine_call_statement> p<409> c<407> l<43:9> el<43:36>
-n<> u<409> t<Statement_item> p<410> c<408> l<43:9> el<43:36>
-n<> u<410> t<Statement> p<411> c<409> l<43:9> el<43:36>
-n<> u<411> t<Statement_or_null> p<412> c<410> l<43:9> el<43:36>
-n<> u<412> t<Cover_property_statement> p<413> c<399> l<39:19> el<43:36>
-n<> u<413> t<Concurrent_assertion_statement> p<414> c<412> l<39:19> el<43:36>
-n<> u<414> t<Concurrent_assertion_item> p<415> c<348> l<39:5> el<43:36>
-n<> u<415> t<Assertion_item> p<416> c<414> l<39:5> el<43:36>
-n<> u<416> t<Module_common_item> p<417> c<415> l<39:5> el<43:36>
-n<> u<417> t<Module_or_generate_item> p<418> c<416> l<39:5> el<43:36>
-n<> u<418> t<Generate_item> p<421> c<417> s<420> l<39:5> el<43:36>
-n<cover_b> u<419> t<StringConst> p<421> l<44:12> el<44:19>
-n<> u<420> t<End> p<421> s<419> l<44:6> el<44:9>
-n<> u<421> t<Generate_block> p<422> c<311> l<36:38> el<44:19>
-n<> u<422> t<If_generate_construct> p<423> c<310> l<36:12> el<44:19>
-n<> u<423> t<Conditional_generate_construct> p<424> c<422> l<36:12> el<44:19>
-n<> u<424> t<Module_common_item> p<425> c<423> l<36:12> el<44:19>
-n<> u<425> t<Module_or_generate_item> p<426> c<424> l<36:12> el<44:19>
-n<> u<426> t<Generate_item> p<428> c<425> s<427> l<36:12> el<44:19>
-n<> u<427> t<Endgenerate> p<428> l<45:4> el<45:15>
-n<> u<428> t<Generate_region> p<429> c<426> l<36:3> el<45:15>
-n<> u<429> t<Checker_generate_item> p<430> c<428> l<36:3> el<45:15>
-n<> u<430> t<Checker_or_generate_item> p<433> c<429> s<432> l<36:3> el<45:15>
-n<assert_window1> u<431> t<StringConst> p<433> l<47:14> el<47:28>
-n<> u<432> t<Endchecker> p<433> s<431> l<47:1> el<47:11>
-n<> u<433> t<Checker_declaration> p<434> c<1> l<1:1> el<47:28>
-n<> u<434> t<Package_or_generate_item_declaration> p<435> c<433> l<1:1> el<47:28>
-n<> u<435> t<Package_item> p<436> c<434> l<1:1> el<47:28>
-n<> u<436> t<Description> p<600> c<435> s<599> l<1:1> el<47:28>
-n<op_test> u<437> t<StringConst> p<596> s<472> l<50:9> el<50:16>
-n<> u<438> t<IntVec_TypeLogic> p<439> l<50:18> el<50:23>
-n<> u<439> t<Data_type> p<440> c<438> l<50:18> el<50:23>
-n<> u<440> t<Data_type_or_implicit> p<441> c<439> l<50:18> el<50:23>
-n<> u<441> t<SeqFormatType_Data> p<442> c<440> l<50:18> el<50:23>
-n<> u<442> t<Property_formal_type> p<444> c<441> s<443> l<50:18> el<50:23>
-n<clk> u<443> t<StringConst> p<444> l<50:24> el<50:27>
-n<> u<444> t<Checker_port_item> p<472> c<442> s<449> l<50:18> el<50:27>
-n<> u<445> t<Data_type_or_implicit> p<446> l<50:29> el<50:29>
-n<> u<446> t<SeqFormatType_Data> p<447> c<445> l<50:29> el<50:29>
-n<> u<447> t<Property_formal_type> p<449> c<446> s<448> l<50:29> el<50:29>
-n<vld_1> u<448> t<StringConst> p<449> l<50:29> el<50:34>
-n<> u<449> t<Checker_port_item> p<472> c<447> s<454> l<50:29> el<50:34>
-n<> u<450> t<Data_type_or_implicit> p<451> l<50:36> el<50:36>
-n<> u<451> t<SeqFormatType_Data> p<452> c<450> l<50:36> el<50:36>
-n<> u<452> t<Property_formal_type> p<454> c<451> s<453> l<50:36> el<50:36>
-n<vld_2> u<453> t<StringConst> p<454> l<50:36> el<50:41>
-n<> u<454> t<Checker_port_item> p<472> c<452> s<471> l<50:36> el<50:41>
-n<> u<455> t<IntVec_TypeLogic> p<466> s<465> l<50:43> el<50:48>
-n<3> u<456> t<IntConst> p<457> l<50:50> el<50:51>
-n<> u<457> t<Primary_literal> p<458> c<456> l<50:50> el<50:51>
-n<> u<458> t<Constant_primary> p<459> c<457> l<50:50> el<50:51>
-n<> u<459> t<Constant_expression> p<464> c<458> s<463> l<50:50> el<50:51>
-n<0> u<460> t<IntConst> p<461> l<50:52> el<50:53>
-n<> u<461> t<Primary_literal> p<462> c<460> l<50:52> el<50:53>
-n<> u<462> t<Constant_primary> p<463> c<461> l<50:52> el<50:53>
-n<> u<463> t<Constant_expression> p<464> c<462> l<50:52> el<50:53>
-n<> u<464> t<Constant_range> p<465> c<459> l<50:50> el<50:53>
-n<> u<465> t<Packed_dimension> p<466> c<464> l<50:49> el<50:54>
-n<> u<466> t<Data_type> p<467> c<455> l<50:43> el<50:54>
-n<> u<467> t<Data_type_or_implicit> p<468> c<466> l<50:43> el<50:54>
-n<> u<468> t<SeqFormatType_Data> p<469> c<467> l<50:43> el<50:54>
-n<> u<469> t<Property_formal_type> p<471> c<468> s<470> l<50:43> el<50:54>
-n<opcode> u<470> t<StringConst> p<471> l<50:55> el<50:61>
-n<> u<471> t<Checker_port_item> p<472> c<469> l<50:43> el<50:61>
-n<> u<472> t<Checker_port_list> p<596> c<444> s<491> l<50:18> el<50:61>
-n<> u<473> t<IntVec_TypeBit> p<484> s<483> l<52:3> el<52:6>
-n<3> u<474> t<IntConst> p<475> l<52:8> el<52:9>
-n<> u<475> t<Primary_literal> p<476> c<474> l<52:8> el<52:9>
-n<> u<476> t<Constant_primary> p<477> c<475> l<52:8> el<52:9>
-n<> u<477> t<Constant_expression> p<482> c<476> s<481> l<52:8> el<52:9>
-n<0> u<478> t<IntConst> p<479> l<52:10> el<52:11>
-n<> u<479> t<Primary_literal> p<480> c<478> l<52:10> el<52:11>
-n<> u<480> t<Constant_primary> p<481> c<479> l<52:10> el<52:11>
-n<> u<481> t<Constant_expression> p<482> c<480> l<52:10> el<52:11>
-n<> u<482> t<Constant_range> p<483> c<477> l<52:8> el<52:11>
-n<> u<483> t<Packed_dimension> p<484> c<482> l<52:7> el<52:12>
-n<> u<484> t<Data_type> p<488> c<473> s<487> l<52:3> el<52:12>
-n<opcode_d1> u<485> t<StringConst> p<486> l<52:13> el<52:22>
-n<> u<486> t<Variable_decl_assignment> p<487> c<485> l<52:13> el<52:22>
-n<> u<487> t<List_of_variable_decl_assignments> p<488> c<486> l<52:13> el<52:22>
-n<> u<488> t<Variable_declaration> p<489> c<484> l<52:3> el<52:23>
-n<> u<489> t<Data_declaration> p<490> c<488> l<52:3> el<52:23>
-n<> u<490> t<Checker_or_generate_item_declaration> p<491> c<489> l<52:3> el<52:23>
-n<> u<491> t<Checker_or_generate_item> p<596> c<490> s<518> l<52:3> el<52:23>
-n<> u<492> t<AlwaysKeywd_FF> p<517> s<516> l<53:3> el<53:12>
-n<> u<493> t<Edge_Posedge> p<498> s<497> l<53:15> el<53:22>
-n<clk> u<494> t<StringConst> p<495> l<53:23> el<53:26>
-n<> u<495> t<Primary_literal> p<496> c<494> l<53:23> el<53:26>
-n<> u<496> t<Primary> p<497> c<495> l<53:23> el<53:26>
-n<> u<497> t<Expression> p<498> c<496> l<53:23> el<53:26>
-n<> u<498> t<Event_expression> p<499> c<493> l<53:15> el<53:26>
-n<> u<499> t<Event_control> p<500> c<498> l<53:13> el<53:27>
-n<> u<500> t<Procedural_timing_control> p<514> c<499> s<513> l<53:13> el<53:27>
-n<opcode_d1> u<501> t<StringConst> p<502> l<53:28> el<53:37>
-n<> u<502> t<Ps_or_hierarchical_identifier> p<505> c<501> s<504> l<53:28> el<53:37>
-n<> u<503> t<Bit_select> p<504> l<53:38> el<53:38>
-n<> u<504> t<Select> p<505> c<503> l<53:38> el<53:38>
-n<> u<505> t<Variable_lvalue> p<510> c<502> s<509> l<53:28> el<53:37>
-n<opcode> u<506> t<StringConst> p<507> l<53:41> el<53:47>
-n<> u<507> t<Primary_literal> p<508> c<506> l<53:41> el<53:47>
-n<> u<508> t<Primary> p<509> c<507> l<53:41> el<53:47>
-n<> u<509> t<Expression> p<510> c<508> l<53:41> el<53:47>
-n<> u<510> t<Nonblocking_assignment> p<511> c<505> l<53:28> el<53:47>
-n<> u<511> t<Statement_item> p<512> c<510> l<53:28> el<53:48>
-n<> u<512> t<Statement> p<513> c<511> l<53:28> el<53:48>
-n<> u<513> t<Statement_or_null> p<514> c<512> l<53:28> el<53:48>
-n<> u<514> t<Procedural_timing_control_statement> p<515> c<500> l<53:13> el<53:48>
-n<> u<515> t<Statement_item> p<516> c<514> l<53:13> el<53:48>
-n<> u<516> t<Statement> p<517> c<515> l<53:13> el<53:48>
-n<> u<517> t<Always_construct> p<518> c<492> l<53:3> el<53:48>
-n<> u<518> t<Checker_or_generate_item> p<596> c<517> s<534> l<53:3> el<53:48>
-n<cg_op> u<519> t<StringConst> p<532> s<529> l<54:14> el<54:19>
-n<> u<520> t<Data_type_or_implicit> p<527> s<521> l<55:5> el<54:25>
-n<cp_op> u<521> t<StringConst> p<527> s<525> l<55:5> el<55:10>
-n<opcode_d1> u<522> t<StringConst> p<523> l<55:24> el<55:33>
-n<> u<523> t<Primary_literal> p<524> c<522> l<55:24> el<55:33>
-n<> u<524> t<Primary> p<525> c<523> l<55:24> el<55:33>
-n<> u<525> t<Expression> p<527> c<524> s<526> l<55:24> el<55:33>
-n<> u<526> t<Bins_or_empty> p<527> l<55:33> el<55:34>
-n<> u<527> t<Cover_point> p<528> c<520> l<55:5> el<55:34>
-n<> u<528> t<Coverage_spec> p<529> c<527> l<55:5> el<55:34>
-n<> u<529> t<Coverage_spec_or_option> p<532> c<528> s<531> l<55:5> el<55:34>
-n<cg_op> u<530> t<StringConst> p<532> l<56:13> el<56:18>
-n<> u<531> t<Endgroup> p<532> s<530> l<56:3> el<56:11>
-n<> u<532> t<Covergroup_declaration> p<533> c<519> l<54:3> el<56:18>
-n<> u<533> t<Checker_or_generate_item_declaration> p<534> c<532> l<54:3> el<56:18>
-n<> u<534> t<Checker_or_generate_item> p<596> c<533> s<545> l<54:3> el<56:18>
-n<cg_op> u<535> t<StringConst> p<536> l<57:3> el<57:8>
-n<> u<536> t<Data_type> p<542> c<535> s<541> l<57:3> el<57:8>
-n<cg_op_1> u<537> t<StringConst> p<540> s<539> l<57:9> el<57:16>
-n<> u<538> t<List_of_arguments> p<539> l<57:23> el<57:23>
-n<> u<539> t<Class_new> p<540> c<538> l<57:19> el<57:24>
-n<> u<540> t<Variable_decl_assignment> p<541> c<537> l<57:9> el<57:24>
-n<> u<541> t<List_of_variable_decl_assignments> p<542> c<540> l<57:9> el<57:24>
-n<> u<542> t<Variable_declaration> p<543> c<536> l<57:3> el<57:25>
-n<> u<543> t<Data_declaration> p<544> c<542> l<57:3> el<57:25>
-n<> u<544> t<Checker_or_generate_item_declaration> p<545> c<543> l<57:3> el<57:25>
-n<> u<545> t<Checker_or_generate_item> p<596> c<544> s<580> l<57:3> el<57:25>
-n<op_accept> u<546> t<StringConst> p<577> s<575> l<58:12> el<58:21>
-n<> u<547> t<Edge_Posedge> p<552> s<551> l<59:7> el<59:14>
-n<clk> u<548> t<StringConst> p<549> l<59:15> el<59:18>
-n<> u<549> t<Primary_literal> p<550> c<548> l<59:15> el<59:18>
-n<> u<550> t<Primary> p<551> c<549> l<59:15> el<59:18>
-n<> u<551> t<Expression> p<552> c<550> l<59:15> el<59:18>
-n<> u<552> t<Event_expression> p<553> c<547> l<59:7> el<59:18>
-n<> u<553> t<Clocking_event> p<575> c<552> s<574> l<59:5> el<59:19>
-n<vld_1> u<554> t<StringConst> p<555> l<59:20> el<59:25>
-n<> u<555> t<Primary_literal> p<556> c<554> l<59:20> el<59:25>
-n<> u<556> t<Primary> p<557> c<555> l<59:20> el<59:25>
-n<> u<557> t<Expression> p<558> c<556> l<59:20> el<59:25>
-n<> u<558> t<Expression_or_dist> p<559> c<557> l<59:20> el<59:25>
-n<> u<559> t<Sequence_expr> p<574> c<558> s<561> l<59:20> el<59:25>
-n<##1> u<560> t<Pound_Pound_delay> p<561> l<59:26> el<59:29>
-n<> u<561> t<Cycle_delay_range> p<574> c<560> s<573> l<59:26> el<59:29>
-n<vld_2> u<562> t<StringConst> p<563> l<59:31> el<59:36>
-n<> u<563> t<Primary_literal> p<564> c<562> l<59:31> el<59:36>
-n<> u<564> t<Primary> p<565> c<563> l<59:31> el<59:36>
-n<> u<565> t<Expression> p<566> c<564> l<59:31> el<59:36>
-n<> u<566> t<Expression_or_dist> p<573> c<565> s<572> l<59:31> el<59:36>
-n<cg_op_1> u<567> t<StringConst> p<571> s<568> l<59:38> el<59:45>
-n<> u<568> t<Constant_bit_select> p<571> s<569> l<59:45> el<59:45>
-n<sample> u<569> t<StringConst> p<571> s<570> l<59:46> el<59:52>
-n<> u<570> t<List_of_arguments> p<571> l<59:53> el<59:53>
-n<> u<571> t<Subroutine_call> p<572> c<567> l<59:38> el<59:54>
-n<> u<572> t<Sequence_match_item> p<573> c<571> l<59:38> el<59:54>
-n<> u<573> t<Sequence_expr> p<574> c<566> l<59:30> el<59:55>
-n<> u<574> t<Sequence_expr> p<575> c<559> l<59:20> el<59:55>
-n<> u<575> t<Sequence_expr> p<577> c<553> s<576> l<59:5> el<59:55>
-n<> u<576> t<Endsequence> p<577> l<60:3> el<60:14>
-n<> u<577> t<Sequence_declaration> p<578> c<546> l<58:3> el<60:14>
-n<> u<578> t<Assertion_item_declaration> p<579> c<577> l<58:3> el<60:14>
-n<> u<579> t<Checker_or_generate_item_declaration> p<580> c<578> l<58:3> el<60:14>
-n<> u<580> t<Checker_or_generate_item> p<596> c<579> s<594> l<58:3> el<60:14>
-n<op_accept> u<581> t<StringConst> p<582> l<61:19> el<61:28>
-n<> u<582> t<Primary_literal> p<583> c<581> l<61:19> el<61:28>
-n<> u<583> t<Primary> p<584> c<582> l<61:19> el<61:28>
-n<> u<584> t<Expression> p<585> c<583> l<61:19> el<61:28>
-n<> u<585> t<Expression_or_dist> p<586> c<584> l<61:19> el<61:28>
-n<> u<586> t<Sequence_expr> p<587> c<585> l<61:19> el<61:28>
-n<> u<587> t<Property_expr> p<588> c<586> l<61:19> el<61:28>
-n<> u<588> t<Property_spec> p<590> c<587> s<589> l<61:19> el<61:28>
-n<> u<589> t<Statement_or_null> p<590> l<61:29> el<61:30>
-n<> u<590> t<Cover_property_statement> p<591> c<588> l<61:3> el<61:30>
-n<> u<591> t<Concurrent_assertion_statement> p<592> c<590> l<61:3> el<61:30>
-n<> u<592> t<Concurrent_assertion_item> p<593> c<591> l<61:3> el<61:30>
-n<> u<593> t<Assertion_item> p<594> c<592> l<61:3> el<61:30>
-n<> u<594> t<Checker_or_generate_item> p<596> c<593> s<595> l<61:3> el<61:30>
-n<> u<595> t<Endchecker> p<596> l<63:1> el<63:11>
-n<> u<596> t<Checker_declaration> p<597> c<437> l<50:1> el<63:11>
-n<> u<597> t<Package_or_generate_item_declaration> p<598> c<596> l<50:1> el<63:11>
-n<> u<598> t<Package_item> p<599> c<597> l<50:1> el<63:11>
-n<> u<599> t<Description> p<600> c<598> l<50:1> el<63:11>
-n<> u<600> t<Source_text> p<601> c<436> l<1:1> el<63:11>
-n<> u<601> t<Top_level_rule> l<1:1> el<64:1>
+n<> u<345> t<Checker_or_generate_item> p<346> c<344> l<37:5> el<37:96>
+n<> u<346> t<Generate_item> p<419> c<345> s<416> l<37:5> el<37:96>
+n<cover_window> u<347> t<StringConst> p<413> s<412> l<39:5> el<39:17>
+n<start_event> u<348> t<StringConst> p<349> l<40:7> el<40:18>
+n<> u<349> t<Primary_literal> p<350> c<348> l<40:7> el<40:18>
+n<> u<350> t<Primary> p<351> c<349> l<40:7> el<40:18>
+n<> u<351> t<Expression> p<359> c<350> s<358> l<40:7> el<40:18>
+n<window> u<352> t<StringConst> p<353> l<40:23> el<40:29>
+n<> u<353> t<Primary_literal> p<354> c<352> l<40:23> el<40:29>
+n<> u<354> t<Primary> p<355> c<353> l<40:23> el<40:29>
+n<> u<355> t<Expression> p<357> c<354> l<40:23> el<40:29>
+n<> u<356> t<Unary_Not> p<357> s<355> l<40:22> el<40:23>
+n<> u<357> t<Expression> p<359> c<356> l<40:22> el<40:29>
+n<> u<358> t<BinOp_LogicAnd> p<359> s<357> l<40:19> el<40:21>
+n<> u<359> t<Expression> p<360> c<351> l<40:7> el<40:29>
+n<> u<360> t<Expression_or_dist> p<361> c<359> l<40:7> el<40:29>
+n<> u<361> t<Sequence_expr> p<396> c<360> s<363> l<40:7> el<40:29>
+n<##1> u<362> t<Pound_Pound_delay> p<363> l<41:7> el<41:10>
+n<> u<363> t<Cycle_delay_range> p<396> c<362> s<395> l<41:7> el<41:10>
+n<end_event> u<364> t<StringConst> p<365> l<41:13> el<41:22>
+n<> u<365> t<Primary_literal> p<366> c<364> l<41:13> el<41:22>
+n<> u<366> t<Primary> p<367> c<365> l<41:13> el<41:22>
+n<> u<367> t<Expression> p<369> c<366> l<41:13> el<41:22>
+n<> u<368> t<Unary_Not> p<369> s<367> l<41:12> el<41:13>
+n<> u<369> t<Expression> p<375> c<368> s<374> l<41:12> el<41:22>
+n<window> u<370> t<StringConst> p<371> l<41:26> el<41:32>
+n<> u<371> t<Primary_literal> p<372> c<370> l<41:26> el<41:32>
+n<> u<372> t<Primary> p<373> c<371> l<41:26> el<41:32>
+n<> u<373> t<Expression> p<375> c<372> l<41:26> el<41:32>
+n<> u<374> t<BinOp_LogicAnd> p<375> s<373> l<41:23> el<41:25>
+n<> u<375> t<Expression> p<376> c<369> l<41:12> el<41:32>
+n<> u<376> t<Expression> p<377> c<375> l<41:11> el<41:33>
+n<> u<377> t<Expression_or_dist> p<380> c<376> s<379> l<41:11> el<41:33>
+n<> u<378> t<Consecutive_repetition> p<379> l<41:34> el<41:37>
+n<> u<379> t<Boolean_abbrev> p<380> c<378> l<41:34> el<41:37>
+n<> u<380> t<Sequence_expr> p<395> c<377> s<382> l<41:11> el<41:37>
+n<##1> u<381> t<Pound_Pound_delay> p<382> l<42:7> el<42:10>
+n<> u<382> t<Cycle_delay_range> p<395> c<381> s<394> l<42:7> el<42:10>
+n<end_event> u<383> t<StringConst> p<384> l<42:11> el<42:20>
+n<> u<384> t<Primary_literal> p<385> c<383> l<42:11> el<42:20>
+n<> u<385> t<Primary> p<386> c<384> l<42:11> el<42:20>
+n<> u<386> t<Expression> p<392> c<385> s<391> l<42:11> el<42:20>
+n<window> u<387> t<StringConst> p<388> l<42:24> el<42:30>
+n<> u<388> t<Primary_literal> p<389> c<387> l<42:24> el<42:30>
+n<> u<389> t<Primary> p<390> c<388> l<42:24> el<42:30>
+n<> u<390> t<Expression> p<392> c<389> l<42:24> el<42:30>
+n<> u<391> t<BinOp_LogicAnd> p<392> s<390> l<42:21> el<42:23>
+n<> u<392> t<Expression> p<393> c<386> l<42:11> el<42:30>
+n<> u<393> t<Expression_or_dist> p<394> c<392> l<42:11> el<42:30>
+n<> u<394> t<Sequence_expr> p<395> c<393> l<42:11> el<42:30>
+n<> u<395> t<Sequence_expr> p<396> c<380> l<41:11> el<42:30>
+n<> u<396> t<Sequence_expr> p<397> c<361> l<40:7> el<42:30>
+n<> u<397> t<Property_expr> p<398> c<396> l<40:7> el<42:30>
+n<> u<398> t<Property_spec> p<411> c<397> s<410> l<40:7> el<42:30>
+n<> u<399> t<Dollar_keyword> p<406> s<400> l<43:9> el<43:10>
+n<display> u<400> t<StringConst> p<406> s<405> l<43:10> el<43:17>
+n<"window covered"> u<401> t<StringLiteral> p<402> l<43:18> el<43:34>
+n<> u<402> t<Primary_literal> p<403> c<401> l<43:18> el<43:34>
+n<> u<403> t<Primary> p<404> c<402> l<43:18> el<43:34>
+n<> u<404> t<Expression> p<405> c<403> l<43:18> el<43:34>
+n<> u<405> t<List_of_arguments> p<406> c<404> l<43:18> el<43:34>
+n<> u<406> t<Subroutine_call> p<407> c<399> l<43:9> el<43:35>
+n<> u<407> t<Subroutine_call_statement> p<408> c<406> l<43:9> el<43:36>
+n<> u<408> t<Statement_item> p<409> c<407> l<43:9> el<43:36>
+n<> u<409> t<Statement> p<410> c<408> l<43:9> el<43:36>
+n<> u<410> t<Statement_or_null> p<411> c<409> l<43:9> el<43:36>
+n<> u<411> t<Cover_property_statement> p<412> c<398> l<39:19> el<43:36>
+n<> u<412> t<Concurrent_assertion_statement> p<413> c<411> l<39:19> el<43:36>
+n<> u<413> t<Concurrent_assertion_item> p<414> c<347> l<39:5> el<43:36>
+n<> u<414> t<Assertion_item> p<415> c<413> l<39:5> el<43:36>
+n<> u<415> t<Checker_or_generate_item> p<416> c<414> l<39:5> el<43:36>
+n<> u<416> t<Generate_item> p<419> c<415> s<418> l<39:5> el<43:36>
+n<cover_b> u<417> t<StringConst> p<419> l<44:12> el<44:19>
+n<> u<418> t<End> p<419> s<417> l<44:6> el<44:9>
+n<> u<419> t<Generate_block> p<420> c<311> l<36:38> el<44:19>
+n<> u<420> t<If_generate_construct> p<421> c<310> l<36:12> el<44:19>
+n<> u<421> t<Conditional_generate_construct> p<422> c<420> l<36:12> el<44:19>
+n<> u<422> t<Checker_generate_item> p<423> c<421> l<36:12> el<44:19>
+n<> u<423> t<Checker_or_generate_item> p<424> c<422> l<36:12> el<44:19>
+n<> u<424> t<Generate_item> p<425> c<423> l<36:12> el<44:19>
+n<> u<425> t<Generate_block> p<427> c<424> s<426> l<36:12> el<44:19>
+n<> u<426> t<Endgenerate> p<427> l<45:4> el<45:15>
+n<> u<427> t<Generate_region> p<428> c<425> l<36:3> el<45:15>
+n<> u<428> t<Checker_generate_item> p<429> c<427> l<36:3> el<45:15>
+n<> u<429> t<Checker_or_generate_item> p<432> c<428> s<431> l<36:3> el<45:15>
+n<assert_window1> u<430> t<StringConst> p<432> l<47:14> el<47:28>
+n<> u<431> t<Endchecker> p<432> s<430> l<47:1> el<47:11>
+n<> u<432> t<Checker_declaration> p<433> c<1> l<1:1> el<47:28>
+n<> u<433> t<Package_or_generate_item_declaration> p<434> c<432> l<1:1> el<47:28>
+n<> u<434> t<Package_item> p<435> c<433> l<1:1> el<47:28>
+n<> u<435> t<Description> p<599> c<434> s<598> l<1:1> el<47:28>
+n<op_test> u<436> t<StringConst> p<595> s<471> l<50:9> el<50:16>
+n<> u<437> t<IntVec_TypeLogic> p<438> l<50:18> el<50:23>
+n<> u<438> t<Data_type> p<439> c<437> l<50:18> el<50:23>
+n<> u<439> t<Data_type_or_implicit> p<440> c<438> l<50:18> el<50:23>
+n<> u<440> t<SeqFormatType_Data> p<441> c<439> l<50:18> el<50:23>
+n<> u<441> t<Property_formal_type> p<443> c<440> s<442> l<50:18> el<50:23>
+n<clk> u<442> t<StringConst> p<443> l<50:24> el<50:27>
+n<> u<443> t<Checker_port_item> p<471> c<441> s<448> l<50:18> el<50:27>
+n<> u<444> t<Data_type_or_implicit> p<445> l<50:29> el<50:29>
+n<> u<445> t<SeqFormatType_Data> p<446> c<444> l<50:29> el<50:29>
+n<> u<446> t<Property_formal_type> p<448> c<445> s<447> l<50:29> el<50:29>
+n<vld_1> u<447> t<StringConst> p<448> l<50:29> el<50:34>
+n<> u<448> t<Checker_port_item> p<471> c<446> s<453> l<50:29> el<50:34>
+n<> u<449> t<Data_type_or_implicit> p<450> l<50:36> el<50:36>
+n<> u<450> t<SeqFormatType_Data> p<451> c<449> l<50:36> el<50:36>
+n<> u<451> t<Property_formal_type> p<453> c<450> s<452> l<50:36> el<50:36>
+n<vld_2> u<452> t<StringConst> p<453> l<50:36> el<50:41>
+n<> u<453> t<Checker_port_item> p<471> c<451> s<470> l<50:36> el<50:41>
+n<> u<454> t<IntVec_TypeLogic> p<465> s<464> l<50:43> el<50:48>
+n<3> u<455> t<IntConst> p<456> l<50:50> el<50:51>
+n<> u<456> t<Primary_literal> p<457> c<455> l<50:50> el<50:51>
+n<> u<457> t<Constant_primary> p<458> c<456> l<50:50> el<50:51>
+n<> u<458> t<Constant_expression> p<463> c<457> s<462> l<50:50> el<50:51>
+n<0> u<459> t<IntConst> p<460> l<50:52> el<50:53>
+n<> u<460> t<Primary_literal> p<461> c<459> l<50:52> el<50:53>
+n<> u<461> t<Constant_primary> p<462> c<460> l<50:52> el<50:53>
+n<> u<462> t<Constant_expression> p<463> c<461> l<50:52> el<50:53>
+n<> u<463> t<Constant_range> p<464> c<458> l<50:50> el<50:53>
+n<> u<464> t<Packed_dimension> p<465> c<463> l<50:49> el<50:54>
+n<> u<465> t<Data_type> p<466> c<454> l<50:43> el<50:54>
+n<> u<466> t<Data_type_or_implicit> p<467> c<465> l<50:43> el<50:54>
+n<> u<467> t<SeqFormatType_Data> p<468> c<466> l<50:43> el<50:54>
+n<> u<468> t<Property_formal_type> p<470> c<467> s<469> l<50:43> el<50:54>
+n<opcode> u<469> t<StringConst> p<470> l<50:55> el<50:61>
+n<> u<470> t<Checker_port_item> p<471> c<468> l<50:43> el<50:61>
+n<> u<471> t<Checker_port_list> p<595> c<443> s<490> l<50:18> el<50:61>
+n<> u<472> t<IntVec_TypeBit> p<483> s<482> l<52:3> el<52:6>
+n<3> u<473> t<IntConst> p<474> l<52:8> el<52:9>
+n<> u<474> t<Primary_literal> p<475> c<473> l<52:8> el<52:9>
+n<> u<475> t<Constant_primary> p<476> c<474> l<52:8> el<52:9>
+n<> u<476> t<Constant_expression> p<481> c<475> s<480> l<52:8> el<52:9>
+n<0> u<477> t<IntConst> p<478> l<52:10> el<52:11>
+n<> u<478> t<Primary_literal> p<479> c<477> l<52:10> el<52:11>
+n<> u<479> t<Constant_primary> p<480> c<478> l<52:10> el<52:11>
+n<> u<480> t<Constant_expression> p<481> c<479> l<52:10> el<52:11>
+n<> u<481> t<Constant_range> p<482> c<476> l<52:8> el<52:11>
+n<> u<482> t<Packed_dimension> p<483> c<481> l<52:7> el<52:12>
+n<> u<483> t<Data_type> p<487> c<472> s<486> l<52:3> el<52:12>
+n<opcode_d1> u<484> t<StringConst> p<485> l<52:13> el<52:22>
+n<> u<485> t<Variable_decl_assignment> p<486> c<484> l<52:13> el<52:22>
+n<> u<486> t<List_of_variable_decl_assignments> p<487> c<485> l<52:13> el<52:22>
+n<> u<487> t<Variable_declaration> p<488> c<483> l<52:3> el<52:23>
+n<> u<488> t<Data_declaration> p<489> c<487> l<52:3> el<52:23>
+n<> u<489> t<Checker_or_generate_item_declaration> p<490> c<488> l<52:3> el<52:23>
+n<> u<490> t<Checker_or_generate_item> p<595> c<489> s<517> l<52:3> el<52:23>
+n<> u<491> t<AlwaysKeywd_FF> p<516> s<515> l<53:3> el<53:12>
+n<> u<492> t<Edge_Posedge> p<497> s<496> l<53:15> el<53:22>
+n<clk> u<493> t<StringConst> p<494> l<53:23> el<53:26>
+n<> u<494> t<Primary_literal> p<495> c<493> l<53:23> el<53:26>
+n<> u<495> t<Primary> p<496> c<494> l<53:23> el<53:26>
+n<> u<496> t<Expression> p<497> c<495> l<53:23> el<53:26>
+n<> u<497> t<Event_expression> p<498> c<492> l<53:15> el<53:26>
+n<> u<498> t<Event_control> p<499> c<497> l<53:13> el<53:27>
+n<> u<499> t<Procedural_timing_control> p<513> c<498> s<512> l<53:13> el<53:27>
+n<opcode_d1> u<500> t<StringConst> p<501> l<53:28> el<53:37>
+n<> u<501> t<Ps_or_hierarchical_identifier> p<504> c<500> s<503> l<53:28> el<53:37>
+n<> u<502> t<Bit_select> p<503> l<53:38> el<53:38>
+n<> u<503> t<Select> p<504> c<502> l<53:38> el<53:38>
+n<> u<504> t<Variable_lvalue> p<509> c<501> s<508> l<53:28> el<53:37>
+n<opcode> u<505> t<StringConst> p<506> l<53:41> el<53:47>
+n<> u<506> t<Primary_literal> p<507> c<505> l<53:41> el<53:47>
+n<> u<507> t<Primary> p<508> c<506> l<53:41> el<53:47>
+n<> u<508> t<Expression> p<509> c<507> l<53:41> el<53:47>
+n<> u<509> t<Nonblocking_assignment> p<510> c<504> l<53:28> el<53:47>
+n<> u<510> t<Statement_item> p<511> c<509> l<53:28> el<53:48>
+n<> u<511> t<Statement> p<512> c<510> l<53:28> el<53:48>
+n<> u<512> t<Statement_or_null> p<513> c<511> l<53:28> el<53:48>
+n<> u<513> t<Procedural_timing_control_statement> p<514> c<499> l<53:13> el<53:48>
+n<> u<514> t<Statement_item> p<515> c<513> l<53:13> el<53:48>
+n<> u<515> t<Statement> p<516> c<514> l<53:13> el<53:48>
+n<> u<516> t<Always_construct> p<517> c<491> l<53:3> el<53:48>
+n<> u<517> t<Checker_or_generate_item> p<595> c<516> s<533> l<53:3> el<53:48>
+n<cg_op> u<518> t<StringConst> p<531> s<528> l<54:14> el<54:19>
+n<> u<519> t<Data_type_or_implicit> p<526> s<520> l<55:5> el<54:25>
+n<cp_op> u<520> t<StringConst> p<526> s<524> l<55:5> el<55:10>
+n<opcode_d1> u<521> t<StringConst> p<522> l<55:24> el<55:33>
+n<> u<522> t<Primary_literal> p<523> c<521> l<55:24> el<55:33>
+n<> u<523> t<Primary> p<524> c<522> l<55:24> el<55:33>
+n<> u<524> t<Expression> p<526> c<523> s<525> l<55:24> el<55:33>
+n<> u<525> t<Bins_or_empty> p<526> l<55:33> el<55:34>
+n<> u<526> t<Cover_point> p<527> c<519> l<55:5> el<55:34>
+n<> u<527> t<Coverage_spec> p<528> c<526> l<55:5> el<55:34>
+n<> u<528> t<Coverage_spec_or_option> p<531> c<527> s<530> l<55:5> el<55:34>
+n<cg_op> u<529> t<StringConst> p<531> l<56:13> el<56:18>
+n<> u<530> t<Endgroup> p<531> s<529> l<56:3> el<56:11>
+n<> u<531> t<Covergroup_declaration> p<532> c<518> l<54:3> el<56:18>
+n<> u<532> t<Checker_or_generate_item_declaration> p<533> c<531> l<54:3> el<56:18>
+n<> u<533> t<Checker_or_generate_item> p<595> c<532> s<544> l<54:3> el<56:18>
+n<cg_op> u<534> t<StringConst> p<535> l<57:3> el<57:8>
+n<> u<535> t<Data_type> p<541> c<534> s<540> l<57:3> el<57:8>
+n<cg_op_1> u<536> t<StringConst> p<539> s<538> l<57:9> el<57:16>
+n<> u<537> t<List_of_arguments> p<538> l<57:23> el<57:23>
+n<> u<538> t<Class_new> p<539> c<537> l<57:19> el<57:24>
+n<> u<539> t<Variable_decl_assignment> p<540> c<536> l<57:9> el<57:24>
+n<> u<540> t<List_of_variable_decl_assignments> p<541> c<539> l<57:9> el<57:24>
+n<> u<541> t<Variable_declaration> p<542> c<535> l<57:3> el<57:25>
+n<> u<542> t<Data_declaration> p<543> c<541> l<57:3> el<57:25>
+n<> u<543> t<Checker_or_generate_item_declaration> p<544> c<542> l<57:3> el<57:25>
+n<> u<544> t<Checker_or_generate_item> p<595> c<543> s<579> l<57:3> el<57:25>
+n<op_accept> u<545> t<StringConst> p<576> s<574> l<58:12> el<58:21>
+n<> u<546> t<Edge_Posedge> p<551> s<550> l<59:7> el<59:14>
+n<clk> u<547> t<StringConst> p<548> l<59:15> el<59:18>
+n<> u<548> t<Primary_literal> p<549> c<547> l<59:15> el<59:18>
+n<> u<549> t<Primary> p<550> c<548> l<59:15> el<59:18>
+n<> u<550> t<Expression> p<551> c<549> l<59:15> el<59:18>
+n<> u<551> t<Event_expression> p<552> c<546> l<59:7> el<59:18>
+n<> u<552> t<Clocking_event> p<574> c<551> s<573> l<59:5> el<59:19>
+n<vld_1> u<553> t<StringConst> p<554> l<59:20> el<59:25>
+n<> u<554> t<Primary_literal> p<555> c<553> l<59:20> el<59:25>
+n<> u<555> t<Primary> p<556> c<554> l<59:20> el<59:25>
+n<> u<556> t<Expression> p<557> c<555> l<59:20> el<59:25>
+n<> u<557> t<Expression_or_dist> p<558> c<556> l<59:20> el<59:25>
+n<> u<558> t<Sequence_expr> p<573> c<557> s<560> l<59:20> el<59:25>
+n<##1> u<559> t<Pound_Pound_delay> p<560> l<59:26> el<59:29>
+n<> u<560> t<Cycle_delay_range> p<573> c<559> s<572> l<59:26> el<59:29>
+n<vld_2> u<561> t<StringConst> p<562> l<59:31> el<59:36>
+n<> u<562> t<Primary_literal> p<563> c<561> l<59:31> el<59:36>
+n<> u<563> t<Primary> p<564> c<562> l<59:31> el<59:36>
+n<> u<564> t<Expression> p<565> c<563> l<59:31> el<59:36>
+n<> u<565> t<Expression_or_dist> p<572> c<564> s<571> l<59:31> el<59:36>
+n<cg_op_1> u<566> t<StringConst> p<570> s<567> l<59:38> el<59:45>
+n<> u<567> t<Constant_bit_select> p<570> s<568> l<59:45> el<59:45>
+n<sample> u<568> t<StringConst> p<570> s<569> l<59:46> el<59:52>
+n<> u<569> t<List_of_arguments> p<570> l<59:53> el<59:53>
+n<> u<570> t<Subroutine_call> p<571> c<566> l<59:38> el<59:54>
+n<> u<571> t<Sequence_match_item> p<572> c<570> l<59:38> el<59:54>
+n<> u<572> t<Sequence_expr> p<573> c<565> l<59:30> el<59:55>
+n<> u<573> t<Sequence_expr> p<574> c<558> l<59:20> el<59:55>
+n<> u<574> t<Sequence_expr> p<576> c<552> s<575> l<59:5> el<59:55>
+n<> u<575> t<Endsequence> p<576> l<60:3> el<60:14>
+n<> u<576> t<Sequence_declaration> p<577> c<545> l<58:3> el<60:14>
+n<> u<577> t<Assertion_item_declaration> p<578> c<576> l<58:3> el<60:14>
+n<> u<578> t<Checker_or_generate_item_declaration> p<579> c<577> l<58:3> el<60:14>
+n<> u<579> t<Checker_or_generate_item> p<595> c<578> s<593> l<58:3> el<60:14>
+n<op_accept> u<580> t<StringConst> p<581> l<61:19> el<61:28>
+n<> u<581> t<Primary_literal> p<582> c<580> l<61:19> el<61:28>
+n<> u<582> t<Primary> p<583> c<581> l<61:19> el<61:28>
+n<> u<583> t<Expression> p<584> c<582> l<61:19> el<61:28>
+n<> u<584> t<Expression_or_dist> p<585> c<583> l<61:19> el<61:28>
+n<> u<585> t<Sequence_expr> p<586> c<584> l<61:19> el<61:28>
+n<> u<586> t<Property_expr> p<587> c<585> l<61:19> el<61:28>
+n<> u<587> t<Property_spec> p<589> c<586> s<588> l<61:19> el<61:28>
+n<> u<588> t<Statement_or_null> p<589> l<61:29> el<61:30>
+n<> u<589> t<Cover_property_statement> p<590> c<587> l<61:3> el<61:30>
+n<> u<590> t<Concurrent_assertion_statement> p<591> c<589> l<61:3> el<61:30>
+n<> u<591> t<Concurrent_assertion_item> p<592> c<590> l<61:3> el<61:30>
+n<> u<592> t<Assertion_item> p<593> c<591> l<61:3> el<61:30>
+n<> u<593> t<Checker_or_generate_item> p<595> c<592> s<594> l<61:3> el<61:30>
+n<> u<594> t<Endchecker> p<595> l<63:1> el<63:11>
+n<> u<595> t<Checker_declaration> p<596> c<436> l<50:1> el<63:11>
+n<> u<596> t<Package_or_generate_item_declaration> p<597> c<595> l<50:1> el<63:11>
+n<> u<597> t<Package_item> p<598> c<596> l<50:1> el<63:11>
+n<> u<598> t<Description> p<599> c<597> l<50:1> el<63:11>
+n<> u<599> t<Source_text> p<600> c<435> l<1:1> el<63:11>
+n<> u<600> t<Top_level_rule> l<1:1> el<64:1>
 [INF:CP0300] Compilation...
 
 [INF:EL0526] Design Elaboration...

--- a/tests/FuncDeclScope/FuncDeclScope.log
+++ b/tests/FuncDeclScope/FuncDeclScope.log
@@ -92,7 +92,7 @@ n<> u<86> t<Function_declaration> p<87> c<69> l<10:7> el<12:18>
 n<> u<87> t<Package_or_generate_item_declaration> p<88> c<86> l<10:7> el<12:18>
 n<> u<88> t<Module_or_generate_item_declaration> p<89> c<87> l<10:7> el<12:18>
 n<> u<89> t<Module_common_item> p<90> c<88> l<10:7> el<12:18>
-n<> u<90> t<Module_or_generate_item> p<91> c<89> l<10:7> el<12:18>
+n<> u<90> t<Interface_or_generate_item> p<91> c<89> l<10:7> el<12:18>
 n<> u<91> t<Generate_item> p<110> c<90> s<107> l<10:7> el<12:18>
 n<o> u<92> t<StringConst> p<93> l<14:14> el<14:15>
 n<> u<93> t<Ps_or_hierarchical_identifier> p<96> c<92> s<95> l<14:14> el<14:15>
@@ -108,7 +108,7 @@ n<> u<102> t<Net_assignment> p<103> c<96> l<14:14> el<14:24>
 n<> u<103> t<List_of_net_assignments> p<104> c<102> l<14:14> el<14:24>
 n<> u<104> t<Continuous_assign> p<105> c<103> l<14:7> el<14:25>
 n<> u<105> t<Module_common_item> p<106> c<104> l<14:7> el<14:25>
-n<> u<106> t<Module_or_generate_item> p<107> c<105> l<14:7> el<14:25>
+n<> u<106> t<Interface_or_generate_item> p<107> c<105> l<14:7> el<14:25>
 n<> u<107> t<Generate_item> p<110> c<106> s<109> l<14:7> el<14:25>
 n<gen_block> u<108> t<StringConst> p<110> l<15:10> el<15:19>
 n<> u<109> t<End> p<110> s<108> l<15:4> el<15:7>
@@ -126,7 +126,7 @@ n<> u<120> t<Net_assignment> p<121> c<115> l<17:13> el<17:18>
 n<> u<121> t<List_of_net_assignments> p<122> c<120> l<17:13> el<17:18>
 n<> u<122> t<Continuous_assign> p<123> c<121> l<17:6> el<17:19>
 n<> u<123> t<Module_common_item> p<124> c<122> l<17:6> el<17:19>
-n<> u<124> t<Module_or_generate_item> p<125> c<123> l<17:6> el<17:19>
+n<> u<124> t<Interface_or_generate_item> p<125> c<123> l<17:6> el<17:19>
 n<> u<125> t<Generate_item> p<126> c<124> l<17:6> el<17:19>
 n<> u<126> t<Generate_block> p<127> c<125> l<17:6> el<17:19>
 n<> u<127> t<If_generate_construct> p<128> c<67> l<9:4> el<17:19>

--- a/tests/GenBlock/GenBlock.log
+++ b/tests/GenBlock/GenBlock.log
@@ -2,19 +2,19 @@
 
 LIB:  work
 FILE: dut.sv
-n<> u<0> t<Null_rule> p<111> s<110> l<1:1> el<1:0>
+n<> u<0> t<Null_rule> p<113> s<112> l<1:1> el<1:0>
 n<> u<1> t<Module_keyword> p<5> s<2> l<1:1> el<1:7>
 n<GOOD> u<2> t<StringConst> p<5> s<4> l<1:8> el<1:12>
 n<> u<3> t<Port> p<4> l<1:13> el<1:13>
 n<> u<4> t<List_of_ports> p<5> c<3> l<1:12> el<1:14>
 n<> u<5> t<Module_nonansi_header> p<6> c<1> l<1:1> el<1:15>
 n<> u<6> t<Module_declaration> p<7> c<5> l<1:1> el<2:10>
-n<> u<7> t<Description> p<110> c<6> s<109> l<1:1> el<2:10>
+n<> u<7> t<Description> p<112> c<6> s<111> l<1:1> el<2:10>
 n<> u<8> t<Module_keyword> p<12> s<9> l<4:1> el<4:7>
 n<axi> u<9> t<StringConst> p<12> s<11> l<4:8> el<4:11>
 n<> u<10> t<Port> p<11> l<4:12> el<4:12>
 n<> u<11> t<List_of_ports> p<12> c<10> l<4:11> el<4:13>
-n<> u<12> t<Module_nonansi_header> p<108> c<8> s<29> l<4:1> el<4:14>
+n<> u<12> t<Module_nonansi_header> p<110> c<8> s<29> l<4:1> el<4:14>
 n<> u<13> t<Data_type_or_implicit> p<23> s<22> l<6:15> el<6:15>
 n<N_MASTER> u<14> t<StringConst> p<21> s<20> l<6:15> el<6:23>
 n<8> u<15> t<IntConst> p<16> l<6:33> el<6:34>
@@ -31,7 +31,7 @@ n<> u<25> t<Module_or_generate_item_declaration> p<26> c<24> l<6:5> el<6:35>
 n<> u<26> t<Module_common_item> p<27> c<25> l<6:5> el<6:35>
 n<> u<27> t<Module_or_generate_item> p<28> c<26> l<6:5> el<6:35>
 n<> u<28> t<Non_port_module_item> p<29> c<27> l<6:5> el<6:35>
-n<> u<29> t<Module_item> p<108> c<28> s<52> l<6:5> el<6:35>
+n<> u<29> t<Module_item> p<110> c<28> s<52> l<6:5> el<6:35>
 n<> u<30> t<Data_type_or_implicit> p<46> s<45> l<7:15> el<7:15>
 n<LOG_MASTER> u<31> t<StringConst> p<44> s<43> l<7:15> el<7:25>
 n<> u<32> t<Dollar_keyword> p<39> s<33> l<7:33> el<7:34>
@@ -54,7 +54,7 @@ n<> u<48> t<Module_or_generate_item_declaration> p<49> c<47> l<7:5> el<7:50>
 n<> u<49> t<Module_common_item> p<50> c<48> l<7:5> el<7:50>
 n<> u<50> t<Module_or_generate_item> p<51> c<49> l<7:5> el<7:50>
 n<> u<51> t<Non_port_module_item> p<52> c<50> l<7:5> el<7:50>
-n<> u<52> t<Module_item> p<108> c<51> s<75> l<7:5> el<7:50>
+n<> u<52> t<Module_item> p<110> c<51> s<75> l<7:5> el<7:50>
 n<> u<53> t<Data_type_or_implicit> p<69> s<68> l<8:16> el<8:16>
 n<TOTAL_N_MASTER> u<54> t<StringConst> p<67> s<66> l<8:16> el<8:30>
 n<2> u<55> t<IntConst> p<56> l<8:36> el<8:37>
@@ -77,7 +77,7 @@ n<> u<71> t<Module_or_generate_item_declaration> p<72> c<70> l<8:5> el<8:50>
 n<> u<72> t<Module_common_item> p<73> c<71> l<8:5> el<8:50>
 n<> u<73> t<Module_or_generate_item> p<74> c<72> l<8:5> el<8:50>
 n<> u<74> t<Non_port_module_item> p<75> c<73> l<8:5> el<8:50>
-n<> u<75> t<Module_item> p<108> c<74> s<107> l<8:5> el<8:50>
+n<> u<75> t<Module_item> p<110> c<74> s<109> l<8:5> el<8:50>
 n<N_MASTER> u<76> t<StringConst> p<77> l<13:10> el<13:18>
 n<> u<77> t<Primary_literal> p<78> c<76> l<13:10> el<13:18>
 n<> u<78> t<Constant_primary> p<79> c<77> l<13:10> el<13:18>
@@ -87,33 +87,35 @@ n<> u<81> t<Primary_literal> p<82> c<80> l<13:22> el<13:36>
 n<> u<82> t<Constant_primary> p<83> c<81> l<13:22> el<13:36>
 n<> u<83> t<Constant_expression> p<85> c<82> l<13:22> el<13:36>
 n<> u<84> t<BinOp_Not> p<85> s<83> l<13:19> el<13:21>
-n<> u<85> t<Constant_expression> p<102> c<79> s<89> l<13:10> el<13:36>
+n<> u<85> t<Constant_expression> p<100> c<79> s<88> l<13:10> el<13:36>
 n<ARRAY_INT> u<86> t<StringConst> p<88> s<87> l<14:15> el<14:24>
 n<> u<87> t<End> p<88> l<15:7> el<15:10>
-n<> u<88> t<Generate_module_block> p<89> c<86> l<14:7> el<15:10>
-n<> u<89> t<Generate_module_item> p<102> c<88> s<101> l<14:7> el<15:10>
-n<GOOD> u<90> t<StringConst> p<96> s<95> l<18:9> el<18:13>
-n<good> u<91> t<StringConst> p<92> l<18:14> el<18:18>
-n<> u<92> t<Name_of_instance> p<95> c<91> s<94> l<18:14> el<18:18>
-n<> u<93> t<Ordered_port_connection> p<94> l<18:19> el<18:19>
-n<> u<94> t<List_of_port_connections> p<95> c<93> l<18:19> el<18:19>
-n<> u<95> t<Hierarchical_instance> p<96> c<92> l<18:14> el<18:20>
-n<> u<96> t<Module_instantiation> p<97> c<90> l<18:9> el<18:21>
-n<> u<97> t<Module_or_generate_item> p<98> c<96> l<18:9> el<18:21>
-n<> u<98> t<Generate_module_item> p<100> c<97> s<99> l<18:9> el<18:21>
-n<> u<99> t<End> p<100> l<19:7> el<19:10>
-n<> u<100> t<Generate_module_block> p<101> c<98> l<17:7> el<19:10>
-n<> u<101> t<Generate_module_item> p<102> c<100> l<17:7> el<19:10>
-n<> u<102> t<Generate_module_conditional_statement> p<103> c<85> l<13:7> el<19:10>
-n<> u<103> t<Generate_module_item> p<105> c<102> s<104> l<13:7> el<19:10>
-n<> u<104> t<Endgenerate> p<105> l<20:7> el<20:18>
-n<> u<105> t<Generated_module_instantiation> p<106> c<103> l<10:7> el<20:18>
-n<> u<106> t<Non_port_module_item> p<107> c<105> l<10:7> el<20:18>
-n<> u<107> t<Module_item> p<108> c<106> l<10:7> el<20:18>
-n<> u<108> t<Module_declaration> p<109> c<12> l<4:1> el<22:10>
-n<> u<109> t<Description> p<110> c<108> l<4:1> el<22:10>
-n<> u<110> t<Source_text> p<111> c<7> l<1:1> el<22:10>
-n<> u<111> t<Top_level_rule> l<1:1> el<23:1>
+n<> u<88> t<Generate_block> p<100> c<86> s<99> l<14:7> el<15:10>
+n<GOOD> u<89> t<StringConst> p<95> s<94> l<18:9> el<18:13>
+n<good> u<90> t<StringConst> p<91> l<18:14> el<18:18>
+n<> u<91> t<Name_of_instance> p<94> c<90> s<93> l<18:14> el<18:18>
+n<> u<92> t<Ordered_port_connection> p<93> l<18:19> el<18:19>
+n<> u<93> t<List_of_port_connections> p<94> c<92> l<18:19> el<18:19>
+n<> u<94> t<Hierarchical_instance> p<95> c<91> l<18:14> el<18:20>
+n<> u<95> t<Module_instantiation> p<96> c<89> l<18:9> el<18:21>
+n<> u<96> t<Module_or_generate_item> p<97> c<95> l<18:9> el<18:21>
+n<> u<97> t<Generate_item> p<99> c<96> s<98> l<18:9> el<18:21>
+n<> u<98> t<End> p<99> l<19:7> el<19:10>
+n<> u<99> t<Generate_block> p<100> c<97> l<17:7> el<19:10>
+n<> u<100> t<If_generate_construct> p<101> c<85> l<13:7> el<19:10>
+n<> u<101> t<Conditional_generate_construct> p<102> c<100> l<13:7> el<19:10>
+n<> u<102> t<Module_common_item> p<103> c<101> l<13:7> el<19:10>
+n<> u<103> t<Module_or_generate_item> p<104> c<102> l<13:7> el<19:10>
+n<> u<104> t<Generate_item> p<105> c<103> l<13:7> el<19:10>
+n<> u<105> t<Generate_block> p<107> c<104> s<106> l<13:7> el<19:10>
+n<> u<106> t<Endgenerate> p<107> l<20:7> el<20:18>
+n<> u<107> t<Generate_region> p<108> c<105> l<10:7> el<20:18>
+n<> u<108> t<Non_port_module_item> p<109> c<107> l<10:7> el<20:18>
+n<> u<109> t<Module_item> p<110> c<108> l<10:7> el<20:18>
+n<> u<110> t<Module_declaration> p<111> c<12> l<4:1> el<22:10>
+n<> u<111> t<Description> p<112> c<110> l<4:1> el<22:10>
+n<> u<112> t<Source_text> p<113> c<7> l<1:1> el<22:10>
+n<> u<113> t<Top_level_rule> l<1:1> el<23:1>
 [WRN:PA0205] dut.sv:1: No timescale set for "GOOD".
 
 [WRN:PA0205] dut.sv:4: No timescale set for "axi".

--- a/tests/GenIf/GenIf.log
+++ b/tests/GenIf/GenIf.log
@@ -2,12 +2,12 @@
 
 LIB:  work
 FILE: dut.sv
-n<> u<0> t<Null_rule> p<97> s<96> l<1:1> el<1:0>
+n<> u<0> t<Null_rule> p<105> s<104> l<1:1> el<1:0>
 n<> u<1> t<Module_keyword> p<5> s<2> l<1:1> el<1:7>
 n<gen_test4> u<2> t<StringConst> p<5> s<4> l<1:8> el<1:17>
 n<> u<3> t<Port> p<4> l<1:18> el<1:18>
 n<> u<4> t<List_of_ports> p<5> c<3> l<1:17> el<1:19>
-n<> u<5> t<Module_nonansi_header> p<94> c<1> s<13> l<1:1> el<1:20>
+n<> u<5> t<Module_nonansi_header> p<102> c<1> s<13> l<1:1> el<1:20>
 n<i> u<6> t<StringConst> p<7> l<5:8> el<5:9>
 n<> u<7> t<Identifier_list> p<8> c<6> l<5:8> el<5:9>
 n<> u<8> t<Genvar_declaration> p<9> c<7> l<5:1> el<5:10>
@@ -15,13 +15,13 @@ n<> u<9> t<Module_or_generate_item_declaration> p<10> c<8> l<5:1> el<5:10>
 n<> u<10> t<Module_common_item> p<11> c<9> l<5:1> el<5:10>
 n<> u<11> t<Module_or_generate_item> p<12> c<10> l<5:1> el<5:10>
 n<> u<12> t<Non_port_module_item> p<13> c<11> l<5:1> el<5:10>
-n<> u<13> t<Module_item> p<94> c<12> s<93> l<5:1> el<5:10>
+n<> u<13> t<Module_item> p<102> c<12> s<101> l<5:1> el<5:10>
 n<i> u<14> t<StringConst> p<19> s<18> l<7:14> el<7:15>
 n<0> u<15> t<IntConst> p<16> l<7:16> el<7:17>
 n<> u<16> t<Primary_literal> p<17> c<15> l<7:16> el<7:17>
 n<> u<17> t<Constant_primary> p<18> c<16> l<7:16> el<7:17>
 n<> u<18> t<Constant_expression> p<19> c<17> l<7:16> el<7:17>
-n<> u<19> t<Genvar_decl_assignment> p<88> c<14> s<29> l<7:14> el<7:17>
+n<> u<19> t<Genvar_initialization> p<93> c<14> s<29> l<7:14> el<7:17>
 n<i> u<20> t<StringConst> p<21> l<7:19> el<7:20>
 n<> u<21> t<Primary_literal> p<22> c<20> l<7:19> el<7:20>
 n<> u<22> t<Constant_primary> p<23> c<21> l<7:19> el<7:20>
@@ -31,7 +31,7 @@ n<> u<25> t<Primary_literal> p<26> c<24> l<7:23> el<7:24>
 n<> u<26> t<Constant_primary> p<27> c<25> l<7:23> el<7:24>
 n<> u<27> t<Constant_expression> p<29> c<26> l<7:23> el<7:24>
 n<> u<28> t<BinOp_Less> p<29> s<27> l<7:21> el<7:22>
-n<> u<29> t<Constant_expression> p<88> c<23> s<42> l<7:19> el<7:24>
+n<> u<29> t<Constant_expression> p<93> c<23> s<42> l<7:19> el<7:24>
 n<i> u<30> t<StringConst> p<42> s<31> l<7:26> el<7:27>
 n<> u<31> t<AssignOp_Assign> p<42> s<41> l<7:27> el<7:28>
 n<i> u<32> t<StringConst> p<33> l<7:28> el<7:29>
@@ -44,8 +44,8 @@ n<> u<38> t<Constant_primary> p<39> c<37> l<7:30> el<7:31>
 n<> u<39> t<Constant_expression> p<41> c<38> l<7:30> el<7:31>
 n<> u<40> t<BinOp_Plus> p<41> s<39> l<7:29> el<7:30>
 n<> u<41> t<Constant_expression> p<42> c<35> l<7:28> el<7:31>
-n<> u<42> t<Genvar_assignment> p<88> c<30> s<87> l<7:26> el<7:31>
-n<foo> u<43> t<StringConst> p<87> s<85> l<7:41> el<7:44>
+n<> u<42> t<Genvar_iteration> p<93> c<30> s<92> l<7:26> el<7:31>
+n<foo> u<43> t<StringConst> p<92> s<90> l<7:41> el<7:44>
 n<i> u<44> t<StringConst> p<45> l<8:21> el<8:22>
 n<> u<45> t<Primary_literal> p<46> c<44> l<8:21> el<8:22>
 n<> u<46> t<Constant_primary> p<47> c<45> l<8:21> el<8:22>
@@ -55,7 +55,7 @@ n<> u<49> t<Primary_literal> p<50> c<48> l<8:26> el<8:27>
 n<> u<50> t<Constant_primary> p<51> c<49> l<8:26> el<8:27>
 n<> u<51> t<Constant_expression> p<53> c<50> l<8:26> el<8:27>
 n<> u<52> t<BinOp_Equiv> p<53> s<51> l<8:23> el<8:25>
-n<> u<53> t<Constant_expression> p<84> c<47> s<68> l<8:21> el<8:27>
+n<> u<53> t<Constant_expression> p<86> c<47> s<69> l<8:21> el<8:27>
 n<temp1> u<54> t<StringConst> p<55> l<9:32> el<9:37>
 n<> u<55> t<Ps_or_hierarchical_identifier> p<58> c<54> s<57> l<9:32> el<9:37>
 n<> u<56> t<Constant_bit_select> p<57> l<9:38> el<9:38>
@@ -70,36 +70,44 @@ n<> u<64> t<List_of_net_assignments> p<65> c<63> l<9:32> el<9:41>
 n<> u<65> t<Continuous_assign> p<66> c<64> l<9:25> el<9:42>
 n<> u<66> t<Module_common_item> p<67> c<65> l<9:25> el<9:42>
 n<> u<67> t<Module_or_generate_item> p<68> c<66> l<9:25> el<9:42>
-n<> u<68> t<Generate_module_item> p<84> c<67> s<83> l<9:25> el<9:42>
-n<temp2> u<69> t<StringConst> p<70> l<11:32> el<11:37>
-n<> u<70> t<Ps_or_hierarchical_identifier> p<73> c<69> s<72> l<11:32> el<11:37>
-n<> u<71> t<Constant_bit_select> p<72> l<11:38> el<11:38>
-n<> u<72> t<Constant_select> p<73> c<71> l<11:38> el<11:38>
-n<> u<73> t<Net_lvalue> p<78> c<70> s<77> l<11:32> el<11:37>
-n<b> u<74> t<StringConst> p<75> l<11:40> el<11:41>
-n<> u<75> t<Primary_literal> p<76> c<74> l<11:40> el<11:41>
-n<> u<76> t<Primary> p<77> c<75> l<11:40> el<11:41>
-n<> u<77> t<Expression> p<78> c<76> l<11:40> el<11:41>
-n<> u<78> t<Net_assignment> p<79> c<73> l<11:32> el<11:41>
-n<> u<79> t<List_of_net_assignments> p<80> c<78> l<11:32> el<11:41>
-n<> u<80> t<Continuous_assign> p<81> c<79> l<11:25> el<11:42>
-n<> u<81> t<Module_common_item> p<82> c<80> l<11:25> el<11:42>
-n<> u<82> t<Module_or_generate_item> p<83> c<81> l<11:25> el<11:42>
-n<> u<83> t<Generate_module_item> p<84> c<82> l<11:25> el<11:42>
-n<> u<84> t<Generate_module_conditional_statement> p<85> c<53> l<8:17> el<11:42>
-n<> u<85> t<Generate_module_item> p<87> c<84> s<86> l<8:17> el<11:42>
-n<> u<86> t<End> p<87> l<12:9> el<12:12>
-n<> u<87> t<Generate_module_named_block> p<88> c<43> l<7:33> el<12:12>
-n<> u<88> t<Generate_module_loop_statement> p<89> c<19> l<7:9> el<12:12>
-n<> u<89> t<Generate_module_item> p<91> c<88> s<90> l<7:9> el<12:12>
-n<> u<90> t<Endgenerate> p<91> l<13:1> el<13:12>
-n<> u<91> t<Generated_module_instantiation> p<92> c<89> l<6:1> el<13:12>
-n<> u<92> t<Non_port_module_item> p<93> c<91> l<6:1> el<13:12>
-n<> u<93> t<Module_item> p<94> c<92> l<6:1> el<13:12>
-n<> u<94> t<Module_declaration> p<95> c<5> l<1:1> el<14:10>
-n<> u<95> t<Description> p<96> c<94> l<1:1> el<14:10>
-n<> u<96> t<Source_text> p<97> c<95> l<1:1> el<14:10>
-n<> u<97> t<Top_level_rule> l<1:1> el<15:1>
+n<> u<68> t<Generate_item> p<69> c<67> l<9:25> el<9:42>
+n<> u<69> t<Generate_block> p<86> c<68> s<85> l<9:25> el<9:42>
+n<temp2> u<70> t<StringConst> p<71> l<11:32> el<11:37>
+n<> u<71> t<Ps_or_hierarchical_identifier> p<74> c<70> s<73> l<11:32> el<11:37>
+n<> u<72> t<Constant_bit_select> p<73> l<11:38> el<11:38>
+n<> u<73> t<Constant_select> p<74> c<72> l<11:38> el<11:38>
+n<> u<74> t<Net_lvalue> p<79> c<71> s<78> l<11:32> el<11:37>
+n<b> u<75> t<StringConst> p<76> l<11:40> el<11:41>
+n<> u<76> t<Primary_literal> p<77> c<75> l<11:40> el<11:41>
+n<> u<77> t<Primary> p<78> c<76> l<11:40> el<11:41>
+n<> u<78> t<Expression> p<79> c<77> l<11:40> el<11:41>
+n<> u<79> t<Net_assignment> p<80> c<74> l<11:32> el<11:41>
+n<> u<80> t<List_of_net_assignments> p<81> c<79> l<11:32> el<11:41>
+n<> u<81> t<Continuous_assign> p<82> c<80> l<11:25> el<11:42>
+n<> u<82> t<Module_common_item> p<83> c<81> l<11:25> el<11:42>
+n<> u<83> t<Module_or_generate_item> p<84> c<82> l<11:25> el<11:42>
+n<> u<84> t<Generate_item> p<85> c<83> l<11:25> el<11:42>
+n<> u<85> t<Generate_block> p<86> c<84> l<11:25> el<11:42>
+n<> u<86> t<If_generate_construct> p<87> c<53> l<8:17> el<11:42>
+n<> u<87> t<Conditional_generate_construct> p<88> c<86> l<8:17> el<11:42>
+n<> u<88> t<Module_common_item> p<89> c<87> l<8:17> el<11:42>
+n<> u<89> t<Module_or_generate_item> p<90> c<88> l<8:17> el<11:42>
+n<> u<90> t<Generate_item> p<92> c<89> s<91> l<8:17> el<11:42>
+n<> u<91> t<End> p<92> l<12:9> el<12:12>
+n<> u<92> t<Generate_block> p<93> c<43> l<7:33> el<12:12>
+n<> u<93> t<Loop_generate_construct> p<94> c<19> l<7:9> el<12:12>
+n<> u<94> t<Module_common_item> p<95> c<93> l<7:9> el<12:12>
+n<> u<95> t<Module_or_generate_item> p<96> c<94> l<7:9> el<12:12>
+n<> u<96> t<Generate_item> p<97> c<95> l<7:9> el<12:12>
+n<> u<97> t<Generate_block> p<99> c<96> s<98> l<7:9> el<12:12>
+n<> u<98> t<Endgenerate> p<99> l<13:1> el<13:12>
+n<> u<99> t<Generate_region> p<100> c<97> l<6:1> el<13:12>
+n<> u<100> t<Non_port_module_item> p<101> c<99> l<6:1> el<13:12>
+n<> u<101> t<Module_item> p<102> c<100> l<6:1> el<13:12>
+n<> u<102> t<Module_declaration> p<103> c<5> l<1:1> el<14:10>
+n<> u<103> t<Description> p<104> c<102> l<1:1> el<14:10>
+n<> u<104> t<Source_text> p<105> c<103> l<1:1> el<14:10>
+n<> u<105> t<Top_level_rule> l<1:1> el<15:1>
 [WRN:PA0205] dut.sv:1: No timescale set for "gen_test4".
 
 [INF:CP0300] Compilation...
@@ -368,7 +376,7 @@ n<> u<245> t<Top_level_rule> f<0> l<0:11>
 
 [INF:CP0335] dut.sv:7: Compile generate block "work@gen_test4.foo[1]".
 
-[INF:CP0335] dut.sv:8: Compile generate block "work@gen_test4.foo[1].genblk1".
+[INF:CP0335] dut.sv:11: Compile generate block "work@gen_test4.foo[1].genblk1".
 
 [NTE:EL0503] dut.sv:1: Top level module "work@gen_test4".
 
@@ -776,7 +784,7 @@ design: (work@gen_test4)
         |vpiName:i
         |vpiFullName:work@gen_test4.foo[1].i
       |vpiGenScopeArray:
-      \_gen_scope_array: (work@gen_test4.foo[1].genblk1), line:8:17, endln:11:42, parent:work@gen_test4.foo[1]
+      \_gen_scope_array: (work@gen_test4.foo[1].genblk1), line:11:25, endln:11:42, parent:work@gen_test4.foo[1]
         |vpiName:genblk1
         |vpiFullName:work@gen_test4.foo[1].genblk1
         |vpiGenScope:

--- a/tests/GenerateInterface/GenerateInterface.log
+++ b/tests/GenerateInterface/GenerateInterface.log
@@ -8,7 +8,7 @@
 
 LIB:  work
 FILE: top.sv
-n<> u<0> t<Null_rule> p<415> s<414> l<1:1> el<1:0>
+n<> u<0> t<Null_rule> p<418> s<417> l<1:1> el<1:0>
 n<abc_if> u<1> t<StringConst> p<2> l<1:11> el<1:17>
 n<> u<2> t<Interface_identifier> p<16> c<1> s<15> l<1:11> el<1:17>
 n<> u<3> t<IntegerAtomType_Int> p<4> l<1:20> el<1:23>
@@ -119,7 +119,7 @@ n<> u<107> t<Endclocking> p<108> l<9:4> el<9:15>
 n<> u<108> t<Clocking_declaration> p<109> c<93> l<7:7> el<9:15>
 n<> u<109> t<Module_or_generate_item_declaration> p<110> c<108> l<7:7> el<9:15>
 n<> u<110> t<Module_common_item> p<111> c<109> l<7:7> el<9:15>
-n<> u<111> t<Module_or_generate_item> p<112> c<110> l<7:7> el<9:15>
+n<> u<111> t<Interface_or_generate_item> p<112> c<110> l<7:7> el<9:15>
 n<> u<112> t<Generate_item> p<115> c<111> s<114> l<7:7> el<9:15>
 n<block> u<113> t<StringConst> p<115> l<10:10> el<10:15>
 n<> u<114> t<End> p<115> s<113> l<10:4> el<10:7>
@@ -130,7 +130,7 @@ n<> u<118> t<Interface_or_generate_item> p<119> c<117> l<6:4> el<10:15>
 n<> u<119> t<Non_port_interface_item> p<121> c<118> s<120> l<6:4> el<10:15>
 n<> u<120> t<Endinterface> p<121> l<13:1> el<13:13>
 n<> u<121> t<Interface_declaration> p<122> c<16> l<1:1> el<13:13>
-n<> u<122> t<Description> p<414> c<121> s<139> l<1:1> el<13:13>
+n<> u<122> t<Description> p<417> c<121> s<139> l<1:1> el<13:13>
 n<> u<123> t<Module_keyword> p<127> s<124> l<16:1> el<16:7>
 n<top> u<124> t<StringConst> p<127> s<126> l<16:8> el<16:11>
 n<> u<125> t<Port> p<126> l<16:13> el<16:13>
@@ -147,7 +147,7 @@ n<> u<135> t<Module_or_generate_item> p<136> c<134> l<17:3> el<17:17>
 n<> u<136> t<Non_port_module_item> p<137> c<135> l<17:3> el<17:17>
 n<> u<137> t<Module_item> p<138> c<136> l<17:3> el<17:17>
 n<> u<138> t<Module_declaration> p<139> c<127> l<16:1> el<19:10>
-n<> u<139> t<Description> p<414> c<138> s<279> l<16:1> el<19:10>
+n<> u<139> t<Description> p<417> c<138> s<279> l<16:1> el<19:10>
 n<pins_if> u<140> t<StringConst> p<141> l<22:11> el<22:18>
 n<> u<141> t<Interface_identifier> p<180> c<140> s<156> l<22:11> el<22:18>
 n<> u<142> t<IntegerAtomType_Int> p<143> l<22:32> el<22:35>
@@ -287,7 +287,7 @@ n<> u<275> t<Generated_interface_instantiation> p<276> c<273> l<27:3> el<31:14>
 n<> u<276> t<Non_port_interface_item> p<278> c<275> s<277> l<27:3> el<31:14>
 n<> u<277> t<Endinterface> p<278> l<32:1> el<32:13>
 n<> u<278> t<Interface_declaration> p<279> c<180> l<22:1> el<32:13>
-n<> u<279> t<Description> p<414> c<278> s<413> l<22:1> el<32:13>
+n<> u<279> t<Description> p<417> c<278> s<416> l<22:1> el<32:13>
 n<> u<280> t<Module_keyword> p<320> s<281> l<34:1> el<34:7>
 n<top2> u<281> t<StringConst> p<320> s<296> l<34:8> el<34:12>
 n<> u<282> t<IntegerAtomType_Int> p<283> l<34:26> el<34:29>
@@ -328,7 +328,7 @@ n<> u<316> t<Net_port_header> p<318> c<297> s<317> l<34:43> el<34:60>
 n<pins> u<317> t<StringConst> p<318> l<34:61> el<34:65>
 n<> u<318> t<Ansi_port_declaration> p<319> c<316> l<34:43> el<34:65>
 n<> u<319> t<List_of_port_declarations> p<320> c<318> l<34:42> el<34:66>
-n<> u<320> t<Module_ansi_header> p<412> c<280> s<343> l<34:1> el<34:67>
+n<> u<320> t<Module_ansi_header> p<415> c<280> s<343> l<34:1> el<34:67>
 n<pins_if> u<321> t<StringConst> p<341> s<331> l<35:1> el<35:8>
 n<Width> u<322> t<StringConst> p<329> s<328> l<35:12> el<35:17>
 n<Width> u<323> t<StringConst> p<324> l<35:18> el<35:23>
@@ -351,13 +351,13 @@ n<> u<339> t<List_of_port_connections> p<340> c<338> l<35:33> el<35:37>
 n<> u<340> t<Hierarchical_instance> p<341> c<333> l<35:26> el<35:38>
 n<> u<341> t<Module_instantiation> p<342> c<321> l<35:1> el<35:39>
 n<> u<342> t<Module_or_generate_item> p<343> c<341> l<35:1> el<35:39>
-n<> u<343> t<Non_port_module_item> p<412> c<342> s<411> l<35:1> el<35:39>
+n<> u<343> t<Non_port_module_item> p<415> c<342> s<414> l<35:1> el<35:39>
 n<i> u<344> t<StringConst> p<349> s<348> l<38:17> el<38:18>
 n<0> u<345> t<IntConst> p<346> l<38:21> el<38:22>
 n<> u<346> t<Primary_literal> p<347> c<345> l<38:21> el<38:22>
 n<> u<347> t<Constant_primary> p<348> c<346> l<38:21> el<38:22>
 n<> u<348> t<Constant_expression> p<349> c<347> l<38:21> el<38:22>
-n<> u<349> t<Genvar_decl_assignment> p<407> c<344> s<359> l<38:10> el<38:22>
+n<> u<349> t<Genvar_initialization> p<407> c<344> s<359> l<38:10> el<38:22>
 n<i> u<350> t<StringConst> p<351> l<38:24> el<38:25>
 n<> u<351> t<Primary_literal> p<352> c<350> l<38:24> el<38:25>
 n<> u<352> t<Constant_primary> p<353> c<351> l<38:24> el<38:25>
@@ -370,7 +370,7 @@ n<> u<358> t<BinOp_Less> p<359> s<357> l<38:26> el<38:27>
 n<> u<359> t<Constant_expression> p<407> c<353> s<362> l<38:24> el<38:33>
 n<i> u<360> t<StringConst> p<362> s<361> l<38:35> el<38:36>
 n<> u<361> t<IncDec_PlusPlus> p<362> l<38:36> el<38:38>
-n<> u<362> t<Genvar_assignment> p<407> c<360> s<406> l<38:35> el<38:38>
+n<> u<362> t<Genvar_iteration> p<407> c<360> s<406> l<38:35> el<38:38>
 n<each_pin> u<363> t<StringConst> p<406> s<404> l<38:48> el<38:56>
 n<pins> u<364> t<StringConst> p<365> l<39:14> el<39:18>
 n<> u<365> t<Ps_or_hierarchical_identifier> p<372> c<364> s<371> l<39:14> el<39:18>
@@ -412,18 +412,21 @@ n<> u<400> t<List_of_net_assignments> p<401> c<399> l<39:14> el<39:53>
 n<> u<401> t<Continuous_assign> p<402> c<400> l<39:7> el<39:54>
 n<> u<402> t<Module_common_item> p<403> c<401> l<39:7> el<39:54>
 n<> u<403> t<Module_or_generate_item> p<404> c<402> l<39:7> el<39:54>
-n<> u<404> t<Generate_module_item> p<406> c<403> s<405> l<39:7> el<39:54>
+n<> u<404> t<Generate_item> p<406> c<403> s<405> l<39:7> el<39:54>
 n<> u<405> t<End> p<406> l<40:5> el<40:8>
-n<> u<406> t<Generate_module_named_block> p<407> c<363> l<38:40> el<40:8>
-n<> u<407> t<Generate_module_loop_statement> p<408> c<349> l<38:5> el<40:8>
-n<> u<408> t<Generate_module_item> p<410> c<407> s<409> l<38:5> el<40:8>
-n<> u<409> t<Endgenerate> p<410> l<41:3> el<41:14>
-n<> u<410> t<Generated_module_instantiation> p<411> c<408> l<37:3> el<41:14>
-n<> u<411> t<Non_port_module_item> p<412> c<410> l<37:3> el<41:14>
-n<> u<412> t<Module_declaration> p<413> c<320> l<34:1> el<43:10>
-n<> u<413> t<Description> p<414> c<412> l<34:1> el<43:10>
-n<> u<414> t<Source_text> p<415> c<122> l<1:1> el<43:10>
-n<> u<415> t<Top_level_rule> l<1:1> el<44:1>
+n<> u<406> t<Generate_block> p<407> c<363> l<38:40> el<40:8>
+n<> u<407> t<Loop_generate_construct> p<408> c<349> l<38:5> el<40:8>
+n<> u<408> t<Module_common_item> p<409> c<407> l<38:5> el<40:8>
+n<> u<409> t<Module_or_generate_item> p<410> c<408> l<38:5> el<40:8>
+n<> u<410> t<Generate_item> p<411> c<409> l<38:5> el<40:8>
+n<> u<411> t<Generate_block> p<413> c<410> s<412> l<38:5> el<40:8>
+n<> u<412> t<Endgenerate> p<413> l<41:3> el<41:14>
+n<> u<413> t<Generate_region> p<414> c<411> l<37:3> el<41:14>
+n<> u<414> t<Non_port_module_item> p<415> c<413> l<37:3> el<41:14>
+n<> u<415> t<Module_declaration> p<416> c<320> l<34:1> el<43:10>
+n<> u<416> t<Description> p<417> c<415> l<34:1> el<43:10>
+n<> u<417> t<Source_text> p<418> c<122> l<1:1> el<43:10>
+n<> u<418> t<Top_level_rule> l<1:1> el<44:1>
 [WRN:PA0205] top.sv:1: No timescale set for "abc_if".
 
 [WRN:PA0205] top.sv:16: No timescale set for "top".

--- a/tests/GenerateModule/GenerateModule.log
+++ b/tests/GenerateModule/GenerateModule.log
@@ -8,12 +8,12 @@
 
 LIB:  work
 FILE: top.v
-n<> u<0> t<Null_rule> p<262> s<261> l<1:1> el<1:0>
+n<> u<0> t<Null_rule> p<269> s<268> l<1:1> el<1:0>
 n<> u<1> t<Module_keyword> p<5> s<2> l<1:1> el<1:7>
 n<small_test> u<2> t<StringConst> p<5> s<4> l<1:8> el<1:18>
 n<> u<3> t<Port> p<4> l<1:19> el<1:19>
 n<> u<4> t<List_of_ports> p<5> c<3> l<1:18> el<1:20>
-n<> u<5> t<Module_nonansi_header> p<149> c<1> s<33> l<1:1> el<1:21>
+n<> u<5> t<Module_nonansi_header> p<156> c<1> s<33> l<1:1> el<1:21>
 n<> u<6> t<Signing_Signed> p<17> s<16> l<3:13> el<3:19>
 n<3> u<7> t<IntConst> p<8> l<3:21> el<3:22>
 n<> u<8> t<Primary_literal> p<9> c<7> l<3:21> el<3:22>
@@ -41,7 +41,7 @@ n<> u<29> t<Module_or_generate_item_declaration> p<30> c<28> l<3:3> el<3:35>
 n<> u<30> t<Module_common_item> p<31> c<29> l<3:3> el<3:35>
 n<> u<31> t<Module_or_generate_item> p<32> c<30> l<3:3> el<3:35>
 n<> u<32> t<Non_port_module_item> p<33> c<31> l<3:3> el<3:35>
-n<> u<33> t<Module_item> p<149> c<32> s<42> l<3:3> el<3:35>
+n<> u<33> t<Module_item> p<156> c<32> s<42> l<3:3> el<3:35>
 n<i> u<34> t<StringConst> p<36> s<35> l<5:10> el<5:11>
 n<m> u<35> t<StringConst> p<36> l<5:13> el<5:14>
 n<> u<36> t<Identifier_list> p<37> c<34> l<5:10> el<5:14>
@@ -50,13 +50,13 @@ n<> u<38> t<Module_or_generate_item_declaration> p<39> c<37> l<5:3> el<5:15>
 n<> u<39> t<Module_common_item> p<40> c<38> l<5:3> el<5:15>
 n<> u<40> t<Module_or_generate_item> p<41> c<39> l<5:3> el<5:15>
 n<> u<41> t<Non_port_module_item> p<42> c<40> l<5:3> el<5:15>
-n<> u<42> t<Module_item> p<149> c<41> s<148> l<5:3> el<5:15>
+n<> u<42> t<Module_item> p<156> c<41> s<155> l<5:3> el<5:15>
 n<i> u<43> t<StringConst> p<48> s<47> l<7:10> el<7:11>
 n<0> u<44> t<IntConst> p<45> l<7:12> el<7:13>
 n<> u<45> t<Primary_literal> p<46> c<44> l<7:12> el<7:13>
 n<> u<46> t<Constant_primary> p<47> c<45> l<7:12> el<7:13>
 n<> u<47> t<Constant_expression> p<48> c<46> l<7:12> el<7:13>
-n<> u<48> t<Genvar_decl_assignment> p<143> c<43> s<58> l<7:10> el<7:13>
+n<> u<48> t<Genvar_initialization> p<147> c<43> s<58> l<7:10> el<7:13>
 n<i> u<49> t<StringConst> p<50> l<7:15> el<7:16>
 n<> u<50> t<Primary_literal> p<51> c<49> l<7:15> el<7:16>
 n<> u<51> t<Constant_primary> p<52> c<50> l<7:15> el<7:16>
@@ -66,7 +66,7 @@ n<> u<54> t<Primary_literal> p<55> c<53> l<7:17> el<7:21>
 n<> u<55> t<Constant_primary> p<56> c<54> l<7:17> el<7:21>
 n<> u<56> t<Constant_expression> p<58> c<55> l<7:17> el<7:21>
 n<> u<57> t<BinOp_Less> p<58> s<56> l<7:16> el<7:17>
-n<> u<58> t<Constant_expression> p<143> c<52> s<71> l<7:15> el<7:21>
+n<> u<58> t<Constant_expression> p<147> c<52> s<71> l<7:15> el<7:21>
 n<i> u<59> t<StringConst> p<71> s<60> l<7:23> el<7:24>
 n<> u<60> t<AssignOp_Assign> p<71> s<70> l<7:24> el<7:25>
 n<i> u<61> t<StringConst> p<62> l<7:25> el<7:26>
@@ -79,8 +79,8 @@ n<> u<67> t<Constant_primary> p<68> c<66> l<7:27> el<7:28>
 n<> u<68> t<Constant_expression> p<70> c<67> l<7:27> el<7:28>
 n<> u<69> t<BinOp_Plus> p<70> s<68> l<7:26> el<7:27>
 n<> u<70> t<Constant_expression> p<71> c<64> l<7:25> el<7:28>
-n<> u<71> t<Genvar_assignment> p<143> c<59> s<142> l<7:23> el<7:28>
-n<B1> u<72> t<StringConst> p<142> s<81> l<7:37> el<7:39>
+n<> u<71> t<Genvar_iteration> p<147> c<59> s<146> l<7:23> el<7:28>
+n<B1> u<72> t<StringConst> p<146> s<81> l<7:37> el<7:39>
 n<M1> u<73> t<StringConst> p<79> s<78> l<9:9> el<9:11>
 n<N1> u<74> t<StringConst> p<75> l<9:12> el<9:14>
 n<> u<75> t<Name_of_instance> p<78> c<74> s<77> l<9:12> el<9:14>
@@ -89,7 +89,7 @@ n<> u<77> t<List_of_port_connections> p<78> c<76> l<9:15> el<9:15>
 n<> u<78> t<Hierarchical_instance> p<79> c<75> l<9:12> el<9:16>
 n<> u<79> t<Module_instantiation> p<80> c<73> l<9:9> el<9:17>
 n<> u<80> t<Module_or_generate_item> p<81> c<79> l<9:9> el<9:17>
-n<> u<81> t<Generate_module_item> p<142> c<80> s<140> l<9:9> el<9:17>
+n<> u<81> t<Generate_item> p<146> c<80> s<144> l<9:9> el<9:17>
 n<i> u<82> t<StringConst> p<83> l<11:13> el<11:14>
 n<> u<83> t<Primary_literal> p<84> c<82> l<11:13> el<11:14>
 n<> u<84> t<Constant_primary> p<85> c<83> l<11:13> el<11:14>
@@ -99,14 +99,14 @@ n<> u<87> t<Primary_literal> p<88> c<86> l<11:16> el<11:17>
 n<> u<88> t<Constant_primary> p<89> c<87> l<11:16> el<11:17>
 n<> u<89> t<Constant_expression> p<91> c<88> l<11:16> el<11:17>
 n<> u<90> t<BinOp_GreatEqual> p<91> s<89> l<11:14> el<11:16>
-n<> u<91> t<Constant_expression> p<139> c<85> s<138> l<11:13> el<11:17>
-n<B4> u<92> t<StringConst> p<137> s<135> l<11:26> el<11:28>
+n<> u<91> t<Constant_expression> p<140> c<85> s<139> l<11:13> el<11:17>
+n<B4> u<92> t<StringConst> p<139> s<137> l<11:26> el<11:28>
 n<m> u<93> t<StringConst> p<98> s<97> l<12:18> el<12:19>
 n<i> u<94> t<StringConst> p<95> l<12:20> el<12:21>
 n<> u<95> t<Primary_literal> p<96> c<94> l<12:20> el<12:21>
 n<> u<96> t<Constant_primary> p<97> c<95> l<12:20> el<12:21>
 n<> u<97> t<Constant_expression> p<98> c<96> l<12:20> el<12:21>
-n<> u<98> t<Genvar_decl_assignment> p<134> c<93> s<108> l<12:18> el<12:21>
+n<> u<98> t<Genvar_initialization> p<134> c<93> s<108> l<12:18> el<12:21>
 n<m> u<99> t<StringConst> p<100> l<12:23> el<12:24>
 n<> u<100> t<Primary_literal> p<101> c<99> l<12:23> el<12:24>
 n<> u<101> t<Constant_primary> p<102> c<100> l<12:23> el<12:24>
@@ -129,7 +129,7 @@ n<> u<117> t<Constant_primary> p<118> c<116> l<12:35> el<12:36>
 n<> u<118> t<Constant_expression> p<120> c<117> l<12:35> el<12:36>
 n<> u<119> t<BinOp_Plus> p<120> s<118> l<12:34> el<12:35>
 n<> u<120> t<Constant_expression> p<121> c<114> l<12:33> el<12:36>
-n<> u<121> t<Genvar_assignment> p<134> c<109> s<133> l<12:31> el<12:36>
+n<> u<121> t<Genvar_iteration> p<134> c<109> s<133> l<12:31> el<12:36>
 n<B5> u<122> t<StringConst> p<133> s<131> l<12:45> el<12:47>
 n<M4> u<123> t<StringConst> p<129> s<128> l<13:17> el<13:19>
 n<N4> u<124> t<StringConst> p<125> l<13:20> el<13:22>
@@ -139,138 +139,145 @@ n<> u<127> t<List_of_port_connections> p<128> c<126> l<13:23> el<13:23>
 n<> u<128> t<Hierarchical_instance> p<129> c<125> l<13:20> el<13:24>
 n<> u<129> t<Module_instantiation> p<130> c<123> l<13:17> el<13:25>
 n<> u<130> t<Module_or_generate_item> p<131> c<129> l<13:17> el<13:25>
-n<> u<131> t<Generate_module_item> p<133> c<130> s<132> l<13:17> el<13:25>
+n<> u<131> t<Generate_item> p<133> c<130> s<132> l<13:17> el<13:25>
 n<> u<132> t<End> p<133> l<14:13> el<14:16>
-n<> u<133> t<Generate_module_named_block> p<134> c<122> l<12:38> el<14:16>
-n<> u<134> t<Generate_module_loop_statement> p<135> c<98> l<12:13> el<14:16>
-n<> u<135> t<Generate_module_item> p<137> c<134> s<136> l<12:13> el<14:16>
-n<> u<136> t<End> p<137> l<15:9> el<15:12>
-n<> u<137> t<Generate_module_block> p<138> c<92> l<11:19> el<15:12>
-n<> u<138> t<Generate_module_item> p<139> c<137> l<11:19> el<15:12>
-n<> u<139> t<Generate_module_conditional_statement> p<140> c<91> l<11:9> el<15:12>
-n<> u<140> t<Generate_module_item> p<142> c<139> s<141> l<11:9> el<15:12>
-n<> u<141> t<End> p<142> l<16:5> el<16:8>
-n<> u<142> t<Generate_module_named_block> p<143> c<72> l<7:30> el<16:8>
-n<> u<143> t<Generate_module_loop_statement> p<144> c<48> l<7:5> el<16:8>
-n<> u<144> t<Generate_module_item> p<146> c<143> s<145> l<7:5> el<16:8>
-n<> u<145> t<Endgenerate> p<146> l<17:3> el<17:14>
-n<> u<146> t<Generated_module_instantiation> p<147> c<144> l<6:3> el<17:14>
-n<> u<147> t<Non_port_module_item> p<148> c<146> l<6:3> el<17:14>
-n<> u<148> t<Module_item> p<149> c<147> l<6:3> el<17:14>
-n<> u<149> t<Module_declaration> p<150> c<5> l<1:1> el<19:10>
-n<> u<150> t<Description> p<261> c<149> s<260> l<1:1> el<19:10>
-n<> u<151> t<Module_keyword> p<186> s<152> l<21:1> el<21:7>
-n<top> u<152> t<StringConst> p<186> s<185> l<21:8> el<21:11>
-n<> u<153> t<PortDir_Inp> p<166> s<165> l<21:12> el<21:17>
-n<2> u<154> t<IntConst> p<155> l<21:19> el<21:20>
-n<> u<155> t<Primary_literal> p<156> c<154> l<21:19> el<21:20>
-n<> u<156> t<Constant_primary> p<157> c<155> l<21:19> el<21:20>
-n<> u<157> t<Constant_expression> p<162> c<156> s<161> l<21:19> el<21:20>
-n<0> u<158> t<IntConst> p<159> l<21:21> el<21:22>
-n<> u<159> t<Primary_literal> p<160> c<158> l<21:21> el<21:22>
-n<> u<160> t<Constant_primary> p<161> c<159> l<21:21> el<21:22>
-n<> u<161> t<Constant_expression> p<162> c<160> l<21:21> el<21:22>
-n<> u<162> t<Constant_range> p<163> c<157> l<21:19> el<21:22>
-n<> u<163> t<Packed_dimension> p<164> c<162> l<21:18> el<21:23>
-n<> u<164> t<Data_type_or_implicit> p<165> c<163> l<21:18> el<21:23>
-n<> u<165> t<Net_port_type> p<166> c<164> l<21:18> el<21:23>
-n<> u<166> t<Net_port_header> p<168> c<153> s<167> l<21:12> el<21:23>
-n<a> u<167> t<StringConst> p<168> l<21:24> el<21:25>
-n<> u<168> t<Ansi_port_declaration> p<185> c<166> s<184> l<21:12> el<21:25>
-n<> u<169> t<PortDir_Out> p<182> s<181> l<21:27> el<21:33>
-n<2> u<170> t<IntConst> p<171> l<21:35> el<21:36>
-n<> u<171> t<Primary_literal> p<172> c<170> l<21:35> el<21:36>
-n<> u<172> t<Constant_primary> p<173> c<171> l<21:35> el<21:36>
-n<> u<173> t<Constant_expression> p<178> c<172> s<177> l<21:35> el<21:36>
-n<0> u<174> t<IntConst> p<175> l<21:37> el<21:38>
-n<> u<175> t<Primary_literal> p<176> c<174> l<21:37> el<21:38>
-n<> u<176> t<Constant_primary> p<177> c<175> l<21:37> el<21:38>
-n<> u<177> t<Constant_expression> p<178> c<176> l<21:37> el<21:38>
-n<> u<178> t<Constant_range> p<179> c<173> l<21:35> el<21:38>
-n<> u<179> t<Packed_dimension> p<180> c<178> l<21:34> el<21:39>
-n<> u<180> t<Data_type_or_implicit> p<181> c<179> l<21:34> el<21:39>
-n<> u<181> t<Net_port_type> p<182> c<180> l<21:34> el<21:39>
-n<> u<182> t<Net_port_header> p<184> c<169> s<183> l<21:27> el<21:39>
-n<b> u<183> t<StringConst> p<184> l<21:40> el<21:41>
-n<> u<184> t<Ansi_port_declaration> p<185> c<182> l<21:27> el<21:41>
-n<> u<185> t<List_of_port_declarations> p<186> c<168> l<21:11> el<21:42>
-n<> u<186> t<Module_ansi_header> p<259> c<151> s<202> l<21:1> el<21:43>
-n<> u<187> t<Data_type_or_implicit> p<197> s<196> l<22:13> el<22:13>
-n<toto> u<188> t<StringConst> p<195> s<194> l<22:13> el<22:17>
-n<> u<189> t<Number_1Tickb1> p<190> l<22:20> el<22:24>
-n<> u<190> t<Primary_literal> p<191> c<189> l<22:20> el<22:24>
-n<> u<191> t<Constant_primary> p<192> c<190> l<22:20> el<22:24>
-n<> u<192> t<Constant_expression> p<193> c<191> l<22:20> el<22:24>
-n<> u<193> t<Constant_mintypmax_expression> p<194> c<192> l<22:20> el<22:24>
-n<> u<194> t<Constant_param_expression> p<195> c<193> l<22:20> el<22:24>
-n<> u<195> t<Param_assignment> p<196> c<188> l<22:13> el<22:24>
-n<> u<196> t<List_of_param_assignments> p<197> c<195> l<22:13> el<22:24>
-n<> u<197> t<Parameter_declaration> p<198> c<187> l<22:3> el<22:24>
-n<> u<198> t<Package_or_generate_item_declaration> p<199> c<197> l<22:3> el<22:25>
-n<> u<199> t<Module_or_generate_item_declaration> p<200> c<198> l<22:3> el<22:25>
-n<> u<200> t<Module_common_item> p<201> c<199> l<22:3> el<22:25>
-n<> u<201> t<Module_or_generate_item> p<202> c<200> l<22:3> el<22:25>
-n<> u<202> t<Non_port_module_item> p<259> c<201> s<258> l<22:3> el<22:25>
-n<i> u<203> t<StringConst> p<208> s<207> l<23:15> el<23:16>
-n<0> u<204> t<IntConst> p<205> l<23:17> el<23:18>
-n<> u<205> t<Primary_literal> p<206> c<204> l<23:17> el<23:18>
-n<> u<206> t<Constant_primary> p<207> c<205> l<23:17> el<23:18>
-n<> u<207> t<Constant_expression> p<208> c<206> l<23:17> el<23:18>
-n<> u<208> t<Genvar_initialization> p<255> c<203> s<218> l<23:8> el<23:18>
-n<i> u<209> t<StringConst> p<210> l<23:20> el<23:21>
-n<> u<210> t<Primary_literal> p<211> c<209> l<23:20> el<23:21>
-n<> u<211> t<Constant_primary> p<212> c<210> l<23:20> el<23:21>
-n<> u<212> t<Constant_expression> p<218> c<211> s<217> l<23:20> el<23:21>
-n<3> u<213> t<IntConst> p<214> l<23:22> el<23:23>
-n<> u<214> t<Primary_literal> p<215> c<213> l<23:22> el<23:23>
-n<> u<215> t<Constant_primary> p<216> c<214> l<23:22> el<23:23>
-n<> u<216> t<Constant_expression> p<218> c<215> l<23:22> el<23:23>
-n<> u<217> t<BinOp_Less> p<218> s<216> l<23:21> el<23:22>
-n<> u<218> t<Constant_expression> p<255> c<212> s<221> l<23:20> el<23:23>
-n<i> u<219> t<StringConst> p<221> s<220> l<23:25> el<23:26>
-n<> u<220> t<IncDec_PlusPlus> p<221> l<23:26> el<23:28>
-n<> u<221> t<Genvar_iteration> p<255> c<219> s<254> l<23:25> el<23:28>
-n<b> u<222> t<StringConst> p<223> l<24:14> el<24:15>
-n<> u<223> t<Ps_or_hierarchical_identifier> p<230> c<222> s<229> l<24:14> el<24:15>
-n<i> u<224> t<StringConst> p<225> l<24:16> el<24:17>
-n<> u<225> t<Primary_literal> p<226> c<224> l<24:16> el<24:17>
-n<> u<226> t<Constant_primary> p<227> c<225> l<24:16> el<24:17>
-n<> u<227> t<Constant_expression> p<228> c<226> l<24:16> el<24:17>
-n<> u<228> t<Constant_bit_select> p<229> c<227> l<24:15> el<24:18>
-n<> u<229> t<Constant_select> p<230> c<228> l<24:15> el<24:18>
-n<> u<230> t<Net_lvalue> p<247> c<223> s<246> l<24:14> el<24:18>
-n<a> u<231> t<StringConst> p<244> s<243> l<24:21> el<24:22>
-n<2> u<232> t<IntConst> p<233> l<24:23> el<24:24>
-n<> u<233> t<Primary_literal> p<234> c<232> l<24:23> el<24:24>
-n<> u<234> t<Primary> p<235> c<233> l<24:23> el<24:24>
-n<> u<235> t<Expression> p<241> c<234> s<240> l<24:23> el<24:24>
-n<i> u<236> t<StringConst> p<237> l<24:25> el<24:26>
-n<> u<237> t<Primary_literal> p<238> c<236> l<24:25> el<24:26>
-n<> u<238> t<Primary> p<239> c<237> l<24:25> el<24:26>
-n<> u<239> t<Expression> p<241> c<238> l<24:25> el<24:26>
-n<> u<240> t<BinOp_Minus> p<241> s<239> l<24:24> el<24:25>
-n<> u<241> t<Expression> p<242> c<235> l<24:23> el<24:26>
-n<> u<242> t<Bit_select> p<243> c<241> l<24:22> el<24:27>
-n<> u<243> t<Select> p<244> c<242> l<24:22> el<24:27>
-n<> u<244> t<Complex_func_call> p<245> c<231> l<24:21> el<24:27>
-n<> u<245> t<Primary> p<246> c<244> l<24:21> el<24:27>
-n<> u<246> t<Expression> p<247> c<245> l<24:21> el<24:27>
-n<> u<247> t<Net_assignment> p<248> c<230> l<24:14> el<24:27>
-n<> u<248> t<List_of_net_assignments> p<249> c<247> l<24:14> el<24:27>
-n<> u<249> t<Continuous_assign> p<250> c<248> l<24:7> el<24:28>
-n<> u<250> t<Module_common_item> p<251> c<249> l<24:7> el<24:28>
-n<> u<251> t<Module_or_generate_item> p<252> c<250> l<24:7> el<24:28>
-n<> u<252> t<Generate_item> p<254> c<251> s<253> l<24:7> el<24:28>
-n<> u<253> t<End> p<254> l<25:3> el<25:6>
-n<> u<254> t<Generate_block> p<255> c<252> l<23:30> el<25:6>
-n<> u<255> t<Loop_generate_construct> p<256> c<208> l<23:3> el<25:6>
-n<> u<256> t<Module_common_item> p<257> c<255> l<23:3> el<25:6>
-n<> u<257> t<Module_or_generate_item> p<258> c<256> l<23:3> el<25:6>
-n<> u<258> t<Non_port_module_item> p<259> c<257> l<23:3> el<25:6>
-n<> u<259> t<Module_declaration> p<260> c<186> l<21:1> el<26:10>
-n<> u<260> t<Description> p<261> c<259> l<21:1> el<26:10>
-n<> u<261> t<Source_text> p<262> c<150> l<1:1> el<26:10>
-n<> u<262> t<Top_level_rule> l<1:1> el<27:1>
+n<> u<133> t<Generate_block> p<134> c<122> l<12:38> el<14:16>
+n<> u<134> t<Loop_generate_construct> p<135> c<98> l<12:13> el<14:16>
+n<> u<135> t<Module_common_item> p<136> c<134> l<12:13> el<14:16>
+n<> u<136> t<Module_or_generate_item> p<137> c<135> l<12:13> el<14:16>
+n<> u<137> t<Generate_item> p<139> c<136> s<138> l<12:13> el<14:16>
+n<> u<138> t<End> p<139> l<15:9> el<15:12>
+n<> u<139> t<Generate_block> p<140> c<92> l<11:19> el<15:12>
+n<> u<140> t<If_generate_construct> p<141> c<91> l<11:9> el<15:12>
+n<> u<141> t<Conditional_generate_construct> p<142> c<140> l<11:9> el<15:12>
+n<> u<142> t<Module_common_item> p<143> c<141> l<11:9> el<15:12>
+n<> u<143> t<Module_or_generate_item> p<144> c<142> l<11:9> el<15:12>
+n<> u<144> t<Generate_item> p<146> c<143> s<145> l<11:9> el<15:12>
+n<> u<145> t<End> p<146> l<16:5> el<16:8>
+n<> u<146> t<Generate_block> p<147> c<72> l<7:30> el<16:8>
+n<> u<147> t<Loop_generate_construct> p<148> c<48> l<7:5> el<16:8>
+n<> u<148> t<Module_common_item> p<149> c<147> l<7:5> el<16:8>
+n<> u<149> t<Module_or_generate_item> p<150> c<148> l<7:5> el<16:8>
+n<> u<150> t<Generate_item> p<151> c<149> l<7:5> el<16:8>
+n<> u<151> t<Generate_block> p<153> c<150> s<152> l<7:5> el<16:8>
+n<> u<152> t<Endgenerate> p<153> l<17:3> el<17:14>
+n<> u<153> t<Generate_region> p<154> c<151> l<6:3> el<17:14>
+n<> u<154> t<Non_port_module_item> p<155> c<153> l<6:3> el<17:14>
+n<> u<155> t<Module_item> p<156> c<154> l<6:3> el<17:14>
+n<> u<156> t<Module_declaration> p<157> c<5> l<1:1> el<19:10>
+n<> u<157> t<Description> p<268> c<156> s<267> l<1:1> el<19:10>
+n<> u<158> t<Module_keyword> p<193> s<159> l<21:1> el<21:7>
+n<top> u<159> t<StringConst> p<193> s<192> l<21:8> el<21:11>
+n<> u<160> t<PortDir_Inp> p<173> s<172> l<21:12> el<21:17>
+n<2> u<161> t<IntConst> p<162> l<21:19> el<21:20>
+n<> u<162> t<Primary_literal> p<163> c<161> l<21:19> el<21:20>
+n<> u<163> t<Constant_primary> p<164> c<162> l<21:19> el<21:20>
+n<> u<164> t<Constant_expression> p<169> c<163> s<168> l<21:19> el<21:20>
+n<0> u<165> t<IntConst> p<166> l<21:21> el<21:22>
+n<> u<166> t<Primary_literal> p<167> c<165> l<21:21> el<21:22>
+n<> u<167> t<Constant_primary> p<168> c<166> l<21:21> el<21:22>
+n<> u<168> t<Constant_expression> p<169> c<167> l<21:21> el<21:22>
+n<> u<169> t<Constant_range> p<170> c<164> l<21:19> el<21:22>
+n<> u<170> t<Packed_dimension> p<171> c<169> l<21:18> el<21:23>
+n<> u<171> t<Data_type_or_implicit> p<172> c<170> l<21:18> el<21:23>
+n<> u<172> t<Net_port_type> p<173> c<171> l<21:18> el<21:23>
+n<> u<173> t<Net_port_header> p<175> c<160> s<174> l<21:12> el<21:23>
+n<a> u<174> t<StringConst> p<175> l<21:24> el<21:25>
+n<> u<175> t<Ansi_port_declaration> p<192> c<173> s<191> l<21:12> el<21:25>
+n<> u<176> t<PortDir_Out> p<189> s<188> l<21:27> el<21:33>
+n<2> u<177> t<IntConst> p<178> l<21:35> el<21:36>
+n<> u<178> t<Primary_literal> p<179> c<177> l<21:35> el<21:36>
+n<> u<179> t<Constant_primary> p<180> c<178> l<21:35> el<21:36>
+n<> u<180> t<Constant_expression> p<185> c<179> s<184> l<21:35> el<21:36>
+n<0> u<181> t<IntConst> p<182> l<21:37> el<21:38>
+n<> u<182> t<Primary_literal> p<183> c<181> l<21:37> el<21:38>
+n<> u<183> t<Constant_primary> p<184> c<182> l<21:37> el<21:38>
+n<> u<184> t<Constant_expression> p<185> c<183> l<21:37> el<21:38>
+n<> u<185> t<Constant_range> p<186> c<180> l<21:35> el<21:38>
+n<> u<186> t<Packed_dimension> p<187> c<185> l<21:34> el<21:39>
+n<> u<187> t<Data_type_or_implicit> p<188> c<186> l<21:34> el<21:39>
+n<> u<188> t<Net_port_type> p<189> c<187> l<21:34> el<21:39>
+n<> u<189> t<Net_port_header> p<191> c<176> s<190> l<21:27> el<21:39>
+n<b> u<190> t<StringConst> p<191> l<21:40> el<21:41>
+n<> u<191> t<Ansi_port_declaration> p<192> c<189> l<21:27> el<21:41>
+n<> u<192> t<List_of_port_declarations> p<193> c<175> l<21:11> el<21:42>
+n<> u<193> t<Module_ansi_header> p<266> c<158> s<209> l<21:1> el<21:43>
+n<> u<194> t<Data_type_or_implicit> p<204> s<203> l<22:13> el<22:13>
+n<toto> u<195> t<StringConst> p<202> s<201> l<22:13> el<22:17>
+n<> u<196> t<Number_1Tickb1> p<197> l<22:20> el<22:24>
+n<> u<197> t<Primary_literal> p<198> c<196> l<22:20> el<22:24>
+n<> u<198> t<Constant_primary> p<199> c<197> l<22:20> el<22:24>
+n<> u<199> t<Constant_expression> p<200> c<198> l<22:20> el<22:24>
+n<> u<200> t<Constant_mintypmax_expression> p<201> c<199> l<22:20> el<22:24>
+n<> u<201> t<Constant_param_expression> p<202> c<200> l<22:20> el<22:24>
+n<> u<202> t<Param_assignment> p<203> c<195> l<22:13> el<22:24>
+n<> u<203> t<List_of_param_assignments> p<204> c<202> l<22:13> el<22:24>
+n<> u<204> t<Parameter_declaration> p<205> c<194> l<22:3> el<22:24>
+n<> u<205> t<Package_or_generate_item_declaration> p<206> c<204> l<22:3> el<22:25>
+n<> u<206> t<Module_or_generate_item_declaration> p<207> c<205> l<22:3> el<22:25>
+n<> u<207> t<Module_common_item> p<208> c<206> l<22:3> el<22:25>
+n<> u<208> t<Module_or_generate_item> p<209> c<207> l<22:3> el<22:25>
+n<> u<209> t<Non_port_module_item> p<266> c<208> s<265> l<22:3> el<22:25>
+n<i> u<210> t<StringConst> p<215> s<214> l<23:15> el<23:16>
+n<0> u<211> t<IntConst> p<212> l<23:17> el<23:18>
+n<> u<212> t<Primary_literal> p<213> c<211> l<23:17> el<23:18>
+n<> u<213> t<Constant_primary> p<214> c<212> l<23:17> el<23:18>
+n<> u<214> t<Constant_expression> p<215> c<213> l<23:17> el<23:18>
+n<> u<215> t<Genvar_initialization> p<262> c<210> s<225> l<23:8> el<23:18>
+n<i> u<216> t<StringConst> p<217> l<23:20> el<23:21>
+n<> u<217> t<Primary_literal> p<218> c<216> l<23:20> el<23:21>
+n<> u<218> t<Constant_primary> p<219> c<217> l<23:20> el<23:21>
+n<> u<219> t<Constant_expression> p<225> c<218> s<224> l<23:20> el<23:21>
+n<3> u<220> t<IntConst> p<221> l<23:22> el<23:23>
+n<> u<221> t<Primary_literal> p<222> c<220> l<23:22> el<23:23>
+n<> u<222> t<Constant_primary> p<223> c<221> l<23:22> el<23:23>
+n<> u<223> t<Constant_expression> p<225> c<222> l<23:22> el<23:23>
+n<> u<224> t<BinOp_Less> p<225> s<223> l<23:21> el<23:22>
+n<> u<225> t<Constant_expression> p<262> c<219> s<228> l<23:20> el<23:23>
+n<i> u<226> t<StringConst> p<228> s<227> l<23:25> el<23:26>
+n<> u<227> t<IncDec_PlusPlus> p<228> l<23:26> el<23:28>
+n<> u<228> t<Genvar_iteration> p<262> c<226> s<261> l<23:25> el<23:28>
+n<b> u<229> t<StringConst> p<230> l<24:14> el<24:15>
+n<> u<230> t<Ps_or_hierarchical_identifier> p<237> c<229> s<236> l<24:14> el<24:15>
+n<i> u<231> t<StringConst> p<232> l<24:16> el<24:17>
+n<> u<232> t<Primary_literal> p<233> c<231> l<24:16> el<24:17>
+n<> u<233> t<Constant_primary> p<234> c<232> l<24:16> el<24:17>
+n<> u<234> t<Constant_expression> p<235> c<233> l<24:16> el<24:17>
+n<> u<235> t<Constant_bit_select> p<236> c<234> l<24:15> el<24:18>
+n<> u<236> t<Constant_select> p<237> c<235> l<24:15> el<24:18>
+n<> u<237> t<Net_lvalue> p<254> c<230> s<253> l<24:14> el<24:18>
+n<a> u<238> t<StringConst> p<251> s<250> l<24:21> el<24:22>
+n<2> u<239> t<IntConst> p<240> l<24:23> el<24:24>
+n<> u<240> t<Primary_literal> p<241> c<239> l<24:23> el<24:24>
+n<> u<241> t<Primary> p<242> c<240> l<24:23> el<24:24>
+n<> u<242> t<Expression> p<248> c<241> s<247> l<24:23> el<24:24>
+n<i> u<243> t<StringConst> p<244> l<24:25> el<24:26>
+n<> u<244> t<Primary_literal> p<245> c<243> l<24:25> el<24:26>
+n<> u<245> t<Primary> p<246> c<244> l<24:25> el<24:26>
+n<> u<246> t<Expression> p<248> c<245> l<24:25> el<24:26>
+n<> u<247> t<BinOp_Minus> p<248> s<246> l<24:24> el<24:25>
+n<> u<248> t<Expression> p<249> c<242> l<24:23> el<24:26>
+n<> u<249> t<Bit_select> p<250> c<248> l<24:22> el<24:27>
+n<> u<250> t<Select> p<251> c<249> l<24:22> el<24:27>
+n<> u<251> t<Complex_func_call> p<252> c<238> l<24:21> el<24:27>
+n<> u<252> t<Primary> p<253> c<251> l<24:21> el<24:27>
+n<> u<253> t<Expression> p<254> c<252> l<24:21> el<24:27>
+n<> u<254> t<Net_assignment> p<255> c<237> l<24:14> el<24:27>
+n<> u<255> t<List_of_net_assignments> p<256> c<254> l<24:14> el<24:27>
+n<> u<256> t<Continuous_assign> p<257> c<255> l<24:7> el<24:28>
+n<> u<257> t<Module_common_item> p<258> c<256> l<24:7> el<24:28>
+n<> u<258> t<Module_or_generate_item> p<259> c<257> l<24:7> el<24:28>
+n<> u<259> t<Generate_item> p<261> c<258> s<260> l<24:7> el<24:28>
+n<> u<260> t<End> p<261> l<25:3> el<25:6>
+n<> u<261> t<Generate_block> p<262> c<259> l<23:30> el<25:6>
+n<> u<262> t<Loop_generate_construct> p<263> c<215> l<23:3> el<25:6>
+n<> u<263> t<Module_common_item> p<264> c<262> l<23:3> el<25:6>
+n<> u<264> t<Module_or_generate_item> p<265> c<263> l<23:3> el<25:6>
+n<> u<265> t<Non_port_module_item> p<266> c<264> l<23:3> el<25:6>
+n<> u<266> t<Module_declaration> p<267> c<193> l<21:1> el<26:10>
+n<> u<267> t<Description> p<268> c<266> l<21:1> el<26:10>
+n<> u<268> t<Source_text> p<269> c<157> l<1:1> el<26:10>
+n<> u<269> t<Top_level_rule> l<1:1> el<27:1>
 [WRN:PA0205] top.v:1: No timescale set for "small_test".
 
 [WRN:PA0205] top.v:21: No timescale set for "top".

--- a/tests/IfElseIf/test1/IfElseIf1.log
+++ b/tests/IfElseIf/test1/IfElseIf1.log
@@ -2,19 +2,19 @@
 
 LIB:  work
 FILE: dut.sv
-n<> u<0> t<Null_rule> p<105> s<104> l<1:1> el<1:0>
+n<> u<0> t<Null_rule> p<110> s<109> l<1:1> el<1:0>
 n<> u<1> t<Module_keyword> p<5> s<2> l<1:1> el<1:7>
 n<GOOD> u<2> t<StringConst> p<5> s<4> l<1:8> el<1:12>
 n<> u<3> t<Port> p<4> l<1:13> el<1:13>
 n<> u<4> t<List_of_ports> p<5> c<3> l<1:12> el<1:14>
 n<> u<5> t<Module_nonansi_header> p<6> c<1> l<1:1> el<1:15>
 n<> u<6> t<Module_declaration> p<7> c<5> l<1:1> el<2:10>
-n<> u<7> t<Description> p<104> c<6> s<103> l<1:1> el<2:10>
+n<> u<7> t<Description> p<109> c<6> s<108> l<1:1> el<2:10>
 n<> u<8> t<Module_keyword> p<12> s<9> l<4:1> el<4:7>
 n<axi> u<9> t<StringConst> p<12> s<11> l<4:8> el<4:11>
 n<> u<10> t<Port> p<11> l<4:12> el<4:12>
 n<> u<11> t<List_of_ports> p<12> c<10> l<4:11> el<4:13>
-n<> u<12> t<Module_nonansi_header> p<102> c<8> s<29> l<4:1> el<4:14>
+n<> u<12> t<Module_nonansi_header> p<107> c<8> s<29> l<4:1> el<4:14>
 n<> u<13> t<Data_type_or_implicit> p<23> s<22> l<6:15> el<6:15>
 n<j> u<14> t<StringConst> p<21> s<20> l<6:15> el<6:16>
 n<6> u<15> t<IntConst> p<16> l<6:19> el<6:20>
@@ -31,7 +31,7 @@ n<> u<25> t<Module_or_generate_item_declaration> p<26> c<24> l<6:5> el<6:21>
 n<> u<26> t<Module_common_item> p<27> c<25> l<6:5> el<6:21>
 n<> u<27> t<Module_or_generate_item> p<28> c<26> l<6:5> el<6:21>
 n<> u<28> t<Non_port_module_item> p<29> c<27> l<6:5> el<6:21>
-n<> u<29> t<Module_item> p<102> c<28> s<46> l<6:5> el<6:21>
+n<> u<29> t<Module_item> p<107> c<28> s<46> l<6:5> el<6:21>
 n<> u<30> t<Data_type_or_implicit> p<40> s<39> l<7:15> el<7:15>
 n<LOG_MASTER> u<31> t<StringConst> p<38> s<37> l<7:15> el<7:25>
 n<5> u<32> t<IntConst> p<33> l<7:33> el<7:34>
@@ -48,7 +48,7 @@ n<> u<42> t<Module_or_generate_item_declaration> p<43> c<41> l<7:5> el<7:35>
 n<> u<43> t<Module_common_item> p<44> c<42> l<7:5> el<7:35>
 n<> u<44> t<Module_or_generate_item> p<45> c<43> l<7:5> el<7:35>
 n<> u<45> t<Non_port_module_item> p<46> c<44> l<7:5> el<7:35>
-n<> u<46> t<Module_item> p<102> c<45> s<101> l<7:5> el<7:35>
+n<> u<46> t<Module_item> p<107> c<45> s<106> l<7:5> el<7:35>
 n<j> u<47> t<StringConst> p<48> l<11:11> el<11:12>
 n<> u<48> t<Primary_literal> p<49> c<47> l<11:11> el<11:12>
 n<> u<49> t<Constant_primary> p<50> c<48> l<11:11> el<11:12>
@@ -58,56 +58,61 @@ n<> u<52> t<Primary_literal> p<53> c<51> l<11:16> el<11:17>
 n<> u<53> t<Constant_primary> p<54> c<52> l<11:16> el<11:17>
 n<> u<54> t<Constant_expression> p<56> c<53> l<11:16> el<11:17>
 n<> u<55> t<BinOp_Equiv> p<56> s<54> l<11:13> el<11:15>
-n<> u<56> t<Constant_expression> p<96> c<50> s<60> l<11:11> el<11:17>
+n<> u<56> t<Constant_expression> p<97> c<50> s<59> l<11:11> el<11:17>
 n<LAST_NODE> u<57> t<StringConst> p<59> s<58> l<11:29> el<11:38>
 n<> u<58> t<End> p<59> l<13:7> el<13:10>
-n<> u<59> t<Generate_module_block> p<60> c<57> l<11:21> el<13:10>
-n<> u<60> t<Generate_module_item> p<96> c<59> s<95> l<11:21> el<13:10>
-n<j> u<61> t<StringConst> p<62> l<13:21> el<13:22>
-n<> u<62> t<Primary_literal> p<63> c<61> l<13:21> el<13:22>
-n<> u<63> t<Constant_primary> p<64> c<62> l<13:21> el<13:22>
-n<> u<64> t<Constant_expression> p<76> c<63> s<75> l<13:21> el<13:22>
-n<LOG_MASTER> u<65> t<StringConst> p<66> l<13:25> el<13:35>
-n<> u<66> t<Primary_literal> p<67> c<65> l<13:25> el<13:35>
-n<> u<67> t<Constant_primary> p<68> c<66> l<13:25> el<13:35>
-n<> u<68> t<Constant_expression> p<74> c<67> s<73> l<13:25> el<13:35>
-n<1> u<69> t<IntConst> p<70> l<13:38> el<13:39>
-n<> u<70> t<Primary_literal> p<71> c<69> l<13:38> el<13:39>
-n<> u<71> t<Constant_primary> p<72> c<70> l<13:38> el<13:39>
-n<> u<72> t<Constant_expression> p<74> c<71> l<13:38> el<13:39>
-n<> u<73> t<BinOp_Minus> p<74> s<72> l<13:36> el<13:37>
-n<> u<74> t<Constant_expression> p<76> c<68> l<13:25> el<13:39>
-n<> u<75> t<BinOp_Less> p<76> s<74> l<13:23> el<13:24>
-n<> u<76> t<Constant_expression> p<94> c<64> s<80> l<13:21> el<13:39>
-n<MIDDLE_NODES> u<77> t<StringConst> p<79> s<78> l<13:50> el<13:62>
-n<> u<78> t<End> p<79> l<15:11> el<15:14>
-n<> u<79> t<Generate_module_block> p<80> c<77> l<13:42> el<15:14>
-n<> u<80> t<Generate_module_item> p<94> c<79> s<93> l<13:42> el<15:14>
-n<LEAF_NODES> u<81> t<StringConst> p<92> s<90> l<16:24> el<16:34>
-n<GOOD> u<82> t<StringConst> p<88> s<87> l<17:14> el<17:18>
-n<good> u<83> t<StringConst> p<84> l<17:19> el<17:23>
-n<> u<84> t<Name_of_instance> p<87> c<83> s<86> l<17:19> el<17:23>
-n<> u<85> t<Ordered_port_connection> p<86> l<17:24> el<17:24>
-n<> u<86> t<List_of_port_connections> p<87> c<85> l<17:24> el<17:24>
-n<> u<87> t<Hierarchical_instance> p<88> c<84> l<17:19> el<17:25>
-n<> u<88> t<Module_instantiation> p<89> c<82> l<17:14> el<17:26>
-n<> u<89> t<Module_or_generate_item> p<90> c<88> l<17:14> el<17:26>
-n<> u<90> t<Generate_module_item> p<92> c<89> s<91> l<17:14> el<17:26>
-n<> u<91> t<End> p<92> l<18:11> el<18:14>
-n<> u<92> t<Generate_module_block> p<93> c<81> l<16:16> el<18:14>
-n<> u<93> t<Generate_module_item> p<94> c<92> l<16:16> el<18:14>
-n<> u<94> t<Generate_module_conditional_statement> p<95> c<76> l<13:16> el<18:14>
-n<> u<95> t<Generate_module_item> p<96> c<94> l<13:16> el<18:14>
-n<> u<96> t<Generate_module_conditional_statement> p<97> c<56> l<11:7> el<18:14>
-n<> u<97> t<Generate_module_item> p<99> c<96> s<98> l<11:7> el<18:14>
-n<> u<98> t<Endgenerate> p<99> l<19:5> el<19:16>
-n<> u<99> t<Generated_module_instantiation> p<100> c<97> l<9:5> el<19:16>
-n<> u<100> t<Non_port_module_item> p<101> c<99> l<9:5> el<19:16>
-n<> u<101> t<Module_item> p<102> c<100> l<9:5> el<19:16>
-n<> u<102> t<Module_declaration> p<103> c<12> l<4:1> el<21:10>
-n<> u<103> t<Description> p<104> c<102> l<4:1> el<21:10>
-n<> u<104> t<Source_text> p<105> c<7> l<1:1> el<21:10>
-n<> u<105> t<Top_level_rule> l<1:1> el<23:1>
+n<> u<59> t<Generate_block> p<97> c<57> s<96> l<11:21> el<13:10>
+n<j> u<60> t<StringConst> p<61> l<13:21> el<13:22>
+n<> u<61> t<Primary_literal> p<62> c<60> l<13:21> el<13:22>
+n<> u<62> t<Constant_primary> p<63> c<61> l<13:21> el<13:22>
+n<> u<63> t<Constant_expression> p<75> c<62> s<74> l<13:21> el<13:22>
+n<LOG_MASTER> u<64> t<StringConst> p<65> l<13:25> el<13:35>
+n<> u<65> t<Primary_literal> p<66> c<64> l<13:25> el<13:35>
+n<> u<66> t<Constant_primary> p<67> c<65> l<13:25> el<13:35>
+n<> u<67> t<Constant_expression> p<73> c<66> s<72> l<13:25> el<13:35>
+n<1> u<68> t<IntConst> p<69> l<13:38> el<13:39>
+n<> u<69> t<Primary_literal> p<70> c<68> l<13:38> el<13:39>
+n<> u<70> t<Constant_primary> p<71> c<69> l<13:38> el<13:39>
+n<> u<71> t<Constant_expression> p<73> c<70> l<13:38> el<13:39>
+n<> u<72> t<BinOp_Minus> p<73> s<71> l<13:36> el<13:37>
+n<> u<73> t<Constant_expression> p<75> c<67> l<13:25> el<13:39>
+n<> u<74> t<BinOp_Less> p<75> s<73> l<13:23> el<13:24>
+n<> u<75> t<Constant_expression> p<91> c<63> s<78> l<13:21> el<13:39>
+n<MIDDLE_NODES> u<76> t<StringConst> p<78> s<77> l<13:50> el<13:62>
+n<> u<77> t<End> p<78> l<15:11> el<15:14>
+n<> u<78> t<Generate_block> p<91> c<76> s<90> l<13:42> el<15:14>
+n<LEAF_NODES> u<79> t<StringConst> p<90> s<88> l<16:24> el<16:34>
+n<GOOD> u<80> t<StringConst> p<86> s<85> l<17:14> el<17:18>
+n<good> u<81> t<StringConst> p<82> l<17:19> el<17:23>
+n<> u<82> t<Name_of_instance> p<85> c<81> s<84> l<17:19> el<17:23>
+n<> u<83> t<Ordered_port_connection> p<84> l<17:24> el<17:24>
+n<> u<84> t<List_of_port_connections> p<85> c<83> l<17:24> el<17:24>
+n<> u<85> t<Hierarchical_instance> p<86> c<82> l<17:19> el<17:25>
+n<> u<86> t<Module_instantiation> p<87> c<80> l<17:14> el<17:26>
+n<> u<87> t<Module_or_generate_item> p<88> c<86> l<17:14> el<17:26>
+n<> u<88> t<Generate_item> p<90> c<87> s<89> l<17:14> el<17:26>
+n<> u<89> t<End> p<90> l<18:11> el<18:14>
+n<> u<90> t<Generate_block> p<91> c<79> l<16:16> el<18:14>
+n<> u<91> t<If_generate_construct> p<92> c<75> l<13:16> el<18:14>
+n<> u<92> t<Conditional_generate_construct> p<93> c<91> l<13:16> el<18:14>
+n<> u<93> t<Module_common_item> p<94> c<92> l<13:16> el<18:14>
+n<> u<94> t<Module_or_generate_item> p<95> c<93> l<13:16> el<18:14>
+n<> u<95> t<Generate_item> p<96> c<94> l<13:16> el<18:14>
+n<> u<96> t<Generate_block> p<97> c<95> l<13:16> el<18:14>
+n<> u<97> t<If_generate_construct> p<98> c<56> l<11:7> el<18:14>
+n<> u<98> t<Conditional_generate_construct> p<99> c<97> l<11:7> el<18:14>
+n<> u<99> t<Module_common_item> p<100> c<98> l<11:7> el<18:14>
+n<> u<100> t<Module_or_generate_item> p<101> c<99> l<11:7> el<18:14>
+n<> u<101> t<Generate_item> p<102> c<100> l<11:7> el<18:14>
+n<> u<102> t<Generate_block> p<104> c<101> s<103> l<11:7> el<18:14>
+n<> u<103> t<Endgenerate> p<104> l<19:5> el<19:16>
+n<> u<104> t<Generate_region> p<105> c<102> l<9:5> el<19:16>
+n<> u<105> t<Non_port_module_item> p<106> c<104> l<9:5> el<19:16>
+n<> u<106> t<Module_item> p<107> c<105> l<9:5> el<19:16>
+n<> u<107> t<Module_declaration> p<108> c<12> l<4:1> el<21:10>
+n<> u<108> t<Description> p<109> c<107> l<4:1> el<21:10>
+n<> u<109> t<Source_text> p<110> c<7> l<1:1> el<21:10>
+n<> u<110> t<Top_level_rule> l<1:1> el<23:1>
 [WRN:PA0205] dut.sv:1: No timescale set for "GOOD".
 
 [WRN:PA0205] dut.sv:4: No timescale set for "axi".
@@ -120,7 +125,7 @@ n<> u<105> t<Top_level_rule> l<1:1> el<23:1>
 
 [INF:EL0526] Design Elaboration...
 
-[INF:CP0335] dut.sv:17: Compile generate block "work@axi.LEAF_NODES".
+[INF:CP0335] dut.sv:16: Compile generate block "work@axi.LEAF_NODES".
 
 Instance tree:
 [TOP] work@axi work@axi
@@ -139,7 +144,7 @@ Instance tree:
 
 [NTE:EL0523] dut.sv:4: Instance "work@axi".
 
-[NTE:EL0522] dut.sv:17: Scope "work@axi.LEAF_NODES".
+[NTE:EL0522] dut.sv:16: Scope "work@axi.LEAF_NODES".
 
 [NTE:EL0523] dut.sv:17: Instance "work@axi.LEAF_NODES.good".
 
@@ -232,7 +237,7 @@ design: (work@axi)
     \_parameter: (work@axi.LOG_MASTER), line:7:15, endln:7:34, parent:work@axi
   |vpiDefName:work@axi
   |vpiGenScopeArray:
-  \_gen_scope_array: (work@axi.LEAF_NODES), line:17:14, endln:17:26, parent:work@axi
+  \_gen_scope_array: (work@axi.LEAF_NODES), line:16:16, endln:18:14, parent:work@axi
     |vpiName:LEAF_NODES
     |vpiFullName:work@axi.LEAF_NODES
     |vpiGenScope:

--- a/tests/IfElseIf/test2/IfElseIf2.log
+++ b/tests/IfElseIf/test2/IfElseIf2.log
@@ -2,19 +2,19 @@
 
 LIB:  work
 FILE: dut.sv
-n<> u<0> t<Null_rule> p<105> s<104> l<1:1> el<1:0>
+n<> u<0> t<Null_rule> p<110> s<109> l<1:1> el<1:0>
 n<> u<1> t<Module_keyword> p<5> s<2> l<1:1> el<1:7>
 n<GOOD> u<2> t<StringConst> p<5> s<4> l<1:8> el<1:12>
 n<> u<3> t<Port> p<4> l<1:13> el<1:13>
 n<> u<4> t<List_of_ports> p<5> c<3> l<1:12> el<1:14>
 n<> u<5> t<Module_nonansi_header> p<6> c<1> l<1:1> el<1:15>
 n<> u<6> t<Module_declaration> p<7> c<5> l<1:1> el<2:10>
-n<> u<7> t<Description> p<104> c<6> s<103> l<1:1> el<2:10>
+n<> u<7> t<Description> p<109> c<6> s<108> l<1:1> el<2:10>
 n<> u<8> t<Module_keyword> p<12> s<9> l<4:1> el<4:7>
 n<axi> u<9> t<StringConst> p<12> s<11> l<4:8> el<4:11>
 n<> u<10> t<Port> p<11> l<4:12> el<4:12>
 n<> u<11> t<List_of_ports> p<12> c<10> l<4:11> el<4:13>
-n<> u<12> t<Module_nonansi_header> p<102> c<8> s<29> l<4:1> el<4:14>
+n<> u<12> t<Module_nonansi_header> p<107> c<8> s<29> l<4:1> el<4:14>
 n<> u<13> t<Data_type_or_implicit> p<23> s<22> l<6:15> el<6:15>
 n<j> u<14> t<StringConst> p<21> s<20> l<6:15> el<6:16>
 n<3> u<15> t<IntConst> p<16> l<6:19> el<6:20>
@@ -31,7 +31,7 @@ n<> u<25> t<Module_or_generate_item_declaration> p<26> c<24> l<6:5> el<6:21>
 n<> u<26> t<Module_common_item> p<27> c<25> l<6:5> el<6:21>
 n<> u<27> t<Module_or_generate_item> p<28> c<26> l<6:5> el<6:21>
 n<> u<28> t<Non_port_module_item> p<29> c<27> l<6:5> el<6:21>
-n<> u<29> t<Module_item> p<102> c<28> s<46> l<6:5> el<6:21>
+n<> u<29> t<Module_item> p<107> c<28> s<46> l<6:5> el<6:21>
 n<> u<30> t<Data_type_or_implicit> p<40> s<39> l<7:15> el<7:15>
 n<LOG_MASTER> u<31> t<StringConst> p<38> s<37> l<7:15> el<7:25>
 n<5> u<32> t<IntConst> p<33> l<7:33> el<7:34>
@@ -48,7 +48,7 @@ n<> u<42> t<Module_or_generate_item_declaration> p<43> c<41> l<7:5> el<7:35>
 n<> u<43> t<Module_common_item> p<44> c<42> l<7:5> el<7:35>
 n<> u<44> t<Module_or_generate_item> p<45> c<43> l<7:5> el<7:35>
 n<> u<45> t<Non_port_module_item> p<46> c<44> l<7:5> el<7:35>
-n<> u<46> t<Module_item> p<102> c<45> s<101> l<7:5> el<7:35>
+n<> u<46> t<Module_item> p<107> c<45> s<106> l<7:5> el<7:35>
 n<j> u<47> t<StringConst> p<48> l<11:11> el<11:12>
 n<> u<48> t<Primary_literal> p<49> c<47> l<11:11> el<11:12>
 n<> u<49> t<Constant_primary> p<50> c<48> l<11:11> el<11:12>
@@ -58,56 +58,61 @@ n<> u<52> t<Primary_literal> p<53> c<51> l<11:16> el<11:17>
 n<> u<53> t<Constant_primary> p<54> c<52> l<11:16> el<11:17>
 n<> u<54> t<Constant_expression> p<56> c<53> l<11:16> el<11:17>
 n<> u<55> t<BinOp_Equiv> p<56> s<54> l<11:13> el<11:15>
-n<> u<56> t<Constant_expression> p<96> c<50> s<60> l<11:11> el<11:17>
+n<> u<56> t<Constant_expression> p<97> c<50> s<59> l<11:11> el<11:17>
 n<LAST_NODE> u<57> t<StringConst> p<59> s<58> l<11:29> el<11:38>
 n<> u<58> t<End> p<59> l<13:7> el<13:10>
-n<> u<59> t<Generate_module_block> p<60> c<57> l<11:21> el<13:10>
-n<> u<60> t<Generate_module_item> p<96> c<59> s<95> l<11:21> el<13:10>
-n<j> u<61> t<StringConst> p<62> l<13:21> el<13:22>
-n<> u<62> t<Primary_literal> p<63> c<61> l<13:21> el<13:22>
-n<> u<63> t<Constant_primary> p<64> c<62> l<13:21> el<13:22>
-n<> u<64> t<Constant_expression> p<76> c<63> s<75> l<13:21> el<13:22>
-n<LOG_MASTER> u<65> t<StringConst> p<66> l<13:25> el<13:35>
-n<> u<66> t<Primary_literal> p<67> c<65> l<13:25> el<13:35>
-n<> u<67> t<Constant_primary> p<68> c<66> l<13:25> el<13:35>
-n<> u<68> t<Constant_expression> p<74> c<67> s<73> l<13:25> el<13:35>
-n<1> u<69> t<IntConst> p<70> l<13:38> el<13:39>
-n<> u<70> t<Primary_literal> p<71> c<69> l<13:38> el<13:39>
-n<> u<71> t<Constant_primary> p<72> c<70> l<13:38> el<13:39>
-n<> u<72> t<Constant_expression> p<74> c<71> l<13:38> el<13:39>
-n<> u<73> t<BinOp_Minus> p<74> s<72> l<13:36> el<13:37>
-n<> u<74> t<Constant_expression> p<76> c<68> l<13:25> el<13:39>
-n<> u<75> t<BinOp_Less> p<76> s<74> l<13:23> el<13:24>
-n<> u<76> t<Constant_expression> p<94> c<64> s<89> l<13:21> el<13:39>
-n<MIDDLE_NODES> u<77> t<StringConst> p<88> s<86> l<13:50> el<13:62>
-n<GOOD> u<78> t<StringConst> p<84> s<83> l<14:13> el<14:17>
-n<good> u<79> t<StringConst> p<80> l<14:18> el<14:22>
-n<> u<80> t<Name_of_instance> p<83> c<79> s<82> l<14:18> el<14:22>
-n<> u<81> t<Ordered_port_connection> p<82> l<14:23> el<14:23>
-n<> u<82> t<List_of_port_connections> p<83> c<81> l<14:23> el<14:23>
-n<> u<83> t<Hierarchical_instance> p<84> c<80> l<14:18> el<14:24>
-n<> u<84> t<Module_instantiation> p<85> c<78> l<14:13> el<14:25>
-n<> u<85> t<Module_or_generate_item> p<86> c<84> l<14:13> el<14:25>
-n<> u<86> t<Generate_module_item> p<88> c<85> s<87> l<14:13> el<14:25>
-n<> u<87> t<End> p<88> l<15:11> el<15:14>
-n<> u<88> t<Generate_module_block> p<89> c<77> l<13:42> el<15:14>
-n<> u<89> t<Generate_module_item> p<94> c<88> s<93> l<13:42> el<15:14>
-n<LEAF_NODES> u<90> t<StringConst> p<92> s<91> l<16:24> el<16:34>
-n<> u<91> t<End> p<92> l<17:11> el<17:14>
-n<> u<92> t<Generate_module_block> p<93> c<90> l<16:16> el<17:14>
-n<> u<93> t<Generate_module_item> p<94> c<92> l<16:16> el<17:14>
-n<> u<94> t<Generate_module_conditional_statement> p<95> c<76> l<13:16> el<17:14>
-n<> u<95> t<Generate_module_item> p<96> c<94> l<13:16> el<17:14>
-n<> u<96> t<Generate_module_conditional_statement> p<97> c<56> l<11:7> el<17:14>
-n<> u<97> t<Generate_module_item> p<99> c<96> s<98> l<11:7> el<17:14>
-n<> u<98> t<Endgenerate> p<99> l<18:5> el<18:16>
-n<> u<99> t<Generated_module_instantiation> p<100> c<97> l<9:5> el<18:16>
-n<> u<100> t<Non_port_module_item> p<101> c<99> l<9:5> el<18:16>
-n<> u<101> t<Module_item> p<102> c<100> l<9:5> el<18:16>
-n<> u<102> t<Module_declaration> p<103> c<12> l<4:1> el<20:10>
-n<> u<103> t<Description> p<104> c<102> l<4:1> el<20:10>
-n<> u<104> t<Source_text> p<105> c<7> l<1:1> el<20:10>
-n<> u<105> t<Top_level_rule> l<1:1> el<22:1>
+n<> u<59> t<Generate_block> p<97> c<57> s<96> l<11:21> el<13:10>
+n<j> u<60> t<StringConst> p<61> l<13:21> el<13:22>
+n<> u<61> t<Primary_literal> p<62> c<60> l<13:21> el<13:22>
+n<> u<62> t<Constant_primary> p<63> c<61> l<13:21> el<13:22>
+n<> u<63> t<Constant_expression> p<75> c<62> s<74> l<13:21> el<13:22>
+n<LOG_MASTER> u<64> t<StringConst> p<65> l<13:25> el<13:35>
+n<> u<65> t<Primary_literal> p<66> c<64> l<13:25> el<13:35>
+n<> u<66> t<Constant_primary> p<67> c<65> l<13:25> el<13:35>
+n<> u<67> t<Constant_expression> p<73> c<66> s<72> l<13:25> el<13:35>
+n<1> u<68> t<IntConst> p<69> l<13:38> el<13:39>
+n<> u<69> t<Primary_literal> p<70> c<68> l<13:38> el<13:39>
+n<> u<70> t<Constant_primary> p<71> c<69> l<13:38> el<13:39>
+n<> u<71> t<Constant_expression> p<73> c<70> l<13:38> el<13:39>
+n<> u<72> t<BinOp_Minus> p<73> s<71> l<13:36> el<13:37>
+n<> u<73> t<Constant_expression> p<75> c<67> l<13:25> el<13:39>
+n<> u<74> t<BinOp_Less> p<75> s<73> l<13:23> el<13:24>
+n<> u<75> t<Constant_expression> p<91> c<63> s<87> l<13:21> el<13:39>
+n<MIDDLE_NODES> u<76> t<StringConst> p<87> s<85> l<13:50> el<13:62>
+n<GOOD> u<77> t<StringConst> p<83> s<82> l<14:13> el<14:17>
+n<good> u<78> t<StringConst> p<79> l<14:18> el<14:22>
+n<> u<79> t<Name_of_instance> p<82> c<78> s<81> l<14:18> el<14:22>
+n<> u<80> t<Ordered_port_connection> p<81> l<14:23> el<14:23>
+n<> u<81> t<List_of_port_connections> p<82> c<80> l<14:23> el<14:23>
+n<> u<82> t<Hierarchical_instance> p<83> c<79> l<14:18> el<14:24>
+n<> u<83> t<Module_instantiation> p<84> c<77> l<14:13> el<14:25>
+n<> u<84> t<Module_or_generate_item> p<85> c<83> l<14:13> el<14:25>
+n<> u<85> t<Generate_item> p<87> c<84> s<86> l<14:13> el<14:25>
+n<> u<86> t<End> p<87> l<15:11> el<15:14>
+n<> u<87> t<Generate_block> p<91> c<76> s<90> l<13:42> el<15:14>
+n<LEAF_NODES> u<88> t<StringConst> p<90> s<89> l<16:24> el<16:34>
+n<> u<89> t<End> p<90> l<17:11> el<17:14>
+n<> u<90> t<Generate_block> p<91> c<88> l<16:16> el<17:14>
+n<> u<91> t<If_generate_construct> p<92> c<75> l<13:16> el<17:14>
+n<> u<92> t<Conditional_generate_construct> p<93> c<91> l<13:16> el<17:14>
+n<> u<93> t<Module_common_item> p<94> c<92> l<13:16> el<17:14>
+n<> u<94> t<Module_or_generate_item> p<95> c<93> l<13:16> el<17:14>
+n<> u<95> t<Generate_item> p<96> c<94> l<13:16> el<17:14>
+n<> u<96> t<Generate_block> p<97> c<95> l<13:16> el<17:14>
+n<> u<97> t<If_generate_construct> p<98> c<56> l<11:7> el<17:14>
+n<> u<98> t<Conditional_generate_construct> p<99> c<97> l<11:7> el<17:14>
+n<> u<99> t<Module_common_item> p<100> c<98> l<11:7> el<17:14>
+n<> u<100> t<Module_or_generate_item> p<101> c<99> l<11:7> el<17:14>
+n<> u<101> t<Generate_item> p<102> c<100> l<11:7> el<17:14>
+n<> u<102> t<Generate_block> p<104> c<101> s<103> l<11:7> el<17:14>
+n<> u<103> t<Endgenerate> p<104> l<18:5> el<18:16>
+n<> u<104> t<Generate_region> p<105> c<102> l<9:5> el<18:16>
+n<> u<105> t<Non_port_module_item> p<106> c<104> l<9:5> el<18:16>
+n<> u<106> t<Module_item> p<107> c<105> l<9:5> el<18:16>
+n<> u<107> t<Module_declaration> p<108> c<12> l<4:1> el<20:10>
+n<> u<108> t<Description> p<109> c<107> l<4:1> el<20:10>
+n<> u<109> t<Source_text> p<110> c<7> l<1:1> el<20:10>
+n<> u<110> t<Top_level_rule> l<1:1> el<22:1>
 [WRN:PA0205] dut.sv:1: No timescale set for "GOOD".
 
 [WRN:PA0205] dut.sv:4: No timescale set for "axi".

--- a/tests/IfElseIf/test3/IfElseIf3.log
+++ b/tests/IfElseIf/test3/IfElseIf3.log
@@ -2,19 +2,19 @@
 
 LIB:  work
 FILE: dut.sv
-n<> u<0> t<Null_rule> p<105> s<104> l<1:1> el<1:0>
+n<> u<0> t<Null_rule> p<110> s<109> l<1:1> el<1:0>
 n<> u<1> t<Module_keyword> p<5> s<2> l<1:1> el<1:7>
 n<GOOD> u<2> t<StringConst> p<5> s<4> l<1:8> el<1:12>
 n<> u<3> t<Port> p<4> l<1:13> el<1:13>
 n<> u<4> t<List_of_ports> p<5> c<3> l<1:12> el<1:14>
 n<> u<5> t<Module_nonansi_header> p<6> c<1> l<1:1> el<1:15>
 n<> u<6> t<Module_declaration> p<7> c<5> l<1:1> el<2:10>
-n<> u<7> t<Description> p<104> c<6> s<103> l<1:1> el<2:10>
+n<> u<7> t<Description> p<109> c<6> s<108> l<1:1> el<2:10>
 n<> u<8> t<Module_keyword> p<12> s<9> l<4:1> el<4:7>
 n<axi> u<9> t<StringConst> p<12> s<11> l<4:8> el<4:11>
 n<> u<10> t<Port> p<11> l<4:12> el<4:12>
 n<> u<11> t<List_of_ports> p<12> c<10> l<4:11> el<4:13>
-n<> u<12> t<Module_nonansi_header> p<102> c<8> s<29> l<4:1> el<4:14>
+n<> u<12> t<Module_nonansi_header> p<107> c<8> s<29> l<4:1> el<4:14>
 n<> u<13> t<Data_type_or_implicit> p<23> s<22> l<6:15> el<6:15>
 n<j> u<14> t<StringConst> p<21> s<20> l<6:15> el<6:16>
 n<0> u<15> t<IntConst> p<16> l<6:19> el<6:20>
@@ -31,7 +31,7 @@ n<> u<25> t<Module_or_generate_item_declaration> p<26> c<24> l<6:5> el<6:21>
 n<> u<26> t<Module_common_item> p<27> c<25> l<6:5> el<6:21>
 n<> u<27> t<Module_or_generate_item> p<28> c<26> l<6:5> el<6:21>
 n<> u<28> t<Non_port_module_item> p<29> c<27> l<6:5> el<6:21>
-n<> u<29> t<Module_item> p<102> c<28> s<46> l<6:5> el<6:21>
+n<> u<29> t<Module_item> p<107> c<28> s<46> l<6:5> el<6:21>
 n<> u<30> t<Data_type_or_implicit> p<40> s<39> l<7:15> el<7:15>
 n<LOG_MASTER> u<31> t<StringConst> p<38> s<37> l<7:15> el<7:25>
 n<5> u<32> t<IntConst> p<33> l<7:33> el<7:34>
@@ -48,7 +48,7 @@ n<> u<42> t<Module_or_generate_item_declaration> p<43> c<41> l<7:5> el<7:35>
 n<> u<43> t<Module_common_item> p<44> c<42> l<7:5> el<7:35>
 n<> u<44> t<Module_or_generate_item> p<45> c<43> l<7:5> el<7:35>
 n<> u<45> t<Non_port_module_item> p<46> c<44> l<7:5> el<7:35>
-n<> u<46> t<Module_item> p<102> c<45> s<101> l<7:5> el<7:35>
+n<> u<46> t<Module_item> p<107> c<45> s<106> l<7:5> el<7:35>
 n<j> u<47> t<StringConst> p<48> l<11:11> el<11:12>
 n<> u<48> t<Primary_literal> p<49> c<47> l<11:11> el<11:12>
 n<> u<49> t<Constant_primary> p<50> c<48> l<11:11> el<11:12>
@@ -58,7 +58,7 @@ n<> u<52> t<Primary_literal> p<53> c<51> l<11:16> el<11:17>
 n<> u<53> t<Constant_primary> p<54> c<52> l<11:16> el<11:17>
 n<> u<54> t<Constant_expression> p<56> c<53> l<11:16> el<11:17>
 n<> u<55> t<BinOp_Equiv> p<56> s<54> l<11:13> el<11:15>
-n<> u<56> t<Constant_expression> p<96> c<50> s<69> l<11:11> el<11:17>
+n<> u<56> t<Constant_expression> p<97> c<50> s<68> l<11:11> el<11:17>
 n<LAST_NODE> u<57> t<StringConst> p<68> s<66> l<11:29> el<11:38>
 n<GOOD> u<58> t<StringConst> p<64> s<63> l<12:10> el<12:14>
 n<good> u<59> t<StringConst> p<60> l<12:15> el<12:19>
@@ -68,46 +68,51 @@ n<> u<62> t<List_of_port_connections> p<63> c<61> l<12:20> el<12:20>
 n<> u<63> t<Hierarchical_instance> p<64> c<60> l<12:15> el<12:21>
 n<> u<64> t<Module_instantiation> p<65> c<58> l<12:10> el<12:22>
 n<> u<65> t<Module_or_generate_item> p<66> c<64> l<12:10> el<12:22>
-n<> u<66> t<Generate_module_item> p<68> c<65> s<67> l<12:10> el<12:22>
+n<> u<66> t<Generate_item> p<68> c<65> s<67> l<12:10> el<12:22>
 n<> u<67> t<End> p<68> l<13:7> el<13:10>
-n<> u<68> t<Generate_module_block> p<69> c<57> l<11:21> el<13:10>
-n<> u<69> t<Generate_module_item> p<96> c<68> s<95> l<11:21> el<13:10>
-n<j> u<70> t<StringConst> p<71> l<13:21> el<13:22>
-n<> u<71> t<Primary_literal> p<72> c<70> l<13:21> el<13:22>
-n<> u<72> t<Constant_primary> p<73> c<71> l<13:21> el<13:22>
-n<> u<73> t<Constant_expression> p<85> c<72> s<84> l<13:21> el<13:22>
-n<LOG_MASTER> u<74> t<StringConst> p<75> l<13:25> el<13:35>
-n<> u<75> t<Primary_literal> p<76> c<74> l<13:25> el<13:35>
-n<> u<76> t<Constant_primary> p<77> c<75> l<13:25> el<13:35>
-n<> u<77> t<Constant_expression> p<83> c<76> s<82> l<13:25> el<13:35>
-n<1> u<78> t<IntConst> p<79> l<13:38> el<13:39>
-n<> u<79> t<Primary_literal> p<80> c<78> l<13:38> el<13:39>
-n<> u<80> t<Constant_primary> p<81> c<79> l<13:38> el<13:39>
-n<> u<81> t<Constant_expression> p<83> c<80> l<13:38> el<13:39>
-n<> u<82> t<BinOp_Minus> p<83> s<81> l<13:36> el<13:37>
-n<> u<83> t<Constant_expression> p<85> c<77> l<13:25> el<13:39>
-n<> u<84> t<BinOp_Less> p<85> s<83> l<13:23> el<13:24>
-n<> u<85> t<Constant_expression> p<94> c<73> s<89> l<13:21> el<13:39>
-n<MIDDLE_NODES> u<86> t<StringConst> p<88> s<87> l<13:50> el<13:62>
-n<> u<87> t<End> p<88> l<14:7> el<14:10>
-n<> u<88> t<Generate_module_block> p<89> c<86> l<13:42> el<14:10>
-n<> u<89> t<Generate_module_item> p<94> c<88> s<93> l<13:42> el<14:10>
-n<LEAF_NODES> u<90> t<StringConst> p<92> s<91> l<15:20> el<15:30>
-n<> u<91> t<End> p<92> l<16:7> el<16:10>
-n<> u<92> t<Generate_module_block> p<93> c<90> l<15:12> el<16:10>
-n<> u<93> t<Generate_module_item> p<94> c<92> l<15:12> el<16:10>
-n<> u<94> t<Generate_module_conditional_statement> p<95> c<85> l<13:16> el<16:10>
-n<> u<95> t<Generate_module_item> p<96> c<94> l<13:16> el<16:10>
-n<> u<96> t<Generate_module_conditional_statement> p<97> c<56> l<11:7> el<16:10>
-n<> u<97> t<Generate_module_item> p<99> c<96> s<98> l<11:7> el<16:10>
-n<> u<98> t<Endgenerate> p<99> l<17:5> el<17:16>
-n<> u<99> t<Generated_module_instantiation> p<100> c<97> l<9:5> el<17:16>
-n<> u<100> t<Non_port_module_item> p<101> c<99> l<9:5> el<17:16>
-n<> u<101> t<Module_item> p<102> c<100> l<9:5> el<17:16>
-n<> u<102> t<Module_declaration> p<103> c<12> l<4:1> el<19:10>
-n<> u<103> t<Description> p<104> c<102> l<4:1> el<19:10>
-n<> u<104> t<Source_text> p<105> c<7> l<1:1> el<19:10>
-n<> u<105> t<Top_level_rule> l<1:1> el<21:1>
+n<> u<68> t<Generate_block> p<97> c<57> s<96> l<11:21> el<13:10>
+n<j> u<69> t<StringConst> p<70> l<13:21> el<13:22>
+n<> u<70> t<Primary_literal> p<71> c<69> l<13:21> el<13:22>
+n<> u<71> t<Constant_primary> p<72> c<70> l<13:21> el<13:22>
+n<> u<72> t<Constant_expression> p<84> c<71> s<83> l<13:21> el<13:22>
+n<LOG_MASTER> u<73> t<StringConst> p<74> l<13:25> el<13:35>
+n<> u<74> t<Primary_literal> p<75> c<73> l<13:25> el<13:35>
+n<> u<75> t<Constant_primary> p<76> c<74> l<13:25> el<13:35>
+n<> u<76> t<Constant_expression> p<82> c<75> s<81> l<13:25> el<13:35>
+n<1> u<77> t<IntConst> p<78> l<13:38> el<13:39>
+n<> u<78> t<Primary_literal> p<79> c<77> l<13:38> el<13:39>
+n<> u<79> t<Constant_primary> p<80> c<78> l<13:38> el<13:39>
+n<> u<80> t<Constant_expression> p<82> c<79> l<13:38> el<13:39>
+n<> u<81> t<BinOp_Minus> p<82> s<80> l<13:36> el<13:37>
+n<> u<82> t<Constant_expression> p<84> c<76> l<13:25> el<13:39>
+n<> u<83> t<BinOp_Less> p<84> s<82> l<13:23> el<13:24>
+n<> u<84> t<Constant_expression> p<91> c<72> s<87> l<13:21> el<13:39>
+n<MIDDLE_NODES> u<85> t<StringConst> p<87> s<86> l<13:50> el<13:62>
+n<> u<86> t<End> p<87> l<14:7> el<14:10>
+n<> u<87> t<Generate_block> p<91> c<85> s<90> l<13:42> el<14:10>
+n<LEAF_NODES> u<88> t<StringConst> p<90> s<89> l<15:20> el<15:30>
+n<> u<89> t<End> p<90> l<16:7> el<16:10>
+n<> u<90> t<Generate_block> p<91> c<88> l<15:12> el<16:10>
+n<> u<91> t<If_generate_construct> p<92> c<84> l<13:16> el<16:10>
+n<> u<92> t<Conditional_generate_construct> p<93> c<91> l<13:16> el<16:10>
+n<> u<93> t<Module_common_item> p<94> c<92> l<13:16> el<16:10>
+n<> u<94> t<Module_or_generate_item> p<95> c<93> l<13:16> el<16:10>
+n<> u<95> t<Generate_item> p<96> c<94> l<13:16> el<16:10>
+n<> u<96> t<Generate_block> p<97> c<95> l<13:16> el<16:10>
+n<> u<97> t<If_generate_construct> p<98> c<56> l<11:7> el<16:10>
+n<> u<98> t<Conditional_generate_construct> p<99> c<97> l<11:7> el<16:10>
+n<> u<99> t<Module_common_item> p<100> c<98> l<11:7> el<16:10>
+n<> u<100> t<Module_or_generate_item> p<101> c<99> l<11:7> el<16:10>
+n<> u<101> t<Generate_item> p<102> c<100> l<11:7> el<16:10>
+n<> u<102> t<Generate_block> p<104> c<101> s<103> l<11:7> el<16:10>
+n<> u<103> t<Endgenerate> p<104> l<17:5> el<17:16>
+n<> u<104> t<Generate_region> p<105> c<102> l<9:5> el<17:16>
+n<> u<105> t<Non_port_module_item> p<106> c<104> l<9:5> el<17:16>
+n<> u<106> t<Module_item> p<107> c<105> l<9:5> el<17:16>
+n<> u<107> t<Module_declaration> p<108> c<12> l<4:1> el<19:10>
+n<> u<108> t<Description> p<109> c<107> l<4:1> el<19:10>
+n<> u<109> t<Source_text> p<110> c<7> l<1:1> el<19:10>
+n<> u<110> t<Top_level_rule> l<1:1> el<21:1>
 [WRN:PA0205] dut.sv:1: No timescale set for "GOOD".
 
 [WRN:PA0205] dut.sv:4: No timescale set for "axi".

--- a/tests/MultContAssign/MultContAssign.log
+++ b/tests/MultContAssign/MultContAssign.log
@@ -1,0 +1,1489 @@
+[INF:CM0023] Creating log file ../../build/tests/MultContAssign/slpp_all/surelog.log.
+
+LIB:  work
+FILE: dut.sv
+n<> u<0> t<Null_rule> p<506> s<505> l<3:1> el<1:3>
+n<> u<1> t<Module_keyword> p<5> s<2> l<3:1> el<3:7>
+n<top> u<2> t<StringConst> p<5> s<4> l<3:8> el<3:11>
+n<> u<3> t<Port> p<4> l<3:12> el<3:12>
+n<> u<4> t<List_of_ports> p<5> c<3> l<3:11> el<3:13>
+n<> u<5> t<Module_nonansi_header> p<375> c<1> s<18> l<3:1> el<3:14>
+n<> u<6> t<IntegerAtomType_Int> p<7> l<5:2> el<5:5>
+n<> u<7> t<Data_type> p<11> c<6> s<10> l<5:2> el<5:5>
+n<v> u<8> t<StringConst> p<9> l<5:6> el<5:7>
+n<> u<9> t<Variable_decl_assignment> p<10> c<8> l<5:6> el<5:7>
+n<> u<10> t<List_of_variable_decl_assignments> p<11> c<9> l<5:6> el<5:7>
+n<> u<11> t<Variable_declaration> p<12> c<7> l<5:2> el<5:8>
+n<> u<12> t<Data_declaration> p<13> c<11> l<5:2> el<5:8>
+n<> u<13> t<Package_or_generate_item_declaration> p<14> c<12> l<5:2> el<5:8>
+n<> u<14> t<Module_or_generate_item_declaration> p<15> c<13> l<5:2> el<5:8>
+n<> u<15> t<Module_common_item> p<16> c<14> l<5:2> el<5:8>
+n<> u<16> t<Module_or_generate_item> p<17> c<15> l<5:2> el<5:8>
+n<> u<17> t<Non_port_module_item> p<18> c<16> l<5:2> el<5:8>
+n<> u<18> t<Module_item> p<375> c<17> s<37> l<5:2> el<5:8>
+n<> u<19> t<Weak1> p<21> l<6:20> el<6:25>
+n<> u<20> t<HighZ0> p<21> s<19> l<6:12> el<6:18>
+n<> u<21> t<Drive_strength> p<33> c<20> s<32> l<6:11> el<6:26>
+n<inout_i1> u<22> t<StringConst> p<23> l<6:30> el<6:38>
+n<> u<23> t<Ps_or_hierarchical_identifier> p<26> c<22> s<25> l<6:30> el<6:38>
+n<> u<24> t<Constant_bit_select> p<25> l<6:39> el<6:39>
+n<> u<25> t<Constant_select> p<26> c<24> l<6:39> el<6:39>
+n<> u<26> t<Net_lvalue> p<31> c<23> s<30> l<6:30> el<6:38>
+n<pu> u<27> t<StringConst> p<28> l<6:41> el<6:43>
+n<> u<28> t<Primary_literal> p<29> c<27> l<6:41> el<6:43>
+n<> u<29> t<Primary> p<30> c<28> l<6:41> el<6:43>
+n<> u<30> t<Expression> p<31> c<29> l<6:41> el<6:43>
+n<> u<31> t<Net_assignment> p<32> c<26> l<6:30> el<6:43>
+n<> u<32> t<List_of_net_assignments> p<33> c<31> l<6:30> el<6:43>
+n<> u<33> t<Continuous_assign> p<34> c<21> l<6:4> el<6:44>
+n<> u<34> t<Module_common_item> p<35> c<33> l<6:4> el<6:44>
+n<> u<35> t<Module_or_generate_item> p<36> c<34> l<6:4> el<6:44>
+n<> u<36> t<Non_port_module_item> p<37> c<35> l<6:4> el<6:44>
+n<> u<37> t<Module_item> p<375> c<36> s<58> l<6:4> el<6:44>
+n<> u<38> t<Weak0> p<40> s<39> l<7:12> el<7:17>
+n<> u<39> t<HighZ1> p<40> l<7:19> el<7:25>
+n<> u<40> t<Drive_strength> p<54> c<38> s<53> l<7:11> el<7:26>
+n<inout_i1> u<41> t<StringConst> p<42> l<7:30> el<7:38>
+n<> u<42> t<Ps_or_hierarchical_identifier> p<45> c<41> s<44> l<7:30> el<7:38>
+n<> u<43> t<Constant_bit_select> p<44> l<7:39> el<7:39>
+n<> u<44> t<Constant_select> p<45> c<43> l<7:39> el<7:39>
+n<> u<45> t<Net_lvalue> p<52> c<42> s<51> l<7:30> el<7:38>
+n<pd> u<46> t<StringConst> p<47> l<7:42> el<7:44>
+n<> u<47> t<Primary_literal> p<48> c<46> l<7:42> el<7:44>
+n<> u<48> t<Primary> p<49> c<47> l<7:42> el<7:44>
+n<> u<49> t<Expression> p<51> c<48> l<7:42> el<7:44>
+n<> u<50> t<Unary_Tilda> p<51> s<49> l<7:41> el<7:42>
+n<> u<51> t<Expression> p<52> c<50> l<7:41> el<7:44>
+n<> u<52> t<Net_assignment> p<53> c<45> l<7:30> el<7:44>
+n<> u<53> t<List_of_net_assignments> p<54> c<52> l<7:30> el<7:44>
+n<> u<54> t<Continuous_assign> p<55> c<40> l<7:4> el<7:45>
+n<> u<55> t<Module_common_item> p<56> c<54> l<7:4> el<7:45>
+n<> u<56> t<Module_or_generate_item> p<57> c<55> l<7:4> el<7:45>
+n<> u<57> t<Non_port_module_item> p<58> c<56> l<7:4> el<7:45>
+n<> u<58> t<Module_item> p<375> c<57> s<74> l<7:4> el<7:45>
+n<v> u<59> t<StringConst> p<60> l<9:9> el<9:10>
+n<> u<60> t<Ps_or_hierarchical_identifier> p<63> c<59> s<62> l<9:9> el<9:10>
+n<> u<61> t<Constant_bit_select> p<62> l<9:11> el<9:11>
+n<> u<62> t<Constant_select> p<63> c<61> l<9:11> el<9:11>
+n<> u<63> t<Net_lvalue> p<68> c<60> s<67> l<9:9> el<9:10>
+n<12> u<64> t<IntConst> p<65> l<9:13> el<9:15>
+n<> u<65> t<Primary_literal> p<66> c<64> l<9:13> el<9:15>
+n<> u<66> t<Primary> p<67> c<65> l<9:13> el<9:15>
+n<> u<67> t<Expression> p<68> c<66> l<9:13> el<9:15>
+n<> u<68> t<Net_assignment> p<69> c<63> l<9:9> el<9:15>
+n<> u<69> t<List_of_net_assignments> p<70> c<68> l<9:9> el<9:15>
+n<> u<70> t<Continuous_assign> p<71> c<69> l<9:2> el<9:16>
+n<> u<71> t<Module_common_item> p<72> c<70> l<9:2> el<9:16>
+n<> u<72> t<Module_or_generate_item> p<73> c<71> l<9:2> el<9:16>
+n<> u<73> t<Non_port_module_item> p<74> c<72> l<9:2> el<9:16>
+n<> u<74> t<Module_item> p<375> c<73> s<90> l<9:2> el<9:16>
+n<v> u<75> t<StringConst> p<76> l<10:9> el<10:10>
+n<> u<76> t<Ps_or_hierarchical_identifier> p<79> c<75> s<78> l<10:9> el<10:10>
+n<> u<77> t<Constant_bit_select> p<78> l<10:11> el<10:11>
+n<> u<78> t<Constant_select> p<79> c<77> l<10:11> el<10:11>
+n<> u<79> t<Net_lvalue> p<84> c<76> s<83> l<10:9> el<10:10>
+n<13> u<80> t<IntConst> p<81> l<10:13> el<10:15>
+n<> u<81> t<Primary_literal> p<82> c<80> l<10:13> el<10:15>
+n<> u<82> t<Primary> p<83> c<81> l<10:13> el<10:15>
+n<> u<83> t<Expression> p<84> c<82> l<10:13> el<10:15>
+n<> u<84> t<Net_assignment> p<85> c<79> l<10:9> el<10:15>
+n<> u<85> t<List_of_net_assignments> p<86> c<84> l<10:9> el<10:15>
+n<> u<86> t<Continuous_assign> p<87> c<85> l<10:2> el<10:16>
+n<> u<87> t<Module_common_item> p<88> c<86> l<10:2> el<10:16>
+n<> u<88> t<Module_or_generate_item> p<89> c<87> l<10:2> el<10:16>
+n<> u<89> t<Non_port_module_item> p<90> c<88> l<10:2> el<10:16>
+n<> u<90> t<Module_item> p<375> c<89> s<109> l<10:2> el<10:16>
+n<> u<91> t<Weak0> p<93> s<92> l<13:12> el<13:17>
+n<> u<92> t<Weak1> p<93> l<13:19> el<13:24>
+n<> u<93> t<Drive_strength> p<105> c<91> s<104> l<13:11> el<13:25>
+n<inout_i2> u<94> t<StringConst> p<95> l<13:29> el<13:37>
+n<> u<95> t<Ps_or_hierarchical_identifier> p<98> c<94> s<97> l<13:29> el<13:37>
+n<> u<96> t<Constant_bit_select> p<97> l<13:38> el<13:38>
+n<> u<97> t<Constant_select> p<98> c<96> l<13:38> el<13:38>
+n<> u<98> t<Net_lvalue> p<103> c<95> s<102> l<13:29> el<13:37>
+n<pu> u<99> t<StringConst> p<100> l<13:40> el<13:42>
+n<> u<100> t<Primary_literal> p<101> c<99> l<13:40> el<13:42>
+n<> u<101> t<Primary> p<102> c<100> l<13:40> el<13:42>
+n<> u<102> t<Expression> p<103> c<101> l<13:40> el<13:42>
+n<> u<103> t<Net_assignment> p<104> c<98> l<13:29> el<13:42>
+n<> u<104> t<List_of_net_assignments> p<105> c<103> l<13:29> el<13:42>
+n<> u<105> t<Continuous_assign> p<106> c<93> l<13:4> el<13:43>
+n<> u<106> t<Module_common_item> p<107> c<105> l<13:4> el<13:43>
+n<> u<107> t<Module_or_generate_item> p<108> c<106> l<13:4> el<13:43>
+n<> u<108> t<Non_port_module_item> p<109> c<107> l<13:4> el<13:43>
+n<> u<109> t<Module_item> p<375> c<108> s<130> l<13:4> el<13:43>
+n<> u<110> t<Weak0> p<112> l<14:19> el<14:24>
+n<> u<111> t<Weak1> p<112> s<110> l<14:12> el<14:17>
+n<> u<112> t<Drive_strength> p<126> c<111> s<125> l<14:11> el<14:25>
+n<inout_i2> u<113> t<StringConst> p<114> l<14:30> el<14:38>
+n<> u<114> t<Ps_or_hierarchical_identifier> p<117> c<113> s<116> l<14:30> el<14:38>
+n<> u<115> t<Constant_bit_select> p<116> l<14:39> el<14:39>
+n<> u<116> t<Constant_select> p<117> c<115> l<14:39> el<14:39>
+n<> u<117> t<Net_lvalue> p<124> c<114> s<123> l<14:30> el<14:38>
+n<pd> u<118> t<StringConst> p<119> l<14:42> el<14:44>
+n<> u<119> t<Primary_literal> p<120> c<118> l<14:42> el<14:44>
+n<> u<120> t<Primary> p<121> c<119> l<14:42> el<14:44>
+n<> u<121> t<Expression> p<123> c<120> l<14:42> el<14:44>
+n<> u<122> t<Unary_Tilda> p<123> s<121> l<14:41> el<14:42>
+n<> u<123> t<Expression> p<124> c<122> l<14:41> el<14:44>
+n<> u<124> t<Net_assignment> p<125> c<117> l<14:30> el<14:44>
+n<> u<125> t<List_of_net_assignments> p<126> c<124> l<14:30> el<14:44>
+n<> u<126> t<Continuous_assign> p<127> c<112> l<14:4> el<14:45>
+n<> u<127> t<Module_common_item> p<128> c<126> l<14:4> el<14:45>
+n<> u<128> t<Module_or_generate_item> p<129> c<127> l<14:4> el<14:45>
+n<> u<129> t<Non_port_module_item> p<130> c<128> l<14:4> el<14:45>
+n<> u<130> t<Module_item> p<375> c<129> s<180> l<14:4> el<14:45>
+n<0> u<131> t<IntConst> p<132> l<17:8> el<17:9>
+n<> u<132> t<Primary_literal> p<133> c<131> l<17:8> el<17:9>
+n<> u<133> t<Constant_primary> p<134> c<132> l<17:8> el<17:9>
+n<> u<134> t<Constant_expression> p<175> c<133> s<153> l<17:8> el<17:9>
+n<> u<135> t<Weak0> p<137> s<136> l<17:19> el<17:24>
+n<> u<136> t<Weak1> p<137> l<17:26> el<17:31>
+n<> u<137> t<Drive_strength> p<149> c<135> s<148> l<17:18> el<17:32>
+n<inout_i3> u<138> t<StringConst> p<139> l<17:36> el<17:44>
+n<> u<139> t<Ps_or_hierarchical_identifier> p<142> c<138> s<141> l<17:36> el<17:44>
+n<> u<140> t<Constant_bit_select> p<141> l<17:45> el<17:45>
+n<> u<141> t<Constant_select> p<142> c<140> l<17:45> el<17:45>
+n<> u<142> t<Net_lvalue> p<147> c<139> s<146> l<17:36> el<17:44>
+n<pu> u<143> t<StringConst> p<144> l<17:47> el<17:49>
+n<> u<144> t<Primary_literal> p<145> c<143> l<17:47> el<17:49>
+n<> u<145> t<Primary> p<146> c<144> l<17:47> el<17:49>
+n<> u<146> t<Expression> p<147> c<145> l<17:47> el<17:49>
+n<> u<147> t<Net_assignment> p<148> c<142> l<17:36> el<17:49>
+n<> u<148> t<List_of_net_assignments> p<149> c<147> l<17:36> el<17:49>
+n<> u<149> t<Continuous_assign> p<150> c<137> l<17:11> el<17:50>
+n<> u<150> t<Module_common_item> p<151> c<149> l<17:11> el<17:50>
+n<> u<151> t<Module_or_generate_item> p<152> c<150> l<17:11> el<17:50>
+n<> u<152> t<Generate_item> p<153> c<151> l<17:11> el<17:50>
+n<> u<153> t<Generate_block> p<175> c<152> s<174> l<17:11> el<17:50>
+n<> u<154> t<Weak0> p<156> l<18:24> el<18:29>
+n<> u<155> t<Weak1> p<156> s<154> l<18:17> el<18:22>
+n<> u<156> t<Drive_strength> p<170> c<155> s<169> l<18:16> el<18:30>
+n<inout_i3> u<157> t<StringConst> p<158> l<18:35> el<18:43>
+n<> u<158> t<Ps_or_hierarchical_identifier> p<161> c<157> s<160> l<18:35> el<18:43>
+n<> u<159> t<Constant_bit_select> p<160> l<18:44> el<18:44>
+n<> u<160> t<Constant_select> p<161> c<159> l<18:44> el<18:44>
+n<> u<161> t<Net_lvalue> p<168> c<158> s<167> l<18:35> el<18:43>
+n<pd> u<162> t<StringConst> p<163> l<18:47> el<18:49>
+n<> u<163> t<Primary_literal> p<164> c<162> l<18:47> el<18:49>
+n<> u<164> t<Primary> p<165> c<163> l<18:47> el<18:49>
+n<> u<165> t<Expression> p<167> c<164> l<18:47> el<18:49>
+n<> u<166> t<Unary_Tilda> p<167> s<165> l<18:46> el<18:47>
+n<> u<167> t<Expression> p<168> c<166> l<18:46> el<18:49>
+n<> u<168> t<Net_assignment> p<169> c<161> l<18:35> el<18:49>
+n<> u<169> t<List_of_net_assignments> p<170> c<168> l<18:35> el<18:49>
+n<> u<170> t<Continuous_assign> p<171> c<156> l<18:9> el<18:50>
+n<> u<171> t<Module_common_item> p<172> c<170> l<18:9> el<18:50>
+n<> u<172> t<Module_or_generate_item> p<173> c<171> l<18:9> el<18:50>
+n<> u<173> t<Generate_item> p<174> c<172> l<18:9> el<18:50>
+n<> u<174> t<Generate_block> p<175> c<173> l<18:9> el<18:50>
+n<> u<175> t<If_generate_construct> p<176> c<134> l<17:4> el<18:50>
+n<> u<176> t<Conditional_generate_construct> p<177> c<175> l<17:4> el<18:50>
+n<> u<177> t<Module_common_item> p<178> c<176> l<17:4> el<18:50>
+n<> u<178> t<Module_or_generate_item> p<179> c<177> l<17:4> el<18:50>
+n<> u<179> t<Non_port_module_item> p<180> c<178> l<17:4> el<18:50>
+n<> u<180> t<Module_item> p<375> c<179> s<213> l<17:4> el<18:50>
+n<out> u<181> t<StringConst> p<182> l<21:17> el<21:20>
+n<> u<182> t<Ps_or_hierarchical_identifier> p<185> c<181> s<184> l<21:17> el<21:20>
+n<> u<183> t<Constant_bit_select> p<184> l<21:21> el<21:21>
+n<> u<184> t<Constant_select> p<185> c<183> l<21:21> el<21:21>
+n<> u<185> t<Net_lvalue> p<207> c<182> s<206> l<21:17> el<21:20>
+n<sel> u<186> t<StringConst> p<187> l<21:24> el<21:27>
+n<> u<187> t<Primary_literal> p<188> c<186> l<21:24> el<21:27>
+n<> u<188> t<Primary> p<189> c<187> l<21:24> el<21:27>
+n<> u<189> t<Expression> p<195> c<188> s<194> l<21:24> el<21:27>
+n<2'b00> u<190> t<IntConst> p<191> l<21:31> el<21:36>
+n<> u<191> t<Primary_literal> p<192> c<190> l<21:31> el<21:36>
+n<> u<192> t<Primary> p<193> c<191> l<21:31> el<21:36>
+n<> u<193> t<Expression> p<195> c<192> l<21:31> el<21:36>
+n<> u<194> t<BinOp_Equiv> p<195> s<193> l<21:28> el<21:30>
+n<> u<195> t<Expression> p<196> c<189> l<21:24> el<21:36>
+n<> u<196> t<Expression> p<206> c<195> s<205> l<21:23> el<21:37>
+n<v0> u<197> t<StringConst> p<198> l<21:39> el<21:41>
+n<> u<198> t<Primary_literal> p<199> c<197> l<21:39> el<21:41>
+n<> u<199> t<Primary> p<200> c<198> l<21:39> el<21:41>
+n<> u<200> t<Expression> p<206> c<199> s<204> l<21:39> el<21:41>
+n<2'bz> u<201> t<IntConst> p<202> l<21:44> el<21:48>
+n<> u<202> t<Primary_literal> p<203> c<201> l<21:44> el<21:48>
+n<> u<203> t<Primary> p<204> c<202> l<21:44> el<21:48>
+n<> u<204> t<Expression> p<206> c<203> l<21:44> el<21:48>
+n<> u<205> t<Qmark> p<206> s<200> l<21:37> el<21:38>
+n<> u<206> t<Expression> p<207> c<196> l<21:23> el<21:48>
+n<> u<207> t<Net_assignment> p<208> c<185> l<21:17> el<21:48>
+n<> u<208> t<List_of_net_assignments> p<209> c<207> l<21:17> el<21:48>
+n<> u<209> t<Continuous_assign> p<210> c<208> l<21:7> el<21:49>
+n<> u<210> t<Module_common_item> p<211> c<209> l<21:7> el<21:49>
+n<> u<211> t<Module_or_generate_item> p<212> c<210> l<21:7> el<21:49>
+n<> u<212> t<Non_port_module_item> p<213> c<211> l<21:7> el<21:49>
+n<> u<213> t<Module_item> p<375> c<212> s<246> l<21:7> el<21:49>
+n<out> u<214> t<StringConst> p<215> l<22:17> el<22:20>
+n<> u<215> t<Ps_or_hierarchical_identifier> p<218> c<214> s<217> l<22:17> el<22:20>
+n<> u<216> t<Constant_bit_select> p<217> l<22:21> el<22:21>
+n<> u<217> t<Constant_select> p<218> c<216> l<22:21> el<22:21>
+n<> u<218> t<Net_lvalue> p<240> c<215> s<239> l<22:17> el<22:20>
+n<sel> u<219> t<StringConst> p<220> l<22:24> el<22:27>
+n<> u<220> t<Primary_literal> p<221> c<219> l<22:24> el<22:27>
+n<> u<221> t<Primary> p<222> c<220> l<22:24> el<22:27>
+n<> u<222> t<Expression> p<228> c<221> s<227> l<22:24> el<22:27>
+n<2'b01> u<223> t<IntConst> p<224> l<22:31> el<22:36>
+n<> u<224> t<Primary_literal> p<225> c<223> l<22:31> el<22:36>
+n<> u<225> t<Primary> p<226> c<224> l<22:31> el<22:36>
+n<> u<226> t<Expression> p<228> c<225> l<22:31> el<22:36>
+n<> u<227> t<BinOp_Equiv> p<228> s<226> l<22:28> el<22:30>
+n<> u<228> t<Expression> p<229> c<222> l<22:24> el<22:36>
+n<> u<229> t<Expression> p<239> c<228> s<238> l<22:23> el<22:37>
+n<v1> u<230> t<StringConst> p<231> l<22:39> el<22:41>
+n<> u<231> t<Primary_literal> p<232> c<230> l<22:39> el<22:41>
+n<> u<232> t<Primary> p<233> c<231> l<22:39> el<22:41>
+n<> u<233> t<Expression> p<239> c<232> s<237> l<22:39> el<22:41>
+n<2'bz> u<234> t<IntConst> p<235> l<22:44> el<22:48>
+n<> u<235> t<Primary_literal> p<236> c<234> l<22:44> el<22:48>
+n<> u<236> t<Primary> p<237> c<235> l<22:44> el<22:48>
+n<> u<237> t<Expression> p<239> c<236> l<22:44> el<22:48>
+n<> u<238> t<Qmark> p<239> s<233> l<22:37> el<22:38>
+n<> u<239> t<Expression> p<240> c<229> l<22:23> el<22:48>
+n<> u<240> t<Net_assignment> p<241> c<218> l<22:17> el<22:48>
+n<> u<241> t<List_of_net_assignments> p<242> c<240> l<22:17> el<22:48>
+n<> u<242> t<Continuous_assign> p<243> c<241> l<22:7> el<22:49>
+n<> u<243> t<Module_common_item> p<244> c<242> l<22:7> el<22:49>
+n<> u<244> t<Module_or_generate_item> p<245> c<243> l<22:7> el<22:49>
+n<> u<245> t<Non_port_module_item> p<246> c<244> l<22:7> el<22:49>
+n<> u<246> t<Module_item> p<375> c<245> s<265> l<22:7> el<22:49>
+n<> u<247> t<Pull0> p<249> l<24:26> el<24:31>
+n<> u<248> t<Pull1> p<249> s<247> l<24:19> el<24:24>
+n<> u<249> t<Drive_strength> p<261> c<248> s<260> l<24:18> el<24:32>
+n<pull_up_1> u<250> t<StringConst> p<251> l<24:33> el<24:42>
+n<> u<251> t<Ps_or_hierarchical_identifier> p<254> c<250> s<253> l<24:33> el<24:42>
+n<> u<252> t<Constant_bit_select> p<253> l<24:43> el<24:43>
+n<> u<253> t<Constant_select> p<254> c<252> l<24:43> el<24:43>
+n<> u<254> t<Net_lvalue> p<259> c<251> s<258> l<24:33> el<24:42>
+n<> u<255> t<Number_1Tickb1> p<256> l<24:45> el<24:49>
+n<> u<256> t<Primary_literal> p<257> c<255> l<24:45> el<24:49>
+n<> u<257> t<Primary> p<258> c<256> l<24:45> el<24:49>
+n<> u<258> t<Expression> p<259> c<257> l<24:45> el<24:49>
+n<> u<259> t<Net_assignment> p<260> c<254> l<24:33> el<24:49>
+n<> u<260> t<List_of_net_assignments> p<261> c<259> l<24:33> el<24:49>
+n<> u<261> t<Continuous_assign> p<262> c<249> l<24:7> el<24:50>
+n<> u<262> t<Module_common_item> p<263> c<261> l<24:7> el<24:50>
+n<> u<263> t<Module_or_generate_item> p<264> c<262> l<24:7> el<24:50>
+n<> u<264> t<Non_port_module_item> p<265> c<263> l<24:7> el<24:50>
+n<> u<265> t<Module_item> p<375> c<264> s<292> l<24:7> el<24:50>
+n<pull_up_1> u<266> t<StringConst> p<267> l<26:18> el<26:27>
+n<> u<267> t<Ps_or_hierarchical_identifier> p<270> c<266> s<269> l<26:18> el<26:27>
+n<> u<268> t<Constant_bit_select> p<269> l<26:28> el<26:28>
+n<> u<269> t<Constant_select> p<270> c<268> l<26:28> el<26:28>
+n<> u<270> t<Net_lvalue> p<286> c<267> s<285> l<26:18> el<26:27>
+n<driver_1_en> u<271> t<StringConst> p<272> l<26:31> el<26:42>
+n<> u<272> t<Primary_literal> p<273> c<271> l<26:31> el<26:42>
+n<> u<273> t<Primary> p<274> c<272> l<26:31> el<26:42>
+n<> u<274> t<Expression> p<275> c<273> l<26:31> el<26:42>
+n<> u<275> t<Expression> p<285> c<274> s<284> l<26:30> el<26:43>
+n<driver_1> u<276> t<StringConst> p<277> l<26:46> el<26:54>
+n<> u<277> t<Primary_literal> p<278> c<276> l<26:46> el<26:54>
+n<> u<278> t<Primary> p<279> c<277> l<26:46> el<26:54>
+n<> u<279> t<Expression> p<285> c<278> s<283> l<26:46> el<26:54>
+n<1'bz> u<280> t<IntConst> p<281> l<26:57> el<26:61>
+n<> u<281> t<Primary_literal> p<282> c<280> l<26:57> el<26:61>
+n<> u<282> t<Primary> p<283> c<281> l<26:57> el<26:61>
+n<> u<283> t<Expression> p<285> c<282> l<26:57> el<26:61>
+n<> u<284> t<Qmark> p<285> s<279> l<26:44> el<26:45>
+n<> u<285> t<Expression> p<286> c<275> l<26:30> el<26:61>
+n<> u<286> t<Net_assignment> p<287> c<270> l<26:18> el<26:61>
+n<> u<287> t<List_of_net_assignments> p<288> c<286> l<26:18> el<26:61>
+n<> u<288> t<Continuous_assign> p<289> c<287> l<26:7> el<26:62>
+n<> u<289> t<Module_common_item> p<290> c<288> l<26:7> el<26:62>
+n<> u<290> t<Module_or_generate_item> p<291> c<289> l<26:7> el<26:62>
+n<> u<291> t<Non_port_module_item> p<292> c<290> l<26:7> el<26:62>
+n<> u<292> t<Module_item> p<375> c<291> s<309> l<26:7> el<26:62>
+n<> u<293> t<Data_type_or_implicit> p<303> s<302> l<29:11> el<29:11>
+n<NUM_WAYS> u<294> t<StringConst> p<301> s<300> l<29:11> el<29:19>
+n<1> u<295> t<IntConst> p<296> l<29:22> el<29:23>
+n<> u<296> t<Primary_literal> p<297> c<295> l<29:22> el<29:23>
+n<> u<297> t<Constant_primary> p<298> c<296> l<29:22> el<29:23>
+n<> u<298> t<Constant_expression> p<299> c<297> l<29:22> el<29:23>
+n<> u<299> t<Constant_mintypmax_expression> p<300> c<298> l<29:22> el<29:23>
+n<> u<300> t<Constant_param_expression> p<301> c<299> l<29:22> el<29:23>
+n<> u<301> t<Param_assignment> p<302> c<294> l<29:11> el<29:23>
+n<> u<302> t<List_of_param_assignments> p<303> c<301> l<29:11> el<29:23>
+n<> u<303> t<Parameter_declaration> p<304> c<293> l<29:1> el<29:23>
+n<> u<304> t<Package_or_generate_item_declaration> p<305> c<303> l<29:1> el<29:24>
+n<> u<305> t<Module_or_generate_item_declaration> p<306> c<304> l<29:1> el<29:24>
+n<> u<306> t<Module_common_item> p<307> c<305> l<29:1> el<29:24>
+n<> u<307> t<Module_or_generate_item> p<308> c<306> l<29:1> el<29:24>
+n<> u<308> t<Non_port_module_item> p<309> c<307> l<29:1> el<29:24>
+n<> u<309> t<Module_item> p<375> c<308> s<374> l<29:1> el<29:24>
+n<NUM_WAYS> u<310> t<StringConst> p<311> l<31:10> el<31:18>
+n<> u<311> t<Primary_literal> p<312> c<310> l<31:10> el<31:18>
+n<> u<312> t<Constant_primary> p<313> c<311> l<31:10> el<31:18>
+n<> u<313> t<Constant_expression> p<369> c<312> s<336> l<31:10> el<31:18>
+n<1> u<314> t<IntConst> p<315> l<32:8> el<32:9>
+n<> u<315> t<Primary_literal> p<316> c<314> l<32:8> el<32:9>
+n<> u<316> t<Constant_primary> p<317> c<315> l<32:8> el<32:9>
+n<> u<317> t<Constant_expression> p<336> c<316> s<335> l<32:8> el<32:9>
+n<fill_way> u<318> t<StringConst> p<319> l<34:19> el<34:27>
+n<> u<319> t<Ps_or_hierarchical_identifier> p<322> c<318> s<321> l<34:19> el<34:27>
+n<> u<320> t<Constant_bit_select> p<321> l<34:28> el<34:28>
+n<> u<321> t<Constant_select> p<322> c<320> l<34:28> el<34:28>
+n<> u<322> t<Net_lvalue> p<327> c<319> s<326> l<34:19> el<34:27>
+n<0> u<323> t<IntConst> p<324> l<34:30> el<34:31>
+n<> u<324> t<Primary_literal> p<325> c<323> l<34:30> el<34:31>
+n<> u<325> t<Primary> p<326> c<324> l<34:30> el<34:31>
+n<> u<326> t<Expression> p<327> c<325> l<34:30> el<34:31>
+n<> u<327> t<Net_assignment> p<328> c<322> l<34:19> el<34:31>
+n<> u<328> t<List_of_net_assignments> p<329> c<327> l<34:19> el<34:31>
+n<> u<329> t<Continuous_assign> p<330> c<328> l<34:12> el<34:32>
+n<> u<330> t<Module_common_item> p<331> c<329> l<34:12> el<34:32>
+n<> u<331> t<Module_or_generate_item> p<332> c<330> l<34:12> el<34:32>
+n<> u<332> t<Generate_module_item> p<334> c<331> s<333> l<34:12> el<34:32>
+n<> u<333> t<End> p<334> l<36:8> el<36:11>
+n<> u<334> t<Generate_module_block> p<335> c<332> l<33:8> el<36:11>
+n<> u<335> t<Generate_module_item> p<336> c<334> l<33:8> el<36:11>
+n<> u<336> t<Genvar_module_case_item> p<369> c<317> s<367> l<32:8> el<36:11>
+n<2> u<337> t<IntConst> p<338> l<37:8> el<37:9>
+n<> u<338> t<Primary_literal> p<339> c<337> l<37:8> el<37:9>
+n<> u<339> t<Constant_primary> p<340> c<338> l<37:8> el<37:9>
+n<> u<340> t<Constant_expression> p<367> c<339> s<366> l<37:8> el<37:9>
+n<fill_way> u<341> t<StringConst> p<342> l<39:19> el<39:27>
+n<> u<342> t<Ps_or_hierarchical_identifier> p<345> c<341> s<344> l<39:19> el<39:27>
+n<> u<343> t<Constant_bit_select> p<344> l<39:28> el<39:28>
+n<> u<344> t<Constant_select> p<345> c<343> l<39:28> el<39:28>
+n<> u<345> t<Net_lvalue> p<358> c<342> s<357> l<39:19> el<39:27>
+n<lru_flags> u<346> t<StringConst> p<353> s<352> l<39:31> el<39:40>
+n<0> u<347> t<IntConst> p<348> l<39:41> el<39:42>
+n<> u<348> t<Primary_literal> p<349> c<347> l<39:41> el<39:42>
+n<> u<349> t<Primary> p<350> c<348> l<39:41> el<39:42>
+n<> u<350> t<Expression> p<351> c<349> l<39:41> el<39:42>
+n<> u<351> t<Bit_select> p<352> c<350> l<39:40> el<39:43>
+n<> u<352> t<Select> p<353> c<351> l<39:40> el<39:43>
+n<> u<353> t<Complex_func_call> p<354> c<346> l<39:31> el<39:43>
+n<> u<354> t<Primary> p<355> c<353> l<39:31> el<39:43>
+n<> u<355> t<Expression> p<357> c<354> l<39:31> el<39:43>
+n<> u<356> t<Unary_Not> p<357> s<355> l<39:30> el<39:31>
+n<> u<357> t<Expression> p<358> c<356> l<39:30> el<39:43>
+n<> u<358> t<Net_assignment> p<359> c<345> l<39:19> el<39:43>
+n<> u<359> t<List_of_net_assignments> p<360> c<358> l<39:19> el<39:43>
+n<> u<360> t<Continuous_assign> p<361> c<359> l<39:12> el<39:44>
+n<> u<361> t<Module_common_item> p<362> c<360> l<39:12> el<39:44>
+n<> u<362> t<Module_or_generate_item> p<363> c<361> l<39:12> el<39:44>
+n<> u<363> t<Generate_module_item> p<365> c<362> s<364> l<39:12> el<39:44>
+n<> u<364> t<End> p<365> l<41:8> el<41:11>
+n<> u<365> t<Generate_module_block> p<366> c<363> l<38:8> el<41:11>
+n<> u<366> t<Generate_module_item> p<367> c<365> l<38:8> el<41:11>
+n<> u<367> t<Genvar_module_case_item> p<369> c<340> s<368> l<37:8> el<41:11>
+n<> u<368> t<Endcase> p<369> l<42:4> el<42:11>
+n<> u<369> t<Generate_module_case_statement> p<370> c<313> l<31:4> el<42:11>
+n<> u<370> t<Generate_module_item> p<372> c<369> s<371> l<31:4> el<42:11>
+n<> u<371> t<Endgenerate> p<372> l<43:1> el<43:12>
+n<> u<372> t<Generated_module_instantiation> p<373> c<370> l<30:1> el<43:12>
+n<> u<373> t<Non_port_module_item> p<374> c<372> l<30:1> el<43:12>
+n<> u<374> t<Module_item> p<375> c<373> l<30:1> el<43:12>
+n<> u<375> t<Module_declaration> p<376> c<5> l<3:1> el<45:10>
+n<> u<376> t<Description> p<505> c<375> s<442> l<3:1> el<45:10>
+n<> u<377> t<Module_keyword> p<398> s<378> l<48:1> el<48:7>
+n<wandwor_test0> u<378> t<StringConst> p<398> s<397> l<48:8> el<48:21>
+n<A> u<379> t<StringConst> p<382> s<381> l<48:23> el<48:24>
+n<> u<380> t<Constant_bit_select> p<381> l<48:24> el<48:24>
+n<> u<381> t<Constant_select> p<382> c<380> l<48:24> el<48:24>
+n<> u<382> t<Port_reference> p<383> c<379> l<48:23> el<48:24>
+n<> u<383> t<Port_expression> p<384> c<382> l<48:23> el<48:24>
+n<> u<384> t<Port> p<397> c<383> s<390> l<48:23> el<48:24>
+n<B> u<385> t<StringConst> p<388> s<387> l<48:26> el<48:27>
+n<> u<386> t<Constant_bit_select> p<387> l<48:27> el<48:27>
+n<> u<387> t<Constant_select> p<388> c<386> l<48:27> el<48:27>
+n<> u<388> t<Port_reference> p<389> c<385> l<48:26> el<48:27>
+n<> u<389> t<Port_expression> p<390> c<388> l<48:26> el<48:27>
+n<> u<390> t<Port> p<397> c<389> s<396> l<48:26> el<48:27>
+n<X> u<391> t<StringConst> p<394> s<393> l<48:29> el<48:30>
+n<> u<392> t<Constant_bit_select> p<393> l<48:30> el<48:30>
+n<> u<393> t<Constant_select> p<394> c<392> l<48:30> el<48:30>
+n<> u<394> t<Port_reference> p<395> c<391> l<48:29> el<48:30>
+n<> u<395> t<Port_expression> p<396> c<394> l<48:29> el<48:30>
+n<> u<396> t<Port> p<397> c<395> l<48:29> el<48:30>
+n<> u<397> t<List_of_ports> p<398> c<384> l<48:22> el<48:31>
+n<> u<398> t<Module_nonansi_header> p<441> c<377> s<406> l<48:1> el<48:32>
+n<> u<399> t<Data_type_or_implicit> p<400> l<49:8> el<49:8>
+n<> u<400> t<Net_port_type> p<404> c<399> s<403> l<49:8> el<49:8>
+n<A> u<401> t<StringConst> p<403> s<402> l<49:8> el<49:9>
+n<B> u<402> t<StringConst> p<403> l<49:11> el<49:12>
+n<> u<403> t<List_of_port_identifiers> p<404> c<401> l<49:8> el<49:12>
+n<> u<404> t<Input_declaration> p<405> c<400> l<49:2> el<49:12>
+n<> u<405> t<Port_declaration> p<406> c<404> l<49:2> el<49:12>
+n<> u<406> t<Module_item> p<441> c<405> s<414> l<49:2> el<49:13>
+n<> u<407> t<NetType_Wor> p<409> s<408> l<50:9> el<50:12>
+n<> u<408> t<Data_type_or_implicit> p<409> l<50:13> el<50:13>
+n<> u<409> t<Net_port_type> p<412> c<407> s<411> l<50:9> el<50:12>
+n<X> u<410> t<StringConst> p<411> l<50:13> el<50:14>
+n<> u<411> t<List_of_port_identifiers> p<412> c<410> l<50:13> el<50:14>
+n<> u<412> t<Output_declaration> p<413> c<409> l<50:2> el<50:14>
+n<> u<413> t<Port_declaration> p<414> c<412> l<50:2> el<50:14>
+n<> u<414> t<Module_item> p<441> c<413> s<440> l<50:2> el<50:15>
+n<X> u<415> t<StringConst> p<416> l<52:9> el<52:10>
+n<> u<416> t<Ps_or_hierarchical_identifier> p<419> c<415> s<418> l<52:9> el<52:10>
+n<> u<417> t<Constant_bit_select> p<418> l<52:11> el<52:11>
+n<> u<418> t<Constant_select> p<419> c<417> l<52:11> el<52:11>
+n<> u<419> t<Net_lvalue> p<424> c<416> s<423> l<52:9> el<52:10>
+n<A> u<420> t<StringConst> p<421> l<52:13> el<52:14>
+n<> u<421> t<Primary_literal> p<422> c<420> l<52:13> el<52:14>
+n<> u<422> t<Primary> p<423> c<421> l<52:13> el<52:14>
+n<> u<423> t<Expression> p<424> c<422> l<52:13> el<52:14>
+n<> u<424> t<Net_assignment> p<435> c<419> s<434> l<52:9> el<52:14>
+n<X> u<425> t<StringConst> p<426> l<52:16> el<52:17>
+n<> u<426> t<Ps_or_hierarchical_identifier> p<429> c<425> s<428> l<52:16> el<52:17>
+n<> u<427> t<Constant_bit_select> p<428> l<52:18> el<52:18>
+n<> u<428> t<Constant_select> p<429> c<427> l<52:18> el<52:18>
+n<> u<429> t<Net_lvalue> p<434> c<426> s<433> l<52:16> el<52:17>
+n<B> u<430> t<StringConst> p<431> l<52:20> el<52:21>
+n<> u<431> t<Primary_literal> p<432> c<430> l<52:20> el<52:21>
+n<> u<432> t<Primary> p<433> c<431> l<52:20> el<52:21>
+n<> u<433> t<Expression> p<434> c<432> l<52:20> el<52:21>
+n<> u<434> t<Net_assignment> p<435> c<429> l<52:16> el<52:21>
+n<> u<435> t<List_of_net_assignments> p<436> c<424> l<52:9> el<52:21>
+n<> u<436> t<Continuous_assign> p<437> c<435> l<52:2> el<52:22>
+n<> u<437> t<Module_common_item> p<438> c<436> l<52:2> el<52:22>
+n<> u<438> t<Module_or_generate_item> p<439> c<437> l<52:2> el<52:22>
+n<> u<439> t<Non_port_module_item> p<440> c<438> l<52:2> el<52:22>
+n<> u<440> t<Module_item> p<441> c<439> l<52:2> el<52:22>
+n<> u<441> t<Module_declaration> p<442> c<398> l<48:1> el<54:10>
+n<> u<442> t<Description> p<505> c<441> s<504> l<48:1> el<54:10>
+n<> u<443> t<Module_keyword> p<445> s<444> l<57:1> el<57:7>
+n<top2> u<444> t<StringConst> p<445> l<57:8> el<57:12>
+n<> u<445> t<Module_ansi_header> p<503> c<443> s<456> l<57:1> el<57:13>
+n<> u<446> t<NetType_Uwire> p<451> s<447> l<58:3> el<58:8>
+n<> u<447> t<Data_type_or_implicit> p<451> s<450> l<58:9> el<58:9>
+n<two> u<448> t<StringConst> p<449> l<58:9> el<58:12>
+n<> u<449> t<Net_decl_assignment> p<450> c<448> l<58:9> el<58:12>
+n<> u<450> t<List_of_net_decl_assignments> p<451> c<449> l<58:9> el<58:12>
+n<> u<451> t<Net_declaration> p<452> c<446> l<58:3> el<58:13>
+n<> u<452> t<Package_or_generate_item_declaration> p<453> c<451> l<58:3> el<58:13>
+n<> u<453> t<Module_or_generate_item_declaration> p<454> c<452> l<58:3> el<58:13>
+n<> u<454> t<Module_common_item> p<455> c<453> l<58:3> el<58:13>
+n<> u<455> t<Module_or_generate_item> p<456> c<454> l<58:3> el<58:13>
+n<> u<456> t<Non_port_module_item> p<503> c<455> s<471> l<58:3> el<58:13>
+n<two> u<457> t<StringConst> p<458> l<60:10> el<60:13>
+n<> u<458> t<Ps_or_hierarchical_identifier> p<461> c<457> s<460> l<60:10> el<60:13>
+n<> u<459> t<Constant_bit_select> p<460> l<60:14> el<60:14>
+n<> u<460> t<Constant_select> p<461> c<459> l<60:14> el<60:14>
+n<> u<461> t<Net_lvalue> p<466> c<458> s<465> l<60:10> el<60:13>
+n<> u<462> t<Number_1Tickb1> p<463> l<60:16> el<60:20>
+n<> u<463> t<Primary_literal> p<464> c<462> l<60:16> el<60:20>
+n<> u<464> t<Primary> p<465> c<463> l<60:16> el<60:20>
+n<> u<465> t<Expression> p<466> c<464> l<60:16> el<60:20>
+n<> u<466> t<Net_assignment> p<467> c<461> l<60:10> el<60:20>
+n<> u<467> t<List_of_net_assignments> p<468> c<466> l<60:10> el<60:20>
+n<> u<468> t<Continuous_assign> p<469> c<467> l<60:3> el<60:21>
+n<> u<469> t<Module_common_item> p<470> c<468> l<60:3> el<60:21>
+n<> u<470> t<Module_or_generate_item> p<471> c<469> l<60:3> el<60:21>
+n<> u<471> t<Non_port_module_item> p<503> c<470> s<486> l<60:3> el<60:21>
+n<two> u<472> t<StringConst> p<473> l<61:10> el<61:13>
+n<> u<473> t<Ps_or_hierarchical_identifier> p<476> c<472> s<475> l<61:10> el<61:13>
+n<> u<474> t<Constant_bit_select> p<475> l<61:14> el<61:14>
+n<> u<475> t<Constant_select> p<476> c<474> l<61:14> el<61:14>
+n<> u<476> t<Net_lvalue> p<481> c<473> s<480> l<61:10> el<61:13>
+n<> u<477> t<Number_1Tickb0> p<478> l<61:16> el<61:20>
+n<> u<478> t<Primary_literal> p<479> c<477> l<61:16> el<61:20>
+n<> u<479> t<Primary> p<480> c<478> l<61:16> el<61:20>
+n<> u<480> t<Expression> p<481> c<479> l<61:16> el<61:20>
+n<> u<481> t<Net_assignment> p<482> c<476> l<61:10> el<61:20>
+n<> u<482> t<List_of_net_assignments> p<483> c<481> l<61:10> el<61:20>
+n<> u<483> t<Continuous_assign> p<484> c<482> l<61:3> el<61:21>
+n<> u<484> t<Module_common_item> p<485> c<483> l<61:3> el<61:21>
+n<> u<485> t<Module_or_generate_item> p<486> c<484> l<61:3> el<61:21>
+n<> u<486> t<Non_port_module_item> p<503> c<485> s<502> l<61:3> el<61:21>
+n<> u<487> t<Dollar_keyword> p<494> s<488> l<63:11> el<63:12>
+n<display> u<488> t<StringConst> p<494> s<493> l<63:12> el<63:19>
+n<"Failed: this should be a compile time error!"> u<489> t<StringLiteral> p<490> l<63:20> el<63:66>
+n<> u<490> t<Primary_literal> p<491> c<489> l<63:20> el<63:66>
+n<> u<491> t<Primary> p<492> c<490> l<63:20> el<63:66>
+n<> u<492> t<Expression> p<493> c<491> l<63:20> el<63:66>
+n<> u<493> t<List_of_arguments> p<494> c<492> l<63:20> el<63:66>
+n<> u<494> t<Subroutine_call> p<495> c<487> l<63:11> el<63:67>
+n<> u<495> t<Subroutine_call_statement> p<496> c<494> l<63:11> el<63:68>
+n<> u<496> t<Statement_item> p<497> c<495> l<63:11> el<63:68>
+n<> u<497> t<Statement> p<498> c<496> l<63:11> el<63:68>
+n<> u<498> t<Statement_or_null> p<499> c<497> l<63:11> el<63:68>
+n<> u<499> t<Initial_construct> p<500> c<498> l<63:3> el<63:68>
+n<> u<500> t<Module_common_item> p<501> c<499> l<63:3> el<63:68>
+n<> u<501> t<Module_or_generate_item> p<502> c<500> l<63:3> el<63:68>
+n<> u<502> t<Non_port_module_item> p<503> c<501> l<63:3> el<63:68>
+n<> u<503> t<Module_declaration> p<504> c<445> l<57:1> el<64:10>
+n<> u<504> t<Description> p<505> c<503> l<57:1> el<64:10>
+n<> u<505> t<Source_text> p<506> c<376> l<3:1> el<64:10>
+n<> u<506> t<Top_level_rule> l<3:1> el<65:1>
+[WRN:PA0205] dut.sv:3: No timescale set for "top".
+
+[WRN:PA0205] dut.sv:48: No timescale set for "wandwor_test0".
+
+[WRN:PA0205] dut.sv:57: No timescale set for "top2".
+
+[INF:CP0300] Compilation...
+
+[INF:CP0303] dut.sv:3: Compile module "work@top".
+
+[INF:CP0303] dut.sv:57: Compile module "work@top2".
+
+[INF:CP0303] dut.sv:48: Compile module "work@wandwor_test0".
+
+[INF:EL0526] Design Elaboration...
+
+[INF:CP0335] dut.sv:18: Compile generate block "work@top.genblk1".
+
+[NTE:EL0503] dut.sv:3: Top level module "work@top".
+
+[NTE:EL0503] dut.sv:48: Top level module "work@wandwor_test0".
+
+[NTE:EL0503] dut.sv:57: Top level module "work@top2".
+
+[NTE:EL0504] Multiple top level modules in design.
+
+[NTE:EL0508] Nb Top level modules: 3.
+
+[NTE:EL0509] Max instance depth: 1.
+
+[NTE:EL0510] Nb instances: 3.
+
+[NTE:EL0511] Nb leaf instances: 2.
+
+[INF:UH0706] Creating UHDM Model...
+
+[INF:UH0707] Elaborating UHDM...
+
+[ERR:UH0717] dut.sv:9:9: Multiple continuous assignments to: v,
+             dut.sv:10:9: other assignment.
+
+[ERR:UH0717] dut.sv:34:19: Multiple continuous assignments to: fill_way,
+             dut.sv:39:19: other assignment.
+
+[ERR:UH0717] dut.sv:60:10: Multiple continuous assignments to: two,
+             dut.sv:61:10: other assignment.
+
+[INF:UH0708] Writing UHDM DB: ../../build/tests/MultContAssign/slpp_all/surelog.uhdm ...
+
+[INF:UH0709] Writing UHDM Html Coverage: ../../build/tests/MultContAssign/slpp_all/surelog.uhdm.chk.html ...
+
+[INF:UH0710] Loading UHDM DB: ../../build/tests/MultContAssign/slpp_all/surelog.uhdm ...
+
+[INF:UH0711] Decompiling UHDM...
+
+====== UHDM =======
+design: (work@top)
+|vpiElaborated:1
+|vpiName:work@top
+|uhdmallModules:
+\_module: work@top (work@top) dut.sv:3:1: , endln:45:10, parent:work@top
+  |vpiFullName:work@top
+  |vpiParameter:
+  \_parameter: (work@top.NUM_WAYS), line:29:11, endln:29:23, parent:work@top
+    |UINT:1
+    |vpiName:NUM_WAYS
+    |vpiFullName:work@top.NUM_WAYS
+  |vpiParamAssign:
+  \_param_assign: , line:29:11, endln:29:23, parent:work@top
+    |vpiRhs:
+    \_constant: , line:29:22, endln:29:23
+      |vpiDecompile:1
+      |vpiSize:64
+      |UINT:1
+      |vpiConstType:9
+    |vpiLhs:
+    \_parameter: (work@top.NUM_WAYS), line:29:11, endln:29:23, parent:work@top
+  |vpiDefName:work@top
+  |vpiNet:
+  \_logic_net: (work@top.v), line:5:6, parent:work@top
+    |vpiName:v
+    |vpiFullName:work@top.v
+  |vpiContAssign:
+  \_cont_assign: , line:6:30, endln:6:43, parent:work@top
+    |vpiStrength0:1
+    |vpiStrength1:8
+    |vpiRhs:
+    \_ref_obj: (work@top.pu), line:6:41, endln:6:43
+      |vpiName:pu
+      |vpiFullName:work@top.pu
+      |vpiActual:
+      \_logic_net: (pu)
+        |vpiName:pu
+        |vpiNetType:1
+    |vpiLhs:
+    \_ref_obj: (work@top.inout_i1), line:6:30, endln:6:38
+      |vpiName:inout_i1
+      |vpiFullName:work@top.inout_i1
+      |vpiActual:
+      \_logic_net: (inout_i1)
+        |vpiName:inout_i1
+        |vpiNetType:1
+  |vpiContAssign:
+  \_cont_assign: , line:7:30, endln:7:44, parent:work@top
+    |vpiStrength0:8
+    |vpiStrength1:1
+    |vpiRhs:
+    \_operation: , line:7:41, endln:7:42
+      |vpiOpType:4
+      |vpiOperand:
+      \_ref_obj: (work@top.pd), line:7:42, endln:7:44
+        |vpiName:pd
+        |vpiFullName:work@top.pd
+        |vpiActual:
+        \_logic_net: (pd)
+          |vpiName:pd
+          |vpiNetType:1
+    |vpiLhs:
+    \_ref_obj: (work@top.inout_i1), line:7:30, endln:7:38
+      |vpiName:inout_i1
+      |vpiFullName:work@top.inout_i1
+      |vpiActual:
+      \_logic_net: (inout_i1)
+  |vpiContAssign:
+  \_cont_assign: , line:9:9, endln:9:15, parent:work@top
+    |vpiRhs:
+    \_constant: , line:9:13, endln:9:15
+      |vpiDecompile:12
+      |vpiSize:64
+      |UINT:12
+      |vpiConstType:9
+    |vpiLhs:
+    \_ref_obj: (work@top.v), line:9:9, endln:9:10
+      |vpiName:v
+      |vpiFullName:work@top.v
+      |vpiActual:
+      \_int_var: (work@top.v), line:5:6, endln:5:7, parent:work@top
+        |vpiName:v
+        |vpiFullName:work@top.v
+        |vpiAutomatic:1
+        |vpiVisibility:1
+  |vpiContAssign:
+  \_cont_assign: , line:10:9, endln:10:15, parent:work@top
+    |vpiRhs:
+    \_constant: , line:10:13, endln:10:15
+      |vpiDecompile:13
+      |vpiSize:64
+      |UINT:13
+      |vpiConstType:9
+    |vpiLhs:
+    \_ref_obj: (work@top.v), line:10:9, endln:10:10
+      |vpiName:v
+      |vpiFullName:work@top.v
+      |vpiActual:
+      \_int_var: (work@top.v), line:5:6, endln:5:7, parent:work@top
+  |vpiContAssign:
+  \_cont_assign: , line:13:29, endln:13:42, parent:work@top
+    |vpiStrength0:8
+    |vpiStrength1:8
+    |vpiRhs:
+    \_ref_obj: (work@top.pu), line:13:40, endln:13:42
+      |vpiName:pu
+      |vpiFullName:work@top.pu
+      |vpiActual:
+      \_logic_net: (pu)
+    |vpiLhs:
+    \_ref_obj: (work@top.inout_i2), line:13:29, endln:13:37
+      |vpiName:inout_i2
+      |vpiFullName:work@top.inout_i2
+      |vpiActual:
+      \_logic_net: (inout_i2)
+        |vpiName:inout_i2
+        |vpiNetType:1
+  |vpiContAssign:
+  \_cont_assign: , line:14:30, endln:14:44, parent:work@top
+    |vpiStrength0:8
+    |vpiStrength1:8
+    |vpiRhs:
+    \_operation: , line:14:41, endln:14:42
+      |vpiOpType:4
+      |vpiOperand:
+      \_ref_obj: (work@top.pd), line:14:42, endln:14:44
+        |vpiName:pd
+        |vpiFullName:work@top.pd
+        |vpiActual:
+        \_logic_net: (pd)
+    |vpiLhs:
+    \_ref_obj: (work@top.inout_i2), line:14:30, endln:14:38
+      |vpiName:inout_i2
+      |vpiFullName:work@top.inout_i2
+      |vpiActual:
+      \_logic_net: (inout_i2)
+  |vpiContAssign:
+  \_cont_assign: , line:21:17, endln:21:48, parent:work@top
+    |vpiRhs:
+    \_operation: , line:21:23, endln:21:37
+      |vpiOpType:32
+      |vpiOperand:
+      \_operation: , line:21:24, endln:21:36
+        |vpiOpType:14
+        |vpiOperand:
+        \_ref_obj: (work@top.sel), line:21:24, endln:21:27
+          |vpiName:sel
+          |vpiFullName:work@top.sel
+          |vpiActual:
+          \_logic_net: (sel)
+            |vpiName:sel
+            |vpiNetType:1
+        |vpiOperand:
+        \_constant: , line:21:31, endln:21:36
+          |vpiDecompile:2'b00
+          |vpiSize:2
+          |BIN:00
+          |vpiConstType:3
+      |vpiOperand:
+      \_ref_obj: (work@top.v0), line:21:39, endln:21:41
+        |vpiName:v0
+        |vpiFullName:work@top.v0
+        |vpiActual:
+        \_logic_net: (v0)
+          |vpiName:v0
+          |vpiNetType:1
+      |vpiOperand:
+      \_constant: , line:21:44, endln:21:48
+        |vpiDecompile:2'bz
+        |vpiSize:2
+        |BIN:z
+        |vpiConstType:3
+    |vpiLhs:
+    \_ref_obj: (work@top.out), line:21:17, endln:21:20
+      |vpiName:out
+      |vpiFullName:work@top.out
+      |vpiActual:
+      \_logic_net: (out)
+        |vpiName:out
+        |vpiNetType:1
+  |vpiContAssign:
+  \_cont_assign: , line:22:17, endln:22:48, parent:work@top
+    |vpiRhs:
+    \_operation: , line:22:23, endln:22:37
+      |vpiOpType:32
+      |vpiOperand:
+      \_operation: , line:22:24, endln:22:36
+        |vpiOpType:14
+        |vpiOperand:
+        \_ref_obj: (work@top.sel), line:22:24, endln:22:27
+          |vpiName:sel
+          |vpiFullName:work@top.sel
+          |vpiActual:
+          \_logic_net: (sel)
+        |vpiOperand:
+        \_constant: , line:22:31, endln:22:36
+          |vpiDecompile:2'b01
+          |vpiSize:2
+          |BIN:01
+          |vpiConstType:3
+      |vpiOperand:
+      \_ref_obj: (work@top.v1), line:22:39, endln:22:41
+        |vpiName:v1
+        |vpiFullName:work@top.v1
+        |vpiActual:
+        \_logic_net: (v1)
+          |vpiName:v1
+          |vpiNetType:1
+      |vpiOperand:
+      \_constant: , line:22:44, endln:22:48
+        |vpiDecompile:2'bz
+        |vpiSize:2
+        |BIN:z
+        |vpiConstType:3
+    |vpiLhs:
+    \_ref_obj: (work@top.out), line:22:17, endln:22:20
+      |vpiName:out
+      |vpiFullName:work@top.out
+      |vpiActual:
+      \_logic_net: (out)
+  |vpiContAssign:
+  \_cont_assign: , line:24:33, endln:24:49, parent:work@top
+    |vpiStrength0:32
+    |vpiStrength1:32
+    |vpiRhs:
+    \_constant: , line:24:45, endln:24:49
+      |vpiDecompile:1'b1
+      |vpiSize:1
+      |BIN:1
+      |vpiConstType:3
+    |vpiLhs:
+    \_ref_obj: (work@top.pull_up_1), line:24:33, endln:24:42
+      |vpiName:pull_up_1
+      |vpiFullName:work@top.pull_up_1
+      |vpiActual:
+      \_logic_net: (pull_up_1)
+        |vpiName:pull_up_1
+        |vpiNetType:1
+  |vpiContAssign:
+  \_cont_assign: , line:26:18, endln:26:61, parent:work@top
+    |vpiRhs:
+    \_operation: , line:26:30, endln:26:43
+      |vpiOpType:32
+      |vpiOperand:
+      \_ref_obj: (work@top.driver_1_en), line:26:31, endln:26:42
+        |vpiName:driver_1_en
+        |vpiFullName:work@top.driver_1_en
+        |vpiActual:
+        \_logic_net: (driver_1_en)
+          |vpiName:driver_1_en
+          |vpiNetType:1
+      |vpiOperand:
+      \_ref_obj: (work@top.driver_1), line:26:46, endln:26:54
+        |vpiName:driver_1
+        |vpiFullName:work@top.driver_1
+        |vpiActual:
+        \_logic_net: (driver_1)
+          |vpiName:driver_1
+          |vpiNetType:1
+      |vpiOperand:
+      \_constant: , line:26:57, endln:26:61
+        |vpiDecompile:1'bz
+        |vpiSize:1
+        |BIN:z
+        |vpiConstType:3
+    |vpiLhs:
+    \_ref_obj: (work@top.pull_up_1), line:26:18, endln:26:27
+      |vpiName:pull_up_1
+      |vpiFullName:work@top.pull_up_1
+      |vpiActual:
+      \_logic_net: (pull_up_1)
+  |vpiContAssign:
+  \_cont_assign: , line:34:19, endln:34:31, parent:work@top
+    |vpiRhs:
+    \_constant: , line:34:30, endln:34:31
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+    |vpiLhs:
+    \_ref_obj: (work@top.fill_way), line:34:19, endln:34:27
+      |vpiName:fill_way
+      |vpiFullName:work@top.fill_way
+      |vpiActual:
+      \_logic_net: (fill_way)
+        |vpiName:fill_way
+        |vpiNetType:1
+  |vpiContAssign:
+  \_cont_assign: , line:39:19, endln:39:43, parent:work@top
+    |vpiRhs:
+    \_operation: , line:39:30, endln:39:31
+      |vpiOpType:3
+      |vpiOperand:
+      \_bit_select: (work@top.lru_flags), line:39:31, endln:39:43, parent:work@top.lru_flags
+        |vpiName:lru_flags
+        |vpiFullName:work@top.lru_flags
+        |vpiIndex:
+        \_constant: , line:39:41, endln:39:42, parent:work@top.lru_flags
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
+    |vpiLhs:
+    \_ref_obj: (work@top.fill_way), line:39:19, endln:39:27
+      |vpiName:fill_way
+      |vpiFullName:work@top.fill_way
+      |vpiActual:
+      \_logic_net: (fill_way)
+|uhdmallModules:
+\_module: work@top2 (work@top2) dut.sv:57:1: , endln:64:10, parent:work@top
+  |vpiFullName:work@top2
+  |vpiDefName:work@top2
+  |vpiNet:
+  \_logic_net: (work@top2.two), line:58:9, parent:work@top2
+    |vpiName:two
+    |vpiFullName:work@top2.two
+    |vpiNetType:13
+  |vpiProcess:
+  \_initial: , parent:work@top2
+    |vpiStmt:
+    \_sys_func_call: ($display), line:63:11, endln:63:68
+      |vpiArgument:
+      \_constant: , line:63:20, endln:63:66
+        |vpiDecompile:Failed: this should be a compile time error!
+        |vpiSize:44
+        |STRING:Failed: this should be a compile time error!
+        |vpiConstType:6
+      |vpiName:$display
+  |vpiContAssign:
+  \_cont_assign: , line:60:10, endln:60:20, parent:work@top2
+    |vpiRhs:
+    \_constant: , line:60:16, endln:60:20
+      |vpiDecompile:1'b1
+      |vpiSize:1
+      |BIN:1
+      |vpiConstType:3
+    |vpiLhs:
+    \_ref_obj: (work@top2.two), line:60:10, endln:60:13
+      |vpiName:two
+      |vpiFullName:work@top2.two
+      |vpiActual:
+      \_logic_net: (work@top2.two), line:58:9, endln:58:12, parent:work@top2
+        |vpiName:two
+        |vpiFullName:work@top2.two
+        |vpiNetType:13
+  |vpiContAssign:
+  \_cont_assign: , line:61:10, endln:61:20, parent:work@top2
+    |vpiRhs:
+    \_constant: , line:61:16, endln:61:20
+      |vpiDecompile:1'b0
+      |vpiSize:1
+      |BIN:0
+      |vpiConstType:3
+    |vpiLhs:
+    \_ref_obj: (work@top2.two), line:61:10, endln:61:13
+      |vpiName:two
+      |vpiFullName:work@top2.two
+      |vpiActual:
+      \_logic_net: (work@top2.two), line:58:9, endln:58:12, parent:work@top2
+|uhdmallModules:
+\_module: work@wandwor_test0 (work@wandwor_test0) dut.sv:48:1: , endln:54:10, parent:work@top
+  |vpiFullName:work@wandwor_test0
+  |vpiDefName:work@wandwor_test0
+  |vpiNet:
+  \_logic_net: (work@wandwor_test0.A), line:48:23, parent:work@wandwor_test0
+    |vpiName:A
+    |vpiFullName:work@wandwor_test0.A
+  |vpiNet:
+  \_logic_net: (work@wandwor_test0.B), line:48:26, parent:work@wandwor_test0
+    |vpiName:B
+    |vpiFullName:work@wandwor_test0.B
+  |vpiNet:
+  \_logic_net: (work@wandwor_test0.X), line:48:29, parent:work@wandwor_test0
+    |vpiName:X
+    |vpiFullName:work@wandwor_test0.X
+    |vpiNetType:3
+  |vpiPort:
+  \_port: (A), line:48:23, parent:work@wandwor_test0
+    |vpiName:A
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: 
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.A), line:48:23, parent:work@wandwor_test0
+  |vpiPort:
+  \_port: (B), line:48:26, parent:work@wandwor_test0
+    |vpiName:B
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: 
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.B), line:48:26, parent:work@wandwor_test0
+  |vpiPort:
+  \_port: (X), line:48:29, parent:work@wandwor_test0
+    |vpiName:X
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: 
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.X), line:48:29, parent:work@wandwor_test0
+  |vpiContAssign:
+  \_cont_assign: , line:52:9, endln:52:21, parent:work@wandwor_test0
+    |vpiRhs:
+    \_ref_obj: (work@wandwor_test0.A), line:52:13, endln:52:14
+      |vpiName:A
+      |vpiFullName:work@wandwor_test0.A
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.A), line:48:23, endln:48:24, parent:work@wandwor_test0
+        |vpiName:A
+        |vpiFullName:work@wandwor_test0.A
+    |vpiLhs:
+    \_ref_obj: (work@wandwor_test0.X), line:52:9, endln:52:10
+      |vpiName:X
+      |vpiFullName:work@wandwor_test0.X
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.X), line:48:29, endln:48:30, parent:work@wandwor_test0
+        |vpiName:X
+        |vpiFullName:work@wandwor_test0.X
+        |vpiNetType:3
+  |vpiContAssign:
+  \_cont_assign: , line:52:9, endln:52:21, parent:work@wandwor_test0
+    |vpiRhs:
+    \_ref_obj: (work@wandwor_test0.B), line:52:20, endln:52:21
+      |vpiName:B
+      |vpiFullName:work@wandwor_test0.B
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.B), line:48:26, endln:48:27, parent:work@wandwor_test0
+        |vpiName:B
+        |vpiFullName:work@wandwor_test0.B
+    |vpiLhs:
+    \_ref_obj: (work@wandwor_test0.X), line:52:16, endln:52:17
+      |vpiName:X
+      |vpiFullName:work@wandwor_test0.X
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.X), line:48:29, endln:48:30, parent:work@wandwor_test0
+|uhdmtopModules:
+\_module: work@top (work@top) dut.sv:3:1: , endln:45:10
+  |vpiName:work@top
+  |vpiVariables:
+  \_int_var: (work@top.v), line:5:6, endln:5:7, parent:work@top
+    |vpiName:v
+    |vpiFullName:work@top.v
+    |vpiAutomatic:1
+    |vpiVisibility:1
+  |vpiParameter:
+  \_parameter: (work@top.NUM_WAYS), line:29:11, endln:29:23, parent:work@top
+    |UINT:1
+    |vpiName:NUM_WAYS
+    |vpiFullName:work@top.NUM_WAYS
+  |vpiParamAssign:
+  \_param_assign: , line:29:11, endln:29:23, parent:work@top
+    |vpiRhs:
+    \_constant: , line:29:22, endln:29:23
+      |vpiDecompile:1
+      |vpiSize:64
+      |UINT:1
+      |vpiConstType:9
+    |vpiLhs:
+    \_parameter: (work@top.NUM_WAYS), line:29:11, endln:29:23, parent:work@top
+  |vpiDefName:work@top
+  |vpiNet:
+  \_logic_net: (inout_i1)
+    |vpiName:inout_i1
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (pu)
+    |vpiName:pu
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (pd)
+    |vpiName:pd
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (inout_i2)
+    |vpiName:inout_i2
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (out)
+    |vpiName:out
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (sel)
+    |vpiName:sel
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (v0)
+    |vpiName:v0
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (v1)
+    |vpiName:v1
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (pull_up_1)
+    |vpiName:pull_up_1
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (driver_1_en)
+    |vpiName:driver_1_en
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (driver_1)
+    |vpiName:driver_1
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (fill_way)
+    |vpiName:fill_way
+    |vpiNetType:1
+  |vpiContAssign:
+  \_cont_assign: , line:6:30, endln:6:43, parent:work@top
+    |vpiStrength0:1
+    |vpiStrength1:8
+    |vpiRhs:
+    \_ref_obj: (work@top.pu), line:6:41, endln:6:43
+      |vpiName:pu
+      |vpiFullName:work@top.pu
+      |vpiActual:
+      \_logic_net: (pu)
+    |vpiLhs:
+    \_ref_obj: (work@top.inout_i1), line:6:30, endln:6:38
+      |vpiName:inout_i1
+      |vpiFullName:work@top.inout_i1
+      |vpiActual:
+      \_logic_net: (inout_i1)
+  |vpiContAssign:
+  \_cont_assign: , line:7:30, endln:7:44, parent:work@top
+    |vpiStrength0:8
+    |vpiStrength1:1
+    |vpiRhs:
+    \_operation: , line:7:41, endln:7:42
+      |vpiOpType:4
+      |vpiOperand:
+      \_ref_obj: (work@top.pd), line:7:42, endln:7:44
+        |vpiName:pd
+        |vpiFullName:work@top.pd
+        |vpiActual:
+        \_logic_net: (pd)
+    |vpiLhs:
+    \_ref_obj: (work@top.inout_i1), line:7:30, endln:7:38
+      |vpiName:inout_i1
+      |vpiFullName:work@top.inout_i1
+      |vpiActual:
+      \_logic_net: (inout_i1)
+  |vpiContAssign:
+  \_cont_assign: , line:9:9, endln:9:15, parent:work@top
+    |vpiRhs:
+    \_constant: , line:9:13, endln:9:15
+      |vpiDecompile:12
+      |vpiSize:64
+      |UINT:12
+      |vpiConstType:9
+    |vpiLhs:
+    \_ref_obj: (work@top.v), line:9:9, endln:9:10
+      |vpiName:v
+      |vpiFullName:work@top.v
+      |vpiActual:
+      \_int_var: (work@top.v), line:5:6, endln:5:7, parent:work@top
+  |vpiContAssign:
+  \_cont_assign: , line:10:9, endln:10:15, parent:work@top
+    |vpiRhs:
+    \_constant: , line:10:13, endln:10:15
+      |vpiDecompile:13
+      |vpiSize:64
+      |UINT:13
+      |vpiConstType:9
+    |vpiLhs:
+    \_ref_obj: (work@top.v), line:10:9, endln:10:10
+      |vpiName:v
+      |vpiFullName:work@top.v
+      |vpiActual:
+      \_int_var: (work@top.v), line:5:6, endln:5:7, parent:work@top
+  |vpiContAssign:
+  \_cont_assign: , line:13:29, endln:13:42, parent:work@top
+    |vpiStrength0:8
+    |vpiStrength1:8
+    |vpiRhs:
+    \_ref_obj: (work@top.pu), line:13:40, endln:13:42
+      |vpiName:pu
+      |vpiFullName:work@top.pu
+      |vpiActual:
+      \_logic_net: (pu)
+    |vpiLhs:
+    \_ref_obj: (work@top.inout_i2), line:13:29, endln:13:37
+      |vpiName:inout_i2
+      |vpiFullName:work@top.inout_i2
+      |vpiActual:
+      \_logic_net: (inout_i2)
+  |vpiContAssign:
+  \_cont_assign: , line:14:30, endln:14:44, parent:work@top
+    |vpiStrength0:8
+    |vpiStrength1:8
+    |vpiRhs:
+    \_operation: , line:14:41, endln:14:42
+      |vpiOpType:4
+      |vpiOperand:
+      \_ref_obj: (work@top.pd), line:14:42, endln:14:44
+        |vpiName:pd
+        |vpiFullName:work@top.pd
+        |vpiActual:
+        \_logic_net: (pd)
+    |vpiLhs:
+    \_ref_obj: (work@top.inout_i2), line:14:30, endln:14:38
+      |vpiName:inout_i2
+      |vpiFullName:work@top.inout_i2
+      |vpiActual:
+      \_logic_net: (inout_i2)
+  |vpiContAssign:
+  \_cont_assign: , line:21:17, endln:21:48, parent:work@top
+    |vpiRhs:
+    \_operation: , line:21:23, endln:21:37
+      |vpiOpType:32
+      |vpiOperand:
+      \_operation: , line:21:24, endln:21:36
+        |vpiOpType:14
+        |vpiOperand:
+        \_ref_obj: (work@top.sel), line:21:24, endln:21:27
+          |vpiName:sel
+          |vpiFullName:work@top.sel
+          |vpiActual:
+          \_logic_net: (sel)
+        |vpiOperand:
+        \_constant: , line:21:31, endln:21:36
+          |vpiDecompile:2'b00
+          |vpiSize:2
+          |BIN:00
+          |vpiConstType:3
+      |vpiOperand:
+      \_ref_obj: (work@top.v0), line:21:39, endln:21:41
+        |vpiName:v0
+        |vpiFullName:work@top.v0
+        |vpiActual:
+        \_logic_net: (v0)
+      |vpiOperand:
+      \_constant: , line:21:44, endln:21:48
+        |vpiDecompile:2'bz
+        |vpiSize:2
+        |BIN:z
+        |vpiConstType:3
+    |vpiLhs:
+    \_ref_obj: (work@top.out), line:21:17, endln:21:20
+      |vpiName:out
+      |vpiFullName:work@top.out
+      |vpiActual:
+      \_logic_net: (out)
+  |vpiContAssign:
+  \_cont_assign: , line:22:17, endln:22:48, parent:work@top
+    |vpiRhs:
+    \_operation: , line:22:23, endln:22:37
+      |vpiOpType:32
+      |vpiOperand:
+      \_operation: , line:22:24, endln:22:36
+        |vpiOpType:14
+        |vpiOperand:
+        \_ref_obj: (work@top.sel), line:22:24, endln:22:27
+          |vpiName:sel
+          |vpiFullName:work@top.sel
+          |vpiActual:
+          \_logic_net: (sel)
+        |vpiOperand:
+        \_constant: , line:22:31, endln:22:36
+          |vpiDecompile:2'b01
+          |vpiSize:2
+          |BIN:01
+          |vpiConstType:3
+      |vpiOperand:
+      \_ref_obj: (work@top.v1), line:22:39, endln:22:41
+        |vpiName:v1
+        |vpiFullName:work@top.v1
+        |vpiActual:
+        \_logic_net: (v1)
+      |vpiOperand:
+      \_constant: , line:22:44, endln:22:48
+        |vpiDecompile:2'bz
+        |vpiSize:2
+        |BIN:z
+        |vpiConstType:3
+    |vpiLhs:
+    \_ref_obj: (work@top.out), line:22:17, endln:22:20
+      |vpiName:out
+      |vpiFullName:work@top.out
+      |vpiActual:
+      \_logic_net: (out)
+  |vpiContAssign:
+  \_cont_assign: , line:24:33, endln:24:49, parent:work@top
+    |vpiStrength0:32
+    |vpiStrength1:32
+    |vpiRhs:
+    \_constant: , line:24:45, endln:24:49
+      |vpiDecompile:1'b1
+      |vpiSize:1
+      |BIN:1
+      |vpiConstType:3
+    |vpiLhs:
+    \_ref_obj: (work@top.pull_up_1), line:24:33, endln:24:42
+      |vpiName:pull_up_1
+      |vpiFullName:work@top.pull_up_1
+      |vpiActual:
+      \_logic_net: (pull_up_1)
+  |vpiContAssign:
+  \_cont_assign: , line:26:18, endln:26:61, parent:work@top
+    |vpiRhs:
+    \_operation: , line:26:30, endln:26:43
+      |vpiOpType:32
+      |vpiOperand:
+      \_ref_obj: (work@top.driver_1_en), line:26:31, endln:26:42
+        |vpiName:driver_1_en
+        |vpiFullName:work@top.driver_1_en
+        |vpiActual:
+        \_logic_net: (driver_1_en)
+      |vpiOperand:
+      \_ref_obj: (work@top.driver_1), line:26:46, endln:26:54
+        |vpiName:driver_1
+        |vpiFullName:work@top.driver_1
+        |vpiActual:
+        \_logic_net: (driver_1)
+      |vpiOperand:
+      \_constant: , line:26:57, endln:26:61
+        |vpiDecompile:1'bz
+        |vpiSize:1
+        |BIN:z
+        |vpiConstType:3
+    |vpiLhs:
+    \_ref_obj: (work@top.pull_up_1), line:26:18, endln:26:27
+      |vpiName:pull_up_1
+      |vpiFullName:work@top.pull_up_1
+      |vpiActual:
+      \_logic_net: (pull_up_1)
+  |vpiContAssign:
+  \_cont_assign: , line:34:19, endln:34:31, parent:work@top
+    |vpiRhs:
+    \_constant: , line:34:30, endln:34:31
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+    |vpiLhs:
+    \_ref_obj: (work@top.fill_way), line:34:19, endln:34:27
+      |vpiName:fill_way
+      |vpiFullName:work@top.fill_way
+      |vpiActual:
+      \_logic_net: (fill_way)
+  |vpiContAssign:
+  \_cont_assign: , line:39:19, endln:39:43, parent:work@top
+    |vpiRhs:
+    \_operation: , line:39:30, endln:39:31
+      |vpiOpType:3
+      |vpiOperand:
+      \_bit_select: (work@top.lru_flags), line:39:31, endln:39:43, parent:work@top.lru_flags
+        |vpiName:lru_flags
+        |vpiFullName:work@top.lru_flags
+        |vpiIndex:
+        \_constant: , line:39:41, endln:39:42, parent:work@top.lru_flags
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
+    |vpiLhs:
+    \_ref_obj: (work@top.fill_way), line:39:19, endln:39:27
+      |vpiName:fill_way
+      |vpiFullName:work@top.fill_way
+      |vpiActual:
+      \_logic_net: (fill_way)
+  |vpiGenScopeArray:
+  \_gen_scope_array: (work@top.genblk1), line:18:9, endln:18:50, parent:work@top
+    |vpiName:genblk1
+    |vpiFullName:work@top.genblk1
+    |vpiGenScope:
+    \_gen_scope: (work@top.genblk1), parent:work@top.genblk1
+      |vpiFullName:work@top.genblk1
+      |vpiContAssign:
+      \_cont_assign: , line:18:35, endln:18:49, parent:work@top.genblk1
+        |vpiStrength0:8
+        |vpiStrength1:8
+        |vpiRhs:
+        \_operation: , line:18:46, endln:18:47
+          |vpiOpType:4
+          |vpiOperand:
+          \_ref_obj: (work@top.genblk1.pd), line:18:47, endln:18:49
+            |vpiName:pd
+            |vpiFullName:work@top.genblk1.pd
+            |vpiActual:
+            \_logic_net: (pd)
+        |vpiLhs:
+        \_ref_obj: (work@top.genblk1.inout_i3), line:18:35, endln:18:43
+          |vpiName:inout_i3
+          |vpiFullName:work@top.genblk1.inout_i3
+|uhdmtopModules:
+\_module: work@wandwor_test0 (work@wandwor_test0) dut.sv:48:1: , endln:54:10
+  |vpiName:work@wandwor_test0
+  |vpiDefName:work@wandwor_test0
+  |vpiNet:
+  \_logic_net: (work@wandwor_test0.A), line:48:23, endln:48:24, parent:work@wandwor_test0
+    |vpiName:A
+    |vpiFullName:work@wandwor_test0.A
+  |vpiNet:
+  \_logic_net: (work@wandwor_test0.B), line:48:26, endln:48:27, parent:work@wandwor_test0
+    |vpiName:B
+    |vpiFullName:work@wandwor_test0.B
+  |vpiNet:
+  \_logic_net: (work@wandwor_test0.X), line:48:29, endln:48:30, parent:work@wandwor_test0
+    |vpiName:X
+    |vpiFullName:work@wandwor_test0.X
+    |vpiNetType:3
+  |vpiPort:
+  \_port: (A), line:48:23, endln:48:24, parent:work@wandwor_test0
+    |vpiName:A
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@wandwor_test0.A), parent:A
+      |vpiName:A
+      |vpiFullName:work@wandwor_test0.A
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.A), line:48:23, endln:48:24, parent:work@wandwor_test0
+    |vpiInstance:
+    \_module: work@wandwor_test0 (work@wandwor_test0) dut.sv:48:1: , endln:54:10
+  |vpiPort:
+  \_port: (B), line:48:26, endln:48:27, parent:work@wandwor_test0
+    |vpiName:B
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@wandwor_test0.B), parent:B
+      |vpiName:B
+      |vpiFullName:work@wandwor_test0.B
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.B), line:48:26, endln:48:27, parent:work@wandwor_test0
+    |vpiInstance:
+    \_module: work@wandwor_test0 (work@wandwor_test0) dut.sv:48:1: , endln:54:10
+  |vpiPort:
+  \_port: (X), line:48:29, endln:48:30, parent:work@wandwor_test0
+    |vpiName:X
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@wandwor_test0.X), parent:X
+      |vpiName:X
+      |vpiFullName:work@wandwor_test0.X
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.X), line:48:29, endln:48:30, parent:work@wandwor_test0
+    |vpiInstance:
+    \_module: work@wandwor_test0 (work@wandwor_test0) dut.sv:48:1: , endln:54:10
+  |vpiContAssign:
+  \_cont_assign: , line:52:9, endln:52:21, parent:work@wandwor_test0
+    |vpiRhs:
+    \_ref_obj: (work@wandwor_test0.A), line:52:13, endln:52:14
+      |vpiName:A
+      |vpiFullName:work@wandwor_test0.A
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.A), line:48:23, endln:48:24, parent:work@wandwor_test0
+    |vpiLhs:
+    \_ref_obj: (work@wandwor_test0.X), line:52:9, endln:52:10
+      |vpiName:X
+      |vpiFullName:work@wandwor_test0.X
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.X), line:48:29, endln:48:30, parent:work@wandwor_test0
+  |vpiContAssign:
+  \_cont_assign: , line:52:9, endln:52:21, parent:work@wandwor_test0
+    |vpiRhs:
+    \_ref_obj: (work@wandwor_test0.B), line:52:20, endln:52:21
+      |vpiName:B
+      |vpiFullName:work@wandwor_test0.B
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.B), line:48:26, endln:48:27, parent:work@wandwor_test0
+    |vpiLhs:
+    \_ref_obj: (work@wandwor_test0.X), line:52:16, endln:52:17
+      |vpiName:X
+      |vpiFullName:work@wandwor_test0.X
+      |vpiActual:
+      \_logic_net: (work@wandwor_test0.X), line:48:29, endln:48:30, parent:work@wandwor_test0
+|uhdmtopModules:
+\_module: work@top2 (work@top2) dut.sv:57:1: , endln:64:10
+  |vpiName:work@top2
+  |vpiDefName:work@top2
+  |vpiNet:
+  \_logic_net: (work@top2.two), line:58:9, endln:58:12, parent:work@top2
+    |vpiName:two
+    |vpiFullName:work@top2.two
+    |vpiNetType:13
+  |vpiProcess:
+  \_initial: , parent:work@top2
+    |vpiStmt:
+    \_sys_func_call: ($display), line:63:11, endln:63:68
+      |vpiArgument:
+      \_constant: , line:63:20, endln:63:66
+        |vpiDecompile:Failed: this should be a compile time error!
+        |vpiSize:44
+        |STRING:Failed: this should be a compile time error!
+        |vpiConstType:6
+      |vpiName:$display
+  |vpiContAssign:
+  \_cont_assign: , line:60:10, endln:60:20, parent:work@top2
+    |vpiRhs:
+    \_constant: , line:60:16, endln:60:20
+      |vpiDecompile:1'b1
+      |vpiSize:1
+      |BIN:1
+      |vpiConstType:3
+    |vpiLhs:
+    \_ref_obj: (work@top2.two), line:60:10, endln:60:13
+      |vpiName:two
+      |vpiFullName:work@top2.two
+      |vpiActual:
+      \_logic_net: (work@top2.two), line:58:9, endln:58:12, parent:work@top2
+  |vpiContAssign:
+  \_cont_assign: , line:61:10, endln:61:20, parent:work@top2
+    |vpiRhs:
+    \_constant: , line:61:16, endln:61:20
+      |vpiDecompile:1'b0
+      |vpiSize:1
+      |BIN:0
+      |vpiConstType:3
+    |vpiLhs:
+    \_ref_obj: (work@top2.two), line:61:10, endln:61:13
+      |vpiName:two
+      |vpiFullName:work@top2.two
+      |vpiActual:
+      \_logic_net: (work@top2.two), line:58:9, endln:58:12, parent:work@top2
+===================
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 3
+[WARNING] : 3
+[   NOTE] : 8
+

--- a/tests/MultContAssign/MultContAssign.log
+++ b/tests/MultContAssign/MultContAssign.log
@@ -2,12 +2,12 @@
 
 LIB:  work
 FILE: dut.sv
-n<> u<0> t<Null_rule> p<506> s<505> l<3:1> el<1:3>
+n<> u<0> t<Null_rule> p<508> s<507> l<3:1> el<1:3>
 n<> u<1> t<Module_keyword> p<5> s<2> l<3:1> el<3:7>
 n<top> u<2> t<StringConst> p<5> s<4> l<3:8> el<3:11>
 n<> u<3> t<Port> p<4> l<3:12> el<3:12>
 n<> u<4> t<List_of_ports> p<5> c<3> l<3:11> el<3:13>
-n<> u<5> t<Module_nonansi_header> p<375> c<1> s<18> l<3:1> el<3:14>
+n<> u<5> t<Module_nonansi_header> p<377> c<1> s<18> l<3:1> el<3:14>
 n<> u<6> t<IntegerAtomType_Int> p<7> l<5:2> el<5:5>
 n<> u<7> t<Data_type> p<11> c<6> s<10> l<5:2> el<5:5>
 n<v> u<8> t<StringConst> p<9> l<5:6> el<5:7>
@@ -20,7 +20,7 @@ n<> u<14> t<Module_or_generate_item_declaration> p<15> c<13> l<5:2> el<5:8>
 n<> u<15> t<Module_common_item> p<16> c<14> l<5:2> el<5:8>
 n<> u<16> t<Module_or_generate_item> p<17> c<15> l<5:2> el<5:8>
 n<> u<17> t<Non_port_module_item> p<18> c<16> l<5:2> el<5:8>
-n<> u<18> t<Module_item> p<375> c<17> s<37> l<5:2> el<5:8>
+n<> u<18> t<Module_item> p<377> c<17> s<37> l<5:2> el<5:8>
 n<> u<19> t<Weak1> p<21> l<6:20> el<6:25>
 n<> u<20> t<HighZ0> p<21> s<19> l<6:12> el<6:18>
 n<> u<21> t<Drive_strength> p<33> c<20> s<32> l<6:11> el<6:26>
@@ -39,7 +39,7 @@ n<> u<33> t<Continuous_assign> p<34> c<21> l<6:4> el<6:44>
 n<> u<34> t<Module_common_item> p<35> c<33> l<6:4> el<6:44>
 n<> u<35> t<Module_or_generate_item> p<36> c<34> l<6:4> el<6:44>
 n<> u<36> t<Non_port_module_item> p<37> c<35> l<6:4> el<6:44>
-n<> u<37> t<Module_item> p<375> c<36> s<58> l<6:4> el<6:44>
+n<> u<37> t<Module_item> p<377> c<36> s<58> l<6:4> el<6:44>
 n<> u<38> t<Weak0> p<40> s<39> l<7:12> el<7:17>
 n<> u<39> t<HighZ1> p<40> l<7:19> el<7:25>
 n<> u<40> t<Drive_strength> p<54> c<38> s<53> l<7:11> el<7:26>
@@ -60,7 +60,7 @@ n<> u<54> t<Continuous_assign> p<55> c<40> l<7:4> el<7:45>
 n<> u<55> t<Module_common_item> p<56> c<54> l<7:4> el<7:45>
 n<> u<56> t<Module_or_generate_item> p<57> c<55> l<7:4> el<7:45>
 n<> u<57> t<Non_port_module_item> p<58> c<56> l<7:4> el<7:45>
-n<> u<58> t<Module_item> p<375> c<57> s<74> l<7:4> el<7:45>
+n<> u<58> t<Module_item> p<377> c<57> s<74> l<7:4> el<7:45>
 n<v> u<59> t<StringConst> p<60> l<9:9> el<9:10>
 n<> u<60> t<Ps_or_hierarchical_identifier> p<63> c<59> s<62> l<9:9> el<9:10>
 n<> u<61> t<Constant_bit_select> p<62> l<9:11> el<9:11>
@@ -76,7 +76,7 @@ n<> u<70> t<Continuous_assign> p<71> c<69> l<9:2> el<9:16>
 n<> u<71> t<Module_common_item> p<72> c<70> l<9:2> el<9:16>
 n<> u<72> t<Module_or_generate_item> p<73> c<71> l<9:2> el<9:16>
 n<> u<73> t<Non_port_module_item> p<74> c<72> l<9:2> el<9:16>
-n<> u<74> t<Module_item> p<375> c<73> s<90> l<9:2> el<9:16>
+n<> u<74> t<Module_item> p<377> c<73> s<90> l<9:2> el<9:16>
 n<v> u<75> t<StringConst> p<76> l<10:9> el<10:10>
 n<> u<76> t<Ps_or_hierarchical_identifier> p<79> c<75> s<78> l<10:9> el<10:10>
 n<> u<77> t<Constant_bit_select> p<78> l<10:11> el<10:11>
@@ -92,7 +92,7 @@ n<> u<86> t<Continuous_assign> p<87> c<85> l<10:2> el<10:16>
 n<> u<87> t<Module_common_item> p<88> c<86> l<10:2> el<10:16>
 n<> u<88> t<Module_or_generate_item> p<89> c<87> l<10:2> el<10:16>
 n<> u<89> t<Non_port_module_item> p<90> c<88> l<10:2> el<10:16>
-n<> u<90> t<Module_item> p<375> c<89> s<109> l<10:2> el<10:16>
+n<> u<90> t<Module_item> p<377> c<89> s<109> l<10:2> el<10:16>
 n<> u<91> t<Weak0> p<93> s<92> l<13:12> el<13:17>
 n<> u<92> t<Weak1> p<93> l<13:19> el<13:24>
 n<> u<93> t<Drive_strength> p<105> c<91> s<104> l<13:11> el<13:25>
@@ -111,7 +111,7 @@ n<> u<105> t<Continuous_assign> p<106> c<93> l<13:4> el<13:43>
 n<> u<106> t<Module_common_item> p<107> c<105> l<13:4> el<13:43>
 n<> u<107> t<Module_or_generate_item> p<108> c<106> l<13:4> el<13:43>
 n<> u<108> t<Non_port_module_item> p<109> c<107> l<13:4> el<13:43>
-n<> u<109> t<Module_item> p<375> c<108> s<130> l<13:4> el<13:43>
+n<> u<109> t<Module_item> p<377> c<108> s<130> l<13:4> el<13:43>
 n<> u<110> t<Weak0> p<112> l<14:19> el<14:24>
 n<> u<111> t<Weak1> p<112> s<110> l<14:12> el<14:17>
 n<> u<112> t<Drive_strength> p<126> c<111> s<125> l<14:11> el<14:25>
@@ -132,7 +132,7 @@ n<> u<126> t<Continuous_assign> p<127> c<112> l<14:4> el<14:45>
 n<> u<127> t<Module_common_item> p<128> c<126> l<14:4> el<14:45>
 n<> u<128> t<Module_or_generate_item> p<129> c<127> l<14:4> el<14:45>
 n<> u<129> t<Non_port_module_item> p<130> c<128> l<14:4> el<14:45>
-n<> u<130> t<Module_item> p<375> c<129> s<180> l<14:4> el<14:45>
+n<> u<130> t<Module_item> p<377> c<129> s<180> l<14:4> el<14:45>
 n<0> u<131> t<IntConst> p<132> l<17:8> el<17:9>
 n<> u<132> t<Primary_literal> p<133> c<131> l<17:8> el<17:9>
 n<> u<133> t<Constant_primary> p<134> c<132> l<17:8> el<17:9>
@@ -182,7 +182,7 @@ n<> u<176> t<Conditional_generate_construct> p<177> c<175> l<17:4> el<18:50>
 n<> u<177> t<Module_common_item> p<178> c<176> l<17:4> el<18:50>
 n<> u<178> t<Module_or_generate_item> p<179> c<177> l<17:4> el<18:50>
 n<> u<179> t<Non_port_module_item> p<180> c<178> l<17:4> el<18:50>
-n<> u<180> t<Module_item> p<375> c<179> s<213> l<17:4> el<18:50>
+n<> u<180> t<Module_item> p<377> c<179> s<213> l<17:4> el<18:50>
 n<out> u<181> t<StringConst> p<182> l<21:17> el<21:20>
 n<> u<182> t<Ps_or_hierarchical_identifier> p<185> c<181> s<184> l<21:17> el<21:20>
 n<> u<183> t<Constant_bit_select> p<184> l<21:21> el<21:21>
@@ -215,7 +215,7 @@ n<> u<209> t<Continuous_assign> p<210> c<208> l<21:7> el<21:49>
 n<> u<210> t<Module_common_item> p<211> c<209> l<21:7> el<21:49>
 n<> u<211> t<Module_or_generate_item> p<212> c<210> l<21:7> el<21:49>
 n<> u<212> t<Non_port_module_item> p<213> c<211> l<21:7> el<21:49>
-n<> u<213> t<Module_item> p<375> c<212> s<246> l<21:7> el<21:49>
+n<> u<213> t<Module_item> p<377> c<212> s<246> l<21:7> el<21:49>
 n<out> u<214> t<StringConst> p<215> l<22:17> el<22:20>
 n<> u<215> t<Ps_or_hierarchical_identifier> p<218> c<214> s<217> l<22:17> el<22:20>
 n<> u<216> t<Constant_bit_select> p<217> l<22:21> el<22:21>
@@ -248,7 +248,7 @@ n<> u<242> t<Continuous_assign> p<243> c<241> l<22:7> el<22:49>
 n<> u<243> t<Module_common_item> p<244> c<242> l<22:7> el<22:49>
 n<> u<244> t<Module_or_generate_item> p<245> c<243> l<22:7> el<22:49>
 n<> u<245> t<Non_port_module_item> p<246> c<244> l<22:7> el<22:49>
-n<> u<246> t<Module_item> p<375> c<245> s<265> l<22:7> el<22:49>
+n<> u<246> t<Module_item> p<377> c<245> s<265> l<22:7> el<22:49>
 n<> u<247> t<Pull0> p<249> l<24:26> el<24:31>
 n<> u<248> t<Pull1> p<249> s<247> l<24:19> el<24:24>
 n<> u<249> t<Drive_strength> p<261> c<248> s<260> l<24:18> el<24:32>
@@ -267,7 +267,7 @@ n<> u<261> t<Continuous_assign> p<262> c<249> l<24:7> el<24:50>
 n<> u<262> t<Module_common_item> p<263> c<261> l<24:7> el<24:50>
 n<> u<263> t<Module_or_generate_item> p<264> c<262> l<24:7> el<24:50>
 n<> u<264> t<Non_port_module_item> p<265> c<263> l<24:7> el<24:50>
-n<> u<265> t<Module_item> p<375> c<264> s<292> l<24:7> el<24:50>
+n<> u<265> t<Module_item> p<377> c<264> s<292> l<24:7> el<24:50>
 n<pull_up_1> u<266> t<StringConst> p<267> l<26:18> el<26:27>
 n<> u<267> t<Ps_or_hierarchical_identifier> p<270> c<266> s<269> l<26:18> el<26:27>
 n<> u<268> t<Constant_bit_select> p<269> l<26:28> el<26:28>
@@ -294,7 +294,7 @@ n<> u<288> t<Continuous_assign> p<289> c<287> l<26:7> el<26:62>
 n<> u<289> t<Module_common_item> p<290> c<288> l<26:7> el<26:62>
 n<> u<290> t<Module_or_generate_item> p<291> c<289> l<26:7> el<26:62>
 n<> u<291> t<Non_port_module_item> p<292> c<290> l<26:7> el<26:62>
-n<> u<292> t<Module_item> p<375> c<291> s<309> l<26:7> el<26:62>
+n<> u<292> t<Module_item> p<377> c<291> s<309> l<26:7> el<26:62>
 n<> u<293> t<Data_type_or_implicit> p<303> s<302> l<29:11> el<29:11>
 n<NUM_WAYS> u<294> t<StringConst> p<301> s<300> l<29:11> el<29:19>
 n<1> u<295> t<IntConst> p<296> l<29:22> el<29:23>
@@ -311,15 +311,15 @@ n<> u<305> t<Module_or_generate_item_declaration> p<306> c<304> l<29:1> el<29:24
 n<> u<306> t<Module_common_item> p<307> c<305> l<29:1> el<29:24>
 n<> u<307> t<Module_or_generate_item> p<308> c<306> l<29:1> el<29:24>
 n<> u<308> t<Non_port_module_item> p<309> c<307> l<29:1> el<29:24>
-n<> u<309> t<Module_item> p<375> c<308> s<374> l<29:1> el<29:24>
+n<> u<309> t<Module_item> p<377> c<308> s<376> l<29:1> el<29:24>
 n<NUM_WAYS> u<310> t<StringConst> p<311> l<31:10> el<31:18>
 n<> u<311> t<Primary_literal> p<312> c<310> l<31:10> el<31:18>
 n<> u<312> t<Constant_primary> p<313> c<311> l<31:10> el<31:18>
-n<> u<313> t<Constant_expression> p<369> c<312> s<336> l<31:10> el<31:18>
+n<> u<313> t<Constant_expression> p<367> c<312> s<335> l<31:10> el<31:18>
 n<1> u<314> t<IntConst> p<315> l<32:8> el<32:9>
 n<> u<315> t<Primary_literal> p<316> c<314> l<32:8> el<32:9>
 n<> u<316> t<Constant_primary> p<317> c<315> l<32:8> el<32:9>
-n<> u<317> t<Constant_expression> p<336> c<316> s<335> l<32:8> el<32:9>
+n<> u<317> t<Constant_expression> p<335> c<316> s<334> l<32:8> el<32:9>
 n<fill_way> u<318> t<StringConst> p<319> l<34:19> el<34:27>
 n<> u<319> t<Ps_or_hierarchical_identifier> p<322> c<318> s<321> l<34:19> el<34:27>
 n<> u<320> t<Constant_bit_select> p<321> l<34:28> el<34:28>
@@ -334,181 +334,183 @@ n<> u<328> t<List_of_net_assignments> p<329> c<327> l<34:19> el<34:31>
 n<> u<329> t<Continuous_assign> p<330> c<328> l<34:12> el<34:32>
 n<> u<330> t<Module_common_item> p<331> c<329> l<34:12> el<34:32>
 n<> u<331> t<Module_or_generate_item> p<332> c<330> l<34:12> el<34:32>
-n<> u<332> t<Generate_module_item> p<334> c<331> s<333> l<34:12> el<34:32>
+n<> u<332> t<Generate_item> p<334> c<331> s<333> l<34:12> el<34:32>
 n<> u<333> t<End> p<334> l<36:8> el<36:11>
-n<> u<334> t<Generate_module_block> p<335> c<332> l<33:8> el<36:11>
-n<> u<335> t<Generate_module_item> p<336> c<334> l<33:8> el<36:11>
-n<> u<336> t<Genvar_module_case_item> p<369> c<317> s<367> l<32:8> el<36:11>
-n<2> u<337> t<IntConst> p<338> l<37:8> el<37:9>
-n<> u<338> t<Primary_literal> p<339> c<337> l<37:8> el<37:9>
-n<> u<339> t<Constant_primary> p<340> c<338> l<37:8> el<37:9>
-n<> u<340> t<Constant_expression> p<367> c<339> s<366> l<37:8> el<37:9>
-n<fill_way> u<341> t<StringConst> p<342> l<39:19> el<39:27>
-n<> u<342> t<Ps_or_hierarchical_identifier> p<345> c<341> s<344> l<39:19> el<39:27>
-n<> u<343> t<Constant_bit_select> p<344> l<39:28> el<39:28>
-n<> u<344> t<Constant_select> p<345> c<343> l<39:28> el<39:28>
-n<> u<345> t<Net_lvalue> p<358> c<342> s<357> l<39:19> el<39:27>
-n<lru_flags> u<346> t<StringConst> p<353> s<352> l<39:31> el<39:40>
-n<0> u<347> t<IntConst> p<348> l<39:41> el<39:42>
-n<> u<348> t<Primary_literal> p<349> c<347> l<39:41> el<39:42>
-n<> u<349> t<Primary> p<350> c<348> l<39:41> el<39:42>
-n<> u<350> t<Expression> p<351> c<349> l<39:41> el<39:42>
-n<> u<351> t<Bit_select> p<352> c<350> l<39:40> el<39:43>
-n<> u<352> t<Select> p<353> c<351> l<39:40> el<39:43>
-n<> u<353> t<Complex_func_call> p<354> c<346> l<39:31> el<39:43>
-n<> u<354> t<Primary> p<355> c<353> l<39:31> el<39:43>
-n<> u<355> t<Expression> p<357> c<354> l<39:31> el<39:43>
-n<> u<356> t<Unary_Not> p<357> s<355> l<39:30> el<39:31>
-n<> u<357> t<Expression> p<358> c<356> l<39:30> el<39:43>
-n<> u<358> t<Net_assignment> p<359> c<345> l<39:19> el<39:43>
-n<> u<359> t<List_of_net_assignments> p<360> c<358> l<39:19> el<39:43>
-n<> u<360> t<Continuous_assign> p<361> c<359> l<39:12> el<39:44>
-n<> u<361> t<Module_common_item> p<362> c<360> l<39:12> el<39:44>
-n<> u<362> t<Module_or_generate_item> p<363> c<361> l<39:12> el<39:44>
-n<> u<363> t<Generate_module_item> p<365> c<362> s<364> l<39:12> el<39:44>
-n<> u<364> t<End> p<365> l<41:8> el<41:11>
-n<> u<365> t<Generate_module_block> p<366> c<363> l<38:8> el<41:11>
-n<> u<366> t<Generate_module_item> p<367> c<365> l<38:8> el<41:11>
-n<> u<367> t<Genvar_module_case_item> p<369> c<340> s<368> l<37:8> el<41:11>
-n<> u<368> t<Endcase> p<369> l<42:4> el<42:11>
-n<> u<369> t<Generate_module_case_statement> p<370> c<313> l<31:4> el<42:11>
-n<> u<370> t<Generate_module_item> p<372> c<369> s<371> l<31:4> el<42:11>
-n<> u<371> t<Endgenerate> p<372> l<43:1> el<43:12>
-n<> u<372> t<Generated_module_instantiation> p<373> c<370> l<30:1> el<43:12>
-n<> u<373> t<Non_port_module_item> p<374> c<372> l<30:1> el<43:12>
-n<> u<374> t<Module_item> p<375> c<373> l<30:1> el<43:12>
-n<> u<375> t<Module_declaration> p<376> c<5> l<3:1> el<45:10>
-n<> u<376> t<Description> p<505> c<375> s<442> l<3:1> el<45:10>
-n<> u<377> t<Module_keyword> p<398> s<378> l<48:1> el<48:7>
-n<wandwor_test0> u<378> t<StringConst> p<398> s<397> l<48:8> el<48:21>
-n<A> u<379> t<StringConst> p<382> s<381> l<48:23> el<48:24>
-n<> u<380> t<Constant_bit_select> p<381> l<48:24> el<48:24>
-n<> u<381> t<Constant_select> p<382> c<380> l<48:24> el<48:24>
-n<> u<382> t<Port_reference> p<383> c<379> l<48:23> el<48:24>
-n<> u<383> t<Port_expression> p<384> c<382> l<48:23> el<48:24>
-n<> u<384> t<Port> p<397> c<383> s<390> l<48:23> el<48:24>
-n<B> u<385> t<StringConst> p<388> s<387> l<48:26> el<48:27>
-n<> u<386> t<Constant_bit_select> p<387> l<48:27> el<48:27>
-n<> u<387> t<Constant_select> p<388> c<386> l<48:27> el<48:27>
-n<> u<388> t<Port_reference> p<389> c<385> l<48:26> el<48:27>
-n<> u<389> t<Port_expression> p<390> c<388> l<48:26> el<48:27>
-n<> u<390> t<Port> p<397> c<389> s<396> l<48:26> el<48:27>
-n<X> u<391> t<StringConst> p<394> s<393> l<48:29> el<48:30>
-n<> u<392> t<Constant_bit_select> p<393> l<48:30> el<48:30>
-n<> u<393> t<Constant_select> p<394> c<392> l<48:30> el<48:30>
-n<> u<394> t<Port_reference> p<395> c<391> l<48:29> el<48:30>
-n<> u<395> t<Port_expression> p<396> c<394> l<48:29> el<48:30>
-n<> u<396> t<Port> p<397> c<395> l<48:29> el<48:30>
-n<> u<397> t<List_of_ports> p<398> c<384> l<48:22> el<48:31>
-n<> u<398> t<Module_nonansi_header> p<441> c<377> s<406> l<48:1> el<48:32>
-n<> u<399> t<Data_type_or_implicit> p<400> l<49:8> el<49:8>
-n<> u<400> t<Net_port_type> p<404> c<399> s<403> l<49:8> el<49:8>
-n<A> u<401> t<StringConst> p<403> s<402> l<49:8> el<49:9>
-n<B> u<402> t<StringConst> p<403> l<49:11> el<49:12>
-n<> u<403> t<List_of_port_identifiers> p<404> c<401> l<49:8> el<49:12>
-n<> u<404> t<Input_declaration> p<405> c<400> l<49:2> el<49:12>
-n<> u<405> t<Port_declaration> p<406> c<404> l<49:2> el<49:12>
-n<> u<406> t<Module_item> p<441> c<405> s<414> l<49:2> el<49:13>
-n<> u<407> t<NetType_Wor> p<409> s<408> l<50:9> el<50:12>
-n<> u<408> t<Data_type_or_implicit> p<409> l<50:13> el<50:13>
-n<> u<409> t<Net_port_type> p<412> c<407> s<411> l<50:9> el<50:12>
-n<X> u<410> t<StringConst> p<411> l<50:13> el<50:14>
-n<> u<411> t<List_of_port_identifiers> p<412> c<410> l<50:13> el<50:14>
-n<> u<412> t<Output_declaration> p<413> c<409> l<50:2> el<50:14>
-n<> u<413> t<Port_declaration> p<414> c<412> l<50:2> el<50:14>
-n<> u<414> t<Module_item> p<441> c<413> s<440> l<50:2> el<50:15>
-n<X> u<415> t<StringConst> p<416> l<52:9> el<52:10>
-n<> u<416> t<Ps_or_hierarchical_identifier> p<419> c<415> s<418> l<52:9> el<52:10>
-n<> u<417> t<Constant_bit_select> p<418> l<52:11> el<52:11>
-n<> u<418> t<Constant_select> p<419> c<417> l<52:11> el<52:11>
-n<> u<419> t<Net_lvalue> p<424> c<416> s<423> l<52:9> el<52:10>
-n<A> u<420> t<StringConst> p<421> l<52:13> el<52:14>
-n<> u<421> t<Primary_literal> p<422> c<420> l<52:13> el<52:14>
-n<> u<422> t<Primary> p<423> c<421> l<52:13> el<52:14>
-n<> u<423> t<Expression> p<424> c<422> l<52:13> el<52:14>
-n<> u<424> t<Net_assignment> p<435> c<419> s<434> l<52:9> el<52:14>
-n<X> u<425> t<StringConst> p<426> l<52:16> el<52:17>
-n<> u<426> t<Ps_or_hierarchical_identifier> p<429> c<425> s<428> l<52:16> el<52:17>
-n<> u<427> t<Constant_bit_select> p<428> l<52:18> el<52:18>
-n<> u<428> t<Constant_select> p<429> c<427> l<52:18> el<52:18>
-n<> u<429> t<Net_lvalue> p<434> c<426> s<433> l<52:16> el<52:17>
-n<B> u<430> t<StringConst> p<431> l<52:20> el<52:21>
-n<> u<431> t<Primary_literal> p<432> c<430> l<52:20> el<52:21>
-n<> u<432> t<Primary> p<433> c<431> l<52:20> el<52:21>
-n<> u<433> t<Expression> p<434> c<432> l<52:20> el<52:21>
-n<> u<434> t<Net_assignment> p<435> c<429> l<52:16> el<52:21>
-n<> u<435> t<List_of_net_assignments> p<436> c<424> l<52:9> el<52:21>
-n<> u<436> t<Continuous_assign> p<437> c<435> l<52:2> el<52:22>
-n<> u<437> t<Module_common_item> p<438> c<436> l<52:2> el<52:22>
-n<> u<438> t<Module_or_generate_item> p<439> c<437> l<52:2> el<52:22>
-n<> u<439> t<Non_port_module_item> p<440> c<438> l<52:2> el<52:22>
-n<> u<440> t<Module_item> p<441> c<439> l<52:2> el<52:22>
-n<> u<441> t<Module_declaration> p<442> c<398> l<48:1> el<54:10>
-n<> u<442> t<Description> p<505> c<441> s<504> l<48:1> el<54:10>
-n<> u<443> t<Module_keyword> p<445> s<444> l<57:1> el<57:7>
-n<top2> u<444> t<StringConst> p<445> l<57:8> el<57:12>
-n<> u<445> t<Module_ansi_header> p<503> c<443> s<456> l<57:1> el<57:13>
-n<> u<446> t<NetType_Uwire> p<451> s<447> l<58:3> el<58:8>
-n<> u<447> t<Data_type_or_implicit> p<451> s<450> l<58:9> el<58:9>
-n<two> u<448> t<StringConst> p<449> l<58:9> el<58:12>
-n<> u<449> t<Net_decl_assignment> p<450> c<448> l<58:9> el<58:12>
-n<> u<450> t<List_of_net_decl_assignments> p<451> c<449> l<58:9> el<58:12>
-n<> u<451> t<Net_declaration> p<452> c<446> l<58:3> el<58:13>
-n<> u<452> t<Package_or_generate_item_declaration> p<453> c<451> l<58:3> el<58:13>
-n<> u<453> t<Module_or_generate_item_declaration> p<454> c<452> l<58:3> el<58:13>
-n<> u<454> t<Module_common_item> p<455> c<453> l<58:3> el<58:13>
-n<> u<455> t<Module_or_generate_item> p<456> c<454> l<58:3> el<58:13>
-n<> u<456> t<Non_port_module_item> p<503> c<455> s<471> l<58:3> el<58:13>
-n<two> u<457> t<StringConst> p<458> l<60:10> el<60:13>
-n<> u<458> t<Ps_or_hierarchical_identifier> p<461> c<457> s<460> l<60:10> el<60:13>
-n<> u<459> t<Constant_bit_select> p<460> l<60:14> el<60:14>
-n<> u<460> t<Constant_select> p<461> c<459> l<60:14> el<60:14>
-n<> u<461> t<Net_lvalue> p<466> c<458> s<465> l<60:10> el<60:13>
-n<> u<462> t<Number_1Tickb1> p<463> l<60:16> el<60:20>
-n<> u<463> t<Primary_literal> p<464> c<462> l<60:16> el<60:20>
-n<> u<464> t<Primary> p<465> c<463> l<60:16> el<60:20>
-n<> u<465> t<Expression> p<466> c<464> l<60:16> el<60:20>
-n<> u<466> t<Net_assignment> p<467> c<461> l<60:10> el<60:20>
-n<> u<467> t<List_of_net_assignments> p<468> c<466> l<60:10> el<60:20>
-n<> u<468> t<Continuous_assign> p<469> c<467> l<60:3> el<60:21>
-n<> u<469> t<Module_common_item> p<470> c<468> l<60:3> el<60:21>
-n<> u<470> t<Module_or_generate_item> p<471> c<469> l<60:3> el<60:21>
-n<> u<471> t<Non_port_module_item> p<503> c<470> s<486> l<60:3> el<60:21>
-n<two> u<472> t<StringConst> p<473> l<61:10> el<61:13>
-n<> u<473> t<Ps_or_hierarchical_identifier> p<476> c<472> s<475> l<61:10> el<61:13>
-n<> u<474> t<Constant_bit_select> p<475> l<61:14> el<61:14>
-n<> u<475> t<Constant_select> p<476> c<474> l<61:14> el<61:14>
-n<> u<476> t<Net_lvalue> p<481> c<473> s<480> l<61:10> el<61:13>
-n<> u<477> t<Number_1Tickb0> p<478> l<61:16> el<61:20>
-n<> u<478> t<Primary_literal> p<479> c<477> l<61:16> el<61:20>
-n<> u<479> t<Primary> p<480> c<478> l<61:16> el<61:20>
-n<> u<480> t<Expression> p<481> c<479> l<61:16> el<61:20>
-n<> u<481> t<Net_assignment> p<482> c<476> l<61:10> el<61:20>
-n<> u<482> t<List_of_net_assignments> p<483> c<481> l<61:10> el<61:20>
-n<> u<483> t<Continuous_assign> p<484> c<482> l<61:3> el<61:21>
-n<> u<484> t<Module_common_item> p<485> c<483> l<61:3> el<61:21>
-n<> u<485> t<Module_or_generate_item> p<486> c<484> l<61:3> el<61:21>
-n<> u<486> t<Non_port_module_item> p<503> c<485> s<502> l<61:3> el<61:21>
-n<> u<487> t<Dollar_keyword> p<494> s<488> l<63:11> el<63:12>
-n<display> u<488> t<StringConst> p<494> s<493> l<63:12> el<63:19>
-n<"Failed: this should be a compile time error!"> u<489> t<StringLiteral> p<490> l<63:20> el<63:66>
-n<> u<490> t<Primary_literal> p<491> c<489> l<63:20> el<63:66>
-n<> u<491> t<Primary> p<492> c<490> l<63:20> el<63:66>
-n<> u<492> t<Expression> p<493> c<491> l<63:20> el<63:66>
-n<> u<493> t<List_of_arguments> p<494> c<492> l<63:20> el<63:66>
-n<> u<494> t<Subroutine_call> p<495> c<487> l<63:11> el<63:67>
-n<> u<495> t<Subroutine_call_statement> p<496> c<494> l<63:11> el<63:68>
-n<> u<496> t<Statement_item> p<497> c<495> l<63:11> el<63:68>
-n<> u<497> t<Statement> p<498> c<496> l<63:11> el<63:68>
-n<> u<498> t<Statement_or_null> p<499> c<497> l<63:11> el<63:68>
-n<> u<499> t<Initial_construct> p<500> c<498> l<63:3> el<63:68>
-n<> u<500> t<Module_common_item> p<501> c<499> l<63:3> el<63:68>
-n<> u<501> t<Module_or_generate_item> p<502> c<500> l<63:3> el<63:68>
-n<> u<502> t<Non_port_module_item> p<503> c<501> l<63:3> el<63:68>
-n<> u<503> t<Module_declaration> p<504> c<445> l<57:1> el<64:10>
-n<> u<504> t<Description> p<505> c<503> l<57:1> el<64:10>
-n<> u<505> t<Source_text> p<506> c<376> l<3:1> el<64:10>
-n<> u<506> t<Top_level_rule> l<3:1> el<65:1>
+n<> u<334> t<Generate_block> p<335> c<332> l<33:8> el<36:11>
+n<> u<335> t<Case_generate_item> p<367> c<317> s<365> l<32:8> el<36:11>
+n<2> u<336> t<IntConst> p<337> l<37:8> el<37:9>
+n<> u<337> t<Primary_literal> p<338> c<336> l<37:8> el<37:9>
+n<> u<338> t<Constant_primary> p<339> c<337> l<37:8> el<37:9>
+n<> u<339> t<Constant_expression> p<365> c<338> s<364> l<37:8> el<37:9>
+n<fill_way> u<340> t<StringConst> p<341> l<39:19> el<39:27>
+n<> u<341> t<Ps_or_hierarchical_identifier> p<344> c<340> s<343> l<39:19> el<39:27>
+n<> u<342> t<Constant_bit_select> p<343> l<39:28> el<39:28>
+n<> u<343> t<Constant_select> p<344> c<342> l<39:28> el<39:28>
+n<> u<344> t<Net_lvalue> p<357> c<341> s<356> l<39:19> el<39:27>
+n<lru_flags> u<345> t<StringConst> p<352> s<351> l<39:31> el<39:40>
+n<0> u<346> t<IntConst> p<347> l<39:41> el<39:42>
+n<> u<347> t<Primary_literal> p<348> c<346> l<39:41> el<39:42>
+n<> u<348> t<Primary> p<349> c<347> l<39:41> el<39:42>
+n<> u<349> t<Expression> p<350> c<348> l<39:41> el<39:42>
+n<> u<350> t<Bit_select> p<351> c<349> l<39:40> el<39:43>
+n<> u<351> t<Select> p<352> c<350> l<39:40> el<39:43>
+n<> u<352> t<Complex_func_call> p<353> c<345> l<39:31> el<39:43>
+n<> u<353> t<Primary> p<354> c<352> l<39:31> el<39:43>
+n<> u<354> t<Expression> p<356> c<353> l<39:31> el<39:43>
+n<> u<355> t<Unary_Not> p<356> s<354> l<39:30> el<39:31>
+n<> u<356> t<Expression> p<357> c<355> l<39:30> el<39:43>
+n<> u<357> t<Net_assignment> p<358> c<344> l<39:19> el<39:43>
+n<> u<358> t<List_of_net_assignments> p<359> c<357> l<39:19> el<39:43>
+n<> u<359> t<Continuous_assign> p<360> c<358> l<39:12> el<39:44>
+n<> u<360> t<Module_common_item> p<361> c<359> l<39:12> el<39:44>
+n<> u<361> t<Module_or_generate_item> p<362> c<360> l<39:12> el<39:44>
+n<> u<362> t<Generate_item> p<364> c<361> s<363> l<39:12> el<39:44>
+n<> u<363> t<End> p<364> l<41:8> el<41:11>
+n<> u<364> t<Generate_block> p<365> c<362> l<38:8> el<41:11>
+n<> u<365> t<Case_generate_item> p<367> c<339> s<366> l<37:8> el<41:11>
+n<> u<366> t<Endcase> p<367> l<42:4> el<42:11>
+n<> u<367> t<Case_generate_construct> p<368> c<313> l<31:4> el<42:11>
+n<> u<368> t<Conditional_generate_construct> p<369> c<367> l<31:4> el<42:11>
+n<> u<369> t<Module_common_item> p<370> c<368> l<31:4> el<42:11>
+n<> u<370> t<Module_or_generate_item> p<371> c<369> l<31:4> el<42:11>
+n<> u<371> t<Generate_item> p<372> c<370> l<31:4> el<42:11>
+n<> u<372> t<Generate_block> p<374> c<371> s<373> l<31:4> el<42:11>
+n<> u<373> t<Endgenerate> p<374> l<43:1> el<43:12>
+n<> u<374> t<Generate_region> p<375> c<372> l<30:1> el<43:12>
+n<> u<375> t<Non_port_module_item> p<376> c<374> l<30:1> el<43:12>
+n<> u<376> t<Module_item> p<377> c<375> l<30:1> el<43:12>
+n<> u<377> t<Module_declaration> p<378> c<5> l<3:1> el<45:10>
+n<> u<378> t<Description> p<507> c<377> s<444> l<3:1> el<45:10>
+n<> u<379> t<Module_keyword> p<400> s<380> l<48:1> el<48:7>
+n<wandwor_test0> u<380> t<StringConst> p<400> s<399> l<48:8> el<48:21>
+n<A> u<381> t<StringConst> p<384> s<383> l<48:23> el<48:24>
+n<> u<382> t<Constant_bit_select> p<383> l<48:24> el<48:24>
+n<> u<383> t<Constant_select> p<384> c<382> l<48:24> el<48:24>
+n<> u<384> t<Port_reference> p<385> c<381> l<48:23> el<48:24>
+n<> u<385> t<Port_expression> p<386> c<384> l<48:23> el<48:24>
+n<> u<386> t<Port> p<399> c<385> s<392> l<48:23> el<48:24>
+n<B> u<387> t<StringConst> p<390> s<389> l<48:26> el<48:27>
+n<> u<388> t<Constant_bit_select> p<389> l<48:27> el<48:27>
+n<> u<389> t<Constant_select> p<390> c<388> l<48:27> el<48:27>
+n<> u<390> t<Port_reference> p<391> c<387> l<48:26> el<48:27>
+n<> u<391> t<Port_expression> p<392> c<390> l<48:26> el<48:27>
+n<> u<392> t<Port> p<399> c<391> s<398> l<48:26> el<48:27>
+n<X> u<393> t<StringConst> p<396> s<395> l<48:29> el<48:30>
+n<> u<394> t<Constant_bit_select> p<395> l<48:30> el<48:30>
+n<> u<395> t<Constant_select> p<396> c<394> l<48:30> el<48:30>
+n<> u<396> t<Port_reference> p<397> c<393> l<48:29> el<48:30>
+n<> u<397> t<Port_expression> p<398> c<396> l<48:29> el<48:30>
+n<> u<398> t<Port> p<399> c<397> l<48:29> el<48:30>
+n<> u<399> t<List_of_ports> p<400> c<386> l<48:22> el<48:31>
+n<> u<400> t<Module_nonansi_header> p<443> c<379> s<408> l<48:1> el<48:32>
+n<> u<401> t<Data_type_or_implicit> p<402> l<49:8> el<49:8>
+n<> u<402> t<Net_port_type> p<406> c<401> s<405> l<49:8> el<49:8>
+n<A> u<403> t<StringConst> p<405> s<404> l<49:8> el<49:9>
+n<B> u<404> t<StringConst> p<405> l<49:11> el<49:12>
+n<> u<405> t<List_of_port_identifiers> p<406> c<403> l<49:8> el<49:12>
+n<> u<406> t<Input_declaration> p<407> c<402> l<49:2> el<49:12>
+n<> u<407> t<Port_declaration> p<408> c<406> l<49:2> el<49:12>
+n<> u<408> t<Module_item> p<443> c<407> s<416> l<49:2> el<49:13>
+n<> u<409> t<NetType_Wor> p<411> s<410> l<50:9> el<50:12>
+n<> u<410> t<Data_type_or_implicit> p<411> l<50:13> el<50:13>
+n<> u<411> t<Net_port_type> p<414> c<409> s<413> l<50:9> el<50:12>
+n<X> u<412> t<StringConst> p<413> l<50:13> el<50:14>
+n<> u<413> t<List_of_port_identifiers> p<414> c<412> l<50:13> el<50:14>
+n<> u<414> t<Output_declaration> p<415> c<411> l<50:2> el<50:14>
+n<> u<415> t<Port_declaration> p<416> c<414> l<50:2> el<50:14>
+n<> u<416> t<Module_item> p<443> c<415> s<442> l<50:2> el<50:15>
+n<X> u<417> t<StringConst> p<418> l<52:9> el<52:10>
+n<> u<418> t<Ps_or_hierarchical_identifier> p<421> c<417> s<420> l<52:9> el<52:10>
+n<> u<419> t<Constant_bit_select> p<420> l<52:11> el<52:11>
+n<> u<420> t<Constant_select> p<421> c<419> l<52:11> el<52:11>
+n<> u<421> t<Net_lvalue> p<426> c<418> s<425> l<52:9> el<52:10>
+n<A> u<422> t<StringConst> p<423> l<52:13> el<52:14>
+n<> u<423> t<Primary_literal> p<424> c<422> l<52:13> el<52:14>
+n<> u<424> t<Primary> p<425> c<423> l<52:13> el<52:14>
+n<> u<425> t<Expression> p<426> c<424> l<52:13> el<52:14>
+n<> u<426> t<Net_assignment> p<437> c<421> s<436> l<52:9> el<52:14>
+n<X> u<427> t<StringConst> p<428> l<52:16> el<52:17>
+n<> u<428> t<Ps_or_hierarchical_identifier> p<431> c<427> s<430> l<52:16> el<52:17>
+n<> u<429> t<Constant_bit_select> p<430> l<52:18> el<52:18>
+n<> u<430> t<Constant_select> p<431> c<429> l<52:18> el<52:18>
+n<> u<431> t<Net_lvalue> p<436> c<428> s<435> l<52:16> el<52:17>
+n<B> u<432> t<StringConst> p<433> l<52:20> el<52:21>
+n<> u<433> t<Primary_literal> p<434> c<432> l<52:20> el<52:21>
+n<> u<434> t<Primary> p<435> c<433> l<52:20> el<52:21>
+n<> u<435> t<Expression> p<436> c<434> l<52:20> el<52:21>
+n<> u<436> t<Net_assignment> p<437> c<431> l<52:16> el<52:21>
+n<> u<437> t<List_of_net_assignments> p<438> c<426> l<52:9> el<52:21>
+n<> u<438> t<Continuous_assign> p<439> c<437> l<52:2> el<52:22>
+n<> u<439> t<Module_common_item> p<440> c<438> l<52:2> el<52:22>
+n<> u<440> t<Module_or_generate_item> p<441> c<439> l<52:2> el<52:22>
+n<> u<441> t<Non_port_module_item> p<442> c<440> l<52:2> el<52:22>
+n<> u<442> t<Module_item> p<443> c<441> l<52:2> el<52:22>
+n<> u<443> t<Module_declaration> p<444> c<400> l<48:1> el<54:10>
+n<> u<444> t<Description> p<507> c<443> s<506> l<48:1> el<54:10>
+n<> u<445> t<Module_keyword> p<447> s<446> l<57:1> el<57:7>
+n<top2> u<446> t<StringConst> p<447> l<57:8> el<57:12>
+n<> u<447> t<Module_ansi_header> p<505> c<445> s<458> l<57:1> el<57:13>
+n<> u<448> t<NetType_Uwire> p<453> s<449> l<58:3> el<58:8>
+n<> u<449> t<Data_type_or_implicit> p<453> s<452> l<58:9> el<58:9>
+n<two> u<450> t<StringConst> p<451> l<58:9> el<58:12>
+n<> u<451> t<Net_decl_assignment> p<452> c<450> l<58:9> el<58:12>
+n<> u<452> t<List_of_net_decl_assignments> p<453> c<451> l<58:9> el<58:12>
+n<> u<453> t<Net_declaration> p<454> c<448> l<58:3> el<58:13>
+n<> u<454> t<Package_or_generate_item_declaration> p<455> c<453> l<58:3> el<58:13>
+n<> u<455> t<Module_or_generate_item_declaration> p<456> c<454> l<58:3> el<58:13>
+n<> u<456> t<Module_common_item> p<457> c<455> l<58:3> el<58:13>
+n<> u<457> t<Module_or_generate_item> p<458> c<456> l<58:3> el<58:13>
+n<> u<458> t<Non_port_module_item> p<505> c<457> s<473> l<58:3> el<58:13>
+n<two> u<459> t<StringConst> p<460> l<60:10> el<60:13>
+n<> u<460> t<Ps_or_hierarchical_identifier> p<463> c<459> s<462> l<60:10> el<60:13>
+n<> u<461> t<Constant_bit_select> p<462> l<60:14> el<60:14>
+n<> u<462> t<Constant_select> p<463> c<461> l<60:14> el<60:14>
+n<> u<463> t<Net_lvalue> p<468> c<460> s<467> l<60:10> el<60:13>
+n<> u<464> t<Number_1Tickb1> p<465> l<60:16> el<60:20>
+n<> u<465> t<Primary_literal> p<466> c<464> l<60:16> el<60:20>
+n<> u<466> t<Primary> p<467> c<465> l<60:16> el<60:20>
+n<> u<467> t<Expression> p<468> c<466> l<60:16> el<60:20>
+n<> u<468> t<Net_assignment> p<469> c<463> l<60:10> el<60:20>
+n<> u<469> t<List_of_net_assignments> p<470> c<468> l<60:10> el<60:20>
+n<> u<470> t<Continuous_assign> p<471> c<469> l<60:3> el<60:21>
+n<> u<471> t<Module_common_item> p<472> c<470> l<60:3> el<60:21>
+n<> u<472> t<Module_or_generate_item> p<473> c<471> l<60:3> el<60:21>
+n<> u<473> t<Non_port_module_item> p<505> c<472> s<488> l<60:3> el<60:21>
+n<two> u<474> t<StringConst> p<475> l<61:10> el<61:13>
+n<> u<475> t<Ps_or_hierarchical_identifier> p<478> c<474> s<477> l<61:10> el<61:13>
+n<> u<476> t<Constant_bit_select> p<477> l<61:14> el<61:14>
+n<> u<477> t<Constant_select> p<478> c<476> l<61:14> el<61:14>
+n<> u<478> t<Net_lvalue> p<483> c<475> s<482> l<61:10> el<61:13>
+n<> u<479> t<Number_1Tickb0> p<480> l<61:16> el<61:20>
+n<> u<480> t<Primary_literal> p<481> c<479> l<61:16> el<61:20>
+n<> u<481> t<Primary> p<482> c<480> l<61:16> el<61:20>
+n<> u<482> t<Expression> p<483> c<481> l<61:16> el<61:20>
+n<> u<483> t<Net_assignment> p<484> c<478> l<61:10> el<61:20>
+n<> u<484> t<List_of_net_assignments> p<485> c<483> l<61:10> el<61:20>
+n<> u<485> t<Continuous_assign> p<486> c<484> l<61:3> el<61:21>
+n<> u<486> t<Module_common_item> p<487> c<485> l<61:3> el<61:21>
+n<> u<487> t<Module_or_generate_item> p<488> c<486> l<61:3> el<61:21>
+n<> u<488> t<Non_port_module_item> p<505> c<487> s<504> l<61:3> el<61:21>
+n<> u<489> t<Dollar_keyword> p<496> s<490> l<63:11> el<63:12>
+n<display> u<490> t<StringConst> p<496> s<495> l<63:12> el<63:19>
+n<"Failed: this should be a compile time error!"> u<491> t<StringLiteral> p<492> l<63:20> el<63:66>
+n<> u<492> t<Primary_literal> p<493> c<491> l<63:20> el<63:66>
+n<> u<493> t<Primary> p<494> c<492> l<63:20> el<63:66>
+n<> u<494> t<Expression> p<495> c<493> l<63:20> el<63:66>
+n<> u<495> t<List_of_arguments> p<496> c<494> l<63:20> el<63:66>
+n<> u<496> t<Subroutine_call> p<497> c<489> l<63:11> el<63:67>
+n<> u<497> t<Subroutine_call_statement> p<498> c<496> l<63:11> el<63:68>
+n<> u<498> t<Statement_item> p<499> c<497> l<63:11> el<63:68>
+n<> u<499> t<Statement> p<500> c<498> l<63:11> el<63:68>
+n<> u<500> t<Statement_or_null> p<501> c<499> l<63:11> el<63:68>
+n<> u<501> t<Initial_construct> p<502> c<500> l<63:3> el<63:68>
+n<> u<502> t<Module_common_item> p<503> c<501> l<63:3> el<63:68>
+n<> u<503> t<Module_or_generate_item> p<504> c<502> l<63:3> el<63:68>
+n<> u<504> t<Non_port_module_item> p<505> c<503> l<63:3> el<63:68>
+n<> u<505> t<Module_declaration> p<506> c<447> l<57:1> el<64:10>
+n<> u<506> t<Description> p<507> c<505> l<57:1> el<64:10>
+n<> u<507> t<Source_text> p<508> c<378> l<3:1> el<64:10>
+n<> u<508> t<Top_level_rule> l<3:1> el<65:1>
 [WRN:PA0205] dut.sv:3: No timescale set for "top".
 
 [WRN:PA0205] dut.sv:48: No timescale set for "wandwor_test0".
@@ -526,6 +528,8 @@ n<> u<506> t<Top_level_rule> l<3:1> el<65:1>
 [INF:EL0526] Design Elaboration...
 
 [INF:CP0335] dut.sv:18: Compile generate block "work@top.genblk1".
+
+[INF:CP0335] dut.sv:31: Compile generate block "work@top.genblk2".
 
 [NTE:EL0503] dut.sv:3: Top level module "work@top".
 
@@ -549,9 +553,6 @@ n<> u<506> t<Top_level_rule> l<3:1> el<65:1>
 
 [ERR:UH0717] dut.sv:9:9: Multiple continuous assignments to: v,
              dut.sv:10:9: other assignment.
-
-[ERR:UH0717] dut.sv:34:19: Multiple continuous assignments to: fill_way,
-             dut.sv:39:19: other assignment.
 
 [ERR:UH0717] dut.sv:60:10: Multiple continuous assignments to: two,
              dut.sv:61:10: other assignment.
@@ -836,43 +837,6 @@ design: (work@top)
       |vpiFullName:work@top.pull_up_1
       |vpiActual:
       \_logic_net: (pull_up_1)
-  |vpiContAssign:
-  \_cont_assign: , line:34:19, endln:34:31, parent:work@top
-    |vpiRhs:
-    \_constant: , line:34:30, endln:34:31
-      |vpiDecompile:0
-      |vpiSize:64
-      |UINT:0
-      |vpiConstType:9
-    |vpiLhs:
-    \_ref_obj: (work@top.fill_way), line:34:19, endln:34:27
-      |vpiName:fill_way
-      |vpiFullName:work@top.fill_way
-      |vpiActual:
-      \_logic_net: (fill_way)
-        |vpiName:fill_way
-        |vpiNetType:1
-  |vpiContAssign:
-  \_cont_assign: , line:39:19, endln:39:43, parent:work@top
-    |vpiRhs:
-    \_operation: , line:39:30, endln:39:31
-      |vpiOpType:3
-      |vpiOperand:
-      \_bit_select: (work@top.lru_flags), line:39:31, endln:39:43, parent:work@top.lru_flags
-        |vpiName:lru_flags
-        |vpiFullName:work@top.lru_flags
-        |vpiIndex:
-        \_constant: , line:39:41, endln:39:42, parent:work@top.lru_flags
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
-    |vpiLhs:
-    \_ref_obj: (work@top.fill_way), line:39:19, endln:39:27
-      |vpiName:fill_way
-      |vpiFullName:work@top.fill_way
-      |vpiActual:
-      \_logic_net: (fill_way)
 |uhdmallModules:
 \_module: work@top2 (work@top2) dut.sv:57:1: , endln:64:10, parent:work@top
   |vpiFullName:work@top2
@@ -1068,10 +1032,6 @@ design: (work@top)
   |vpiNet:
   \_logic_net: (driver_1)
     |vpiName:driver_1
-    |vpiNetType:1
-  |vpiNet:
-  \_logic_net: (fill_way)
-    |vpiName:fill_way
     |vpiNetType:1
   |vpiContAssign:
   \_cont_assign: , line:6:30, endln:6:43, parent:work@top
@@ -1292,41 +1252,6 @@ design: (work@top)
       |vpiFullName:work@top.pull_up_1
       |vpiActual:
       \_logic_net: (pull_up_1)
-  |vpiContAssign:
-  \_cont_assign: , line:34:19, endln:34:31, parent:work@top
-    |vpiRhs:
-    \_constant: , line:34:30, endln:34:31
-      |vpiDecompile:0
-      |vpiSize:64
-      |UINT:0
-      |vpiConstType:9
-    |vpiLhs:
-    \_ref_obj: (work@top.fill_way), line:34:19, endln:34:27
-      |vpiName:fill_way
-      |vpiFullName:work@top.fill_way
-      |vpiActual:
-      \_logic_net: (fill_way)
-  |vpiContAssign:
-  \_cont_assign: , line:39:19, endln:39:43, parent:work@top
-    |vpiRhs:
-    \_operation: , line:39:30, endln:39:31
-      |vpiOpType:3
-      |vpiOperand:
-      \_bit_select: (work@top.lru_flags), line:39:31, endln:39:43, parent:work@top.lru_flags
-        |vpiName:lru_flags
-        |vpiFullName:work@top.lru_flags
-        |vpiIndex:
-        \_constant: , line:39:41, endln:39:42, parent:work@top.lru_flags
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
-    |vpiLhs:
-    \_ref_obj: (work@top.fill_way), line:39:19, endln:39:27
-      |vpiName:fill_way
-      |vpiFullName:work@top.fill_way
-      |vpiActual:
-      \_logic_net: (fill_way)
   |vpiGenScopeArray:
   \_gen_scope_array: (work@top.genblk1), line:18:9, endln:18:50, parent:work@top
     |vpiName:genblk1
@@ -1351,6 +1276,25 @@ design: (work@top)
         \_ref_obj: (work@top.genblk1.inout_i3), line:18:35, endln:18:43
           |vpiName:inout_i3
           |vpiFullName:work@top.genblk1.inout_i3
+  |vpiGenScopeArray:
+  \_gen_scope_array: (work@top.genblk2), line:31:4, endln:42:11, parent:work@top
+    |vpiName:genblk2
+    |vpiFullName:work@top.genblk2
+    |vpiGenScope:
+    \_gen_scope: (work@top.genblk2), parent:work@top.genblk2
+      |vpiFullName:work@top.genblk2
+      |vpiContAssign:
+      \_cont_assign: , line:34:19, endln:34:31, parent:work@top.genblk2
+        |vpiRhs:
+        \_constant: , line:34:30, endln:34:31
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
+        |vpiLhs:
+        \_ref_obj: (work@top.genblk2.fill_way), line:34:19, endln:34:27
+          |vpiName:fill_way
+          |vpiFullName:work@top.genblk2.fill_way
 |uhdmtopModules:
 \_module: work@wandwor_test0 (work@wandwor_test0) dut.sv:48:1: , endln:54:10
   |vpiName:work@wandwor_test0
@@ -1483,7 +1427,7 @@ design: (work@top)
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 3
+[  ERROR] : 2
 [WARNING] : 3
 [   NOTE] : 8
 

--- a/tests/MultContAssign/MultContAssign.sl
+++ b/tests/MultContAssign/MultContAssign.sl
@@ -1,0 +1,1 @@
+-parse -d uhdm -d coveruhdm -elabuhdm -d ast dut.sv -nobuiltin

--- a/tests/MultContAssign/dut.sv
+++ b/tests/MultContAssign/dut.sv
@@ -1,0 +1,64 @@
+
+
+module top();
+
+	int v;
+   assign (highz0, weak1)    inout_i1 = pu;
+   assign (weak0, highz1)    inout_i1 = ~pd;
+
+	assign v = 12;
+	assign v = 13;
+
+
+   assign (weak0, weak1)    inout_i2 = pu;
+   assign (weak1, weak0)     inout_i2 = ~pd;
+
+
+   if (0) assign (weak0, weak1)    inout_i3 = pu;
+   else assign (weak1, weak0)     inout_i3 = ~pd;
+
+
+      assign    out = (sel == 2'b00)? v0 : 2'bz;
+      assign    out = (sel == 2'b01)? v1 : 2'bz;
+
+      assign     (pull1, pull0) pull_up_1 = 1'b1;
+      
+      assign     pull_up_1 = (driver_1_en) ? driver_1 : 1'bz;
+
+
+parameter NUM_WAYS = 1;
+generate
+   case (NUM_WAYS)
+       1:
+       begin
+           assign fill_way = 0;
+        
+       end
+       2:
+       begin
+           assign fill_way = !lru_flags[0];
+     
+       end
+   endcase    
+endgenerate
+
+endmodule
+
+
+module wandwor_test0 (A, B, X);
+	input A, B;
+	output wor X;
+  
+	assign X = A, X = B;
+	
+endmodule
+
+
+module top2;
+  uwire two;
+
+  assign two = 1'b1;
+  assign two = 1'b0;
+
+  initial $display("Failed: this should be a compile time error!");
+endmodule

--- a/tests/ParamElab/ParamElab.log
+++ b/tests/ParamElab/ParamElab.log
@@ -2,7 +2,7 @@
 
 LIB:  work
 FILE: dut.sv
-n<> u<0> t<Null_rule> p<136> s<135> l<1:1> el<1:0>
+n<> u<0> t<Null_rule> p<137> s<136> l<1:1> el<1:0>
 n<> u<1> t<Module_keyword> p<5> s<2> l<1:1> el<1:7>
 n<dut> u<2> t<StringConst> p<5> s<4> l<1:8> el<1:11>
 n<> u<3> t<Port> p<4> l<1:13> el<1:13>
@@ -37,7 +37,7 @@ n<> u<31> t<Module_or_generate_item> p<32> c<30> l<2:9> el<5:16>
 n<> u<32> t<Non_port_module_item> p<33> c<31> l<2:9> el<5:16>
 n<> u<33> t<Module_item> p<34> c<32> l<2:9> el<5:16>
 n<> u<34> t<Module_declaration> p<35> c<5> l<1:1> el<6:10>
-n<> u<35> t<Description> p<135> c<34> s<134> l<1:1> el<6:10>
+n<> u<35> t<Description> p<136> c<34> s<135> l<1:1> el<6:10>
 n<> u<36> t<Module_keyword> p<69> s<37> l<8:1> el<8:7>
 n<test> u<37> t<StringConst> p<69> s<66> l<8:8> el<8:12>
 n<> u<38> t<IntegerAtomType_Int> p<39> l<9:12> el<9:15>
@@ -71,7 +71,7 @@ n<> u<65> t<Parameter_port_declaration> p<66> c<64> l<10:1> el<10:35>
 n<> u<66> t<Parameter_port_list> p<69> c<51> s<68> l<8:13> el<11:2>
 n<> u<67> t<Port> p<68> l<11:4> el<11:4>
 n<> u<68> t<List_of_ports> p<69> c<67> l<11:3> el<11:5>
-n<> u<69> t<Module_nonansi_header> p<133> c<36> s<94> l<8:1> el<11:6>
+n<> u<69> t<Module_nonansi_header> p<134> c<36> s<94> l<8:1> el<11:6>
 n<> u<70> t<IntegerAtomType_Int> p<71> l<12:20> el<12:23>
 n<> u<71> t<Data_type> p<72> c<70> l<12:20> el<12:23>
 n<> u<72> t<Data_type_or_implicit> p<88> c<71> s<87> l<12:20> el<12:23>
@@ -96,7 +96,7 @@ n<> u<90> t<Module_or_generate_item_declaration> p<91> c<89> l<12:9> el<12:60>
 n<> u<91> t<Module_common_item> p<92> c<90> l<12:9> el<12:60>
 n<> u<92> t<Module_or_generate_item> p<93> c<91> l<12:9> el<12:60>
 n<> u<93> t<Non_port_module_item> p<94> c<92> l<12:9> el<12:60>
-n<> u<94> t<Module_item> p<133> c<93> s<132> l<12:9> el<12:60>
+n<> u<94> t<Module_item> p<134> c<93> s<133> l<12:9> el<12:60>
 n<i> u<95> t<StringConst> p<100> s<99> l<15:9> el<15:10>
 n<0> u<96> t<IntConst> p<97> l<15:13> el<15:14>
 n<> u<97> t<Primary_literal> p<98> c<96> l<15:13> el<15:14>
@@ -130,15 +130,16 @@ n<> u<124> t<Generate_block> p<125> c<122> l<15:36> el<17:7>
 n<> u<125> t<Loop_generate_construct> p<126> c<100> l<15:4> el<17:7>
 n<> u<126> t<Module_common_item> p<127> c<125> l<15:4> el<17:7>
 n<> u<127> t<Module_or_generate_item> p<128> c<126> l<15:4> el<17:7>
-n<> u<128> t<Generate_module_item> p<130> c<127> s<129> l<15:4> el<17:7>
-n<> u<129> t<Endgenerate> p<130> l<18:1> el<18:12>
-n<> u<130> t<Generated_module_instantiation> p<131> c<128> l<14:1> el<18:12>
-n<> u<131> t<Non_port_module_item> p<132> c<130> l<14:1> el<18:12>
-n<> u<132> t<Module_item> p<133> c<131> l<14:1> el<18:12>
-n<> u<133> t<Module_declaration> p<134> c<69> l<8:1> el<20:10>
-n<> u<134> t<Description> p<135> c<133> l<8:1> el<20:10>
-n<> u<135> t<Source_text> p<136> c<35> l<1:1> el<20:10>
-n<> u<136> t<Top_level_rule> l<1:1> el<22:1>
+n<> u<128> t<Generate_item> p<129> c<127> l<15:4> el<17:7>
+n<> u<129> t<Generate_block> p<131> c<128> s<130> l<15:4> el<17:7>
+n<> u<130> t<Endgenerate> p<131> l<18:1> el<18:12>
+n<> u<131> t<Generate_region> p<132> c<129> l<14:1> el<18:12>
+n<> u<132> t<Non_port_module_item> p<133> c<131> l<14:1> el<18:12>
+n<> u<133> t<Module_item> p<134> c<132> l<14:1> el<18:12>
+n<> u<134> t<Module_declaration> p<135> c<69> l<8:1> el<20:10>
+n<> u<135> t<Description> p<136> c<134> l<8:1> el<20:10>
+n<> u<136> t<Source_text> p<137> c<35> l<1:1> el<20:10>
+n<> u<137> t<Top_level_rule> l<1:1> el<22:1>
 [WRN:PA0205] dut.sv:1: No timescale set for "dut".
 
 [WRN:PA0205] dut.sv:8: No timescale set for "test".

--- a/tests/UnitDefParam/UnitDefParam.log
+++ b/tests/UnitDefParam/UnitDefParam.log
@@ -12,7 +12,7 @@
 
 LIB:  work
 FILE: top.v
-n<> u<0> t<Null_rule> p<333> s<332> l<1:1> el<1:0>
+n<> u<0> t<Null_rule> p<344> s<343> l<1:1> el<1:0>
 n<> u<1> t<Module_keyword> p<5> s<2> l<1:1> el<1:7>
 n<top_def> u<2> t<StringConst> p<5> s<4> l<1:8> el<1:15>
 n<> u<3> t<Port> p<4> l<1:17> el<1:17>
@@ -38,7 +38,7 @@ n<> u<22> t<Module_or_generate_item> p<23> c<21> l<3:5> el<3:19>
 n<> u<23> t<Non_port_module_item> p<24> c<22> l<3:5> el<3:19>
 n<> u<24> t<Module_item> p<25> c<23> l<3:5> el<3:19>
 n<> u<25> t<Module_declaration> p<26> c<5> l<1:1> el<5:10>
-n<> u<26> t<Description> p<332> c<25> s<59> l<1:1> el<5:10>
+n<> u<26> t<Description> p<343> c<25> s<59> l<1:1> el<5:10>
 n<> u<27> t<Module_keyword> p<31> s<28> l<7:1> el<7:7>
 n<small_top> u<28> t<StringConst> p<31> s<30> l<7:8> el<7:17>
 n<> u<29> t<Port> p<30> l<7:18> el<7:18>
@@ -71,12 +71,12 @@ n<> u<55> t<Module_or_generate_item> p<56> c<54> l<8:4> el<8:29>
 n<> u<56> t<Non_port_module_item> p<57> c<55> l<8:4> el<8:29>
 n<> u<57> t<Module_item> p<58> c<56> l<8:4> el<8:29>
 n<> u<58> t<Module_declaration> p<59> c<31> l<7:1> el<9:10>
-n<> u<59> t<Description> p<332> c<58> s<331> l<7:1> el<9:10>
+n<> u<59> t<Description> p<343> c<58> s<342> l<7:1> el<9:10>
 n<> u<60> t<Module_keyword> p<64> s<61> l<11:1> el<11:7>
 n<small_test> u<61> t<StringConst> p<64> s<63> l<11:8> el<11:18>
 n<> u<62> t<Port> p<63> l<11:19> el<11:19>
 n<> u<63> t<List_of_ports> p<64> c<62> l<11:18> el<11:20>
-n<> u<64> t<Module_nonansi_header> p<330> c<60> s<92> l<11:1> el<11:21>
+n<> u<64> t<Module_nonansi_header> p<341> c<60> s<92> l<11:1> el<11:21>
 n<> u<65> t<Signing_Signed> p<76> s<75> l<14:14> el<14:20>
 n<3> u<66> t<IntConst> p<67> l<14:22> el<14:23>
 n<> u<67> t<Primary_literal> p<68> c<66> l<14:22> el<14:23>
@@ -104,7 +104,7 @@ n<> u<88> t<Module_or_generate_item_declaration> p<89> c<87> l<14:4> el<14:38>
 n<> u<89> t<Module_common_item> p<90> c<88> l<14:4> el<14:38>
 n<> u<90> t<Module_or_generate_item> p<91> c<89> l<14:4> el<14:38>
 n<> u<91> t<Non_port_module_item> p<92> c<90> l<14:4> el<14:38>
-n<> u<92> t<Module_item> p<330> c<91> s<109> l<14:4> el<14:38>
+n<> u<92> t<Module_item> p<341> c<91> s<109> l<14:4> el<14:38>
 n<> u<93> t<Data_type_or_implicit> p<103> s<102> l<15:14> el<15:14>
 n<dummy> u<94> t<StringConst> p<101> s<100> l<15:14> el<15:19>
 n<5> u<95> t<IntConst> p<96> l<15:22> el<15:23>
@@ -121,7 +121,7 @@ n<> u<105> t<Module_or_generate_item_declaration> p<106> c<104> l<15:4> el<15:24
 n<> u<106> t<Module_common_item> p<107> c<105> l<15:4> el<15:24>
 n<> u<107> t<Module_or_generate_item> p<108> c<106> l<15:4> el<15:24>
 n<> u<108> t<Non_port_module_item> p<109> c<107> l<15:4> el<15:24>
-n<> u<109> t<Module_item> p<330> c<108> s<126> l<15:4> el<15:24>
+n<> u<109> t<Module_item> p<341> c<108> s<126> l<15:4> el<15:24>
 n<> u<110> t<Data_type_or_implicit> p<120> s<119> l<16:11> el<16:11>
 n<p1> u<111> t<StringConst> p<118> s<117> l<16:11> el<16:13>
 n<13'b100> u<112> t<IntConst> p<113> l<16:16> el<16:23>
@@ -138,7 +138,7 @@ n<> u<122> t<Module_or_generate_item_declaration> p<123> c<121> l<16:1> el<16:24
 n<> u<123> t<Module_common_item> p<124> c<122> l<16:1> el<16:24>
 n<> u<124> t<Module_or_generate_item> p<125> c<123> l<16:1> el<16:24>
 n<> u<125> t<Non_port_module_item> p<126> c<124> l<16:1> el<16:24>
-n<> u<126> t<Module_item> p<330> c<125> s<137> l<16:1> el<16:24>
+n<> u<126> t<Module_item> p<341> c<125> s<137> l<16:1> el<16:24>
 n<i> u<127> t<StringConst> p<131> s<128> l<19:2> el<19:3>
 n<j> u<128> t<StringConst> p<131> s<129> l<19:5> el<19:6>
 n<k> u<129> t<StringConst> p<131> s<130> l<19:8> el<19:9>
@@ -149,13 +149,13 @@ n<> u<133> t<Module_or_generate_item_declaration> p<134> c<132> l<18:1> el<19:13
 n<> u<134> t<Module_common_item> p<135> c<133> l<18:1> el<19:13>
 n<> u<135> t<Module_or_generate_item> p<136> c<134> l<18:1> el<19:13>
 n<> u<136> t<Non_port_module_item> p<137> c<135> l<18:1> el<19:13>
-n<> u<137> t<Module_item> p<330> c<136> s<329> l<18:1> el<19:13>
+n<> u<137> t<Module_item> p<341> c<136> s<340> l<18:1> el<19:13>
 n<i> u<138> t<StringConst> p<143> s<142> l<22:3> el<22:4>
 n<0> u<139> t<IntConst> p<140> l<22:5> el<22:6>
 n<> u<140> t<Primary_literal> p<141> c<139> l<22:5> el<22:6>
 n<> u<141> t<Constant_primary> p<142> c<140> l<22:5> el<22:6>
 n<> u<142> t<Constant_expression> p<143> c<141> l<22:5> el<22:6>
-n<> u<143> t<Genvar_decl_assignment> p<324> c<138> s<153> l<22:3> el<22:6>
+n<> u<143> t<Genvar_initialization> p<332> c<138> s<153> l<22:3> el<22:6>
 n<i> u<144> t<StringConst> p<145> l<22:8> el<22:9>
 n<> u<145> t<Primary_literal> p<146> c<144> l<22:8> el<22:9>
 n<> u<146> t<Constant_primary> p<147> c<145> l<22:8> el<22:9>
@@ -165,7 +165,7 @@ n<> u<149> t<Primary_literal> p<150> c<148> l<22:10> el<22:14>
 n<> u<150> t<Constant_primary> p<151> c<149> l<22:10> el<22:14>
 n<> u<151> t<Constant_expression> p<153> c<150> l<22:10> el<22:14>
 n<> u<152> t<BinOp_Less> p<153> s<151> l<22:9> el<22:10>
-n<> u<153> t<Constant_expression> p<324> c<147> s<166> l<22:8> el<22:14>
+n<> u<153> t<Constant_expression> p<332> c<147> s<166> l<22:8> el<22:14>
 n<i> u<154> t<StringConst> p<166> s<155> l<22:16> el<22:17>
 n<> u<155> t<AssignOp_Assign> p<166> s<165> l<22:17> el<22:18>
 n<i> u<156> t<StringConst> p<157> l<22:18> el<22:19>
@@ -178,8 +178,8 @@ n<> u<162> t<Constant_primary> p<163> c<161> l<22:20> el<22:21>
 n<> u<163> t<Constant_expression> p<165> c<162> l<22:20> el<22:21>
 n<> u<164> t<BinOp_Plus> p<165> s<163> l<22:19> el<22:20>
 n<> u<165> t<Constant_expression> p<166> c<159> l<22:18> el<22:21>
-n<> u<166> t<Genvar_assignment> p<324> c<154> s<323> l<22:16> el<22:21>
-n<B1> u<167> t<StringConst> p<323> s<176> l<24:2> el<24:4>
+n<> u<166> t<Genvar_iteration> p<332> c<154> s<331> l<22:16> el<22:21>
+n<B1> u<167> t<StringConst> p<331> s<176> l<24:2> el<24:4>
 n<M1> u<168> t<StringConst> p<174> s<173> l<26:1> el<26:3>
 n<N1> u<169> t<StringConst> p<170> l<26:4> el<26:6>
 n<> u<170> t<Name_of_instance> p<173> c<169> s<172> l<26:4> el<26:6>
@@ -188,13 +188,13 @@ n<> u<172> t<List_of_port_connections> p<173> c<171> l<26:7> el<26:7>
 n<> u<173> t<Hierarchical_instance> p<174> c<170> l<26:4> el<26:8>
 n<> u<174> t<Module_instantiation> p<175> c<168> l<26:1> el<26:9>
 n<> u<175> t<Module_or_generate_item> p<176> c<174> l<26:1> el<26:9>
-n<> u<176> t<Generate_module_item> p<323> c<175> s<262> l<26:1> el<26:9>
+n<> u<176> t<Generate_item> p<331> c<175> s<266> l<26:1> el<26:9>
 n<j> u<177> t<StringConst> p<182> s<181> l<29:3> el<29:4>
 n<0> u<178> t<IntConst> p<179> l<29:5> el<29:6>
 n<> u<179> t<Primary_literal> p<180> c<178> l<29:5> el<29:6>
 n<> u<180> t<Constant_primary> p<181> c<179> l<29:5> el<29:6>
 n<> u<181> t<Constant_expression> p<182> c<180> l<29:5> el<29:6>
-n<> u<182> t<Genvar_decl_assignment> p<261> c<177> s<192> l<29:3> el<29:6>
+n<> u<182> t<Genvar_initialization> p<263> c<177> s<192> l<29:3> el<29:6>
 n<j> u<183> t<StringConst> p<184> l<29:8> el<29:9>
 n<> u<184> t<Primary_literal> p<185> c<183> l<29:8> el<29:9>
 n<> u<185> t<Constant_primary> p<186> c<184> l<29:8> el<29:9>
@@ -204,7 +204,7 @@ n<> u<188> t<Primary_literal> p<189> c<187> l<29:10> el<29:14>
 n<> u<189> t<Constant_primary> p<190> c<188> l<29:10> el<29:14>
 n<> u<190> t<Constant_expression> p<192> c<189> l<29:10> el<29:14>
 n<> u<191> t<BinOp_Less> p<192> s<190> l<29:9> el<29:10>
-n<> u<192> t<Constant_expression> p<261> c<186> s<205> l<29:8> el<29:14>
+n<> u<192> t<Constant_expression> p<263> c<186> s<205> l<29:8> el<29:14>
 n<j> u<193> t<StringConst> p<205> s<194> l<29:16> el<29:17>
 n<> u<194> t<AssignOp_Assign> p<205> s<204> l<29:17> el<29:18>
 n<j> u<195> t<StringConst> p<196> l<29:18> el<29:19>
@@ -217,8 +217,8 @@ n<> u<201> t<Constant_primary> p<202> c<200> l<29:20> el<29:21>
 n<> u<202> t<Constant_expression> p<204> c<201> l<29:20> el<29:21>
 n<> u<203> t<BinOp_Plus> p<204> s<202> l<29:19> el<29:20>
 n<> u<204> t<Constant_expression> p<205> c<198> l<29:18> el<29:21>
-n<> u<205> t<Genvar_assignment> p<261> c<193> s<260> l<29:16> el<29:21>
-n<B2> u<206> t<StringConst> p<260> s<215> l<31:2> el<31:4>
+n<> u<205> t<Genvar_iteration> p<263> c<193> s<262> l<29:16> el<29:21>
+n<B2> u<206> t<StringConst> p<262> s<215> l<31:2> el<31:4>
 n<M2> u<207> t<StringConst> p<213> s<212> l<32:1> el<32:3>
 n<N2> u<208> t<StringConst> p<209> l<32:4> el<32:6>
 n<> u<209> t<Name_of_instance> p<212> c<208> s<211> l<32:4> el<32:6>
@@ -227,13 +227,13 @@ n<> u<211> t<List_of_port_connections> p<212> c<210> l<32:7> el<32:7>
 n<> u<212> t<Hierarchical_instance> p<213> c<209> l<32:4> el<32:8>
 n<> u<213> t<Module_instantiation> p<214> c<207> l<32:1> el<32:9>
 n<> u<214> t<Module_or_generate_item> p<215> c<213> l<32:1> el<32:9>
-n<> u<215> t<Generate_module_item> p<260> c<214> s<258> l<32:1> el<32:9>
+n<> u<215> t<Generate_item> p<262> c<214> s<260> l<32:1> el<32:9>
 n<k> u<216> t<StringConst> p<221> s<220> l<36:3> el<36:4>
 n<0> u<217> t<IntConst> p<218> l<36:5> el<36:6>
 n<> u<218> t<Primary_literal> p<219> c<217> l<36:5> el<36:6>
 n<> u<219> t<Constant_primary> p<220> c<218> l<36:5> el<36:6>
 n<> u<220> t<Constant_expression> p<221> c<219> l<36:5> el<36:6>
-n<> u<221> t<Genvar_decl_assignment> p<257> c<216> s<231> l<36:3> el<36:6>
+n<> u<221> t<Genvar_initialization> p<257> c<216> s<231> l<36:3> el<36:6>
 n<k> u<222> t<StringConst> p<223> l<36:8> el<36:9>
 n<> u<223> t<Primary_literal> p<224> c<222> l<36:8> el<36:9>
 n<> u<224> t<Constant_primary> p<225> c<223> l<36:8> el<36:9>
@@ -256,7 +256,7 @@ n<> u<240> t<Constant_primary> p<241> c<239> l<36:20> el<36:21>
 n<> u<241> t<Constant_expression> p<243> c<240> l<36:20> el<36:21>
 n<> u<242> t<BinOp_Plus> p<243> s<241> l<36:19> el<36:20>
 n<> u<243> t<Constant_expression> p<244> c<237> l<36:18> el<36:21>
-n<> u<244> t<Genvar_assignment> p<257> c<232> s<256> l<36:16> el<36:21>
+n<> u<244> t<Genvar_iteration> p<257> c<232> s<256> l<36:16> el<36:21>
 n<B3> u<245> t<StringConst> p<256> s<254> l<38:2> el<38:4>
 n<M3> u<246> t<StringConst> p<252> s<251> l<39:1> el<39:3>
 n<N3> u<247> t<StringConst> p<248> l<39:4> el<39:6>
@@ -266,86 +266,97 @@ n<> u<250> t<List_of_port_connections> p<251> c<249> l<39:7> el<39:7>
 n<> u<251> t<Hierarchical_instance> p<252> c<248> l<39:4> el<39:8>
 n<> u<252> t<Module_instantiation> p<253> c<246> l<39:1> el<39:9>
 n<> u<253> t<Module_or_generate_item> p<254> c<252> l<39:1> el<39:9>
-n<> u<254> t<Generate_module_item> p<256> c<253> s<255> l<39:1> el<39:9>
+n<> u<254> t<Generate_item> p<256> c<253> s<255> l<39:1> el<39:9>
 n<> u<255> t<End> p<256> l<40:1> el<40:4>
-n<> u<256> t<Generate_module_named_block> p<257> c<245> l<37:1> el<40:4>
-n<> u<257> t<Generate_module_loop_statement> p<258> c<221> l<35:1> el<40:4>
-n<> u<258> t<Generate_module_item> p<260> c<257> s<259> l<35:1> el<40:4>
-n<> u<259> t<End> p<260> l<42:1> el<42:4>
-n<> u<260> t<Generate_module_named_block> p<261> c<206> l<30:1> el<42:4>
-n<> u<261> t<Generate_module_loop_statement> p<262> c<182> l<28:1> el<42:4>
-n<> u<262> t<Generate_module_item> p<323> c<261> s<321> l<28:1> el<42:4>
-n<i> u<263> t<StringConst> p<264> l<44:3> el<44:4>
-n<> u<264> t<Primary_literal> p<265> c<263> l<44:3> el<44:4>
-n<> u<265> t<Constant_primary> p<266> c<264> l<44:3> el<44:4>
-n<> u<266> t<Constant_expression> p<272> c<265> s<271> l<44:3> el<44:4>
-n<0> u<267> t<IntConst> p<268> l<44:5> el<44:6>
-n<> u<268> t<Primary_literal> p<269> c<267> l<44:5> el<44:6>
-n<> u<269> t<Constant_primary> p<270> c<268> l<44:5> el<44:6>
-n<> u<270> t<Constant_expression> p<272> c<269> l<44:5> el<44:6>
-n<> u<271> t<BinOp_Great> p<272> s<270> l<44:4> el<44:5>
-n<> u<272> t<Constant_expression> p<320> c<266> s<319> l<44:3> el<44:6>
-n<B4> u<273> t<StringConst> p<318> s<316> l<46:2> el<46:4>
-n<m> u<274> t<StringConst> p<279> s<278> l<49:3> el<49:4>
-n<0> u<275> t<IntConst> p<276> l<49:5> el<49:6>
-n<> u<276> t<Primary_literal> p<277> c<275> l<49:5> el<49:6>
-n<> u<277> t<Constant_primary> p<278> c<276> l<49:5> el<49:6>
-n<> u<278> t<Constant_expression> p<279> c<277> l<49:5> el<49:6>
-n<> u<279> t<Genvar_decl_assignment> p<315> c<274> s<289> l<49:3> el<49:6>
-n<m> u<280> t<StringConst> p<281> l<49:8> el<49:9>
-n<> u<281> t<Primary_literal> p<282> c<280> l<49:8> el<49:9>
-n<> u<282> t<Constant_primary> p<283> c<281> l<49:8> el<49:9>
-n<> u<283> t<Constant_expression> p<289> c<282> s<288> l<49:8> el<49:9>
-n<SIZE> u<284> t<StringConst> p<285> l<49:10> el<49:14>
-n<> u<285> t<Primary_literal> p<286> c<284> l<49:10> el<49:14>
-n<> u<286> t<Constant_primary> p<287> c<285> l<49:10> el<49:14>
-n<> u<287> t<Constant_expression> p<289> c<286> l<49:10> el<49:14>
-n<> u<288> t<BinOp_Less> p<289> s<287> l<49:9> el<49:10>
-n<> u<289> t<Constant_expression> p<315> c<283> s<302> l<49:8> el<49:14>
-n<m> u<290> t<StringConst> p<302> s<291> l<49:16> el<49:17>
-n<> u<291> t<AssignOp_Assign> p<302> s<301> l<49:17> el<49:18>
-n<m> u<292> t<StringConst> p<293> l<49:18> el<49:19>
-n<> u<293> t<Primary_literal> p<294> c<292> l<49:18> el<49:19>
-n<> u<294> t<Constant_primary> p<295> c<293> l<49:18> el<49:19>
-n<> u<295> t<Constant_expression> p<301> c<294> s<300> l<49:18> el<49:19>
-n<1> u<296> t<IntConst> p<297> l<49:20> el<49:21>
-n<> u<297> t<Primary_literal> p<298> c<296> l<49:20> el<49:21>
-n<> u<298> t<Constant_primary> p<299> c<297> l<49:20> el<49:21>
-n<> u<299> t<Constant_expression> p<301> c<298> l<49:20> el<49:21>
-n<> u<300> t<BinOp_Plus> p<301> s<299> l<49:19> el<49:20>
-n<> u<301> t<Constant_expression> p<302> c<295> l<49:18> el<49:21>
-n<> u<302> t<Genvar_assignment> p<315> c<290> s<314> l<49:16> el<49:21>
-n<B5> u<303> t<StringConst> p<314> s<312> l<51:2> el<51:4>
-n<M4> u<304> t<StringConst> p<310> s<309> l<52:1> el<52:3>
-n<N4> u<305> t<StringConst> p<306> l<52:4> el<52:6>
-n<> u<306> t<Name_of_instance> p<309> c<305> s<308> l<52:4> el<52:6>
-n<> u<307> t<Ordered_port_connection> p<308> l<52:7> el<52:7>
-n<> u<308> t<List_of_port_connections> p<309> c<307> l<52:7> el<52:7>
-n<> u<309> t<Hierarchical_instance> p<310> c<306> l<52:4> el<52:8>
-n<> u<310> t<Module_instantiation> p<311> c<304> l<52:1> el<52:9>
-n<> u<311> t<Module_or_generate_item> p<312> c<310> l<52:1> el<52:9>
-n<> u<312> t<Generate_module_item> p<314> c<311> s<313> l<52:1> el<52:9>
-n<> u<313> t<End> p<314> l<54:1> el<54:4>
-n<> u<314> t<Generate_module_named_block> p<315> c<303> l<50:1> el<54:4>
-n<> u<315> t<Generate_module_loop_statement> p<316> c<279> l<48:1> el<54:4>
-n<> u<316> t<Generate_module_item> p<318> c<315> s<317> l<48:1> el<54:4>
-n<> u<317> t<End> p<318> l<56:1> el<56:4>
-n<> u<318> t<Generate_module_block> p<319> c<273> l<45:1> el<56:4>
-n<> u<319> t<Generate_module_item> p<320> c<318> l<45:1> el<56:4>
-n<> u<320> t<Generate_module_conditional_statement> p<321> c<272> l<43:1> el<56:4>
-n<> u<321> t<Generate_module_item> p<323> c<320> s<322> l<43:1> el<56:4>
-n<> u<322> t<End> p<323> l<57:1> el<57:4>
-n<> u<323> t<Generate_module_named_block> p<324> c<167> l<23:1> el<57:4>
-n<> u<324> t<Generate_module_loop_statement> p<325> c<143> l<21:1> el<57:4>
-n<> u<325> t<Generate_module_item> p<327> c<324> s<326> l<21:1> el<57:4>
-n<> u<326> t<Endgenerate> p<327> l<58:1> el<58:12>
-n<> u<327> t<Generated_module_instantiation> p<328> c<325> l<20:1> el<58:12>
-n<> u<328> t<Non_port_module_item> p<329> c<327> l<20:1> el<58:12>
-n<> u<329> t<Module_item> p<330> c<328> l<20:1> el<58:12>
-n<> u<330> t<Module_declaration> p<331> c<64> l<11:1> el<60:10>
-n<> u<331> t<Description> p<332> c<330> l<11:1> el<60:10>
-n<> u<332> t<Source_text> p<333> c<26> l<1:1> el<60:10>
-n<> u<333> t<Top_level_rule> l<1:1> el<62:1>
+n<> u<256> t<Generate_block> p<257> c<245> l<37:1> el<40:4>
+n<> u<257> t<Loop_generate_construct> p<258> c<221> l<35:1> el<40:4>
+n<> u<258> t<Module_common_item> p<259> c<257> l<35:1> el<40:4>
+n<> u<259> t<Module_or_generate_item> p<260> c<258> l<35:1> el<40:4>
+n<> u<260> t<Generate_item> p<262> c<259> s<261> l<35:1> el<40:4>
+n<> u<261> t<End> p<262> l<42:1> el<42:4>
+n<> u<262> t<Generate_block> p<263> c<206> l<30:1> el<42:4>
+n<> u<263> t<Loop_generate_construct> p<264> c<182> l<28:1> el<42:4>
+n<> u<264> t<Module_common_item> p<265> c<263> l<28:1> el<42:4>
+n<> u<265> t<Module_or_generate_item> p<266> c<264> l<28:1> el<42:4>
+n<> u<266> t<Generate_item> p<331> c<265> s<329> l<28:1> el<42:4>
+n<i> u<267> t<StringConst> p<268> l<44:3> el<44:4>
+n<> u<268> t<Primary_literal> p<269> c<267> l<44:3> el<44:4>
+n<> u<269> t<Constant_primary> p<270> c<268> l<44:3> el<44:4>
+n<> u<270> t<Constant_expression> p<276> c<269> s<275> l<44:3> el<44:4>
+n<0> u<271> t<IntConst> p<272> l<44:5> el<44:6>
+n<> u<272> t<Primary_literal> p<273> c<271> l<44:5> el<44:6>
+n<> u<273> t<Constant_primary> p<274> c<272> l<44:5> el<44:6>
+n<> u<274> t<Constant_expression> p<276> c<273> l<44:5> el<44:6>
+n<> u<275> t<BinOp_Great> p<276> s<274> l<44:4> el<44:5>
+n<> u<276> t<Constant_expression> p<325> c<270> s<324> l<44:3> el<44:6>
+n<B4> u<277> t<StringConst> p<324> s<322> l<46:2> el<46:4>
+n<m> u<278> t<StringConst> p<283> s<282> l<49:3> el<49:4>
+n<0> u<279> t<IntConst> p<280> l<49:5> el<49:6>
+n<> u<280> t<Primary_literal> p<281> c<279> l<49:5> el<49:6>
+n<> u<281> t<Constant_primary> p<282> c<280> l<49:5> el<49:6>
+n<> u<282> t<Constant_expression> p<283> c<281> l<49:5> el<49:6>
+n<> u<283> t<Genvar_initialization> p<319> c<278> s<293> l<49:3> el<49:6>
+n<m> u<284> t<StringConst> p<285> l<49:8> el<49:9>
+n<> u<285> t<Primary_literal> p<286> c<284> l<49:8> el<49:9>
+n<> u<286> t<Constant_primary> p<287> c<285> l<49:8> el<49:9>
+n<> u<287> t<Constant_expression> p<293> c<286> s<292> l<49:8> el<49:9>
+n<SIZE> u<288> t<StringConst> p<289> l<49:10> el<49:14>
+n<> u<289> t<Primary_literal> p<290> c<288> l<49:10> el<49:14>
+n<> u<290> t<Constant_primary> p<291> c<289> l<49:10> el<49:14>
+n<> u<291> t<Constant_expression> p<293> c<290> l<49:10> el<49:14>
+n<> u<292> t<BinOp_Less> p<293> s<291> l<49:9> el<49:10>
+n<> u<293> t<Constant_expression> p<319> c<287> s<306> l<49:8> el<49:14>
+n<m> u<294> t<StringConst> p<306> s<295> l<49:16> el<49:17>
+n<> u<295> t<AssignOp_Assign> p<306> s<305> l<49:17> el<49:18>
+n<m> u<296> t<StringConst> p<297> l<49:18> el<49:19>
+n<> u<297> t<Primary_literal> p<298> c<296> l<49:18> el<49:19>
+n<> u<298> t<Constant_primary> p<299> c<297> l<49:18> el<49:19>
+n<> u<299> t<Constant_expression> p<305> c<298> s<304> l<49:18> el<49:19>
+n<1> u<300> t<IntConst> p<301> l<49:20> el<49:21>
+n<> u<301> t<Primary_literal> p<302> c<300> l<49:20> el<49:21>
+n<> u<302> t<Constant_primary> p<303> c<301> l<49:20> el<49:21>
+n<> u<303> t<Constant_expression> p<305> c<302> l<49:20> el<49:21>
+n<> u<304> t<BinOp_Plus> p<305> s<303> l<49:19> el<49:20>
+n<> u<305> t<Constant_expression> p<306> c<299> l<49:18> el<49:21>
+n<> u<306> t<Genvar_iteration> p<319> c<294> s<318> l<49:16> el<49:21>
+n<B5> u<307> t<StringConst> p<318> s<316> l<51:2> el<51:4>
+n<M4> u<308> t<StringConst> p<314> s<313> l<52:1> el<52:3>
+n<N4> u<309> t<StringConst> p<310> l<52:4> el<52:6>
+n<> u<310> t<Name_of_instance> p<313> c<309> s<312> l<52:4> el<52:6>
+n<> u<311> t<Ordered_port_connection> p<312> l<52:7> el<52:7>
+n<> u<312> t<List_of_port_connections> p<313> c<311> l<52:7> el<52:7>
+n<> u<313> t<Hierarchical_instance> p<314> c<310> l<52:4> el<52:8>
+n<> u<314> t<Module_instantiation> p<315> c<308> l<52:1> el<52:9>
+n<> u<315> t<Module_or_generate_item> p<316> c<314> l<52:1> el<52:9>
+n<> u<316> t<Generate_item> p<318> c<315> s<317> l<52:1> el<52:9>
+n<> u<317> t<End> p<318> l<54:1> el<54:4>
+n<> u<318> t<Generate_block> p<319> c<307> l<50:1> el<54:4>
+n<> u<319> t<Loop_generate_construct> p<320> c<283> l<48:1> el<54:4>
+n<> u<320> t<Module_common_item> p<321> c<319> l<48:1> el<54:4>
+n<> u<321> t<Module_or_generate_item> p<322> c<320> l<48:1> el<54:4>
+n<> u<322> t<Generate_item> p<324> c<321> s<323> l<48:1> el<54:4>
+n<> u<323> t<End> p<324> l<56:1> el<56:4>
+n<> u<324> t<Generate_block> p<325> c<277> l<45:1> el<56:4>
+n<> u<325> t<If_generate_construct> p<326> c<276> l<43:1> el<56:4>
+n<> u<326> t<Conditional_generate_construct> p<327> c<325> l<43:1> el<56:4>
+n<> u<327> t<Module_common_item> p<328> c<326> l<43:1> el<56:4>
+n<> u<328> t<Module_or_generate_item> p<329> c<327> l<43:1> el<56:4>
+n<> u<329> t<Generate_item> p<331> c<328> s<330> l<43:1> el<56:4>
+n<> u<330> t<End> p<331> l<57:1> el<57:4>
+n<> u<331> t<Generate_block> p<332> c<167> l<23:1> el<57:4>
+n<> u<332> t<Loop_generate_construct> p<333> c<143> l<21:1> el<57:4>
+n<> u<333> t<Module_common_item> p<334> c<332> l<21:1> el<57:4>
+n<> u<334> t<Module_or_generate_item> p<335> c<333> l<21:1> el<57:4>
+n<> u<335> t<Generate_item> p<336> c<334> l<21:1> el<57:4>
+n<> u<336> t<Generate_block> p<338> c<335> s<337> l<21:1> el<57:4>
+n<> u<337> t<Endgenerate> p<338> l<58:1> el<58:12>
+n<> u<338> t<Generate_region> p<339> c<336> l<20:1> el<58:12>
+n<> u<339> t<Non_port_module_item> p<340> c<338> l<20:1> el<58:12>
+n<> u<340> t<Module_item> p<341> c<339> l<20:1> el<58:12>
+n<> u<341> t<Module_declaration> p<342> c<64> l<11:1> el<60:10>
+n<> u<342> t<Description> p<343> c<341> l<11:1> el<60:10>
+n<> u<343> t<Source_text> p<344> c<26> l<1:1> el<60:10>
+n<> u<344> t<Top_level_rule> l<1:1> el<62:1>
 [INF:PA0201] Parsing source file "def.v".
 
 LIB:  work
@@ -411,10 +422,10 @@ n<> u<56> t<Top_level_rule> l<2:1> el<9:1>
 
 LIB:  work
 FILE: small.v
-n<> u<0> t<Null_rule> p<233> s<232> l<2:1> el<1:2>
+n<> u<0> t<Null_rule> p<236> s<235> l<2:1> el<1:2>
 n<> u<1> t<Module_keyword> p<3> s<2> l<2:1> el<2:7>
 n<secret_number> u<2> t<StringConst> p<3> l<2:8> el<2:21>
-n<> u<3> t<Module_ansi_header> p<73> c<1> s<19> l<2:1> el<2:22>
+n<> u<3> t<Module_ansi_header> p<76> c<1> s<19> l<2:1> el<2:22>
 n<> u<4> t<Data_type_or_implicit> p<14> s<13> l<3:12> el<3:12>
 n<SIZE> u<5> t<StringConst> p<12> s<11> l<3:12> el<3:16>
 n<0> u<6> t<IntConst> p<7> l<3:19> el<3:20>
@@ -430,20 +441,20 @@ n<> u<15> t<Package_or_generate_item_declaration> p<16> c<14> l<3:2> el<3:21>
 n<> u<16> t<Module_or_generate_item_declaration> p<17> c<15> l<3:2> el<3:21>
 n<> u<17> t<Module_common_item> p<18> c<16> l<3:2> el<3:21>
 n<> u<18> t<Module_or_generate_item> p<19> c<17> l<3:2> el<3:21>
-n<> u<19> t<Non_port_module_item> p<73> c<18> s<26> l<3:2> el<3:21>
+n<> u<19> t<Non_port_module_item> p<76> c<18> s<26> l<3:2> el<3:21>
 n<i> u<20> t<StringConst> p<21> l<5:11> el<5:12>
 n<> u<21> t<Identifier_list> p<22> c<20> l<5:11> el<5:12>
 n<> u<22> t<Genvar_declaration> p<23> c<21> l<5:4> el<5:13>
 n<> u<23> t<Module_or_generate_item_declaration> p<24> c<22> l<5:4> el<5:13>
 n<> u<24> t<Module_common_item> p<25> c<23> l<5:4> el<5:13>
 n<> u<25> t<Module_or_generate_item> p<26> c<24> l<5:4> el<5:13>
-n<> u<26> t<Non_port_module_item> p<73> c<25> s<72> l<5:4> el<5:13>
+n<> u<26> t<Non_port_module_item> p<76> c<25> s<75> l<5:4> el<5:13>
 n<i> u<27> t<StringConst> p<32> s<31> l<6:16> el<6:17>
 n<0> u<28> t<IntConst> p<29> l<6:18> el<6:19>
 n<> u<29> t<Primary_literal> p<30> c<28> l<6:18> el<6:19>
 n<> u<30> t<Constant_primary> p<31> c<29> l<6:18> el<6:19>
 n<> u<31> t<Constant_expression> p<32> c<30> l<6:18> el<6:19>
-n<> u<32> t<Genvar_decl_assignment> p<68> c<27> s<42> l<6:16> el<6:19>
+n<> u<32> t<Genvar_initialization> p<68> c<27> s<42> l<6:16> el<6:19>
 n<i> u<33> t<StringConst> p<34> l<6:21> el<6:22>
 n<> u<34> t<Primary_literal> p<35> c<33> l<6:21> el<6:22>
 n<> u<35> t<Constant_primary> p<36> c<34> l<6:21> el<6:22>
@@ -466,7 +477,7 @@ n<> u<51> t<Constant_primary> p<52> c<50> l<6:33> el<6:34>
 n<> u<52> t<Constant_expression> p<54> c<51> l<6:33> el<6:34>
 n<> u<53> t<BinOp_Plus> p<54> s<52> l<6:32> el<6:33>
 n<> u<54> t<Constant_expression> p<55> c<48> l<6:31> el<6:34>
-n<> u<55> t<Genvar_assignment> p<68> c<43> s<67> l<6:29> el<6:34>
+n<> u<55> t<Genvar_iteration> p<68> c<43> s<67> l<6:29> el<6:34>
 n<B1> u<56> t<StringConst> p<67> s<65> l<6:43> el<6:45>
 n<M1> u<57> t<StringConst> p<63> s<62> l<7:3> el<7:5>
 n<N1> u<58> t<StringConst> p<59> l<7:6> el<7:8>
@@ -476,175 +487,178 @@ n<> u<61> t<List_of_port_connections> p<62> c<60> l<7:9> el<7:9>
 n<> u<62> t<Hierarchical_instance> p<63> c<59> l<7:6> el<7:10>
 n<> u<63> t<Module_instantiation> p<64> c<57> l<7:3> el<7:11>
 n<> u<64> t<Module_or_generate_item> p<65> c<63> l<7:3> el<7:11>
-n<> u<65> t<Generate_module_item> p<67> c<64> s<66> l<7:3> el<7:11>
+n<> u<65> t<Generate_item> p<67> c<64> s<66> l<7:3> el<7:11>
 n<> u<66> t<End> p<67> l<8:2> el<8:5>
-n<> u<67> t<Generate_module_named_block> p<68> c<56> l<6:36> el<8:5>
-n<> u<68> t<Generate_module_loop_statement> p<69> c<32> l<6:11> el<8:5>
-n<> u<69> t<Generate_module_item> p<71> c<68> s<70> l<6:11> el<8:5>
-n<> u<70> t<Endgenerate> p<71> l<10:2> el<10:13>
-n<> u<71> t<Generated_module_instantiation> p<72> c<69> l<6:2> el<10:13>
-n<> u<72> t<Non_port_module_item> p<73> c<71> l<6:2> el<10:13>
-n<> u<73> t<Module_declaration> p<74> c<3> l<2:1> el<12:10>
-n<> u<74> t<Description> p<232> c<73> s<231> l<2:1> el<12:10>
-n<> u<75> t<Module_keyword> p<79> s<76> l<14:1> el<14:7>
-n<defparam_example> u<76> t<StringConst> p<79> s<78> l<14:8> el<14:24>
-n<> u<77> t<Port> p<78> l<14:25> el<14:25>
-n<> u<78> t<List_of_ports> p<79> c<77> l<14:24> el<14:26>
-n<> u<79> t<Module_nonansi_header> p<230> c<75> s<94> l<14:1> el<14:27>
-n<defparam_example> u<80> t<StringConst> p<83> s<81> l<15:12> el<15:28>
-n<U1> u<81> t<StringConst> p<83> s<82> l<15:29> el<15:31>
-n<SIZE> u<82> t<StringConst> p<83> l<15:32> el<15:36>
-n<> u<83> t<Hierarchical_identifier> p<89> c<80> s<88> l<15:12> el<15:36>
-n<1> u<84> t<IntConst> p<85> l<15:39> el<15:40>
-n<> u<85> t<Primary_literal> p<86> c<84> l<15:39> el<15:40>
-n<> u<86> t<Constant_primary> p<87> c<85> l<15:39> el<15:40>
-n<> u<87> t<Constant_expression> p<88> c<86> l<15:39> el<15:40>
-n<> u<88> t<Constant_mintypmax_expression> p<89> c<87> l<15:39> el<15:40>
-n<> u<89> t<Defparam_assignment> p<90> c<83> l<15:12> el<15:40>
-n<> u<90> t<List_of_defparam_assignments> p<91> c<89> l<15:12> el<15:40>
-n<> u<91> t<Parameter_override> p<92> c<90> l<15:3> el<15:41>
-n<> u<92> t<Module_or_generate_item> p<93> c<91> l<15:3> el<15:41>
-n<> u<93> t<Non_port_module_item> p<94> c<92> l<15:3> el<15:41>
-n<> u<94> t<Module_item> p<230> c<93> s<108> l<15:3> el<15:41>
-n<U2> u<95> t<StringConst> p<97> s<96> l<16:12> el<16:14>
-n<SIZE> u<96> t<StringConst> p<97> l<16:15> el<16:19>
-n<> u<97> t<Hierarchical_identifier> p<103> c<95> s<102> l<16:12> el<16:19>
-n<2> u<98> t<IntConst> p<99> l<16:22> el<16:23>
-n<> u<99> t<Primary_literal> p<100> c<98> l<16:22> el<16:23>
-n<> u<100> t<Constant_primary> p<101> c<99> l<16:22> el<16:23>
-n<> u<101> t<Constant_expression> p<102> c<100> l<16:22> el<16:23>
-n<> u<102> t<Constant_mintypmax_expression> p<103> c<101> l<16:22> el<16:23>
-n<> u<103> t<Defparam_assignment> p<104> c<97> l<16:12> el<16:23>
-n<> u<104> t<List_of_defparam_assignments> p<105> c<103> l<16:12> el<16:23>
-n<> u<105> t<Parameter_override> p<106> c<104> l<16:3> el<16:24>
-n<> u<106> t<Module_or_generate_item> p<107> c<105> l<16:3> el<16:24>
-n<> u<107> t<Non_port_module_item> p<108> c<106> l<16:3> el<16:24>
-n<> u<108> t<Module_item> p<230> c<107> s<122> l<16:3> el<16:24>
-n<U3> u<109> t<StringConst> p<111> s<110> l<17:12> el<17:14>
-n<SIZE> u<110> t<StringConst> p<111> l<17:15> el<17:19>
-n<> u<111> t<Hierarchical_identifier> p<117> c<109> s<116> l<17:12> el<17:19>
-n<3> u<112> t<IntConst> p<113> l<17:22> el<17:23>
-n<> u<113> t<Primary_literal> p<114> c<112> l<17:22> el<17:23>
-n<> u<114> t<Constant_primary> p<115> c<113> l<17:22> el<17:23>
-n<> u<115> t<Constant_expression> p<116> c<114> l<17:22> el<17:23>
-n<> u<116> t<Constant_mintypmax_expression> p<117> c<115> l<17:22> el<17:23>
-n<> u<117> t<Defparam_assignment> p<118> c<111> l<17:12> el<17:23>
-n<> u<118> t<List_of_defparam_assignments> p<119> c<117> l<17:12> el<17:23>
-n<> u<119> t<Parameter_override> p<120> c<118> l<17:3> el<17:24>
-n<> u<120> t<Module_or_generate_item> p<121> c<119> l<17:3> el<17:24>
-n<> u<121> t<Non_port_module_item> p<122> c<120> l<17:3> el<17:24>
-n<> u<122> t<Module_item> p<230> c<121> s<136> l<17:3> el<17:24>
-n<U3> u<123> t<StringConst> p<125> s<124> l<18:12> el<18:14>
-n<SIZE> u<124> t<StringConst> p<125> l<18:15> el<18:19>
-n<> u<125> t<Hierarchical_identifier> p<131> c<123> s<130> l<18:12> el<18:19>
-n<3> u<126> t<IntConst> p<127> l<18:22> el<18:23>
-n<> u<127> t<Primary_literal> p<128> c<126> l<18:22> el<18:23>
-n<> u<128> t<Constant_primary> p<129> c<127> l<18:22> el<18:23>
-n<> u<129> t<Constant_expression> p<130> c<128> l<18:22> el<18:23>
-n<> u<130> t<Constant_mintypmax_expression> p<131> c<129> l<18:22> el<18:23>
-n<> u<131> t<Defparam_assignment> p<132> c<125> l<18:12> el<18:23>
-n<> u<132> t<List_of_defparam_assignments> p<133> c<131> l<18:12> el<18:23>
-n<> u<133> t<Parameter_override> p<134> c<132> l<18:3> el<18:24>
-n<> u<134> t<Module_or_generate_item> p<135> c<133> l<18:3> el<18:24>
-n<> u<135> t<Non_port_module_item> p<136> c<134> l<18:3> el<18:24>
-n<> u<136> t<Module_item> p<230> c<135> s<146> l<18:3> el<18:24>
-n<secret_number> u<137> t<StringConst> p<143> s<142> l<19:3> el<19:16>
-n<U0> u<138> t<StringConst> p<139> l<19:17> el<19:19>
-n<> u<139> t<Name_of_instance> p<142> c<138> s<141> l<19:17> el<19:19>
-n<> u<140> t<Ordered_port_connection> p<141> l<19:20> el<19:20>
-n<> u<141> t<List_of_port_connections> p<142> c<140> l<19:20> el<19:20>
-n<> u<142> t<Hierarchical_instance> p<143> c<139> l<19:17> el<19:21>
-n<> u<143> t<Module_instantiation> p<144> c<137> l<19:3> el<19:22>
-n<> u<144> t<Module_or_generate_item> p<145> c<143> l<19:3> el<19:22>
-n<> u<145> t<Non_port_module_item> p<146> c<144> l<19:3> el<19:22>
-n<> u<146> t<Module_item> p<230> c<145> s<156> l<19:3> el<19:22>
-n<secret_number> u<147> t<StringConst> p<153> s<152> l<20:3> el<20:16>
-n<U1> u<148> t<StringConst> p<149> l<20:17> el<20:19>
-n<> u<149> t<Name_of_instance> p<152> c<148> s<151> l<20:17> el<20:19>
-n<> u<150> t<Ordered_port_connection> p<151> l<20:20> el<20:20>
-n<> u<151> t<List_of_port_connections> p<152> c<150> l<20:20> el<20:20>
-n<> u<152> t<Hierarchical_instance> p<153> c<149> l<20:17> el<20:21>
-n<> u<153> t<Module_instantiation> p<154> c<147> l<20:3> el<20:22>
-n<> u<154> t<Module_or_generate_item> p<155> c<153> l<20:3> el<20:22>
-n<> u<155> t<Non_port_module_item> p<156> c<154> l<20:3> el<20:22>
-n<> u<156> t<Module_item> p<230> c<155> s<166> l<20:3> el<20:22>
-n<secret_number> u<157> t<StringConst> p<163> s<162> l<21:3> el<21:16>
-n<U2> u<158> t<StringConst> p<159> l<21:17> el<21:19>
-n<> u<159> t<Name_of_instance> p<162> c<158> s<161> l<21:17> el<21:19>
-n<> u<160> t<Ordered_port_connection> p<161> l<21:20> el<21:20>
-n<> u<161> t<List_of_port_connections> p<162> c<160> l<21:20> el<21:20>
-n<> u<162> t<Hierarchical_instance> p<163> c<159> l<21:17> el<21:21>
-n<> u<163> t<Module_instantiation> p<164> c<157> l<21:3> el<21:22>
-n<> u<164> t<Module_or_generate_item> p<165> c<163> l<21:3> el<21:22>
-n<> u<165> t<Non_port_module_item> p<166> c<164> l<21:3> el<21:22>
-n<> u<166> t<Module_item> p<230> c<165> s<176> l<21:3> el<21:22>
-n<secret_number> u<167> t<StringConst> p<173> s<172> l<22:3> el<22:16>
-n<U3> u<168> t<StringConst> p<169> l<22:17> el<22:19>
-n<> u<169> t<Name_of_instance> p<172> c<168> s<171> l<22:17> el<22:19>
-n<> u<170> t<Ordered_port_connection> p<171> l<22:20> el<22:20>
-n<> u<171> t<List_of_port_connections> p<172> c<170> l<22:20> el<22:20>
-n<> u<172> t<Hierarchical_instance> p<173> c<169> l<22:17> el<22:21>
-n<> u<173> t<Module_instantiation> p<174> c<167> l<22:3> el<22:22>
-n<> u<174> t<Module_or_generate_item> p<175> c<173> l<22:3> el<22:22>
-n<> u<175> t<Non_port_module_item> p<176> c<174> l<22:3> el<22:22>
-n<> u<176> t<Module_item> p<230> c<175> s<186> l<22:3> el<22:22>
-n<NO_DEF> u<177> t<StringConst> p<183> s<182> l<23:3> el<23:9>
-n<U5> u<178> t<StringConst> p<179> l<23:10> el<23:12>
-n<> u<179> t<Name_of_instance> p<182> c<178> s<181> l<23:10> el<23:12>
-n<> u<180> t<Ordered_port_connection> p<181> l<23:13> el<23:13>
-n<> u<181> t<List_of_port_connections> p<182> c<180> l<23:13> el<23:13>
-n<> u<182> t<Hierarchical_instance> p<183> c<179> l<23:10> el<23:14>
-n<> u<183> t<Module_instantiation> p<184> c<177> l<23:3> el<23:15>
-n<> u<184> t<Module_or_generate_item> p<185> c<183> l<23:3> el<23:15>
-n<> u<185> t<Non_port_module_item> p<186> c<184> l<23:3> el<23:15>
-n<> u<186> t<Module_item> p<230> c<185> s<200> l<23:3> el<23:15>
-n<U5> u<187> t<StringConst> p<189> s<188> l<24:12> el<24:14>
-n<SIZE> u<188> t<StringConst> p<189> l<24:15> el<24:19>
-n<> u<189> t<Hierarchical_identifier> p<195> c<187> s<194> l<24:12> el<24:19>
-n<1> u<190> t<IntConst> p<191> l<24:22> el<24:23>
-n<> u<191> t<Primary_literal> p<192> c<190> l<24:22> el<24:23>
-n<> u<192> t<Constant_primary> p<193> c<191> l<24:22> el<24:23>
-n<> u<193> t<Constant_expression> p<194> c<192> l<24:22> el<24:23>
-n<> u<194> t<Constant_mintypmax_expression> p<195> c<193> l<24:22> el<24:23>
-n<> u<195> t<Defparam_assignment> p<196> c<189> l<24:12> el<24:23>
-n<> u<196> t<List_of_defparam_assignments> p<197> c<195> l<24:12> el<24:23>
-n<> u<197> t<Parameter_override> p<198> c<196> l<24:3> el<24:24>
-n<> u<198> t<Module_or_generate_item> p<199> c<197> l<24:3> el<24:24>
-n<> u<199> t<Non_port_module_item> p<200> c<198> l<24:3> el<24:24>
-n<> u<200> t<Module_item> p<230> c<199> s<214> l<24:3> el<24:24>
-n<NO_MATCH> u<201> t<StringConst> p<203> s<202> l<25:12> el<25:20>
-n<SIZE1> u<202> t<StringConst> p<203> l<25:21> el<25:26>
-n<> u<203> t<Hierarchical_identifier> p<209> c<201> s<208> l<25:12> el<25:26>
-n<2> u<204> t<IntConst> p<205> l<25:29> el<25:30>
-n<> u<205> t<Primary_literal> p<206> c<204> l<25:29> el<25:30>
-n<> u<206> t<Constant_primary> p<207> c<205> l<25:29> el<25:30>
-n<> u<207> t<Constant_expression> p<208> c<206> l<25:29> el<25:30>
-n<> u<208> t<Constant_mintypmax_expression> p<209> c<207> l<25:29> el<25:30>
-n<> u<209> t<Defparam_assignment> p<210> c<203> l<25:12> el<25:30>
-n<> u<210> t<List_of_defparam_assignments> p<211> c<209> l<25:12> el<25:30>
-n<> u<211> t<Parameter_override> p<212> c<210> l<25:3> el<25:31>
-n<> u<212> t<Module_or_generate_item> p<213> c<211> l<25:3> el<25:31>
-n<> u<213> t<Non_port_module_item> p<214> c<212> l<25:3> el<25:31>
-n<> u<214> t<Module_item> p<230> c<213> s<229> l<25:3> el<25:31>
-n<defparam_example> u<215> t<StringConst> p<218> s<216> l<26:12> el<26:28>
-n<NO_MATCH> u<216> t<StringConst> p<218> s<217> l<26:29> el<26:37>
-n<SIZE2> u<217> t<StringConst> p<218> l<26:38> el<26:43>
-n<> u<218> t<Hierarchical_identifier> p<224> c<215> s<223> l<26:12> el<26:43>
-n<2> u<219> t<IntConst> p<220> l<26:46> el<26:47>
-n<> u<220> t<Primary_literal> p<221> c<219> l<26:46> el<26:47>
-n<> u<221> t<Constant_primary> p<222> c<220> l<26:46> el<26:47>
-n<> u<222> t<Constant_expression> p<223> c<221> l<26:46> el<26:47>
-n<> u<223> t<Constant_mintypmax_expression> p<224> c<222> l<26:46> el<26:47>
-n<> u<224> t<Defparam_assignment> p<225> c<218> l<26:12> el<26:47>
-n<> u<225> t<List_of_defparam_assignments> p<226> c<224> l<26:12> el<26:47>
-n<> u<226> t<Parameter_override> p<227> c<225> l<26:3> el<26:48>
-n<> u<227> t<Module_or_generate_item> p<228> c<226> l<26:3> el<26:48>
-n<> u<228> t<Non_port_module_item> p<229> c<227> l<26:3> el<26:48>
-n<> u<229> t<Module_item> p<230> c<228> l<26:3> el<26:48>
-n<> u<230> t<Module_declaration> p<231> c<79> l<14:1> el<27:10>
-n<> u<231> t<Description> p<232> c<230> l<14:1> el<27:10>
-n<> u<232> t<Source_text> p<233> c<74> l<2:1> el<27:10>
-n<> u<233> t<Top_level_rule> l<2:1> el<29:1>
+n<> u<67> t<Generate_block> p<68> c<56> l<6:36> el<8:5>
+n<> u<68> t<Loop_generate_construct> p<69> c<32> l<6:11> el<8:5>
+n<> u<69> t<Module_common_item> p<70> c<68> l<6:11> el<8:5>
+n<> u<70> t<Module_or_generate_item> p<71> c<69> l<6:11> el<8:5>
+n<> u<71> t<Generate_item> p<72> c<70> l<6:11> el<8:5>
+n<> u<72> t<Generate_block> p<74> c<71> s<73> l<6:11> el<8:5>
+n<> u<73> t<Endgenerate> p<74> l<10:2> el<10:13>
+n<> u<74> t<Generate_region> p<75> c<72> l<6:2> el<10:13>
+n<> u<75> t<Non_port_module_item> p<76> c<74> l<6:2> el<10:13>
+n<> u<76> t<Module_declaration> p<77> c<3> l<2:1> el<12:10>
+n<> u<77> t<Description> p<235> c<76> s<234> l<2:1> el<12:10>
+n<> u<78> t<Module_keyword> p<82> s<79> l<14:1> el<14:7>
+n<defparam_example> u<79> t<StringConst> p<82> s<81> l<14:8> el<14:24>
+n<> u<80> t<Port> p<81> l<14:25> el<14:25>
+n<> u<81> t<List_of_ports> p<82> c<80> l<14:24> el<14:26>
+n<> u<82> t<Module_nonansi_header> p<233> c<78> s<97> l<14:1> el<14:27>
+n<defparam_example> u<83> t<StringConst> p<86> s<84> l<15:12> el<15:28>
+n<U1> u<84> t<StringConst> p<86> s<85> l<15:29> el<15:31>
+n<SIZE> u<85> t<StringConst> p<86> l<15:32> el<15:36>
+n<> u<86> t<Hierarchical_identifier> p<92> c<83> s<91> l<15:12> el<15:36>
+n<1> u<87> t<IntConst> p<88> l<15:39> el<15:40>
+n<> u<88> t<Primary_literal> p<89> c<87> l<15:39> el<15:40>
+n<> u<89> t<Constant_primary> p<90> c<88> l<15:39> el<15:40>
+n<> u<90> t<Constant_expression> p<91> c<89> l<15:39> el<15:40>
+n<> u<91> t<Constant_mintypmax_expression> p<92> c<90> l<15:39> el<15:40>
+n<> u<92> t<Defparam_assignment> p<93> c<86> l<15:12> el<15:40>
+n<> u<93> t<List_of_defparam_assignments> p<94> c<92> l<15:12> el<15:40>
+n<> u<94> t<Parameter_override> p<95> c<93> l<15:3> el<15:41>
+n<> u<95> t<Module_or_generate_item> p<96> c<94> l<15:3> el<15:41>
+n<> u<96> t<Non_port_module_item> p<97> c<95> l<15:3> el<15:41>
+n<> u<97> t<Module_item> p<233> c<96> s<111> l<15:3> el<15:41>
+n<U2> u<98> t<StringConst> p<100> s<99> l<16:12> el<16:14>
+n<SIZE> u<99> t<StringConst> p<100> l<16:15> el<16:19>
+n<> u<100> t<Hierarchical_identifier> p<106> c<98> s<105> l<16:12> el<16:19>
+n<2> u<101> t<IntConst> p<102> l<16:22> el<16:23>
+n<> u<102> t<Primary_literal> p<103> c<101> l<16:22> el<16:23>
+n<> u<103> t<Constant_primary> p<104> c<102> l<16:22> el<16:23>
+n<> u<104> t<Constant_expression> p<105> c<103> l<16:22> el<16:23>
+n<> u<105> t<Constant_mintypmax_expression> p<106> c<104> l<16:22> el<16:23>
+n<> u<106> t<Defparam_assignment> p<107> c<100> l<16:12> el<16:23>
+n<> u<107> t<List_of_defparam_assignments> p<108> c<106> l<16:12> el<16:23>
+n<> u<108> t<Parameter_override> p<109> c<107> l<16:3> el<16:24>
+n<> u<109> t<Module_or_generate_item> p<110> c<108> l<16:3> el<16:24>
+n<> u<110> t<Non_port_module_item> p<111> c<109> l<16:3> el<16:24>
+n<> u<111> t<Module_item> p<233> c<110> s<125> l<16:3> el<16:24>
+n<U3> u<112> t<StringConst> p<114> s<113> l<17:12> el<17:14>
+n<SIZE> u<113> t<StringConst> p<114> l<17:15> el<17:19>
+n<> u<114> t<Hierarchical_identifier> p<120> c<112> s<119> l<17:12> el<17:19>
+n<3> u<115> t<IntConst> p<116> l<17:22> el<17:23>
+n<> u<116> t<Primary_literal> p<117> c<115> l<17:22> el<17:23>
+n<> u<117> t<Constant_primary> p<118> c<116> l<17:22> el<17:23>
+n<> u<118> t<Constant_expression> p<119> c<117> l<17:22> el<17:23>
+n<> u<119> t<Constant_mintypmax_expression> p<120> c<118> l<17:22> el<17:23>
+n<> u<120> t<Defparam_assignment> p<121> c<114> l<17:12> el<17:23>
+n<> u<121> t<List_of_defparam_assignments> p<122> c<120> l<17:12> el<17:23>
+n<> u<122> t<Parameter_override> p<123> c<121> l<17:3> el<17:24>
+n<> u<123> t<Module_or_generate_item> p<124> c<122> l<17:3> el<17:24>
+n<> u<124> t<Non_port_module_item> p<125> c<123> l<17:3> el<17:24>
+n<> u<125> t<Module_item> p<233> c<124> s<139> l<17:3> el<17:24>
+n<U3> u<126> t<StringConst> p<128> s<127> l<18:12> el<18:14>
+n<SIZE> u<127> t<StringConst> p<128> l<18:15> el<18:19>
+n<> u<128> t<Hierarchical_identifier> p<134> c<126> s<133> l<18:12> el<18:19>
+n<3> u<129> t<IntConst> p<130> l<18:22> el<18:23>
+n<> u<130> t<Primary_literal> p<131> c<129> l<18:22> el<18:23>
+n<> u<131> t<Constant_primary> p<132> c<130> l<18:22> el<18:23>
+n<> u<132> t<Constant_expression> p<133> c<131> l<18:22> el<18:23>
+n<> u<133> t<Constant_mintypmax_expression> p<134> c<132> l<18:22> el<18:23>
+n<> u<134> t<Defparam_assignment> p<135> c<128> l<18:12> el<18:23>
+n<> u<135> t<List_of_defparam_assignments> p<136> c<134> l<18:12> el<18:23>
+n<> u<136> t<Parameter_override> p<137> c<135> l<18:3> el<18:24>
+n<> u<137> t<Module_or_generate_item> p<138> c<136> l<18:3> el<18:24>
+n<> u<138> t<Non_port_module_item> p<139> c<137> l<18:3> el<18:24>
+n<> u<139> t<Module_item> p<233> c<138> s<149> l<18:3> el<18:24>
+n<secret_number> u<140> t<StringConst> p<146> s<145> l<19:3> el<19:16>
+n<U0> u<141> t<StringConst> p<142> l<19:17> el<19:19>
+n<> u<142> t<Name_of_instance> p<145> c<141> s<144> l<19:17> el<19:19>
+n<> u<143> t<Ordered_port_connection> p<144> l<19:20> el<19:20>
+n<> u<144> t<List_of_port_connections> p<145> c<143> l<19:20> el<19:20>
+n<> u<145> t<Hierarchical_instance> p<146> c<142> l<19:17> el<19:21>
+n<> u<146> t<Module_instantiation> p<147> c<140> l<19:3> el<19:22>
+n<> u<147> t<Module_or_generate_item> p<148> c<146> l<19:3> el<19:22>
+n<> u<148> t<Non_port_module_item> p<149> c<147> l<19:3> el<19:22>
+n<> u<149> t<Module_item> p<233> c<148> s<159> l<19:3> el<19:22>
+n<secret_number> u<150> t<StringConst> p<156> s<155> l<20:3> el<20:16>
+n<U1> u<151> t<StringConst> p<152> l<20:17> el<20:19>
+n<> u<152> t<Name_of_instance> p<155> c<151> s<154> l<20:17> el<20:19>
+n<> u<153> t<Ordered_port_connection> p<154> l<20:20> el<20:20>
+n<> u<154> t<List_of_port_connections> p<155> c<153> l<20:20> el<20:20>
+n<> u<155> t<Hierarchical_instance> p<156> c<152> l<20:17> el<20:21>
+n<> u<156> t<Module_instantiation> p<157> c<150> l<20:3> el<20:22>
+n<> u<157> t<Module_or_generate_item> p<158> c<156> l<20:3> el<20:22>
+n<> u<158> t<Non_port_module_item> p<159> c<157> l<20:3> el<20:22>
+n<> u<159> t<Module_item> p<233> c<158> s<169> l<20:3> el<20:22>
+n<secret_number> u<160> t<StringConst> p<166> s<165> l<21:3> el<21:16>
+n<U2> u<161> t<StringConst> p<162> l<21:17> el<21:19>
+n<> u<162> t<Name_of_instance> p<165> c<161> s<164> l<21:17> el<21:19>
+n<> u<163> t<Ordered_port_connection> p<164> l<21:20> el<21:20>
+n<> u<164> t<List_of_port_connections> p<165> c<163> l<21:20> el<21:20>
+n<> u<165> t<Hierarchical_instance> p<166> c<162> l<21:17> el<21:21>
+n<> u<166> t<Module_instantiation> p<167> c<160> l<21:3> el<21:22>
+n<> u<167> t<Module_or_generate_item> p<168> c<166> l<21:3> el<21:22>
+n<> u<168> t<Non_port_module_item> p<169> c<167> l<21:3> el<21:22>
+n<> u<169> t<Module_item> p<233> c<168> s<179> l<21:3> el<21:22>
+n<secret_number> u<170> t<StringConst> p<176> s<175> l<22:3> el<22:16>
+n<U3> u<171> t<StringConst> p<172> l<22:17> el<22:19>
+n<> u<172> t<Name_of_instance> p<175> c<171> s<174> l<22:17> el<22:19>
+n<> u<173> t<Ordered_port_connection> p<174> l<22:20> el<22:20>
+n<> u<174> t<List_of_port_connections> p<175> c<173> l<22:20> el<22:20>
+n<> u<175> t<Hierarchical_instance> p<176> c<172> l<22:17> el<22:21>
+n<> u<176> t<Module_instantiation> p<177> c<170> l<22:3> el<22:22>
+n<> u<177> t<Module_or_generate_item> p<178> c<176> l<22:3> el<22:22>
+n<> u<178> t<Non_port_module_item> p<179> c<177> l<22:3> el<22:22>
+n<> u<179> t<Module_item> p<233> c<178> s<189> l<22:3> el<22:22>
+n<NO_DEF> u<180> t<StringConst> p<186> s<185> l<23:3> el<23:9>
+n<U5> u<181> t<StringConst> p<182> l<23:10> el<23:12>
+n<> u<182> t<Name_of_instance> p<185> c<181> s<184> l<23:10> el<23:12>
+n<> u<183> t<Ordered_port_connection> p<184> l<23:13> el<23:13>
+n<> u<184> t<List_of_port_connections> p<185> c<183> l<23:13> el<23:13>
+n<> u<185> t<Hierarchical_instance> p<186> c<182> l<23:10> el<23:14>
+n<> u<186> t<Module_instantiation> p<187> c<180> l<23:3> el<23:15>
+n<> u<187> t<Module_or_generate_item> p<188> c<186> l<23:3> el<23:15>
+n<> u<188> t<Non_port_module_item> p<189> c<187> l<23:3> el<23:15>
+n<> u<189> t<Module_item> p<233> c<188> s<203> l<23:3> el<23:15>
+n<U5> u<190> t<StringConst> p<192> s<191> l<24:12> el<24:14>
+n<SIZE> u<191> t<StringConst> p<192> l<24:15> el<24:19>
+n<> u<192> t<Hierarchical_identifier> p<198> c<190> s<197> l<24:12> el<24:19>
+n<1> u<193> t<IntConst> p<194> l<24:22> el<24:23>
+n<> u<194> t<Primary_literal> p<195> c<193> l<24:22> el<24:23>
+n<> u<195> t<Constant_primary> p<196> c<194> l<24:22> el<24:23>
+n<> u<196> t<Constant_expression> p<197> c<195> l<24:22> el<24:23>
+n<> u<197> t<Constant_mintypmax_expression> p<198> c<196> l<24:22> el<24:23>
+n<> u<198> t<Defparam_assignment> p<199> c<192> l<24:12> el<24:23>
+n<> u<199> t<List_of_defparam_assignments> p<200> c<198> l<24:12> el<24:23>
+n<> u<200> t<Parameter_override> p<201> c<199> l<24:3> el<24:24>
+n<> u<201> t<Module_or_generate_item> p<202> c<200> l<24:3> el<24:24>
+n<> u<202> t<Non_port_module_item> p<203> c<201> l<24:3> el<24:24>
+n<> u<203> t<Module_item> p<233> c<202> s<217> l<24:3> el<24:24>
+n<NO_MATCH> u<204> t<StringConst> p<206> s<205> l<25:12> el<25:20>
+n<SIZE1> u<205> t<StringConst> p<206> l<25:21> el<25:26>
+n<> u<206> t<Hierarchical_identifier> p<212> c<204> s<211> l<25:12> el<25:26>
+n<2> u<207> t<IntConst> p<208> l<25:29> el<25:30>
+n<> u<208> t<Primary_literal> p<209> c<207> l<25:29> el<25:30>
+n<> u<209> t<Constant_primary> p<210> c<208> l<25:29> el<25:30>
+n<> u<210> t<Constant_expression> p<211> c<209> l<25:29> el<25:30>
+n<> u<211> t<Constant_mintypmax_expression> p<212> c<210> l<25:29> el<25:30>
+n<> u<212> t<Defparam_assignment> p<213> c<206> l<25:12> el<25:30>
+n<> u<213> t<List_of_defparam_assignments> p<214> c<212> l<25:12> el<25:30>
+n<> u<214> t<Parameter_override> p<215> c<213> l<25:3> el<25:31>
+n<> u<215> t<Module_or_generate_item> p<216> c<214> l<25:3> el<25:31>
+n<> u<216> t<Non_port_module_item> p<217> c<215> l<25:3> el<25:31>
+n<> u<217> t<Module_item> p<233> c<216> s<232> l<25:3> el<25:31>
+n<defparam_example> u<218> t<StringConst> p<221> s<219> l<26:12> el<26:28>
+n<NO_MATCH> u<219> t<StringConst> p<221> s<220> l<26:29> el<26:37>
+n<SIZE2> u<220> t<StringConst> p<221> l<26:38> el<26:43>
+n<> u<221> t<Hierarchical_identifier> p<227> c<218> s<226> l<26:12> el<26:43>
+n<2> u<222> t<IntConst> p<223> l<26:46> el<26:47>
+n<> u<223> t<Primary_literal> p<224> c<222> l<26:46> el<26:47>
+n<> u<224> t<Constant_primary> p<225> c<223> l<26:46> el<26:47>
+n<> u<225> t<Constant_expression> p<226> c<224> l<26:46> el<26:47>
+n<> u<226> t<Constant_mintypmax_expression> p<227> c<225> l<26:46> el<26:47>
+n<> u<227> t<Defparam_assignment> p<228> c<221> l<26:12> el<26:47>
+n<> u<228> t<List_of_defparam_assignments> p<229> c<227> l<26:12> el<26:47>
+n<> u<229> t<Parameter_override> p<230> c<228> l<26:3> el<26:48>
+n<> u<230> t<Module_or_generate_item> p<231> c<229> l<26:3> el<26:48>
+n<> u<231> t<Non_port_module_item> p<232> c<230> l<26:3> el<26:48>
+n<> u<232> t<Module_item> p<233> c<231> l<26:3> el<26:48>
+n<> u<233> t<Module_declaration> p<234> c<82> l<14:1> el<27:10>
+n<> u<234> t<Description> p<235> c<233> l<14:1> el<27:10>
+n<> u<235> t<Source_text> p<236> c<77> l<2:1> el<27:10>
+n<> u<236> t<Top_level_rule> l<2:1> el<29:1>
 [WRN:PA0205] top.v:1: No timescale set for "top_def".
 
 [WRN:PA0205] top.v:7: No timescale set for "small_top".

--- a/tests/UnitElab/UnitElab.log
+++ b/tests/UnitElab/UnitElab.log
@@ -10,7 +10,7 @@
 
 LIB:  work
 FILE: top.v
-n<> u<0> t<Null_rule> p<667> s<666> l<1:1> el<1:0>
+n<> u<0> t<Null_rule> p<681> s<680> l<1:1> el<1:0>
 n<> u<1> t<Module_keyword> p<16> s<2> l<1:1> el<1:7>
 n<bottom1> u<2> t<StringConst> p<16> s<15> l<1:8> el<1:15>
 n<> u<3> t<PortDir_Inp> p<6> s<5> l<1:17> el<1:22>
@@ -60,7 +60,7 @@ n<> u<46> t<Udp_instantiation> p<47> c<33> l<3:2> el<3:20>
 n<> u<47> t<Module_or_generate_item> p<48> c<46> l<3:2> el<3:20>
 n<> u<48> t<Non_port_module_item> p<49> c<47> l<3:2> el<3:20>
 n<> u<49> t<Module_declaration> p<50> c<16> l<1:1> el<4:10>
-n<> u<50> t<Description> p<666> c<49> s<84> l<1:1> el<4:10>
+n<> u<50> t<Description> p<680> c<49> s<84> l<1:1> el<4:10>
 n<> u<51> t<Module_keyword> p<66> s<52> l<6:1> el<6:7>
 n<bottom2> u<52> t<StringConst> p<66> s<65> l<6:8> el<6:15>
 n<> u<53> t<PortDir_Inp> p<56> s<55> l<6:17> el<6:22>
@@ -94,7 +94,7 @@ n<> u<80> t<Udp_instantiation> p<81> c<67> l<7:2> el<7:20>
 n<> u<81> t<Module_or_generate_item> p<82> c<80> l<7:2> el<7:20>
 n<> u<82> t<Non_port_module_item> p<83> c<81> l<7:2> el<7:20>
 n<> u<83> t<Module_declaration> p<84> c<66> l<6:1> el<8:10>
-n<> u<84> t<Description> p<666> c<83> s<118> l<6:1> el<8:10>
+n<> u<84> t<Description> p<680> c<83> s<118> l<6:1> el<8:10>
 n<> u<85> t<Module_keyword> p<100> s<86> l<11:1> el<11:7>
 n<bottom4> u<86> t<StringConst> p<100> s<99> l<11:8> el<11:15>
 n<> u<87> t<PortDir_Inp> p<90> s<89> l<11:17> el<11:22>
@@ -128,7 +128,7 @@ n<> u<114> t<Udp_instantiation> p<115> c<101> l<12:1> el<12:19>
 n<> u<115> t<Module_or_generate_item> p<116> c<114> l<12:1> el<12:19>
 n<> u<116> t<Non_port_module_item> p<117> c<115> l<12:1> el<12:19>
 n<> u<117> t<Module_declaration> p<118> c<100> l<11:1> el<13:10>
-n<> u<118> t<Description> p<666> c<117> s<136> l<11:1> el<13:10>
+n<> u<118> t<Description> p<680> c<117> s<136> l<11:1> el<13:10>
 n<> u<119> t<Module_keyword> p<134> s<120> l<16:1> el<16:7>
 n<bottom5> u<120> t<StringConst> p<134> s<133> l<16:8> el<16:15>
 n<> u<121> t<PortDir_Inp> p<124> s<123> l<16:17> el<16:22>
@@ -146,7 +146,7 @@ n<> u<132> t<Ansi_port_declaration> p<133> c<130> l<16:26> el<16:33>
 n<> u<133> t<List_of_port_declarations> p<134> c<126> l<16:16> el<16:34>
 n<> u<134> t<Module_ansi_header> p<135> c<119> l<16:1> el<16:36>
 n<> u<135> t<Module_declaration> p<136> c<134> l<16:1> el<17:10>
-n<> u<136> t<Description> p<666> c<135> s<197> l<16:1> el<17:10>
+n<> u<136> t<Description> p<680> c<135> s<197> l<16:1> el<17:10>
 n<> u<137> t<Module_keyword> p<158> s<138> l<20:1> el<20:7>
 n<my_module> u<138> t<StringConst> p<158> s<157> l<20:8> el<20:17>
 n<a> u<139> t<StringConst> p<142> s<141> l<20:19> el<20:20>
@@ -207,7 +207,7 @@ n<> u<193> t<Module_or_generate_item> p<194> c<192> l<23:3> el<23:21>
 n<> u<194> t<Non_port_module_item> p<195> c<193> l<23:3> el<23:21>
 n<> u<195> t<Module_item> p<196> c<194> l<23:3> el<23:21>
 n<> u<196> t<Module_declaration> p<197> c<158> l<20:1> el<24:10>
-n<> u<197> t<Description> p<666> c<196> s<328> l<20:1> el<24:10>
+n<> u<197> t<Description> p<680> c<196> s<328> l<20:1> el<24:10>
 n<> u<198> t<Module_keyword> p<219> s<199> l<26:1> el<26:7>
 n<top> u<199> t<StringConst> p<219> s<218> l<26:8> el<26:11>
 n<a> u<200> t<StringConst> p<203> s<202> l<26:13> el<26:14>
@@ -338,7 +338,7 @@ n<> u<324> t<Module_or_generate_item> p<325> c<323> l<30:3> el<30:30>
 n<> u<325> t<Non_port_module_item> p<326> c<324> l<30:3> el<30:30>
 n<> u<326> t<Module_item> p<327> c<325> l<30:3> el<30:30>
 n<> u<327> t<Module_declaration> p<328> c<219> l<26:1> el<31:10>
-n<> u<328> t<Description> p<666> c<327> s<665> l<26:1> el<31:10>
+n<> u<328> t<Description> p<680> c<327> s<679> l<26:1> el<31:10>
 n<> u<329> t<Module_keyword> p<344> s<330> l<35:1> el<35:7>
 n<test> u<330> t<StringConst> p<344> s<343> l<35:8> el<35:12>
 n<a> u<331> t<StringConst> p<334> s<333> l<35:13> el<35:14>
@@ -354,7 +354,7 @@ n<> u<340> t<Port_reference> p<341> c<337> l<35:16> el<35:17>
 n<> u<341> t<Port_expression> p<342> c<340> l<35:16> el<35:17>
 n<> u<342> t<Port> p<343> c<341> l<35:16> el<35:17>
 n<> u<343> t<List_of_ports> p<344> c<336> l<35:12> el<35:18>
-n<> u<344> t<Module_nonansi_header> p<664> c<329> s<361> l<35:1> el<35:19>
+n<> u<344> t<Module_nonansi_header> p<678> c<329> s<361> l<35:1> el<35:19>
 n<> u<345> t<Data_type_or_implicit> p<355> s<354> l<37:13> el<37:13>
 n<POWER1> u<346> t<StringConst> p<353> s<352> l<37:13> el<37:19>
 n<1> u<347> t<IntConst> p<348> l<37:22> el<37:23>
@@ -371,7 +371,7 @@ n<> u<357> t<Module_or_generate_item_declaration> p<358> c<356> l<37:3> el<37:24
 n<> u<358> t<Module_common_item> p<359> c<357> l<37:3> el<37:24>
 n<> u<359> t<Module_or_generate_item> p<360> c<358> l<37:3> el<37:24>
 n<> u<360> t<Non_port_module_item> p<361> c<359> l<37:3> el<37:24>
-n<> u<361> t<Module_item> p<664> c<360> s<378> l<37:3> el<37:24>
+n<> u<361> t<Module_item> p<678> c<360> s<378> l<37:3> el<37:24>
 n<> u<362> t<Data_type_or_implicit> p<372> s<371> l<38:13> el<38:13>
 n<POWER2> u<363> t<StringConst> p<370> s<369> l<38:13> el<38:19>
 n<1> u<364> t<IntConst> p<365> l<38:22> el<38:23>
@@ -388,7 +388,7 @@ n<> u<374> t<Module_or_generate_item_declaration> p<375> c<373> l<38:3> el<38:24
 n<> u<375> t<Module_common_item> p<376> c<374> l<38:3> el<38:24>
 n<> u<376> t<Module_or_generate_item> p<377> c<375> l<38:3> el<38:24>
 n<> u<377> t<Non_port_module_item> p<378> c<376> l<38:3> el<38:24>
-n<> u<378> t<Module_item> p<664> c<377> s<395> l<38:3> el<38:24>
+n<> u<378> t<Module_item> p<678> c<377> s<395> l<38:3> el<38:24>
 n<> u<379> t<NInpGate_And> p<392> s<391> l<39:3> el<39:6>
 n<u0> u<380> t<StringConst> p<381> l<39:7> el<39:9>
 n<> u<381> t<Name_of_instance> p<391> c<380> s<386> l<39:7> el<39:9>
@@ -405,7 +405,7 @@ n<> u<391> t<N_input_gate_instance> p<392> c<381> l<39:7> el<39:14>
 n<> u<392> t<Gate_instantiation> p<393> c<379> l<39:3> el<39:15>
 n<> u<393> t<Module_or_generate_item> p<394> c<392> l<39:3> el<39:15>
 n<> u<394> t<Non_port_module_item> p<395> c<393> l<39:3> el<39:15>
-n<> u<395> t<Module_item> p<664> c<394> s<495> l<39:3> el<39:15>
+n<> u<395> t<Module_item> p<678> c<394> s<504> l<39:3> el<39:15>
 n<POWER1> u<396> t<StringConst> p<397> l<41:6> el<41:12>
 n<> u<397> t<Primary_literal> p<398> c<396> l<41:6> el<41:12>
 n<> u<398> t<Constant_primary> p<399> c<397> l<41:6> el<41:12>
@@ -415,7 +415,7 @@ n<> u<401> t<Primary_literal> p<402> c<400> l<41:15> el<41:16>
 n<> u<402> t<Constant_primary> p<403> c<401> l<41:15> el<41:16>
 n<> u<403> t<Constant_expression> p<405> c<402> l<41:15> el<41:16>
 n<> u<404> t<BinOp_Great> p<405> s<403> l<41:13> el<41:14>
-n<> u<405> t<Constant_expression> p<490> c<399> s<425> l<41:6> el<41:16>
+n<> u<405> t<Constant_expression> p<495> c<399> s<424> l<41:6> el<41:16>
 n<g1> u<406> t<StringConst> p<424> s<422> l<41:26> el<41:28>
 n<> u<407> t<NInpGate_And> p<420> s<419> l<42:7> el<42:10>
 n<u1> u<408> t<StringConst> p<409> l<42:11> el<42:13>
@@ -432,257 +432,271 @@ n<> u<418> t<Expression> p<419> c<417> l<42:16> el<42:17>
 n<> u<419> t<N_input_gate_instance> p<420> c<409> l<42:11> el<42:18>
 n<> u<420> t<Gate_instantiation> p<421> c<407> l<42:7> el<42:19>
 n<> u<421> t<Module_or_generate_item> p<422> c<420> l<42:7> el<42:19>
-n<> u<422> t<Generate_module_item> p<424> c<421> s<423> l<42:7> el<42:19>
+n<> u<422> t<Generate_item> p<424> c<421> s<423> l<42:7> el<42:19>
 n<> u<423> t<End> p<424> l<43:5> el<43:8>
-n<> u<424> t<Generate_module_block> p<425> c<406> l<41:18> el<43:8>
-n<> u<425> t<Generate_module_item> p<490> c<424> s<489> l<41:18> el<43:8>
-n<POWER2> u<426> t<StringConst> p<427> l<43:18> el<43:24>
-n<> u<427> t<Primary_literal> p<428> c<426> l<43:18> el<43:24>
-n<> u<428> t<Constant_primary> p<429> c<427> l<43:18> el<43:24>
-n<> u<429> t<Constant_expression> p<435> c<428> s<434> l<43:18> el<43:24>
-n<1> u<430> t<IntConst> p<431> l<43:28> el<43:29>
-n<> u<431> t<Primary_literal> p<432> c<430> l<43:28> el<43:29>
-n<> u<432> t<Constant_primary> p<433> c<431> l<43:28> el<43:29>
-n<> u<433> t<Constant_expression> p<435> c<432> l<43:28> el<43:29>
-n<> u<434> t<BinOp_Equiv> p<435> s<433> l<43:25> el<43:27>
-n<> u<435> t<Constant_expression> p<488> c<429> s<455> l<43:18> el<43:29>
-n<g1> u<436> t<StringConst> p<454> s<452> l<43:38> el<43:40>
-n<> u<437> t<NInpGate_And> p<450> s<449> l<44:7> el<44:10>
-n<u2> u<438> t<StringConst> p<439> l<44:11> el<44:13>
-n<> u<439> t<Name_of_instance> p<449> c<438> s<444> l<44:11> el<44:13>
-n<a> u<440> t<StringConst> p<441> l<44:14> el<44:15>
-n<> u<441> t<Ps_or_hierarchical_identifier> p<444> c<440> s<443> l<44:14> el<44:15>
-n<> u<442> t<Constant_bit_select> p<443> l<44:15> el<44:15>
-n<> u<443> t<Constant_select> p<444> c<442> l<44:15> el<44:15>
-n<> u<444> t<Net_lvalue> p<449> c<441> s<448> l<44:14> el<44:15>
-n<b> u<445> t<StringConst> p<446> l<44:16> el<44:17>
-n<> u<446> t<Primary_literal> p<447> c<445> l<44:16> el<44:17>
-n<> u<447> t<Primary> p<448> c<446> l<44:16> el<44:17>
-n<> u<448> t<Expression> p<449> c<447> l<44:16> el<44:17>
-n<> u<449> t<N_input_gate_instance> p<450> c<439> l<44:11> el<44:18>
-n<> u<450> t<Gate_instantiation> p<451> c<437> l<44:7> el<44:19>
-n<> u<451> t<Module_or_generate_item> p<452> c<450> l<44:7> el<44:19>
-n<> u<452> t<Generate_module_item> p<454> c<451> s<453> l<44:7> el<44:19>
-n<> u<453> t<End> p<454> l<45:5> el<45:8>
-n<> u<454> t<Generate_module_block> p<455> c<436> l<43:31> el<45:8>
-n<> u<455> t<Generate_module_item> p<488> c<454> s<487> l<43:31> el<45:8>
-n<POWER2> u<456> t<StringConst> p<457> l<45:18> el<45:24>
-n<> u<457> t<Primary_literal> p<458> c<456> l<45:18> el<45:24>
-n<> u<458> t<Constant_primary> p<459> c<457> l<45:18> el<45:24>
-n<> u<459> t<Constant_expression> p<465> c<458> s<464> l<45:18> el<45:24>
-n<0> u<460> t<IntConst> p<461> l<45:27> el<45:28>
-n<> u<461> t<Primary_literal> p<462> c<460> l<45:27> el<45:28>
-n<> u<462> t<Constant_primary> p<463> c<461> l<45:27> el<45:28>
-n<> u<463> t<Constant_expression> p<465> c<462> l<45:27> el<45:28>
-n<> u<464> t<BinOp_Great> p<465> s<463> l<45:25> el<45:26>
-n<> u<465> t<Constant_expression> p<486> c<459> s<485> l<45:18> el<45:28>
-n<g1> u<466> t<StringConst> p<484> s<482> l<45:37> el<45:39>
-n<> u<467> t<NInpGate_And> p<480> s<479> l<46:7> el<46:10>
-n<u3> u<468> t<StringConst> p<469> l<46:11> el<46:13>
-n<> u<469> t<Name_of_instance> p<479> c<468> s<474> l<46:11> el<46:13>
-n<a> u<470> t<StringConst> p<471> l<46:14> el<46:15>
-n<> u<471> t<Ps_or_hierarchical_identifier> p<474> c<470> s<473> l<46:14> el<46:15>
-n<> u<472> t<Constant_bit_select> p<473> l<46:15> el<46:15>
-n<> u<473> t<Constant_select> p<474> c<472> l<46:15> el<46:15>
-n<> u<474> t<Net_lvalue> p<479> c<471> s<478> l<46:14> el<46:15>
-n<b> u<475> t<StringConst> p<476> l<46:16> el<46:17>
-n<> u<476> t<Primary_literal> p<477> c<475> l<46:16> el<46:17>
-n<> u<477> t<Primary> p<478> c<476> l<46:16> el<46:17>
-n<> u<478> t<Expression> p<479> c<477> l<46:16> el<46:17>
-n<> u<479> t<N_input_gate_instance> p<480> c<469> l<46:11> el<46:18>
-n<> u<480> t<Gate_instantiation> p<481> c<467> l<46:7> el<46:19>
-n<> u<481> t<Module_or_generate_item> p<482> c<480> l<46:7> el<46:19>
-n<> u<482> t<Generate_module_item> p<484> c<481> s<483> l<46:7> el<46:19>
-n<> u<483> t<End> p<484> l<47:5> el<47:8>
-n<> u<484> t<Generate_module_block> p<485> c<466> l<45:30> el<47:8>
-n<> u<485> t<Generate_module_item> p<486> c<484> l<45:30> el<47:8>
-n<> u<486> t<Generate_module_conditional_statement> p<487> c<465> l<45:14> el<47:8>
-n<> u<487> t<Generate_module_item> p<488> c<486> l<45:14> el<47:8>
-n<> u<488> t<Generate_module_conditional_statement> p<489> c<435> l<43:14> el<47:8>
-n<> u<489> t<Generate_module_item> p<490> c<488> l<43:14> el<47:8>
-n<> u<490> t<Generate_module_conditional_statement> p<491> c<405> l<41:2> el<47:8>
-n<> u<491> t<Generate_module_item> p<493> c<490> s<492> l<41:2> el<47:8>
-n<> u<492> t<Endgenerate> p<493> l<48:3> el<48:14>
-n<> u<493> t<Generated_module_instantiation> p<494> c<491> l<40:6> el<48:14>
-n<> u<494> t<Non_port_module_item> p<495> c<493> l<40:6> el<48:14>
-n<> u<495> t<Module_item> p<664> c<494> s<547> l<40:6> el<48:14>
-n<POWER1> u<496> t<StringConst> p<497> l<51:9> el<51:15>
-n<> u<497> t<Primary_literal> p<498> c<496> l<51:9> el<51:15>
-n<> u<498> t<Constant_primary> p<499> c<497> l<51:9> el<51:15>
-n<> u<499> t<Constant_expression> p<505> c<498> s<504> l<51:9> el<51:15>
-n<0> u<500> t<IntConst> p<501> l<51:18> el<51:19>
-n<> u<501> t<Primary_literal> p<502> c<500> l<51:18> el<51:19>
-n<> u<502> t<Constant_primary> p<503> c<501> l<51:18> el<51:19>
-n<> u<503> t<Constant_expression> p<505> c<502> l<51:18> el<51:19>
-n<> u<504> t<BinOp_Great> p<505> s<503> l<51:16> el<51:17>
-n<> u<505> t<Constant_expression> p<542> c<499> s<541> l<51:9> el<51:19>
-n<g1> u<506> t<StringConst> p<540> s<538> l<51:29> el<51:31>
-n<POWER2> u<507> t<StringConst> p<508> l<52:12> el<52:18>
-n<> u<508> t<Primary_literal> p<509> c<507> l<52:12> el<52:18>
-n<> u<509> t<Constant_primary> p<510> c<508> l<52:12> el<52:18>
-n<> u<510> t<Constant_expression> p<516> c<509> s<515> l<52:12> el<52:18>
-n<1> u<511> t<IntConst> p<512> l<52:22> el<52:23>
-n<> u<512> t<Primary_literal> p<513> c<511> l<52:22> el<52:23>
-n<> u<513> t<Constant_primary> p<514> c<512> l<52:22> el<52:23>
-n<> u<514> t<Constant_expression> p<516> c<513> l<52:22> el<52:23>
-n<> u<515> t<BinOp_GreatEqual> p<516> s<514> l<52:19> el<52:21>
-n<> u<516> t<Constant_expression> p<537> c<510> s<536> l<52:12> el<52:23>
-n<g1> u<517> t<StringConst> p<535> s<533> l<52:32> el<52:34>
-n<> u<518> t<NInpGate_And> p<531> s<530> l<53:10> el<53:13>
-n<u4> u<519> t<StringConst> p<520> l<53:14> el<53:16>
-n<> u<520> t<Name_of_instance> p<530> c<519> s<525> l<53:14> el<53:16>
-n<a> u<521> t<StringConst> p<522> l<53:17> el<53:18>
-n<> u<522> t<Ps_or_hierarchical_identifier> p<525> c<521> s<524> l<53:17> el<53:18>
-n<> u<523> t<Constant_bit_select> p<524> l<53:18> el<53:18>
-n<> u<524> t<Constant_select> p<525> c<523> l<53:18> el<53:18>
-n<> u<525> t<Net_lvalue> p<530> c<522> s<529> l<53:17> el<53:18>
-n<b> u<526> t<StringConst> p<527> l<53:19> el<53:20>
-n<> u<527> t<Primary_literal> p<528> c<526> l<53:19> el<53:20>
-n<> u<528> t<Primary> p<529> c<527> l<53:19> el<53:20>
-n<> u<529> t<Expression> p<530> c<528> l<53:19> el<53:20>
-n<> u<530> t<N_input_gate_instance> p<531> c<520> l<53:14> el<53:21>
-n<> u<531> t<Gate_instantiation> p<532> c<518> l<53:10> el<53:22>
-n<> u<532> t<Module_or_generate_item> p<533> c<531> l<53:10> el<53:22>
-n<> u<533> t<Generate_module_item> p<535> c<532> s<534> l<53:10> el<53:22>
-n<> u<534> t<End> p<535> l<54:8> el<54:11>
-n<> u<535> t<Generate_module_block> p<536> c<517> l<52:25> el<54:11>
-n<> u<536> t<Generate_module_item> p<537> c<535> l<52:25> el<54:11>
-n<> u<537> t<Generate_module_conditional_statement> p<538> c<516> l<52:8> el<54:11>
-n<> u<538> t<Generate_module_item> p<540> c<537> s<539> l<52:8> el<54:11>
-n<> u<539> t<End> p<540> l<55:5> el<55:8>
-n<> u<540> t<Generate_module_block> p<541> c<506> l<51:21> el<55:8>
-n<> u<541> t<Generate_module_item> p<542> c<540> l<51:21> el<55:8>
-n<> u<542> t<Generate_module_conditional_statement> p<543> c<505> l<51:5> el<55:8>
-n<> u<543> t<Generate_module_item> p<545> c<542> s<544> l<51:5> el<55:8>
-n<> u<544> t<Endgenerate> p<545> l<56:3> el<56:14>
-n<> u<545> t<Generated_module_instantiation> p<546> c<543> l<50:2> el<56:14>
-n<> u<546> t<Non_port_module_item> p<547> c<545> l<50:2> el<56:14>
-n<> u<547> t<Module_item> p<664> c<546> s<564> l<50:2> el<56:14>
-n<> u<548> t<NInpGate_And> p<561> s<560> l<58:2> el<58:5>
-n<u4> u<549> t<StringConst> p<550> l<58:6> el<58:8>
-n<> u<550> t<Name_of_instance> p<560> c<549> s<555> l<58:6> el<58:8>
-n<a> u<551> t<StringConst> p<552> l<58:9> el<58:10>
-n<> u<552> t<Ps_or_hierarchical_identifier> p<555> c<551> s<554> l<58:9> el<58:10>
-n<> u<553> t<Constant_bit_select> p<554> l<58:10> el<58:10>
-n<> u<554> t<Constant_select> p<555> c<553> l<58:10> el<58:10>
-n<> u<555> t<Net_lvalue> p<560> c<552> s<559> l<58:9> el<58:10>
-n<b> u<556> t<StringConst> p<557> l<58:11> el<58:12>
-n<> u<557> t<Primary_literal> p<558> c<556> l<58:11> el<58:12>
-n<> u<558> t<Primary> p<559> c<557> l<58:11> el<58:12>
-n<> u<559> t<Expression> p<560> c<558> l<58:11> el<58:12>
-n<> u<560> t<N_input_gate_instance> p<561> c<550> l<58:6> el<58:13>
-n<> u<561> t<Gate_instantiation> p<562> c<548> l<58:2> el<58:14>
-n<> u<562> t<Module_or_generate_item> p<563> c<561> l<58:2> el<58:14>
-n<> u<563> t<Non_port_module_item> p<564> c<562> l<58:2> el<58:14>
-n<> u<564> t<Module_item> p<664> c<563> s<663> l<58:2> el<58:14>
-n<POWER1> u<565> t<StringConst> p<566> l<62:12> el<62:18>
-n<> u<566> t<Primary_literal> p<567> c<565> l<62:12> el<62:18>
-n<> u<567> t<Constant_primary> p<568> c<566> l<62:12> el<62:18>
-n<> u<568> t<Constant_expression> p<658> c<567> s<604> l<62:12> el<62:18>
-n<0> u<569> t<IntConst> p<570> l<63:9> el<63:10>
-n<> u<570> t<Primary_literal> p<571> c<569> l<63:9> el<63:10>
-n<> u<571> t<Constant_primary> p<572> c<570> l<63:9> el<63:10>
-n<> u<572> t<Constant_expression> p<604> c<571> s<576> l<63:9> el<63:10>
-n<1> u<573> t<IntConst> p<574> l<63:12> el<63:13>
-n<> u<574> t<Primary_literal> p<575> c<573> l<63:12> el<63:13>
-n<> u<575> t<Constant_primary> p<576> c<574> l<63:12> el<63:13>
-n<> u<576> t<Constant_expression> p<604> c<575> s<580> l<63:12> el<63:13>
-n<2> u<577> t<IntConst> p<578> l<63:15> el<63:16>
-n<> u<578> t<Primary_literal> p<579> c<577> l<63:15> el<63:16>
-n<> u<579> t<Constant_primary> p<580> c<578> l<63:15> el<63:16>
-n<> u<580> t<Constant_expression> p<604> c<579> s<603> l<63:15> el<63:16>
-n<u1> u<581> t<StringConst> p<603> s<601> l<63:26> el<63:28>
-n<> u<582> t<NInpGate_Xor> p<599> s<598> l<64:13> el<64:16>
-n<g1> u<583> t<StringConst> p<584> l<64:17> el<64:19>
-n<> u<584> t<Name_of_instance> p<598> c<583> s<589> l<64:17> el<64:19>
-n<a> u<585> t<StringConst> p<586> l<64:20> el<64:21>
-n<> u<586> t<Ps_or_hierarchical_identifier> p<589> c<585> s<588> l<64:20> el<64:21>
-n<> u<587> t<Constant_bit_select> p<588> l<64:21> el<64:21>
-n<> u<588> t<Constant_select> p<589> c<587> l<64:21> el<64:21>
-n<> u<589> t<Net_lvalue> p<598> c<586> s<593> l<64:20> el<64:21>
-n<b> u<590> t<StringConst> p<591> l<64:23> el<64:24>
-n<> u<591> t<Primary_literal> p<592> c<590> l<64:23> el<64:24>
-n<> u<592> t<Primary> p<593> c<591> l<64:23> el<64:24>
-n<> u<593> t<Expression> p<598> c<592> s<597> l<64:23> el<64:24>
-n<c> u<594> t<StringConst> p<595> l<64:26> el<64:27>
-n<> u<595> t<Primary_literal> p<596> c<594> l<64:26> el<64:27>
-n<> u<596> t<Primary> p<597> c<595> l<64:26> el<64:27>
-n<> u<597> t<Expression> p<598> c<596> l<64:26> el<64:27>
-n<> u<598> t<N_input_gate_instance> p<599> c<584> l<64:17> el<64:28>
-n<> u<599> t<Gate_instantiation> p<600> c<582> l<64:13> el<64:29>
-n<> u<600> t<Module_or_generate_item> p<601> c<599> l<64:13> el<64:29>
-n<> u<601> t<Generate_item> p<603> c<600> s<602> l<64:13> el<64:29>
-n<> u<602> t<End> p<603> l<65:11> el<65:14>
-n<> u<603> t<Generate_block> p<604> c<581> l<63:18> el<65:14>
-n<> u<604> t<Case_generate_item> p<658> c<572> s<632> l<63:9> el<65:14>
-n<3> u<605> t<IntConst> p<606> l<66:9> el<66:10>
-n<> u<606> t<Primary_literal> p<607> c<605> l<66:9> el<66:10>
-n<> u<607> t<Constant_primary> p<608> c<606> l<66:9> el<66:10>
-n<> u<608> t<Constant_expression> p<632> c<607> s<631> l<66:9> el<66:10>
-n<u1> u<609> t<StringConst> p<631> s<629> l<66:20> el<66:22>
-n<> u<610> t<NInpGate_And> p<627> s<626> l<67:13> el<67:16>
-n<g1> u<611> t<StringConst> p<612> l<67:17> el<67:19>
-n<> u<612> t<Name_of_instance> p<626> c<611> s<617> l<67:17> el<67:19>
-n<a> u<613> t<StringConst> p<614> l<67:20> el<67:21>
-n<> u<614> t<Ps_or_hierarchical_identifier> p<617> c<613> s<616> l<67:20> el<67:21>
-n<> u<615> t<Constant_bit_select> p<616> l<67:21> el<67:21>
-n<> u<616> t<Constant_select> p<617> c<615> l<67:21> el<67:21>
-n<> u<617> t<Net_lvalue> p<626> c<614> s<621> l<67:20> el<67:21>
-n<b> u<618> t<StringConst> p<619> l<67:23> el<67:24>
-n<> u<619> t<Primary_literal> p<620> c<618> l<67:23> el<67:24>
-n<> u<620> t<Primary> p<621> c<619> l<67:23> el<67:24>
-n<> u<621> t<Expression> p<626> c<620> s<625> l<67:23> el<67:24>
-n<c> u<622> t<StringConst> p<623> l<67:26> el<67:27>
-n<> u<623> t<Primary_literal> p<624> c<622> l<67:26> el<67:27>
-n<> u<624> t<Primary> p<625> c<623> l<67:26> el<67:27>
-n<> u<625> t<Expression> p<626> c<624> l<67:26> el<67:27>
-n<> u<626> t<N_input_gate_instance> p<627> c<612> l<67:17> el<67:28>
-n<> u<627> t<Gate_instantiation> p<628> c<610> l<67:13> el<67:29>
-n<> u<628> t<Module_or_generate_item> p<629> c<627> l<67:13> el<67:29>
-n<> u<629> t<Generate_item> p<631> c<628> s<630> l<67:13> el<67:29>
-n<> u<630> t<End> p<631> l<68:11> el<68:14>
-n<> u<631> t<Generate_block> p<632> c<609> l<66:12> el<68:14>
-n<> u<632> t<Case_generate_item> p<658> c<608> s<656> l<66:9> el<68:14>
-n<u1> u<633> t<StringConst> p<655> s<653> l<69:26> el<69:28>
-n<> u<634> t<NInpGate_Xnor> p<651> s<650> l<70:13> el<70:17>
-n<g1> u<635> t<StringConst> p<636> l<70:18> el<70:20>
-n<> u<636> t<Name_of_instance> p<650> c<635> s<641> l<70:18> el<70:20>
-n<a> u<637> t<StringConst> p<638> l<70:21> el<70:22>
-n<> u<638> t<Ps_or_hierarchical_identifier> p<641> c<637> s<640> l<70:21> el<70:22>
-n<> u<639> t<Constant_bit_select> p<640> l<70:22> el<70:22>
-n<> u<640> t<Constant_select> p<641> c<639> l<70:22> el<70:22>
-n<> u<641> t<Net_lvalue> p<650> c<638> s<645> l<70:21> el<70:22>
-n<b> u<642> t<StringConst> p<643> l<70:24> el<70:25>
-n<> u<643> t<Primary_literal> p<644> c<642> l<70:24> el<70:25>
-n<> u<644> t<Primary> p<645> c<643> l<70:24> el<70:25>
-n<> u<645> t<Expression> p<650> c<644> s<649> l<70:24> el<70:25>
-n<c> u<646> t<StringConst> p<647> l<70:27> el<70:28>
-n<> u<647> t<Primary_literal> p<648> c<646> l<70:27> el<70:28>
-n<> u<648> t<Primary> p<649> c<647> l<70:27> el<70:28>
-n<> u<649> t<Expression> p<650> c<648> l<70:27> el<70:28>
-n<> u<650> t<N_input_gate_instance> p<651> c<636> l<70:18> el<70:29>
-n<> u<651> t<Gate_instantiation> p<652> c<634> l<70:13> el<70:30>
-n<> u<652> t<Module_or_generate_item> p<653> c<651> l<70:13> el<70:30>
-n<> u<653> t<Generate_item> p<655> c<652> s<654> l<70:13> el<70:30>
-n<> u<654> t<End> p<655> l<71:11> el<71:14>
-n<> u<655> t<Generate_block> p<656> c<633> l<69:18> el<71:14>
-n<> u<656> t<Case_generate_item> p<658> c<655> s<657> l<69:9> el<71:14>
-n<> u<657> t<Endcase> p<658> l<72:7> el<72:14>
-n<> u<658> t<Case_generate_construct> p<659> c<568> l<62:6> el<72:14>
-n<> u<659> t<Conditional_generate_construct> p<660> c<658> l<62:6> el<72:14>
-n<> u<660> t<Module_common_item> p<661> c<659> l<62:6> el<72:14>
-n<> u<661> t<Module_or_generate_item> p<662> c<660> l<62:6> el<72:14>
-n<> u<662> t<Non_port_module_item> p<663> c<661> l<62:6> el<72:14>
-n<> u<663> t<Module_item> p<664> c<662> l<62:6> el<72:14>
-n<> u<664> t<Module_declaration> p<665> c<344> l<35:1> el<76:10>
-n<> u<665> t<Description> p<666> c<664> l<35:1> el<76:10>
-n<> u<666> t<Source_text> p<667> c<50> l<1:1> el<76:10>
-n<> u<667> t<Top_level_rule> l<1:1> el<115:1>
+n<> u<424> t<Generate_block> p<495> c<406> s<494> l<41:18> el<43:8>
+n<POWER2> u<425> t<StringConst> p<426> l<43:18> el<43:24>
+n<> u<426> t<Primary_literal> p<427> c<425> l<43:18> el<43:24>
+n<> u<427> t<Constant_primary> p<428> c<426> l<43:18> el<43:24>
+n<> u<428> t<Constant_expression> p<434> c<427> s<433> l<43:18> el<43:24>
+n<1> u<429> t<IntConst> p<430> l<43:28> el<43:29>
+n<> u<430> t<Primary_literal> p<431> c<429> l<43:28> el<43:29>
+n<> u<431> t<Constant_primary> p<432> c<430> l<43:28> el<43:29>
+n<> u<432> t<Constant_expression> p<434> c<431> l<43:28> el<43:29>
+n<> u<433> t<BinOp_Equiv> p<434> s<432> l<43:25> el<43:27>
+n<> u<434> t<Constant_expression> p<489> c<428> s<453> l<43:18> el<43:29>
+n<g1> u<435> t<StringConst> p<453> s<451> l<43:38> el<43:40>
+n<> u<436> t<NInpGate_And> p<449> s<448> l<44:7> el<44:10>
+n<u2> u<437> t<StringConst> p<438> l<44:11> el<44:13>
+n<> u<438> t<Name_of_instance> p<448> c<437> s<443> l<44:11> el<44:13>
+n<a> u<439> t<StringConst> p<440> l<44:14> el<44:15>
+n<> u<440> t<Ps_or_hierarchical_identifier> p<443> c<439> s<442> l<44:14> el<44:15>
+n<> u<441> t<Constant_bit_select> p<442> l<44:15> el<44:15>
+n<> u<442> t<Constant_select> p<443> c<441> l<44:15> el<44:15>
+n<> u<443> t<Net_lvalue> p<448> c<440> s<447> l<44:14> el<44:15>
+n<b> u<444> t<StringConst> p<445> l<44:16> el<44:17>
+n<> u<445> t<Primary_literal> p<446> c<444> l<44:16> el<44:17>
+n<> u<446> t<Primary> p<447> c<445> l<44:16> el<44:17>
+n<> u<447> t<Expression> p<448> c<446> l<44:16> el<44:17>
+n<> u<448> t<N_input_gate_instance> p<449> c<438> l<44:11> el<44:18>
+n<> u<449> t<Gate_instantiation> p<450> c<436> l<44:7> el<44:19>
+n<> u<450> t<Module_or_generate_item> p<451> c<449> l<44:7> el<44:19>
+n<> u<451> t<Generate_item> p<453> c<450> s<452> l<44:7> el<44:19>
+n<> u<452> t<End> p<453> l<45:5> el<45:8>
+n<> u<453> t<Generate_block> p<489> c<435> s<488> l<43:31> el<45:8>
+n<POWER2> u<454> t<StringConst> p<455> l<45:18> el<45:24>
+n<> u<455> t<Primary_literal> p<456> c<454> l<45:18> el<45:24>
+n<> u<456> t<Constant_primary> p<457> c<455> l<45:18> el<45:24>
+n<> u<457> t<Constant_expression> p<463> c<456> s<462> l<45:18> el<45:24>
+n<0> u<458> t<IntConst> p<459> l<45:27> el<45:28>
+n<> u<459> t<Primary_literal> p<460> c<458> l<45:27> el<45:28>
+n<> u<460> t<Constant_primary> p<461> c<459> l<45:27> el<45:28>
+n<> u<461> t<Constant_expression> p<463> c<460> l<45:27> el<45:28>
+n<> u<462> t<BinOp_Great> p<463> s<461> l<45:25> el<45:26>
+n<> u<463> t<Constant_expression> p<483> c<457> s<482> l<45:18> el<45:28>
+n<g1> u<464> t<StringConst> p<482> s<480> l<45:37> el<45:39>
+n<> u<465> t<NInpGate_And> p<478> s<477> l<46:7> el<46:10>
+n<u3> u<466> t<StringConst> p<467> l<46:11> el<46:13>
+n<> u<467> t<Name_of_instance> p<477> c<466> s<472> l<46:11> el<46:13>
+n<a> u<468> t<StringConst> p<469> l<46:14> el<46:15>
+n<> u<469> t<Ps_or_hierarchical_identifier> p<472> c<468> s<471> l<46:14> el<46:15>
+n<> u<470> t<Constant_bit_select> p<471> l<46:15> el<46:15>
+n<> u<471> t<Constant_select> p<472> c<470> l<46:15> el<46:15>
+n<> u<472> t<Net_lvalue> p<477> c<469> s<476> l<46:14> el<46:15>
+n<b> u<473> t<StringConst> p<474> l<46:16> el<46:17>
+n<> u<474> t<Primary_literal> p<475> c<473> l<46:16> el<46:17>
+n<> u<475> t<Primary> p<476> c<474> l<46:16> el<46:17>
+n<> u<476> t<Expression> p<477> c<475> l<46:16> el<46:17>
+n<> u<477> t<N_input_gate_instance> p<478> c<467> l<46:11> el<46:18>
+n<> u<478> t<Gate_instantiation> p<479> c<465> l<46:7> el<46:19>
+n<> u<479> t<Module_or_generate_item> p<480> c<478> l<46:7> el<46:19>
+n<> u<480> t<Generate_item> p<482> c<479> s<481> l<46:7> el<46:19>
+n<> u<481> t<End> p<482> l<47:5> el<47:8>
+n<> u<482> t<Generate_block> p<483> c<464> l<45:30> el<47:8>
+n<> u<483> t<If_generate_construct> p<484> c<463> l<45:14> el<47:8>
+n<> u<484> t<Conditional_generate_construct> p<485> c<483> l<45:14> el<47:8>
+n<> u<485> t<Module_common_item> p<486> c<484> l<45:14> el<47:8>
+n<> u<486> t<Module_or_generate_item> p<487> c<485> l<45:14> el<47:8>
+n<> u<487> t<Generate_item> p<488> c<486> l<45:14> el<47:8>
+n<> u<488> t<Generate_block> p<489> c<487> l<45:14> el<47:8>
+n<> u<489> t<If_generate_construct> p<490> c<434> l<43:14> el<47:8>
+n<> u<490> t<Conditional_generate_construct> p<491> c<489> l<43:14> el<47:8>
+n<> u<491> t<Module_common_item> p<492> c<490> l<43:14> el<47:8>
+n<> u<492> t<Module_or_generate_item> p<493> c<491> l<43:14> el<47:8>
+n<> u<493> t<Generate_item> p<494> c<492> l<43:14> el<47:8>
+n<> u<494> t<Generate_block> p<495> c<493> l<43:14> el<47:8>
+n<> u<495> t<If_generate_construct> p<496> c<405> l<41:2> el<47:8>
+n<> u<496> t<Conditional_generate_construct> p<497> c<495> l<41:2> el<47:8>
+n<> u<497> t<Module_common_item> p<498> c<496> l<41:2> el<47:8>
+n<> u<498> t<Module_or_generate_item> p<499> c<497> l<41:2> el<47:8>
+n<> u<499> t<Generate_item> p<500> c<498> l<41:2> el<47:8>
+n<> u<500> t<Generate_block> p<502> c<499> s<501> l<41:2> el<47:8>
+n<> u<501> t<Endgenerate> p<502> l<48:3> el<48:14>
+n<> u<502> t<Generate_region> p<503> c<500> l<40:6> el<48:14>
+n<> u<503> t<Non_port_module_item> p<504> c<502> l<40:6> el<48:14>
+n<> u<504> t<Module_item> p<678> c<503> s<561> l<40:6> el<48:14>
+n<POWER1> u<505> t<StringConst> p<506> l<51:9> el<51:15>
+n<> u<506> t<Primary_literal> p<507> c<505> l<51:9> el<51:15>
+n<> u<507> t<Constant_primary> p<508> c<506> l<51:9> el<51:15>
+n<> u<508> t<Constant_expression> p<514> c<507> s<513> l<51:9> el<51:15>
+n<0> u<509> t<IntConst> p<510> l<51:18> el<51:19>
+n<> u<510> t<Primary_literal> p<511> c<509> l<51:18> el<51:19>
+n<> u<511> t<Constant_primary> p<512> c<510> l<51:18> el<51:19>
+n<> u<512> t<Constant_expression> p<514> c<511> l<51:18> el<51:19>
+n<> u<513> t<BinOp_Great> p<514> s<512> l<51:16> el<51:17>
+n<> u<514> t<Constant_expression> p<552> c<508> s<551> l<51:9> el<51:19>
+n<g1> u<515> t<StringConst> p<551> s<549> l<51:29> el<51:31>
+n<POWER2> u<516> t<StringConst> p<517> l<52:12> el<52:18>
+n<> u<517> t<Primary_literal> p<518> c<516> l<52:12> el<52:18>
+n<> u<518> t<Constant_primary> p<519> c<517> l<52:12> el<52:18>
+n<> u<519> t<Constant_expression> p<525> c<518> s<524> l<52:12> el<52:18>
+n<1> u<520> t<IntConst> p<521> l<52:22> el<52:23>
+n<> u<521> t<Primary_literal> p<522> c<520> l<52:22> el<52:23>
+n<> u<522> t<Constant_primary> p<523> c<521> l<52:22> el<52:23>
+n<> u<523> t<Constant_expression> p<525> c<522> l<52:22> el<52:23>
+n<> u<524> t<BinOp_GreatEqual> p<525> s<523> l<52:19> el<52:21>
+n<> u<525> t<Constant_expression> p<545> c<519> s<544> l<52:12> el<52:23>
+n<g1> u<526> t<StringConst> p<544> s<542> l<52:32> el<52:34>
+n<> u<527> t<NInpGate_And> p<540> s<539> l<53:10> el<53:13>
+n<u4> u<528> t<StringConst> p<529> l<53:14> el<53:16>
+n<> u<529> t<Name_of_instance> p<539> c<528> s<534> l<53:14> el<53:16>
+n<a> u<530> t<StringConst> p<531> l<53:17> el<53:18>
+n<> u<531> t<Ps_or_hierarchical_identifier> p<534> c<530> s<533> l<53:17> el<53:18>
+n<> u<532> t<Constant_bit_select> p<533> l<53:18> el<53:18>
+n<> u<533> t<Constant_select> p<534> c<532> l<53:18> el<53:18>
+n<> u<534> t<Net_lvalue> p<539> c<531> s<538> l<53:17> el<53:18>
+n<b> u<535> t<StringConst> p<536> l<53:19> el<53:20>
+n<> u<536> t<Primary_literal> p<537> c<535> l<53:19> el<53:20>
+n<> u<537> t<Primary> p<538> c<536> l<53:19> el<53:20>
+n<> u<538> t<Expression> p<539> c<537> l<53:19> el<53:20>
+n<> u<539> t<N_input_gate_instance> p<540> c<529> l<53:14> el<53:21>
+n<> u<540> t<Gate_instantiation> p<541> c<527> l<53:10> el<53:22>
+n<> u<541> t<Module_or_generate_item> p<542> c<540> l<53:10> el<53:22>
+n<> u<542> t<Generate_item> p<544> c<541> s<543> l<53:10> el<53:22>
+n<> u<543> t<End> p<544> l<54:8> el<54:11>
+n<> u<544> t<Generate_block> p<545> c<526> l<52:25> el<54:11>
+n<> u<545> t<If_generate_construct> p<546> c<525> l<52:8> el<54:11>
+n<> u<546> t<Conditional_generate_construct> p<547> c<545> l<52:8> el<54:11>
+n<> u<547> t<Module_common_item> p<548> c<546> l<52:8> el<54:11>
+n<> u<548> t<Module_or_generate_item> p<549> c<547> l<52:8> el<54:11>
+n<> u<549> t<Generate_item> p<551> c<548> s<550> l<52:8> el<54:11>
+n<> u<550> t<End> p<551> l<55:5> el<55:8>
+n<> u<551> t<Generate_block> p<552> c<515> l<51:21> el<55:8>
+n<> u<552> t<If_generate_construct> p<553> c<514> l<51:5> el<55:8>
+n<> u<553> t<Conditional_generate_construct> p<554> c<552> l<51:5> el<55:8>
+n<> u<554> t<Module_common_item> p<555> c<553> l<51:5> el<55:8>
+n<> u<555> t<Module_or_generate_item> p<556> c<554> l<51:5> el<55:8>
+n<> u<556> t<Generate_item> p<557> c<555> l<51:5> el<55:8>
+n<> u<557> t<Generate_block> p<559> c<556> s<558> l<51:5> el<55:8>
+n<> u<558> t<Endgenerate> p<559> l<56:3> el<56:14>
+n<> u<559> t<Generate_region> p<560> c<557> l<50:2> el<56:14>
+n<> u<560> t<Non_port_module_item> p<561> c<559> l<50:2> el<56:14>
+n<> u<561> t<Module_item> p<678> c<560> s<578> l<50:2> el<56:14>
+n<> u<562> t<NInpGate_And> p<575> s<574> l<58:2> el<58:5>
+n<u4> u<563> t<StringConst> p<564> l<58:6> el<58:8>
+n<> u<564> t<Name_of_instance> p<574> c<563> s<569> l<58:6> el<58:8>
+n<a> u<565> t<StringConst> p<566> l<58:9> el<58:10>
+n<> u<566> t<Ps_or_hierarchical_identifier> p<569> c<565> s<568> l<58:9> el<58:10>
+n<> u<567> t<Constant_bit_select> p<568> l<58:10> el<58:10>
+n<> u<568> t<Constant_select> p<569> c<567> l<58:10> el<58:10>
+n<> u<569> t<Net_lvalue> p<574> c<566> s<573> l<58:9> el<58:10>
+n<b> u<570> t<StringConst> p<571> l<58:11> el<58:12>
+n<> u<571> t<Primary_literal> p<572> c<570> l<58:11> el<58:12>
+n<> u<572> t<Primary> p<573> c<571> l<58:11> el<58:12>
+n<> u<573> t<Expression> p<574> c<572> l<58:11> el<58:12>
+n<> u<574> t<N_input_gate_instance> p<575> c<564> l<58:6> el<58:13>
+n<> u<575> t<Gate_instantiation> p<576> c<562> l<58:2> el<58:14>
+n<> u<576> t<Module_or_generate_item> p<577> c<575> l<58:2> el<58:14>
+n<> u<577> t<Non_port_module_item> p<578> c<576> l<58:2> el<58:14>
+n<> u<578> t<Module_item> p<678> c<577> s<677> l<58:2> el<58:14>
+n<POWER1> u<579> t<StringConst> p<580> l<62:12> el<62:18>
+n<> u<580> t<Primary_literal> p<581> c<579> l<62:12> el<62:18>
+n<> u<581> t<Constant_primary> p<582> c<580> l<62:12> el<62:18>
+n<> u<582> t<Constant_expression> p<672> c<581> s<618> l<62:12> el<62:18>
+n<0> u<583> t<IntConst> p<584> l<63:9> el<63:10>
+n<> u<584> t<Primary_literal> p<585> c<583> l<63:9> el<63:10>
+n<> u<585> t<Constant_primary> p<586> c<584> l<63:9> el<63:10>
+n<> u<586> t<Constant_expression> p<618> c<585> s<590> l<63:9> el<63:10>
+n<1> u<587> t<IntConst> p<588> l<63:12> el<63:13>
+n<> u<588> t<Primary_literal> p<589> c<587> l<63:12> el<63:13>
+n<> u<589> t<Constant_primary> p<590> c<588> l<63:12> el<63:13>
+n<> u<590> t<Constant_expression> p<618> c<589> s<594> l<63:12> el<63:13>
+n<2> u<591> t<IntConst> p<592> l<63:15> el<63:16>
+n<> u<592> t<Primary_literal> p<593> c<591> l<63:15> el<63:16>
+n<> u<593> t<Constant_primary> p<594> c<592> l<63:15> el<63:16>
+n<> u<594> t<Constant_expression> p<618> c<593> s<617> l<63:15> el<63:16>
+n<u1> u<595> t<StringConst> p<617> s<615> l<63:26> el<63:28>
+n<> u<596> t<NInpGate_Xor> p<613> s<612> l<64:13> el<64:16>
+n<g1> u<597> t<StringConst> p<598> l<64:17> el<64:19>
+n<> u<598> t<Name_of_instance> p<612> c<597> s<603> l<64:17> el<64:19>
+n<a> u<599> t<StringConst> p<600> l<64:20> el<64:21>
+n<> u<600> t<Ps_or_hierarchical_identifier> p<603> c<599> s<602> l<64:20> el<64:21>
+n<> u<601> t<Constant_bit_select> p<602> l<64:21> el<64:21>
+n<> u<602> t<Constant_select> p<603> c<601> l<64:21> el<64:21>
+n<> u<603> t<Net_lvalue> p<612> c<600> s<607> l<64:20> el<64:21>
+n<b> u<604> t<StringConst> p<605> l<64:23> el<64:24>
+n<> u<605> t<Primary_literal> p<606> c<604> l<64:23> el<64:24>
+n<> u<606> t<Primary> p<607> c<605> l<64:23> el<64:24>
+n<> u<607> t<Expression> p<612> c<606> s<611> l<64:23> el<64:24>
+n<c> u<608> t<StringConst> p<609> l<64:26> el<64:27>
+n<> u<609> t<Primary_literal> p<610> c<608> l<64:26> el<64:27>
+n<> u<610> t<Primary> p<611> c<609> l<64:26> el<64:27>
+n<> u<611> t<Expression> p<612> c<610> l<64:26> el<64:27>
+n<> u<612> t<N_input_gate_instance> p<613> c<598> l<64:17> el<64:28>
+n<> u<613> t<Gate_instantiation> p<614> c<596> l<64:13> el<64:29>
+n<> u<614> t<Module_or_generate_item> p<615> c<613> l<64:13> el<64:29>
+n<> u<615> t<Generate_item> p<617> c<614> s<616> l<64:13> el<64:29>
+n<> u<616> t<End> p<617> l<65:11> el<65:14>
+n<> u<617> t<Generate_block> p<618> c<595> l<63:18> el<65:14>
+n<> u<618> t<Case_generate_item> p<672> c<586> s<646> l<63:9> el<65:14>
+n<3> u<619> t<IntConst> p<620> l<66:9> el<66:10>
+n<> u<620> t<Primary_literal> p<621> c<619> l<66:9> el<66:10>
+n<> u<621> t<Constant_primary> p<622> c<620> l<66:9> el<66:10>
+n<> u<622> t<Constant_expression> p<646> c<621> s<645> l<66:9> el<66:10>
+n<u1> u<623> t<StringConst> p<645> s<643> l<66:20> el<66:22>
+n<> u<624> t<NInpGate_And> p<641> s<640> l<67:13> el<67:16>
+n<g1> u<625> t<StringConst> p<626> l<67:17> el<67:19>
+n<> u<626> t<Name_of_instance> p<640> c<625> s<631> l<67:17> el<67:19>
+n<a> u<627> t<StringConst> p<628> l<67:20> el<67:21>
+n<> u<628> t<Ps_or_hierarchical_identifier> p<631> c<627> s<630> l<67:20> el<67:21>
+n<> u<629> t<Constant_bit_select> p<630> l<67:21> el<67:21>
+n<> u<630> t<Constant_select> p<631> c<629> l<67:21> el<67:21>
+n<> u<631> t<Net_lvalue> p<640> c<628> s<635> l<67:20> el<67:21>
+n<b> u<632> t<StringConst> p<633> l<67:23> el<67:24>
+n<> u<633> t<Primary_literal> p<634> c<632> l<67:23> el<67:24>
+n<> u<634> t<Primary> p<635> c<633> l<67:23> el<67:24>
+n<> u<635> t<Expression> p<640> c<634> s<639> l<67:23> el<67:24>
+n<c> u<636> t<StringConst> p<637> l<67:26> el<67:27>
+n<> u<637> t<Primary_literal> p<638> c<636> l<67:26> el<67:27>
+n<> u<638> t<Primary> p<639> c<637> l<67:26> el<67:27>
+n<> u<639> t<Expression> p<640> c<638> l<67:26> el<67:27>
+n<> u<640> t<N_input_gate_instance> p<641> c<626> l<67:17> el<67:28>
+n<> u<641> t<Gate_instantiation> p<642> c<624> l<67:13> el<67:29>
+n<> u<642> t<Module_or_generate_item> p<643> c<641> l<67:13> el<67:29>
+n<> u<643> t<Generate_item> p<645> c<642> s<644> l<67:13> el<67:29>
+n<> u<644> t<End> p<645> l<68:11> el<68:14>
+n<> u<645> t<Generate_block> p<646> c<623> l<66:12> el<68:14>
+n<> u<646> t<Case_generate_item> p<672> c<622> s<670> l<66:9> el<68:14>
+n<u1> u<647> t<StringConst> p<669> s<667> l<69:26> el<69:28>
+n<> u<648> t<NInpGate_Xnor> p<665> s<664> l<70:13> el<70:17>
+n<g1> u<649> t<StringConst> p<650> l<70:18> el<70:20>
+n<> u<650> t<Name_of_instance> p<664> c<649> s<655> l<70:18> el<70:20>
+n<a> u<651> t<StringConst> p<652> l<70:21> el<70:22>
+n<> u<652> t<Ps_or_hierarchical_identifier> p<655> c<651> s<654> l<70:21> el<70:22>
+n<> u<653> t<Constant_bit_select> p<654> l<70:22> el<70:22>
+n<> u<654> t<Constant_select> p<655> c<653> l<70:22> el<70:22>
+n<> u<655> t<Net_lvalue> p<664> c<652> s<659> l<70:21> el<70:22>
+n<b> u<656> t<StringConst> p<657> l<70:24> el<70:25>
+n<> u<657> t<Primary_literal> p<658> c<656> l<70:24> el<70:25>
+n<> u<658> t<Primary> p<659> c<657> l<70:24> el<70:25>
+n<> u<659> t<Expression> p<664> c<658> s<663> l<70:24> el<70:25>
+n<c> u<660> t<StringConst> p<661> l<70:27> el<70:28>
+n<> u<661> t<Primary_literal> p<662> c<660> l<70:27> el<70:28>
+n<> u<662> t<Primary> p<663> c<661> l<70:27> el<70:28>
+n<> u<663> t<Expression> p<664> c<662> l<70:27> el<70:28>
+n<> u<664> t<N_input_gate_instance> p<665> c<650> l<70:18> el<70:29>
+n<> u<665> t<Gate_instantiation> p<666> c<648> l<70:13> el<70:30>
+n<> u<666> t<Module_or_generate_item> p<667> c<665> l<70:13> el<70:30>
+n<> u<667> t<Generate_item> p<669> c<666> s<668> l<70:13> el<70:30>
+n<> u<668> t<End> p<669> l<71:11> el<71:14>
+n<> u<669> t<Generate_block> p<670> c<647> l<69:18> el<71:14>
+n<> u<670> t<Case_generate_item> p<672> c<669> s<671> l<69:9> el<71:14>
+n<> u<671> t<Endcase> p<672> l<72:7> el<72:14>
+n<> u<672> t<Case_generate_construct> p<673> c<582> l<62:6> el<72:14>
+n<> u<673> t<Conditional_generate_construct> p<674> c<672> l<62:6> el<72:14>
+n<> u<674> t<Module_common_item> p<675> c<673> l<62:6> el<72:14>
+n<> u<675> t<Module_or_generate_item> p<676> c<674> l<62:6> el<72:14>
+n<> u<676> t<Non_port_module_item> p<677> c<675> l<62:6> el<72:14>
+n<> u<677> t<Module_item> p<678> c<676> l<62:6> el<72:14>
+n<> u<678> t<Module_declaration> p<679> c<344> l<35:1> el<76:10>
+n<> u<679> t<Description> p<680> c<678> l<35:1> el<76:10>
+n<> u<680> t<Source_text> p<681> c<50> l<1:1> el<76:10>
+n<> u<681> t<Top_level_rule> l<1:1> el<115:1>
 [INF:PA0201] Parsing source file "small.v".
 
 LIB:  work
 FILE: small.v
-n<> u<0> t<Null_rule> p<307> s<306> l<1:1> el<1:0>
+n<> u<0> t<Null_rule> p<318> s<317> l<1:1> el<1:0>
 n<> u<1> t<Module_keyword> p<5> s<2> l<1:1> el<1:7>
 n<small_top> u<2> t<StringConst> p<5> s<4> l<1:8> el<1:17>
 n<> u<3> t<Port> p<4> l<1:18> el<1:18>
@@ -715,12 +729,12 @@ n<> u<29> t<Module_or_generate_item> p<30> c<28> l<2:4> el<2:29>
 n<> u<30> t<Non_port_module_item> p<31> c<29> l<2:4> el<2:29>
 n<> u<31> t<Module_item> p<32> c<30> l<2:4> el<2:29>
 n<> u<32> t<Module_declaration> p<33> c<5> l<1:1> el<3:10>
-n<> u<33> t<Description> p<306> c<32> s<305> l<1:1> el<3:10>
+n<> u<33> t<Description> p<317> c<32> s<316> l<1:1> el<3:10>
 n<> u<34> t<Module_keyword> p<38> s<35> l<5:1> el<5:7>
 n<small_test> u<35> t<StringConst> p<38> s<37> l<5:8> el<5:18>
 n<> u<36> t<Port> p<37> l<5:19> el<5:19>
 n<> u<37> t<List_of_ports> p<38> c<36> l<5:18> el<5:20>
-n<> u<38> t<Module_nonansi_header> p<304> c<34> s<66> l<5:1> el<5:21>
+n<> u<38> t<Module_nonansi_header> p<315> c<34> s<66> l<5:1> el<5:21>
 n<> u<39> t<Signing_Signed> p<50> s<49> l<8:14> el<8:20>
 n<3> u<40> t<IntConst> p<41> l<8:22> el<8:23>
 n<> u<41> t<Primary_literal> p<42> c<40> l<8:22> el<8:23>
@@ -748,7 +762,7 @@ n<> u<62> t<Module_or_generate_item_declaration> p<63> c<61> l<8:4> el<8:38>
 n<> u<63> t<Module_common_item> p<64> c<62> l<8:4> el<8:38>
 n<> u<64> t<Module_or_generate_item> p<65> c<63> l<8:4> el<8:38>
 n<> u<65> t<Non_port_module_item> p<66> c<64> l<8:4> el<8:38>
-n<> u<66> t<Module_item> p<304> c<65> s<83> l<8:4> el<8:38>
+n<> u<66> t<Module_item> p<315> c<65> s<83> l<8:4> el<8:38>
 n<> u<67> t<Data_type_or_implicit> p<77> s<76> l<9:14> el<9:14>
 n<dummy> u<68> t<StringConst> p<75> s<74> l<9:14> el<9:19>
 n<5> u<69> t<IntConst> p<70> l<9:22> el<9:23>
@@ -765,7 +779,7 @@ n<> u<79> t<Module_or_generate_item_declaration> p<80> c<78> l<9:4> el<9:24>
 n<> u<80> t<Module_common_item> p<81> c<79> l<9:4> el<9:24>
 n<> u<81> t<Module_or_generate_item> p<82> c<80> l<9:4> el<9:24>
 n<> u<82> t<Non_port_module_item> p<83> c<81> l<9:4> el<9:24>
-n<> u<83> t<Module_item> p<304> c<82> s<100> l<9:4> el<9:24>
+n<> u<83> t<Module_item> p<315> c<82> s<100> l<9:4> el<9:24>
 n<> u<84> t<Data_type_or_implicit> p<94> s<93> l<10:11> el<10:11>
 n<p1> u<85> t<StringConst> p<92> s<91> l<10:11> el<10:13>
 n<13'b100> u<86> t<IntConst> p<87> l<10:16> el<10:23>
@@ -782,7 +796,7 @@ n<> u<96> t<Module_or_generate_item_declaration> p<97> c<95> l<10:1> el<10:24>
 n<> u<97> t<Module_common_item> p<98> c<96> l<10:1> el<10:24>
 n<> u<98> t<Module_or_generate_item> p<99> c<97> l<10:1> el<10:24>
 n<> u<99> t<Non_port_module_item> p<100> c<98> l<10:1> el<10:24>
-n<> u<100> t<Module_item> p<304> c<99> s<111> l<10:1> el<10:24>
+n<> u<100> t<Module_item> p<315> c<99> s<111> l<10:1> el<10:24>
 n<i> u<101> t<StringConst> p<105> s<102> l<13:2> el<13:3>
 n<j> u<102> t<StringConst> p<105> s<103> l<13:5> el<13:6>
 n<k> u<103> t<StringConst> p<105> s<104> l<13:8> el<13:9>
@@ -793,13 +807,13 @@ n<> u<107> t<Module_or_generate_item_declaration> p<108> c<106> l<12:1> el<13:13
 n<> u<108> t<Module_common_item> p<109> c<107> l<12:1> el<13:13>
 n<> u<109> t<Module_or_generate_item> p<110> c<108> l<12:1> el<13:13>
 n<> u<110> t<Non_port_module_item> p<111> c<109> l<12:1> el<13:13>
-n<> u<111> t<Module_item> p<304> c<110> s<303> l<12:1> el<13:13>
+n<> u<111> t<Module_item> p<315> c<110> s<314> l<12:1> el<13:13>
 n<i> u<112> t<StringConst> p<117> s<116> l<16:3> el<16:4>
 n<0> u<113> t<IntConst> p<114> l<16:5> el<16:6>
 n<> u<114> t<Primary_literal> p<115> c<113> l<16:5> el<16:6>
 n<> u<115> t<Constant_primary> p<116> c<114> l<16:5> el<16:6>
 n<> u<116> t<Constant_expression> p<117> c<115> l<16:5> el<16:6>
-n<> u<117> t<Genvar_decl_assignment> p<298> c<112> s<127> l<16:3> el<16:6>
+n<> u<117> t<Genvar_initialization> p<306> c<112> s<127> l<16:3> el<16:6>
 n<i> u<118> t<StringConst> p<119> l<16:8> el<16:9>
 n<> u<119> t<Primary_literal> p<120> c<118> l<16:8> el<16:9>
 n<> u<120> t<Constant_primary> p<121> c<119> l<16:8> el<16:9>
@@ -809,7 +823,7 @@ n<> u<123> t<Primary_literal> p<124> c<122> l<16:10> el<16:14>
 n<> u<124> t<Constant_primary> p<125> c<123> l<16:10> el<16:14>
 n<> u<125> t<Constant_expression> p<127> c<124> l<16:10> el<16:14>
 n<> u<126> t<BinOp_Less> p<127> s<125> l<16:9> el<16:10>
-n<> u<127> t<Constant_expression> p<298> c<121> s<140> l<16:8> el<16:14>
+n<> u<127> t<Constant_expression> p<306> c<121> s<140> l<16:8> el<16:14>
 n<i> u<128> t<StringConst> p<140> s<129> l<16:16> el<16:17>
 n<> u<129> t<AssignOp_Assign> p<140> s<139> l<16:17> el<16:18>
 n<i> u<130> t<StringConst> p<131> l<16:18> el<16:19>
@@ -822,8 +836,8 @@ n<> u<136> t<Constant_primary> p<137> c<135> l<16:20> el<16:21>
 n<> u<137> t<Constant_expression> p<139> c<136> l<16:20> el<16:21>
 n<> u<138> t<BinOp_Plus> p<139> s<137> l<16:19> el<16:20>
 n<> u<139> t<Constant_expression> p<140> c<133> l<16:18> el<16:21>
-n<> u<140> t<Genvar_assignment> p<298> c<128> s<297> l<16:16> el<16:21>
-n<B1> u<141> t<StringConst> p<297> s<150> l<18:2> el<18:4>
+n<> u<140> t<Genvar_iteration> p<306> c<128> s<305> l<16:16> el<16:21>
+n<B1> u<141> t<StringConst> p<305> s<150> l<18:2> el<18:4>
 n<M1> u<142> t<StringConst> p<148> s<147> l<20:1> el<20:3>
 n<N1> u<143> t<StringConst> p<144> l<20:4> el<20:6>
 n<> u<144> t<Name_of_instance> p<147> c<143> s<146> l<20:4> el<20:6>
@@ -832,13 +846,13 @@ n<> u<146> t<List_of_port_connections> p<147> c<145> l<20:7> el<20:7>
 n<> u<147> t<Hierarchical_instance> p<148> c<144> l<20:4> el<20:8>
 n<> u<148> t<Module_instantiation> p<149> c<142> l<20:1> el<20:9>
 n<> u<149> t<Module_or_generate_item> p<150> c<148> l<20:1> el<20:9>
-n<> u<150> t<Generate_module_item> p<297> c<149> s<236> l<20:1> el<20:9>
+n<> u<150> t<Generate_item> p<305> c<149> s<240> l<20:1> el<20:9>
 n<j> u<151> t<StringConst> p<156> s<155> l<23:3> el<23:4>
 n<0> u<152> t<IntConst> p<153> l<23:5> el<23:6>
 n<> u<153> t<Primary_literal> p<154> c<152> l<23:5> el<23:6>
 n<> u<154> t<Constant_primary> p<155> c<153> l<23:5> el<23:6>
 n<> u<155> t<Constant_expression> p<156> c<154> l<23:5> el<23:6>
-n<> u<156> t<Genvar_decl_assignment> p<235> c<151> s<166> l<23:3> el<23:6>
+n<> u<156> t<Genvar_initialization> p<237> c<151> s<166> l<23:3> el<23:6>
 n<j> u<157> t<StringConst> p<158> l<23:8> el<23:9>
 n<> u<158> t<Primary_literal> p<159> c<157> l<23:8> el<23:9>
 n<> u<159> t<Constant_primary> p<160> c<158> l<23:8> el<23:9>
@@ -848,7 +862,7 @@ n<> u<162> t<Primary_literal> p<163> c<161> l<23:10> el<23:14>
 n<> u<163> t<Constant_primary> p<164> c<162> l<23:10> el<23:14>
 n<> u<164> t<Constant_expression> p<166> c<163> l<23:10> el<23:14>
 n<> u<165> t<BinOp_Less> p<166> s<164> l<23:9> el<23:10>
-n<> u<166> t<Constant_expression> p<235> c<160> s<179> l<23:8> el<23:14>
+n<> u<166> t<Constant_expression> p<237> c<160> s<179> l<23:8> el<23:14>
 n<j> u<167> t<StringConst> p<179> s<168> l<23:16> el<23:17>
 n<> u<168> t<AssignOp_Assign> p<179> s<178> l<23:17> el<23:18>
 n<j> u<169> t<StringConst> p<170> l<23:18> el<23:19>
@@ -861,8 +875,8 @@ n<> u<175> t<Constant_primary> p<176> c<174> l<23:20> el<23:21>
 n<> u<176> t<Constant_expression> p<178> c<175> l<23:20> el<23:21>
 n<> u<177> t<BinOp_Plus> p<178> s<176> l<23:19> el<23:20>
 n<> u<178> t<Constant_expression> p<179> c<172> l<23:18> el<23:21>
-n<> u<179> t<Genvar_assignment> p<235> c<167> s<234> l<23:16> el<23:21>
-n<B2> u<180> t<StringConst> p<234> s<189> l<25:2> el<25:4>
+n<> u<179> t<Genvar_iteration> p<237> c<167> s<236> l<23:16> el<23:21>
+n<B2> u<180> t<StringConst> p<236> s<189> l<25:2> el<25:4>
 n<M2> u<181> t<StringConst> p<187> s<186> l<26:1> el<26:3>
 n<N2> u<182> t<StringConst> p<183> l<26:4> el<26:6>
 n<> u<183> t<Name_of_instance> p<186> c<182> s<185> l<26:4> el<26:6>
@@ -871,13 +885,13 @@ n<> u<185> t<List_of_port_connections> p<186> c<184> l<26:7> el<26:7>
 n<> u<186> t<Hierarchical_instance> p<187> c<183> l<26:4> el<26:8>
 n<> u<187> t<Module_instantiation> p<188> c<181> l<26:1> el<26:9>
 n<> u<188> t<Module_or_generate_item> p<189> c<187> l<26:1> el<26:9>
-n<> u<189> t<Generate_module_item> p<234> c<188> s<232> l<26:1> el<26:9>
+n<> u<189> t<Generate_item> p<236> c<188> s<234> l<26:1> el<26:9>
 n<k> u<190> t<StringConst> p<195> s<194> l<30:3> el<30:4>
 n<0> u<191> t<IntConst> p<192> l<30:5> el<30:6>
 n<> u<192> t<Primary_literal> p<193> c<191> l<30:5> el<30:6>
 n<> u<193> t<Constant_primary> p<194> c<192> l<30:5> el<30:6>
 n<> u<194> t<Constant_expression> p<195> c<193> l<30:5> el<30:6>
-n<> u<195> t<Genvar_decl_assignment> p<231> c<190> s<205> l<30:3> el<30:6>
+n<> u<195> t<Genvar_initialization> p<231> c<190> s<205> l<30:3> el<30:6>
 n<k> u<196> t<StringConst> p<197> l<30:8> el<30:9>
 n<> u<197> t<Primary_literal> p<198> c<196> l<30:8> el<30:9>
 n<> u<198> t<Constant_primary> p<199> c<197> l<30:8> el<30:9>
@@ -900,7 +914,7 @@ n<> u<214> t<Constant_primary> p<215> c<213> l<30:20> el<30:21>
 n<> u<215> t<Constant_expression> p<217> c<214> l<30:20> el<30:21>
 n<> u<216> t<BinOp_Plus> p<217> s<215> l<30:19> el<30:20>
 n<> u<217> t<Constant_expression> p<218> c<211> l<30:18> el<30:21>
-n<> u<218> t<Genvar_assignment> p<231> c<206> s<230> l<30:16> el<30:21>
+n<> u<218> t<Genvar_iteration> p<231> c<206> s<230> l<30:16> el<30:21>
 n<B3> u<219> t<StringConst> p<230> s<228> l<32:2> el<32:4>
 n<M3> u<220> t<StringConst> p<226> s<225> l<33:1> el<33:3>
 n<N3> u<221> t<StringConst> p<222> l<33:4> el<33:6>
@@ -910,86 +924,97 @@ n<> u<224> t<List_of_port_connections> p<225> c<223> l<33:7> el<33:7>
 n<> u<225> t<Hierarchical_instance> p<226> c<222> l<33:4> el<33:8>
 n<> u<226> t<Module_instantiation> p<227> c<220> l<33:1> el<33:9>
 n<> u<227> t<Module_or_generate_item> p<228> c<226> l<33:1> el<33:9>
-n<> u<228> t<Generate_module_item> p<230> c<227> s<229> l<33:1> el<33:9>
+n<> u<228> t<Generate_item> p<230> c<227> s<229> l<33:1> el<33:9>
 n<> u<229> t<End> p<230> l<34:1> el<34:4>
-n<> u<230> t<Generate_module_named_block> p<231> c<219> l<31:1> el<34:4>
-n<> u<231> t<Generate_module_loop_statement> p<232> c<195> l<29:1> el<34:4>
-n<> u<232> t<Generate_module_item> p<234> c<231> s<233> l<29:1> el<34:4>
-n<> u<233> t<End> p<234> l<36:1> el<36:4>
-n<> u<234> t<Generate_module_named_block> p<235> c<180> l<24:1> el<36:4>
-n<> u<235> t<Generate_module_loop_statement> p<236> c<156> l<22:1> el<36:4>
-n<> u<236> t<Generate_module_item> p<297> c<235> s<295> l<22:1> el<36:4>
-n<i> u<237> t<StringConst> p<238> l<38:3> el<38:4>
-n<> u<238> t<Primary_literal> p<239> c<237> l<38:3> el<38:4>
-n<> u<239> t<Constant_primary> p<240> c<238> l<38:3> el<38:4>
-n<> u<240> t<Constant_expression> p<246> c<239> s<245> l<38:3> el<38:4>
-n<0> u<241> t<IntConst> p<242> l<38:5> el<38:6>
-n<> u<242> t<Primary_literal> p<243> c<241> l<38:5> el<38:6>
-n<> u<243> t<Constant_primary> p<244> c<242> l<38:5> el<38:6>
-n<> u<244> t<Constant_expression> p<246> c<243> l<38:5> el<38:6>
-n<> u<245> t<BinOp_Great> p<246> s<244> l<38:4> el<38:5>
-n<> u<246> t<Constant_expression> p<294> c<240> s<293> l<38:3> el<38:6>
-n<B4> u<247> t<StringConst> p<292> s<290> l<40:2> el<40:4>
-n<m> u<248> t<StringConst> p<253> s<252> l<43:3> el<43:4>
-n<0> u<249> t<IntConst> p<250> l<43:5> el<43:6>
-n<> u<250> t<Primary_literal> p<251> c<249> l<43:5> el<43:6>
-n<> u<251> t<Constant_primary> p<252> c<250> l<43:5> el<43:6>
-n<> u<252> t<Constant_expression> p<253> c<251> l<43:5> el<43:6>
-n<> u<253> t<Genvar_decl_assignment> p<289> c<248> s<263> l<43:3> el<43:6>
-n<m> u<254> t<StringConst> p<255> l<43:8> el<43:9>
-n<> u<255> t<Primary_literal> p<256> c<254> l<43:8> el<43:9>
-n<> u<256> t<Constant_primary> p<257> c<255> l<43:8> el<43:9>
-n<> u<257> t<Constant_expression> p<263> c<256> s<262> l<43:8> el<43:9>
-n<SIZE> u<258> t<StringConst> p<259> l<43:10> el<43:14>
-n<> u<259> t<Primary_literal> p<260> c<258> l<43:10> el<43:14>
-n<> u<260> t<Constant_primary> p<261> c<259> l<43:10> el<43:14>
-n<> u<261> t<Constant_expression> p<263> c<260> l<43:10> el<43:14>
-n<> u<262> t<BinOp_Less> p<263> s<261> l<43:9> el<43:10>
-n<> u<263> t<Constant_expression> p<289> c<257> s<276> l<43:8> el<43:14>
-n<m> u<264> t<StringConst> p<276> s<265> l<43:16> el<43:17>
-n<> u<265> t<AssignOp_Assign> p<276> s<275> l<43:17> el<43:18>
-n<m> u<266> t<StringConst> p<267> l<43:18> el<43:19>
-n<> u<267> t<Primary_literal> p<268> c<266> l<43:18> el<43:19>
-n<> u<268> t<Constant_primary> p<269> c<267> l<43:18> el<43:19>
-n<> u<269> t<Constant_expression> p<275> c<268> s<274> l<43:18> el<43:19>
-n<1> u<270> t<IntConst> p<271> l<43:20> el<43:21>
-n<> u<271> t<Primary_literal> p<272> c<270> l<43:20> el<43:21>
-n<> u<272> t<Constant_primary> p<273> c<271> l<43:20> el<43:21>
-n<> u<273> t<Constant_expression> p<275> c<272> l<43:20> el<43:21>
-n<> u<274> t<BinOp_Plus> p<275> s<273> l<43:19> el<43:20>
-n<> u<275> t<Constant_expression> p<276> c<269> l<43:18> el<43:21>
-n<> u<276> t<Genvar_assignment> p<289> c<264> s<288> l<43:16> el<43:21>
-n<B5> u<277> t<StringConst> p<288> s<286> l<45:2> el<45:4>
-n<M4> u<278> t<StringConst> p<284> s<283> l<46:1> el<46:3>
-n<N4> u<279> t<StringConst> p<280> l<46:4> el<46:6>
-n<> u<280> t<Name_of_instance> p<283> c<279> s<282> l<46:4> el<46:6>
-n<> u<281> t<Ordered_port_connection> p<282> l<46:7> el<46:7>
-n<> u<282> t<List_of_port_connections> p<283> c<281> l<46:7> el<46:7>
-n<> u<283> t<Hierarchical_instance> p<284> c<280> l<46:4> el<46:8>
-n<> u<284> t<Module_instantiation> p<285> c<278> l<46:1> el<46:9>
-n<> u<285> t<Module_or_generate_item> p<286> c<284> l<46:1> el<46:9>
-n<> u<286> t<Generate_module_item> p<288> c<285> s<287> l<46:1> el<46:9>
-n<> u<287> t<End> p<288> l<48:1> el<48:4>
-n<> u<288> t<Generate_module_named_block> p<289> c<277> l<44:1> el<48:4>
-n<> u<289> t<Generate_module_loop_statement> p<290> c<253> l<42:1> el<48:4>
-n<> u<290> t<Generate_module_item> p<292> c<289> s<291> l<42:1> el<48:4>
-n<> u<291> t<End> p<292> l<50:1> el<50:4>
-n<> u<292> t<Generate_module_block> p<293> c<247> l<39:1> el<50:4>
-n<> u<293> t<Generate_module_item> p<294> c<292> l<39:1> el<50:4>
-n<> u<294> t<Generate_module_conditional_statement> p<295> c<246> l<37:1> el<50:4>
-n<> u<295> t<Generate_module_item> p<297> c<294> s<296> l<37:1> el<50:4>
-n<> u<296> t<End> p<297> l<51:1> el<51:4>
-n<> u<297> t<Generate_module_named_block> p<298> c<141> l<17:1> el<51:4>
-n<> u<298> t<Generate_module_loop_statement> p<299> c<117> l<15:1> el<51:4>
-n<> u<299> t<Generate_module_item> p<301> c<298> s<300> l<15:1> el<51:4>
-n<> u<300> t<Endgenerate> p<301> l<52:1> el<52:12>
-n<> u<301> t<Generated_module_instantiation> p<302> c<299> l<14:1> el<52:12>
-n<> u<302> t<Non_port_module_item> p<303> c<301> l<14:1> el<52:12>
-n<> u<303> t<Module_item> p<304> c<302> l<14:1> el<52:12>
-n<> u<304> t<Module_declaration> p<305> c<38> l<5:1> el<54:10>
-n<> u<305> t<Description> p<306> c<304> l<5:1> el<54:10>
-n<> u<306> t<Source_text> p<307> c<33> l<1:1> el<54:10>
-n<> u<307> t<Top_level_rule> l<1:1> el<56:1>
+n<> u<230> t<Generate_block> p<231> c<219> l<31:1> el<34:4>
+n<> u<231> t<Loop_generate_construct> p<232> c<195> l<29:1> el<34:4>
+n<> u<232> t<Module_common_item> p<233> c<231> l<29:1> el<34:4>
+n<> u<233> t<Module_or_generate_item> p<234> c<232> l<29:1> el<34:4>
+n<> u<234> t<Generate_item> p<236> c<233> s<235> l<29:1> el<34:4>
+n<> u<235> t<End> p<236> l<36:1> el<36:4>
+n<> u<236> t<Generate_block> p<237> c<180> l<24:1> el<36:4>
+n<> u<237> t<Loop_generate_construct> p<238> c<156> l<22:1> el<36:4>
+n<> u<238> t<Module_common_item> p<239> c<237> l<22:1> el<36:4>
+n<> u<239> t<Module_or_generate_item> p<240> c<238> l<22:1> el<36:4>
+n<> u<240> t<Generate_item> p<305> c<239> s<303> l<22:1> el<36:4>
+n<i> u<241> t<StringConst> p<242> l<38:3> el<38:4>
+n<> u<242> t<Primary_literal> p<243> c<241> l<38:3> el<38:4>
+n<> u<243> t<Constant_primary> p<244> c<242> l<38:3> el<38:4>
+n<> u<244> t<Constant_expression> p<250> c<243> s<249> l<38:3> el<38:4>
+n<0> u<245> t<IntConst> p<246> l<38:5> el<38:6>
+n<> u<246> t<Primary_literal> p<247> c<245> l<38:5> el<38:6>
+n<> u<247> t<Constant_primary> p<248> c<246> l<38:5> el<38:6>
+n<> u<248> t<Constant_expression> p<250> c<247> l<38:5> el<38:6>
+n<> u<249> t<BinOp_Great> p<250> s<248> l<38:4> el<38:5>
+n<> u<250> t<Constant_expression> p<299> c<244> s<298> l<38:3> el<38:6>
+n<B4> u<251> t<StringConst> p<298> s<296> l<40:2> el<40:4>
+n<m> u<252> t<StringConst> p<257> s<256> l<43:3> el<43:4>
+n<0> u<253> t<IntConst> p<254> l<43:5> el<43:6>
+n<> u<254> t<Primary_literal> p<255> c<253> l<43:5> el<43:6>
+n<> u<255> t<Constant_primary> p<256> c<254> l<43:5> el<43:6>
+n<> u<256> t<Constant_expression> p<257> c<255> l<43:5> el<43:6>
+n<> u<257> t<Genvar_initialization> p<293> c<252> s<267> l<43:3> el<43:6>
+n<m> u<258> t<StringConst> p<259> l<43:8> el<43:9>
+n<> u<259> t<Primary_literal> p<260> c<258> l<43:8> el<43:9>
+n<> u<260> t<Constant_primary> p<261> c<259> l<43:8> el<43:9>
+n<> u<261> t<Constant_expression> p<267> c<260> s<266> l<43:8> el<43:9>
+n<SIZE> u<262> t<StringConst> p<263> l<43:10> el<43:14>
+n<> u<263> t<Primary_literal> p<264> c<262> l<43:10> el<43:14>
+n<> u<264> t<Constant_primary> p<265> c<263> l<43:10> el<43:14>
+n<> u<265> t<Constant_expression> p<267> c<264> l<43:10> el<43:14>
+n<> u<266> t<BinOp_Less> p<267> s<265> l<43:9> el<43:10>
+n<> u<267> t<Constant_expression> p<293> c<261> s<280> l<43:8> el<43:14>
+n<m> u<268> t<StringConst> p<280> s<269> l<43:16> el<43:17>
+n<> u<269> t<AssignOp_Assign> p<280> s<279> l<43:17> el<43:18>
+n<m> u<270> t<StringConst> p<271> l<43:18> el<43:19>
+n<> u<271> t<Primary_literal> p<272> c<270> l<43:18> el<43:19>
+n<> u<272> t<Constant_primary> p<273> c<271> l<43:18> el<43:19>
+n<> u<273> t<Constant_expression> p<279> c<272> s<278> l<43:18> el<43:19>
+n<1> u<274> t<IntConst> p<275> l<43:20> el<43:21>
+n<> u<275> t<Primary_literal> p<276> c<274> l<43:20> el<43:21>
+n<> u<276> t<Constant_primary> p<277> c<275> l<43:20> el<43:21>
+n<> u<277> t<Constant_expression> p<279> c<276> l<43:20> el<43:21>
+n<> u<278> t<BinOp_Plus> p<279> s<277> l<43:19> el<43:20>
+n<> u<279> t<Constant_expression> p<280> c<273> l<43:18> el<43:21>
+n<> u<280> t<Genvar_iteration> p<293> c<268> s<292> l<43:16> el<43:21>
+n<B5> u<281> t<StringConst> p<292> s<290> l<45:2> el<45:4>
+n<M4> u<282> t<StringConst> p<288> s<287> l<46:1> el<46:3>
+n<N4> u<283> t<StringConst> p<284> l<46:4> el<46:6>
+n<> u<284> t<Name_of_instance> p<287> c<283> s<286> l<46:4> el<46:6>
+n<> u<285> t<Ordered_port_connection> p<286> l<46:7> el<46:7>
+n<> u<286> t<List_of_port_connections> p<287> c<285> l<46:7> el<46:7>
+n<> u<287> t<Hierarchical_instance> p<288> c<284> l<46:4> el<46:8>
+n<> u<288> t<Module_instantiation> p<289> c<282> l<46:1> el<46:9>
+n<> u<289> t<Module_or_generate_item> p<290> c<288> l<46:1> el<46:9>
+n<> u<290> t<Generate_item> p<292> c<289> s<291> l<46:1> el<46:9>
+n<> u<291> t<End> p<292> l<48:1> el<48:4>
+n<> u<292> t<Generate_block> p<293> c<281> l<44:1> el<48:4>
+n<> u<293> t<Loop_generate_construct> p<294> c<257> l<42:1> el<48:4>
+n<> u<294> t<Module_common_item> p<295> c<293> l<42:1> el<48:4>
+n<> u<295> t<Module_or_generate_item> p<296> c<294> l<42:1> el<48:4>
+n<> u<296> t<Generate_item> p<298> c<295> s<297> l<42:1> el<48:4>
+n<> u<297> t<End> p<298> l<50:1> el<50:4>
+n<> u<298> t<Generate_block> p<299> c<251> l<39:1> el<50:4>
+n<> u<299> t<If_generate_construct> p<300> c<250> l<37:1> el<50:4>
+n<> u<300> t<Conditional_generate_construct> p<301> c<299> l<37:1> el<50:4>
+n<> u<301> t<Module_common_item> p<302> c<300> l<37:1> el<50:4>
+n<> u<302> t<Module_or_generate_item> p<303> c<301> l<37:1> el<50:4>
+n<> u<303> t<Generate_item> p<305> c<302> s<304> l<37:1> el<50:4>
+n<> u<304> t<End> p<305> l<51:1> el<51:4>
+n<> u<305> t<Generate_block> p<306> c<141> l<17:1> el<51:4>
+n<> u<306> t<Loop_generate_construct> p<307> c<117> l<15:1> el<51:4>
+n<> u<307> t<Module_common_item> p<308> c<306> l<15:1> el<51:4>
+n<> u<308> t<Module_or_generate_item> p<309> c<307> l<15:1> el<51:4>
+n<> u<309> t<Generate_item> p<310> c<308> l<15:1> el<51:4>
+n<> u<310> t<Generate_block> p<312> c<309> s<311> l<15:1> el<51:4>
+n<> u<311> t<Endgenerate> p<312> l<52:1> el<52:12>
+n<> u<312> t<Generate_region> p<313> c<310> l<14:1> el<52:12>
+n<> u<313> t<Non_port_module_item> p<314> c<312> l<14:1> el<52:12>
+n<> u<314> t<Module_item> p<315> c<313> l<14:1> el<52:12>
+n<> u<315> t<Module_declaration> p<316> c<38> l<5:1> el<54:10>
+n<> u<316> t<Description> p<317> c<315> l<5:1> el<54:10>
+n<> u<317> t<Source_text> p<318> c<33> l<1:1> el<54:10>
+n<> u<318> t<Top_level_rule> l<1:1> el<56:1>
 [WRN:PA0205] top.v:1: No timescale set for "bottom1".
 
 [WRN:PA0205] top.v:6: No timescale set for "bottom2".

--- a/third_party/tests/Google/Google.log
+++ b/third_party/tests/Google/Google.log
@@ -2673,13 +2673,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-prec-uvm.sv -l 16.12--property-prec-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -2687,7 +2681,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2705,13 +2705,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.9--sequence-fell-uvm.sv -l 16.9--sequence-fell-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -2719,7 +2713,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2743,13 +2743,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assert-uvm.sv -l 16.2--assert-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -2757,7 +2751,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2793,13 +2793,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-uvm.sv -l 16.7--sequence-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -2807,7 +2801,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2825,13 +2825,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.15--property-iff-uvm-fail.sv -l 16.15--property-iff-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -2839,7 +2833,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2863,13 +2863,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.17--expect-uvm.sv -l 16.17--expect-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -2877,7 +2871,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2909,13 +2909,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-and-range-uvm.sv -l 16.7--sequence-and-range-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -2923,7 +2917,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2947,13 +2947,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-uvm.sv -l 16.12--property-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -2961,7 +2955,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -2997,13 +2997,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assert-final-uvm.sv -l 16.2--assert-final-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3011,7 +3005,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3041,13 +3041,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.10--property-local-var-uvm.sv -l 16.10--property-local-var-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3055,7 +3049,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3073,13 +3073,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.14--assume-property-uvm-fail.sv -l 16.14--assume-property-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3087,7 +3081,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3105,13 +3105,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.10--sequence-local-var-uvm.sv -l 16.10--sequence-local-var-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3119,7 +3113,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3161,13 +3161,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.9--sequence-stable-uvm.sv -l 16.9--sequence-stable-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3175,7 +3169,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3193,13 +3193,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.11--sequence-subroutine-uvm.sv -l 16.11--sequence-subroutine-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3207,7 +3201,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3243,13 +3243,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-interface-uvm-fail.sv -l 16.12--property-interface-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3257,7 +3251,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3281,13 +3281,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-uvm-fail.sv -l 16.7--sequence-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3295,7 +3289,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3313,13 +3313,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.10--property-local-var-uvm-fail.sv -l 16.10--property-local-var-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3327,7 +3321,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3345,13 +3345,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.17--expect-uvm-fail.sv -l 16.17--expect-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3359,7 +3353,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3385,13 +3385,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.15--property-iff-uvm.sv -l 16.15--property-iff-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3399,7 +3393,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3423,13 +3423,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.13--sequence-multiclock-uvm.sv -l 16.13--sequence-multiclock-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3437,7 +3431,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3461,13 +3461,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-intersect-uvm.sv -l 16.7--sequence-intersect-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3475,7 +3469,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3493,13 +3493,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-or-uvm.sv -l 16.7--sequence-or-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3507,7 +3501,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3525,13 +3525,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.9--sequence-past-uvm.sv -l 16.9--sequence-past-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3539,7 +3533,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3557,13 +3557,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assume-uvm-fail.sv -l 16.2--assume-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3571,7 +3565,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3589,13 +3589,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-throughout-uvm-fail.sv -l 16.7--sequence-throughout-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3603,7 +3597,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3621,13 +3621,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.9--sequence-changed-uvm.sv -l 16.9--sequence-changed-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3635,7 +3629,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3653,13 +3653,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-uvm-fail.sv -l 16.12--property-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3667,7 +3661,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3685,13 +3685,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.14--assume-property-uvm.sv -l 16.14--assume-property-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3699,7 +3693,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3717,13 +3717,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-prec-uvm-fail.sv -l 16.12--property-prec-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3731,7 +3725,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3749,13 +3749,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-and-uvm.sv -l 16.7--sequence-and-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3763,7 +3757,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3799,13 +3799,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-interface-uvm.sv -l 16.12--property-interface-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3813,7 +3807,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3837,13 +3837,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assume-uvm.sv -l 16.2--assume-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3851,7 +3845,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3869,13 +3869,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-intersect-uvm-fail.sv -l 16.7--sequence-intersect-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3883,7 +3877,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3913,13 +3913,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-throughout-uvm.sv -l 16.7--sequence-throughout-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3927,7 +3921,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3945,13 +3945,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-interface-prec-uvm.sv -l 16.12--property-interface-prec-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3959,7 +3953,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 
@@ -3977,13 +3977,7 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assert0-uvm.sv -l 16.2--assert0-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:8: Unused macro argument "TYPE".
 
@@ -3991,7 +3985,13 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:8: Unused macro argument "TYPE".
 
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:12: Unused macro argument "TR_HANDLE".
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:8: Unused macro argument "FLAG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:8: Unused macro argument "ARG".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:8: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:8: Unused macro argument "CB".
 

--- a/third_party/tests/NyuziProcessor/NyuziProcessor.log
+++ b/third_party/tests/NyuziProcessor/NyuziProcessor.log
@@ -451,6 +451,8 @@ there are 2 more instances of this message.
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv:87: Compile generate block "work@soc_tb.nyuzi.l2_cache.l2_cache_arb_stage.genblk2".
 
+[INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv:135: Compile generate block "work@soc_tb.nyuzi.l2_cache.l2_cache_tag_stage.cache_lru.genblk1".
+
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv:83: Compile generate block "work@soc_tb.nyuzi.l2_cache.l2_cache_tag_stage.way_tags_gen[0]".
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv:83: Compile generate block "work@soc_tb.nyuzi.l2_cache.l2_cache_tag_stage.way_tags_gen[1]".
@@ -743,7 +745,7 @@ there are 2 more instances of this message.
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_interconnect.sv:80: Compile generate block "work@soc_tb.nyuzi.io_interconnect.genblk2".
 
-[INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv:109: Compile generate block "work@soc_tb.nyuzi.genblk1".
+[INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv:112: Compile generate block "work@soc_tb.nyuzi.genblk1".
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv:117: Compile generate block "work@soc_tb.nyuzi.core_gen[0]".
 
@@ -770,6 +772,8 @@ there are 2 more instances of this message.
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv:88: Compile generate block "work@soc_tb.nyuzi.core_gen[0].core.ifetch_tag_stage.itlb.way_gen[2]".
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv:88: Compile generate block "work@soc_tb.nyuzi.core_gen[0].core.ifetch_tag_stage.itlb.way_gen[3]".
+
+[INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv:135: Compile generate block "work@soc_tb.nyuzi.core_gen[0].core.ifetch_tag_stage.cache_lru.genblk1".
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv:117: Compile generate block "work@soc_tb.nyuzi.core_gen[0].core.ifetch_data_stage.hit_check_gen[0]".
 
@@ -1010,6 +1014,8 @@ there are 2 more instances of this message.
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv:88: Compile generate block "work@soc_tb.nyuzi.core_gen[0].core.dcache_tag_stage.dtlb.way_gen[2]".
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv:88: Compile generate block "work@soc_tb.nyuzi.core_gen[0].core.dcache_tag_stage.dtlb.way_gen[3]".
+
+[INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv:135: Compile generate block "work@soc_tb.nyuzi.core_gen[0].core.dcache_tag_stage.lru.genblk1".
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/int_execute_stage.sv:77: Compile generate block "work@soc_tb.nyuzi.core_gen[0].core.int_execute_stage.lane_alu_gen[0]".
 
@@ -1469,16 +1475,13 @@ there are 2 more instances of this message.
 
 [INF:UH0707] Elaborating UHDM...
 
-[ERR:UH0717] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv:138:24: Multiple continuous assignments to: fill_way,
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv:144:24: other assignment.
-
 [INF:UH0708] Writing UHDM DB: ../../../build/tests/NyuziProcessor/slpp_all/surelog.uhdm ...
 
 [INF:UH0709] Writing UHDM Html Coverage: ../../../build/tests/NyuziProcessor/slpp_all/surelog.uhdm.chk.html ...
 
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 12
 

--- a/third_party/tests/Scr1/Scr1.log
+++ b/third_party/tests/Scr1/Scr1.log
@@ -519,11 +519,11 @@ Compilation took t.ttts
 
 [INF:CP0335] src/core/scr1_core_top.sv:224: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.gen_rst_inputs_sync".
 
-[INF:CP0335] src/pipeline/scr1_pipe_csr.sv:745: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_pipe_top.i_pipe_csr.mtvec_base_ro_rw".
+[INF:CP0335] src/pipeline/scr1_pipe_csr.sv:744: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_pipe_top.i_pipe_csr.mtvec_base_ro_rw".
 
 [INF:CP0335] src/pipeline/scr1_pipe_hdu.sv:641: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_pipe_top.i_pipe_hdu.genblk1".
 
-[INF:CP0335] src/core/scr1_tapc_shift_reg.sv:59: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_tapc.i_bypass_reg.dr_shift_reg".
+[INF:CP0335] src/core/scr1_tapc_shift_reg.sv:57: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_tapc.i_bypass_reg.dr_shift_reg".
 
 [INF:CP0335] src/core/scr1_tapc_shift_reg.sv:37: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_tapc.i_tap_idcode_reg.dr_shift_reg".
 

--- a/third_party/tests/Scr1SvTests/Scr1SvTests.log
+++ b/third_party/tests/Scr1SvTests/Scr1SvTests.log
@@ -242,25 +242,25 @@
 
 [INF:EL0526] Design Elaboration...
 
-[INF:CP0335] src/core/primitives/scr1_reset_cells.sv:82: Compile generate block "work@scr1_top_tb_axi.i_top.i_pwrup_rstn_reset_sync.gen_reset_sync_cell_multi".
+[INF:CP0335] src/core/primitives/scr1_reset_cells.sv:81: Compile generate block "work@scr1_top_tb_axi.i_top.i_pwrup_rstn_reset_sync.gen_reset_sync_cell_multi".
 
-[INF:CP0335] src/core/primitives/scr1_reset_cells.sv:82: Compile generate block "work@scr1_top_tb_axi.i_top.i_rstn_reset_sync.gen_reset_sync_cell_multi".
+[INF:CP0335] src/core/primitives/scr1_reset_cells.sv:81: Compile generate block "work@scr1_top_tb_axi.i_top.i_rstn_reset_sync.gen_reset_sync_cell_multi".
 
-[INF:CP0335] src/core/primitives/scr1_reset_cells.sv:82: Compile generate block "work@scr1_top_tb_axi.i_top.i_cpu_rstn_reset_sync.gen_reset_sync_cell_multi".
+[INF:CP0335] src/core/primitives/scr1_reset_cells.sv:81: Compile generate block "work@scr1_top_tb_axi.i_top.i_cpu_rstn_reset_sync.gen_reset_sync_cell_multi".
 
-[INF:CP0335] src/core/primitives/scr1_reset_cells.sv:130: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_scu.i_sys_rstn_status_sync.gen_data_sync_cell_multi".
+[INF:CP0335] src/core/primitives/scr1_reset_cells.sv:129: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_scu.i_sys_rstn_status_sync.gen_data_sync_cell_multi".
 
-[INF:CP0335] src/core/primitives/scr1_reset_cells.sv:130: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_scu.i_core_rstn_status_sync.gen_data_sync_cell_multi".
+[INF:CP0335] src/core/primitives/scr1_reset_cells.sv:129: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_scu.i_core_rstn_status_sync.gen_data_sync_cell_multi".
 
-[INF:CP0335] src/core/primitives/scr1_reset_cells.sv:130: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_scu.i_hdu_rstn_status_sync.gen_data_sync_cell_multi".
+[INF:CP0335] src/core/primitives/scr1_reset_cells.sv:129: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_scu.i_hdu_rstn_status_sync.gen_data_sync_cell_multi".
 
-[INF:CP0335] src/core/pipeline/scr1_pipe_csr.sv:703: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_pipe_top.i_pipe_csr.mtvec_base_ro_rw".
+[INF:CP0335] src/core/pipeline/scr1_pipe_csr.sv:701: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_pipe_top.i_pipe_csr.mtvec_base_ro_rw".
 
 [INF:CP0335] src/core/pipeline/scr1_pipe_hdu.sv:611: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_pipe_top.i_pipe_hdu.genblk1".
 
 [INF:CP0335] src/core/pipeline/scr1_pipe_hdu.sv:830: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_pipe_top.i_pipe_hdu.genblk2".
 
-[INF:CP0335] src/core/scr1_tapc_shift_reg.sv:59: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_tapc.i_bypass_reg.dr_shift_reg".
+[INF:CP0335] src/core/scr1_tapc_shift_reg.sv:57: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_tapc.i_bypass_reg.dr_shift_reg".
 
 [INF:CP0335] src/core/scr1_tapc_shift_reg.sv:37: Compile generate block "work@scr1_top_tb_axi.i_top.i_core_top.i_tapc.i_tap_idcode_reg.dr_shift_reg".
 

--- a/third_party/tests/XilinxUnisimLibrary/Unisim.log
+++ b/third_party/tests/XilinxUnisimLibrary/Unisim.log
@@ -5,33 +5,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IOBUFDS_DIFF_OUT_INTERMDISABLE.v -l IOBUFDS_DIFF_OUT_INTERMDISABLE.v.log
-[ERR:UH0717] IOBUFDS_DIFF_OUT_INTERMDISABLE.v:138:32: Multiple continuous assignments to: out_val,
-             IOBUFDS_DIFF_OUT_INTERMDISABLE.v:142:32: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_INTERMDISABLE.v:138:32: Multiple continuous assignments to: out_val,
-             IOBUFDS_DIFF_OUT_INTERMDISABLE.v:146:12: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_INTERMDISABLE.v:139:32: Multiple continuous assignments to: out_b_val,
-             IOBUFDS_DIFF_OUT_INTERMDISABLE.v:143:32: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_INTERMDISABLE.v:139:32: Multiple continuous assignments to: out_b_val,
-             IOBUFDS_DIFF_OUT_INTERMDISABLE.v:147:12: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_INTERMDISABLE.v:142:32: Multiple continuous assignments to: out_val,
-             IOBUFDS_DIFF_OUT_INTERMDISABLE.v:146:12: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_INTERMDISABLE.v:143:32: Multiple continuous assignments to: out_b_val,
-             IOBUFDS_DIFF_OUT_INTERMDISABLE.v:147:12: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_INTERMDISABLE.v:181:31: Multiple continuous assignments to: O,
-             IOBUFDS_DIFF_OUT_INTERMDISABLE.v:185:32: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_INTERMDISABLE.v:182:31: Multiple continuous assignments to: OB,
-             IOBUFDS_DIFF_OUT_INTERMDISABLE.v:186:32: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 8
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v MMCME4_ADV.v -l MMCME4_ADV.v.log
@@ -71,12 +47,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 3
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IBUFDS_INTERMDISABLE.v -l IBUFDS_INTERMDISABLE.v.log
-[ERR:UH0717] IBUFDS_INTERMDISABLE.v:151:32: Multiple continuous assignments to: out_val,
-             IBUFDS_INTERMDISABLE.v:154:32: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v DNA_PORTE2.v -l DNA_PORTE2.v.log
@@ -128,12 +101,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 3
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IBUFE3.v -l IBUFE3.v.log
-[ERR:UH0717] IBUFE3.v:253:22: Multiple continuous assignments to: O_out,
-             IBUFE3.v:256:17: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v OBUFDS_GTE4.v -l OBUFDS_GTE4.v.log
@@ -347,12 +317,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 3
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IBUFCTRL.v -l IBUFCTRL.v.log
-[ERR:UH0717] IBUFCTRL.v:141:22: Multiple continuous assignments to: O_out,
-             IBUFCTRL.v:144:22: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v OBUF.v -l OBUF.v.log
@@ -488,33 +455,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IBUFDS_DIFF_OUT_IBUFDISABLE.v -l IBUFDS_DIFF_OUT_IBUFDISABLE.v.log
-[ERR:UH0717] IBUFDS_DIFF_OUT_IBUFDISABLE.v:146:12: Multiple continuous assignments to: out_val,
-             IBUFDS_DIFF_OUT_IBUFDISABLE.v:150:12: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_IBUFDISABLE.v:146:12: Multiple continuous assignments to: out_val,
-             IBUFDS_DIFF_OUT_IBUFDISABLE.v:154:12: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_IBUFDISABLE.v:147:12: Multiple continuous assignments to: out_b_val,
-             IBUFDS_DIFF_OUT_IBUFDISABLE.v:151:12: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_IBUFDISABLE.v:147:12: Multiple continuous assignments to: out_b_val,
-             IBUFDS_DIFF_OUT_IBUFDISABLE.v:155:12: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_IBUFDISABLE.v:150:12: Multiple continuous assignments to: out_val,
-             IBUFDS_DIFF_OUT_IBUFDISABLE.v:154:12: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_IBUFDISABLE.v:151:12: Multiple continuous assignments to: out_b_val,
-             IBUFDS_DIFF_OUT_IBUFDISABLE.v:155:12: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_IBUFDISABLE.v:163:31: Multiple continuous assignments to: O,
-             IBUFDS_DIFF_OUT_IBUFDISABLE.v:167:31: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_IBUFDISABLE.v:164:31: Multiple continuous assignments to: OB,
-             IBUFDS_DIFF_OUT_IBUFDISABLE.v:168:31: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 8
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v PHY_CONTROL.v -l PHY_CONTROL.v.log
@@ -743,33 +686,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 3
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IBUFDS_DIFF_OUT_INTERMDISABLE.v -l IBUFDS_DIFF_OUT_INTERMDISABLE.v.log
-[ERR:UH0717] IBUFDS_DIFF_OUT_INTERMDISABLE.v:144:32: Multiple continuous assignments to: out_val,
-             IBUFDS_DIFF_OUT_INTERMDISABLE.v:148:32: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_INTERMDISABLE.v:144:32: Multiple continuous assignments to: out_val,
-             IBUFDS_DIFF_OUT_INTERMDISABLE.v:152:12: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_INTERMDISABLE.v:145:32: Multiple continuous assignments to: out_b_val,
-             IBUFDS_DIFF_OUT_INTERMDISABLE.v:149:32: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_INTERMDISABLE.v:145:32: Multiple continuous assignments to: out_b_val,
-             IBUFDS_DIFF_OUT_INTERMDISABLE.v:153:12: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_INTERMDISABLE.v:148:32: Multiple continuous assignments to: out_val,
-             IBUFDS_DIFF_OUT_INTERMDISABLE.v:152:12: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_INTERMDISABLE.v:149:32: Multiple continuous assignments to: out_b_val,
-             IBUFDS_DIFF_OUT_INTERMDISABLE.v:153:12: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_INTERMDISABLE.v:161:31: Multiple continuous assignments to: O,
-             IBUFDS_DIFF_OUT_INTERMDISABLE.v:165:31: other assignment.
-
-[ERR:UH0717] IBUFDS_DIFF_OUT_INTERMDISABLE.v:162:31: Multiple continuous assignments to: OB,
-             IBUFDS_DIFF_OUT_INTERMDISABLE.v:166:31: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 8
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IBUFDS_DIFF_OUT.v -l IBUFDS_DIFF_OUT.v.log
@@ -887,15 +806,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IOBUF_DCIEN.v -l IOBUF_DCIEN.v.log
-[ERR:UH0717] IOBUF_DCIEN.v:118:32: Multiple continuous assignments to: out_val,
-             IOBUF_DCIEN.v:121:32: other assignment.
-
-[ERR:UH0717] IOBUF_DCIEN.v:130:31: Multiple continuous assignments to: O,
-             IOBUF_DCIEN.v:133:32: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 2
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v DPHY_DIFFINBUF.v -l DPHY_DIFFINBUF.v.log
@@ -1007,12 +920,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IOBUFE3.v -l IOBUFE3.v.log
-[ERR:UH0717] IOBUFE3.v:299:22: Multiple continuous assignments to: O_out,
-             IOBUFE3.v:302:17: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v OR2L.v -l OR2L.v.log
@@ -1064,12 +974,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 3
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IOBUFDS_INTERMDISABLE.v -l IOBUFDS_INTERMDISABLE.v.log
-[ERR:UH0717] IOBUFDS_INTERMDISABLE.v:175:32: Multiple continuous assignments to: out_val,
-             IOBUFDS_INTERMDISABLE.v:178:32: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v GTPE2_CHANNEL.v -l GTPE2_CHANNEL.v.log
@@ -1115,12 +1022,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v OSERDESE1.v -l OSERDESE1.v.log
-[ERR:UH0717] OSERDESE1.v:210:21: Multiple continuous assignments to: CLKPERFDELAY_in,
-             OSERDESE1.v:211:21: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v SIM_CONFIGE3.v -l SIM_CONFIGE3.v.log
@@ -1160,12 +1064,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IOBUFDS_DCIEN.v -l IOBUFDS_DCIEN.v.log
-[ERR:UH0717] IOBUFDS_DCIEN.v:173:32: Multiple continuous assignments to: out_val,
-             IOBUFDS_DCIEN.v:176:32: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v OBUFDS_GTE3.v -l OBUFDS_GTE3.v.log
@@ -1253,12 +1154,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IBUFDS_IBUFDISABLE.v -l IBUFDS_IBUFDISABLE.v.log
-[ERR:UH0717] IBUFDS_IBUFDISABLE.v:151:32: Multiple continuous assignments to: out_val,
-             IBUFDS_IBUFDISABLE.v:154:32: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v PLLE4_BASE.v -l PLLE4_BASE.v.log
@@ -1406,15 +1304,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IBUF_INTERMDISABLE.v -l IBUF_INTERMDISABLE.v.log
-[ERR:UH0717] IBUF_INTERMDISABLE.v:100:32: Multiple continuous assignments to: out_val,
-             IBUF_INTERMDISABLE.v:103:32: other assignment.
-
-[ERR:UH0717] IBUF_INTERMDISABLE.v:111:32: Multiple continuous assignments to: O,
-             IBUF_INTERMDISABLE.v:114:32: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 2
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v AUTOBUF.v -l AUTOBUF.v.log
@@ -1628,33 +1520,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IOBUFDS_DIFF_OUT_DCIEN.v -l IOBUFDS_DIFF_OUT_DCIEN.v.log
-[ERR:UH0717] IOBUFDS_DIFF_OUT_DCIEN.v:141:32: Multiple continuous assignments to: out_val,
-             IOBUFDS_DIFF_OUT_DCIEN.v:145:32: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_DCIEN.v:141:32: Multiple continuous assignments to: out_val,
-             IOBUFDS_DIFF_OUT_DCIEN.v:149:12: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_DCIEN.v:142:32: Multiple continuous assignments to: out_b_val,
-             IOBUFDS_DIFF_OUT_DCIEN.v:146:32: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_DCIEN.v:142:32: Multiple continuous assignments to: out_b_val,
-             IOBUFDS_DIFF_OUT_DCIEN.v:150:12: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_DCIEN.v:145:32: Multiple continuous assignments to: out_val,
-             IOBUFDS_DIFF_OUT_DCIEN.v:149:12: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_DCIEN.v:146:32: Multiple continuous assignments to: out_b_val,
-             IOBUFDS_DIFF_OUT_DCIEN.v:150:12: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_DCIEN.v:184:31: Multiple continuous assignments to: O,
-             IOBUFDS_DIFF_OUT_DCIEN.v:188:32: other assignment.
-
-[ERR:UH0717] IOBUFDS_DIFF_OUT_DCIEN.v:185:31: Multiple continuous assignments to: OB,
-             IOBUFDS_DIFF_OUT_DCIEN.v:189:32: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 8
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v RAM32M16.v -l RAM32M16.v.log
@@ -1688,15 +1556,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IOBUF_INTERMDISABLE.v -l IOBUF_INTERMDISABLE.v.log
-[ERR:UH0717] IOBUF_INTERMDISABLE.v:114:32: Multiple continuous assignments to: out_val,
-             IOBUF_INTERMDISABLE.v:117:32: other assignment.
-
-[ERR:UH0717] IOBUF_INTERMDISABLE.v:126:31: Multiple continuous assignments to: O,
-             IOBUF_INTERMDISABLE.v:129:32: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 2
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v RAMB18E2.v -l RAMB18E2.v.log
@@ -1862,15 +1724,9 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v IBUF_IBUFDISABLE.v -l IBUF_IBUFDISABLE.v.log
-[ERR:UH0717] IBUF_IBUFDISABLE.v:99:32: Multiple continuous assignments to: out_val,
-             IBUF_IBUFDISABLE.v:102:32: other assignment.
-
-[ERR:UH0717] IBUF_IBUFDISABLE.v:110:32: Multiple continuous assignments to: O,
-             IBUF_IBUFDISABLE.v:113:32: other assignment.
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 2
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns ../glbl.v MMCME3_BASE.v -l MMCME3_BASE.v.log
@@ -2018,7 +1874,7 @@ Processing: -cd verilog/src/unisims -writepp -parse -nocache -nobuiltin -nonote 
 Processed 250 tests.
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 53
+[  ERROR] : 5
 [WARNING] : 179
 [   NOTE] : 0
 

--- a/third_party/tests/YosysBigSim/lm32/YosysBigSimLm32.log
+++ b/third_party/tests/YosysBigSim/lm32/YosysBigSimLm32.log
@@ -98,6 +98,8 @@
 
 [INF:CP0335] rtl/lm32_icache.v:483: Compile generate block "work@testbench.lm32.cpu.instruction_unit.icache.genblk8".
 
+[INF:CP0335] rtl/lm32_instruction_unit.v:606: Compile generate block "work@testbench.lm32.cpu.instruction_unit.genblk1".
+
 [INF:CP0335] rtl/lm32_dcache.v:219: Compile generate block "work@testbench.lm32.cpu.load_store_unit.dcache.memories[0]".
 
 [INF:CP0335] rtl/lm32_dcache.v:222: Compile generate block "work@testbench.lm32.cpu.load_store_unit.dcache.memories[0].data_memories".
@@ -115,6 +117,8 @@
 [INF:CP0335] rtl/lm32_dcache.v:389: Compile generate block "work@testbench.lm32.cpu.load_store_unit.dcache.we_1".
 
 [INF:CP0335] rtl/lm32_dcache.v:506: Compile generate block "work@testbench.lm32.cpu.load_store_unit.dcache.genblk9".
+
+[INF:CP0335] rtl/lm32_load_store_unit.v:652: Compile generate block "work@testbench.lm32.cpu.load_store_unit.genblk1".
 
 [INF:CP0335] rtl/lm32_interrupt.v:178: Compile generate block "work@testbench.lm32.cpu.interrupt_unit.genblk1".
 
@@ -172,83 +176,11 @@
 
 [INF:UH0706] Creating UHDM Model...
 
-[ERR:UH0717] rtl/lm32_instruction_unit.v:609:8: Multiple continuous assignments to: first_cycle_type,
-             rtl/lm32_instruction_unit.v:620:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_instruction_unit.v:609:8: Multiple continuous assignments to: first_cycle_type,
-             rtl/lm32_instruction_unit.v:631:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_instruction_unit.v:610:8: Multiple continuous assignments to: next_cycle_type,
-             rtl/lm32_instruction_unit.v:621:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_instruction_unit.v:610:8: Multiple continuous assignments to: next_cycle_type,
-             rtl/lm32_instruction_unit.v:632:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_instruction_unit.v:611:8: Multiple continuous assignments to: last_word,
-             rtl/lm32_instruction_unit.v:622:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_instruction_unit.v:611:8: Multiple continuous assignments to: last_word,
-             rtl/lm32_instruction_unit.v:633:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_instruction_unit.v:613:8: Multiple continuous assignments to: first_address,
-             rtl/lm32_instruction_unit.v:624:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_instruction_unit.v:613:8: Multiple continuous assignments to: first_address,
-             rtl/lm32_instruction_unit.v:635:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_instruction_unit.v:620:8: Multiple continuous assignments to: first_cycle_type,
-             rtl/lm32_instruction_unit.v:631:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_instruction_unit.v:621:8: Multiple continuous assignments to: next_cycle_type,
-             rtl/lm32_instruction_unit.v:632:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_instruction_unit.v:622:8: Multiple continuous assignments to: last_word,
-             rtl/lm32_instruction_unit.v:633:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_instruction_unit.v:624:8: Multiple continuous assignments to: first_address,
-             rtl/lm32_instruction_unit.v:635:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_load_store_unit.v:655:8: Multiple continuous assignments to: first_cycle_type,
-             rtl/lm32_load_store_unit.v:662:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_load_store_unit.v:655:8: Multiple continuous assignments to: first_cycle_type,
-             rtl/lm32_load_store_unit.v:669:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_load_store_unit.v:656:8: Multiple continuous assignments to: next_cycle_type,
-             rtl/lm32_load_store_unit.v:663:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_load_store_unit.v:656:8: Multiple continuous assignments to: next_cycle_type,
-             rtl/lm32_load_store_unit.v:670:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_load_store_unit.v:657:8: Multiple continuous assignments to: last_word,
-             rtl/lm32_load_store_unit.v:664:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_load_store_unit.v:657:8: Multiple continuous assignments to: last_word,
-             rtl/lm32_load_store_unit.v:671:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_load_store_unit.v:658:8: Multiple continuous assignments to: first_address,
-             rtl/lm32_load_store_unit.v:665:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_load_store_unit.v:658:8: Multiple continuous assignments to: first_address,
-             rtl/lm32_load_store_unit.v:672:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_load_store_unit.v:662:8: Multiple continuous assignments to: first_cycle_type,
-             rtl/lm32_load_store_unit.v:669:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_load_store_unit.v:663:8: Multiple continuous assignments to: next_cycle_type,
-             rtl/lm32_load_store_unit.v:670:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_load_store_unit.v:664:8: Multiple continuous assignments to: last_word,
-             rtl/lm32_load_store_unit.v:671:8: other assignment.
-
-[ERR:UH0717] rtl/lm32_load_store_unit.v:665:8: Multiple continuous assignments to: first_address,
-             rtl/lm32_load_store_unit.v:672:8: other assignment.
-
 [INF:UH0708] Writing UHDM DB: ../../../../build/tests/YosysBigSimLm32/slpp_unit/surelog.uhdm ...
 
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 24
+[  ERROR] : 0
 [WARNING] : 19
 [   NOTE] : 7
 

--- a/third_party/tests/YosysDsp/YosysDsp.log
+++ b/third_party/tests/YosysDsp/YosysDsp.log
@@ -2550,7 +2550,7 @@
 
 [INF:CP0335] lfsr.v:123: Compile generate block "work@lfsr.RUN_LFSR[23]".
 
-[INF:CP0335] shalfband.v:132: Compile generate block "work@shalfband.DYNAMIC_TAP_ADJUSTMENT".
+[INF:CP0335] shalfband.v:130: Compile generate block "work@shalfband.DYNAMIC_TAP_ADJUSTMENT".
 
 [INF:CP0335] slowfil.v:99: Compile generate block "work@slowfil_fixedtaps.fir.genblk1".
 
@@ -2810,7 +2810,7 @@
 
 [INF:CP0335] slowfil_srl.v:150: Compile generate block "work@slowfil_srl_fixedtaps.fir.genblk2[127]".
 
-[INF:CP0335] slowsymf.v:116: Compile generate block "work@slowsymf.DYNAMIC_TAP_ADJUSTMENT".
+[INF:CP0335] slowsymf.v:114: Compile generate block "work@slowsymf.DYNAMIC_TAP_ADJUSTMENT".
 
 [NTE:EL0503] boxcar.v:74: Top level module "work@boxcar".
 

--- a/third_party/tests/YosysTests/YosysTests.log
+++ b/third_party/tests/YosysTests/YosysTests.log
@@ -6149,7 +6149,7 @@ Processing: -cd architecture/synth_xilinx_srl ug901a.v -writepp -parse -nocache 
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd architecture/synth_xilinx_srl sr_fixed_length_other_users_port.v -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -l sr_fixed_length_other_users_port.v.log
-[SNT:PA0207] sr_fixed_length_other_users_port.v:7:19: Syntax error: mismatched input 'int' expecting {Pound_Pound_delay, Pound_delay, '#', 'this', 'randomize', 'sample', Escaped_identifier, Simple_identifier},
+[SNT:PA0207] sr_fixed_length_other_users_port.v:7:19: Syntax error: no viable alternative at input 'wire [depth:0] int',
     wire [depth:0] int [width-1:0];
                    ^-- ./slpp_all/work/_6142509188972423790/sr_fixed_length_other_users_port.v:7:19:.
 
@@ -6171,7 +6171,7 @@ Processing: -cd architecture/synth_xilinx_srl rotate_3.v -writepp -parse -nocach
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd architecture/synth_xilinx_srl pos_clk_no_enable_no_init_not_inferred_with_reset_var_len.v -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -l pos_clk_no_enable_no_init_not_inferred_with_reset_var_len.v.log
-[SNT:PA0207] pos_clk_no_enable_no_init_not_inferred_with_reset_var_len.v:6:19: Syntax error: mismatched input 'int' expecting {Pound_Pound_delay, Pound_delay, '#', 'this', 'randomize', 'sample', Escaped_identifier, Simple_identifier},
+[SNT:PA0207] pos_clk_no_enable_no_init_not_inferred_with_reset_var_len.v:6:19: Syntax error: no viable alternative at input 'wire [depth:0] int',
     wire [depth:0] int [width-1:0];
                    ^-- ./slpp_all/work/_6142509188972423790/pos_clk_no_enable_no_init_not_inferred_with_reset_var_len.v:6:19:.
 
@@ -6181,7 +6181,7 @@ Processing: -cd architecture/synth_xilinx_srl pos_clk_no_enable_no_init_not_infe
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd architecture/synth_xilinx_srl neg_clk_no_enable_with_init_with_inferred_N_width.v -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -l neg_clk_no_enable_with_init_with_inferred_N_width.v.log
-[SNT:PA0207] neg_clk_no_enable_with_init_with_inferred_N_width.v:6:20: Syntax error: mismatched input 'int' expecting {'this', 'randomize', 'sample', Escaped_identifier, Simple_identifier},
+[SNT:PA0207] neg_clk_no_enable_with_init_with_inferred_N_width.v:6:20: Syntax error: no viable alternative at input 'reg [depth-1:0] int',
     reg [depth-1:0] int [width-1:0];
                     ^-- ./slpp_all/work/_6142509188972423790/neg_clk_no_enable_with_init_with_inferred_N_width.v:6:20:.
 
@@ -6201,7 +6201,7 @@ Processing: -cd architecture/synth_xilinx_srl test21b.v -writepp -parse -nocache
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd architecture/synth_xilinx_srl pos_clk_no_enable_no_init_not_inferred_with_reset.v -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -l pos_clk_no_enable_no_init_not_inferred_with_reset.v.log
-[SNT:PA0207] pos_clk_no_enable_no_init_not_inferred_with_reset.v:6:19: Syntax error: mismatched input 'int' expecting {Pound_Pound_delay, Pound_delay, '#', 'this', 'randomize', 'sample', Escaped_identifier, Simple_identifier},
+[SNT:PA0207] pos_clk_no_enable_no_init_not_inferred_with_reset.v:6:19: Syntax error: no viable alternative at input 'wire [depth:0] int',
     wire [depth:0] int [width-1:0];
                    ^-- ./slpp_all/work/_6142509188972423790/pos_clk_no_enable_no_init_not_inferred_with_reset.v:6:19:.
 
@@ -6223,7 +6223,7 @@ Processing: -cd architecture/synth_xilinx_srl multien.v -writepp -parse -nocache
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd architecture/synth_xilinx_srl sr_var_length_other_users_port.v -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -l sr_var_length_other_users_port.v.log
-[SNT:PA0207] sr_var_length_other_users_port.v:7:20: Syntax error: mismatched input 'int' expecting {'this', 'randomize', 'sample', Escaped_identifier, Simple_identifier},
+[SNT:PA0207] sr_var_length_other_users_port.v:7:20: Syntax error: no viable alternative at input 'reg [depth-1:0] int',
     reg [depth-1:0] int [width-1:0];
                     ^-- ./slpp_all/work/_6142509188972423790/sr_var_length_other_users_port.v:7:20:.
 
@@ -6233,7 +6233,7 @@ Processing: -cd architecture/synth_xilinx_srl sr_var_length_other_users_port.v -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd architecture/synth_xilinx_srl neg_clk_no_enable_with_init_with_inferred_with_reset_var_len.v -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -l neg_clk_no_enable_with_init_with_inferred_with_reset_var_len.v.log
-[SNT:PA0207] neg_clk_no_enable_with_init_with_inferred_with_reset_var_len.v:6:20: Syntax error: mismatched input 'int' expecting {'this', 'randomize', 'sample', Escaped_identifier, Simple_identifier},
+[SNT:PA0207] neg_clk_no_enable_with_init_with_inferred_with_reset_var_len.v:6:20: Syntax error: no viable alternative at input 'reg [depth-1:0] int',
     reg [depth-1:0] int [width-1:0];
                     ^-- ./slpp_all/work/_6142509188972423790/neg_clk_no_enable_with_init_with_inferred_with_reset_var_len.v:6:20:.
 
@@ -6243,7 +6243,7 @@ Processing: -cd architecture/synth_xilinx_srl neg_clk_no_enable_with_init_with_i
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd architecture/synth_xilinx_srl pos_clk_no_enable_no_init_not_inferred_N_width.v -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -l pos_clk_no_enable_no_init_not_inferred_N_width.v.log
-[SNT:PA0207] pos_clk_no_enable_no_init_not_inferred_N_width.v:6:19: Syntax error: mismatched input 'int' expecting {Pound_Pound_delay, Pound_delay, '#', 'this', 'randomize', 'sample', Escaped_identifier, Simple_identifier},
+[SNT:PA0207] pos_clk_no_enable_no_init_not_inferred_N_width.v:6:19: Syntax error: no viable alternative at input 'wire [depth:0] int',
     wire [depth:0] int [width-1:0];
                    ^-- ./slpp_all/work/_6142509188972423790/pos_clk_no_enable_no_init_not_inferred_N_width.v:6:19:.
 
@@ -6253,7 +6253,7 @@ Processing: -cd architecture/synth_xilinx_srl pos_clk_no_enable_no_init_not_infe
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd architecture/synth_xilinx_srl sr_var_length_other_users_xor.v -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -l sr_var_length_other_users_xor.v.log
-[SNT:PA0207] sr_var_length_other_users_xor.v:7:20: Syntax error: mismatched input 'int' expecting {'this', 'randomize', 'sample', Escaped_identifier, Simple_identifier},
+[SNT:PA0207] sr_var_length_other_users_xor.v:7:20: Syntax error: no viable alternative at input 'reg [depth-1:0] int',
     reg [depth-1:0] int [width-1:0];
                     ^-- ./slpp_all/work/_6142509188972423790/sr_var_length_other_users_xor.v:7:20:.
 
@@ -6315,7 +6315,7 @@ Processing: -cd architecture/synth_xilinx_srl test17b.v -writepp -parse -nocache
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd architecture/synth_xilinx_srl neg_clk_no_enable_with_init_with_inferred_with_reset.v -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -l neg_clk_no_enable_with_init_with_inferred_with_reset.v.log
-[SNT:PA0207] neg_clk_no_enable_with_init_with_inferred_with_reset.v:6:20: Syntax error: mismatched input 'int' expecting {'this', 'randomize', 'sample', Escaped_identifier, Simple_identifier},
+[SNT:PA0207] neg_clk_no_enable_with_init_with_inferred_with_reset.v:6:20: Syntax error: no viable alternative at input 'reg [depth-1:0] int',
     reg [depth-1:0] int [width-1:0];
                     ^-- ./slpp_all/work/_6142509188972423790/neg_clk_no_enable_with_init_with_inferred_with_reset.v:6:20:.
 
@@ -6367,7 +6367,7 @@ Processing: -cd architecture/synth_xilinx_srl multiclock_var_len.v -writepp -par
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd architecture/synth_xilinx_srl sr_fixed_length_other_users_xor.v -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -l sr_fixed_length_other_users_xor.v.log
-[SNT:PA0207] sr_fixed_length_other_users_xor.v:7:19: Syntax error: mismatched input 'int' expecting {Pound_Pound_delay, Pound_delay, '#', 'this', 'randomize', 'sample', Escaped_identifier, Simple_identifier},
+[SNT:PA0207] sr_fixed_length_other_users_xor.v:7:19: Syntax error: no viable alternative at input 'wire [depth:0] int',
     wire [depth:0] int [width-1:0];
                    ^-- ./slpp_all/work/_6142509188972423790/sr_fixed_length_other_users_xor.v:7:19:.
 
@@ -6393,7 +6393,7 @@ Processing: -cd architecture/synth_xilinx_srl test21a.v -writepp -parse -nocache
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd architecture/synth_xilinx_srl test20.v -writepp -parse -nocache -nobuiltin -nonote -noinfo -timescale=1ns/1ns -l test20.v.log
-[SNT:PA0207] test20.v:4:20: Syntax error: mismatched input 'int' expecting {'this', 'randomize', 'sample', Escaped_identifier, Simple_identifier},
+[SNT:PA0207] test20.v:4:20: Syntax error: no viable alternative at input 'reg [width-1:0] int',
     reg [width-1:0] int [depth-1:0];
                     ^-- ./slpp_all/work/_6142509188972423790/test20.v:4:20:.
 

--- a/third_party/tests/ariane/Ariane.log
+++ b/third_party/tests/ariane/Ariane.log
@@ -2096,7 +2096,7 @@ there are 1 more instances of this message.
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BW_allocator.sv:255: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[0].RESP_BLOCK.BW_ALLOC.BID_VECTOR_BINDING[9]".
 
-[INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BW_allocator.sv:272: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[0].RESP_BLOCK.BW_ALLOC.ARBITER".
+[INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BW_allocator.sv:270: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[0].RESP_BLOCK.BW_ALLOC.ARBITER".
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node_arbiter.sv:38: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[0].RESP_BLOCK.BW_ALLOC.ARBITER.i_arbiter.gen_inp_meta[0]".
 
@@ -2166,7 +2166,7 @@ there are 1 more instances of this message.
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BR_allocator.sv:346: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[0].RESP_BLOCK.BR_ALLOC.RID_VECTOR_BINDING[9]".
 
-[INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BR_allocator.sv:365: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[0].RESP_BLOCK.BR_ALLOC.ARBITER".
+[INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BR_allocator.sv:363: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[0].RESP_BLOCK.BR_ALLOC.ARBITER".
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node_arbiter.sv:38: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[0].RESP_BLOCK.BR_ALLOC.ARBITER.i_arbiter.gen_inp_meta[0]".
 
@@ -2406,7 +2406,7 @@ there are 1 more instances of this message.
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BW_allocator.sv:255: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[1].RESP_BLOCK.BW_ALLOC.BID_VECTOR_BINDING[9]".
 
-[INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BW_allocator.sv:272: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[1].RESP_BLOCK.BW_ALLOC.ARBITER".
+[INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BW_allocator.sv:270: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[1].RESP_BLOCK.BW_ALLOC.ARBITER".
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node_arbiter.sv:38: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[1].RESP_BLOCK.BW_ALLOC.ARBITER.i_arbiter.gen_inp_meta[0]".
 
@@ -2476,7 +2476,7 @@ there are 1 more instances of this message.
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BR_allocator.sv:346: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[1].RESP_BLOCK.BR_ALLOC.RID_VECTOR_BINDING[9]".
 
-[INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BR_allocator.sv:365: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[1].RESP_BLOCK.BR_ALLOC.ARBITER".
+[INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_BR_allocator.sv:363: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[1].RESP_BLOCK.BR_ALLOC.ARBITER".
 
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/ariane/src/axi_node/src/axi_node_arbiter.sv:38: Compile generate block "work@ariane_testharness.i_axi_xbar.axi_node_i._RESP_BLOCK_GEN[1].RESP_BLOCK.BR_ALLOC.ARBITER.i_arbiter.gen_inp_meta[0]".
 


### PR DESCRIPTION
Based off #2484 which I rescind, few changes to maintain AST compatibility.
The SV grammar is loosy, I checked that testcases that failed with #2484 do pass with commercial tools, then modified the grammar to enable those tests pass again. Incidentally, this also fix the generate case issue I recently found. 
@QuantamHD, you need to check if the same speedup is maintained for complex generate statements.
