### PR TITLE
Fix: ModuleDefinition::getSize() always returns 0

### DIFF
--- a/src/Design/ModuleDefinition.cpp
+++ b/src/Design/ModuleDefinition.cpp
@@ -54,9 +54,6 @@ ModuleDefinition* ModuleDefinitionFactory::newModuleDefinition(
 }
 
 unsigned int ModuleDefinition::getSize() const {
-  if (m_fileContents.size()) {
-    return 0;
-  }
   unsigned int size = 0;
   for (unsigned int i = 0; i < m_fileContents.size(); i++) {
     NodeId end = m_nodeIds[i];


### PR DESCRIPTION
This looks like some unintntional return of 0; possibly
the code meant to test for .empty(), but we don't even
need this branch - the below loop will reliably return
0 in this case.

Signed-off-by: Henner Zeller <h.zeller@acm.org>