### PR TITLE
Improve readability: use empty() when checking for the emptiness of c…

### DIFF
--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -32,6 +32,7 @@ Checks: >
     clang-diagnostic-inconsistent-missing-override,
     clang-diagnostic-unused-private-field,
     modernize-use-override,
+    readability-container-size-empty,
     readability-delete-null-pointer,
     readability-redundant-member-init,
     readability-redundant-string-cstr,

--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -447,22 +447,23 @@ std::string SLgetModuleName(ModuleDefinition* module) {
   return module->getName();
 }
 
+template <typename ClassOrPackageOrProgram>
+static bool ModuleHasFirstFileContent(const ClassOrPackageOrProgram* module) {
+  if (!module) return false;
+  if (module->getFileContents().empty()) return false;
+  return module->getFileContents()[0] != nullptr;
+}
+
 std::string SLgetModuleFile(ModuleDefinition* module) {
-  if (!module) return "";
-  if (module->getFileContents().size())
-    return module->getFileContents()[0]
-        ->getFileName(module->getNodeIds()[0])
-        .string();
-  else
-    return "";
+  if (!ModuleHasFirstFileContent(module)) return "";
+  return module->getFileContents()[0]
+      ->getFileName(module->getNodeIds()[0])
+      .string();
 }
 
 unsigned int SLgetModuleLine(ModuleDefinition* module) {
-  if (!module) return 0;
-  if (module->getFileContents().size())
-    return module->getFileContents()[0]->Line(module->getNodeIds()[0]);
-  else
-    return 0;
+  if (!ModuleHasFirstFileContent(module)) return 0;
+  return module->getFileContents()[0]->Line(module->getNodeIds()[0]);
 }
 
 VObjectType SLgetModuleType(ModuleDefinition* module) {
@@ -471,12 +472,9 @@ VObjectType SLgetModuleType(ModuleDefinition* module) {
 }
 
 FileContent* SLgetModuleFileContent(ModuleDefinition* module) {
-  if (!module) return nullptr;
-  if (module->getFileContents().size())
-    // TODO(alain): fix const cast.
-    return const_cast<FileContent*>(module->getFileContents()[0]);
-  else
-    return nullptr;
+  if (!ModuleHasFirstFileContent(module)) return nullptr;
+  // TODO(alain): fix const cast.
+  return const_cast<FileContent*>(module->getFileContents()[0]);
 }
 
 NodeId SLgetModuleRootNode(ModuleDefinition* module) {
@@ -490,21 +488,15 @@ std::string SLgetClassName(ClassDefinition* module) {
 }
 
 std::string SLgetClassFile(ClassDefinition* module) {
-  if (!module) return "";
-  if (module->getFileContents().size() && module->getFileContents()[0])
-    return module->getFileContents()[0]
-        ->getFileName(module->getNodeIds()[0])
-        .string();
-  else
-    return "";
+  if (!ModuleHasFirstFileContent(module)) return "";
+  return module->getFileContents()[0]
+      ->getFileName(module->getNodeIds()[0])
+      .string();
 }
 
 unsigned int SLgetClassLine(ClassDefinition* module) {
-  if (!module) return 0;
-  if (module->getFileContents().size() && module->getFileContents()[0])
-    return module->getFileContents()[0]->Line(module->getNodeIds()[0]);
-  else
-    return 0;
+  if (!ModuleHasFirstFileContent(module)) return 0;
+  return module->getFileContents()[0]->Line(module->getNodeIds()[0]);
 }
 
 VObjectType SLgetClassType(ClassDefinition* module) {
@@ -513,12 +505,9 @@ VObjectType SLgetClassType(ClassDefinition* module) {
 }
 
 FileContent* SLgetClassFileContent(ClassDefinition* module) {
-  if (!module) return 0;
-  if (module->getFileContents().size() && module->getFileContents()[0])
-    // TODO(Alain): Fix api.
-    return const_cast<FileContent*>(module->getFileContents()[0]);
-  else
-    return nullptr;
+  if (!ModuleHasFirstFileContent(module)) return nullptr;
+  // TODO(Alain): Fix api.
+  return const_cast<FileContent*>(module->getFileContents()[0]);
 }
 
 NodeId SLgetClassRootNode(ClassDefinition* module) {
@@ -532,21 +521,15 @@ std::string SLgetPackageName(Package* module) {
 }
 
 std::string SLgetPackageFile(Package* module) {
-  if (!module) return "";
-  if (module->getFileContents().size())
-    return module->getFileContents()[0]
-        ->getFileName(module->getNodeIds()[0])
-        .string();
-  else
-    return "";
+  if (!ModuleHasFirstFileContent(module)) return "";
+  return module->getFileContents()[0]
+      ->getFileName(module->getNodeIds()[0])
+      .string();
 }
 
 unsigned int SLgetPackageLine(Package* module) {
-  if (!module) return 0;
-  if (module->getFileContents().size())
-    return module->getFileContents()[0]->Line(module->getNodeIds()[0]);
-  else
-    return 0;
+  if (!ModuleHasFirstFileContent(module)) return 0;
+  return module->getFileContents()[0]->Line(module->getNodeIds()[0]);
 }
 
 VObjectType SLgetPackageType(Package* module) {
@@ -555,11 +538,8 @@ VObjectType SLgetPackageType(Package* module) {
 }
 
 FileContent* SLgetPackageFileContent(Package* module) {
-  if (!module) return 0;
-  if (module->getFileContents().size())
-    return const_cast<FileContent*>(module->getFileContents()[0]);
-  else
-    return nullptr;
+  if (!ModuleHasFirstFileContent(module)) return nullptr;
+  return const_cast<FileContent*>(module->getFileContents()[0]);
 }
 
 NodeId SLgetPackageRootNode(Package* module) {
@@ -573,21 +553,15 @@ std::string SLgetProgramName(Program* module) {
 }
 
 std::string SLgetProgramFile(Program* module) {
-  if (!module) return "";
-  if (module->getFileContents().size())
-    return module->getFileContents()[0]
-        ->getFileName(module->getNodeIds()[0])
-        .string();
-  else
-    return "";
+  if (!ModuleHasFirstFileContent(module)) return "";
+  return module->getFileContents()[0]
+      ->getFileName(module->getNodeIds()[0])
+      .string();
 }
 
 unsigned int SLgetProgramLine(Program* module) {
-  if (!module) return 0;
-  if (module->getFileContents().size())
-    return module->getFileContents()[0]->Line(module->getNodeIds()[0]);
-  else
-    return 0;
+  if (!ModuleHasFirstFileContent(module)) return 0;
+  return module->getFileContents()[0]->Line(module->getNodeIds()[0]);
 }
 
 VObjectType SLgetProgramType(Program* module) {
@@ -596,11 +570,8 @@ VObjectType SLgetProgramType(Program* module) {
 }
 
 FileContent* SLgetProgramFileContent(Program* module) {
-  if (!module) return 0;
-  if (module->getFileContents().size())
-    return const_cast<FileContent*>(module->getFileContents()[0]);
-  else
-    return nullptr;
+  if (!ModuleHasFirstFileContent(module)) return nullptr;
+  return const_cast<FileContent*>(module->getFileContents()[0]);
 }
 
 NodeId SLgetProgramRootNode(Program* module) {

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -360,12 +360,13 @@ CommandLineParser::CommandLineParser(ErrorContainer* errors,
       m_symbolTable->registerSymbol(".v"));  // default
 }
 
-void CommandLineParser::splitPlusArg_(std::string s, std::string prefix,
+void CommandLineParser::splitPlusArg_(const std::string& s,
+                                      const std::string& prefix,
                                       std::vector<SymbolId>& container) {
   std::istringstream f(s);
   std::string tmp;
   while (getline(f, tmp, '+')) {
-    if (tmp.size() && (tmp != prefix)) {
+    if (!tmp.empty() && (tmp != prefix)) {
       SymbolId id = m_symbolTable->registerSymbol(tmp);
       container.push_back(id);
     }
@@ -373,12 +374,12 @@ void CommandLineParser::splitPlusArg_(std::string s, std::string prefix,
 }
 
 void CommandLineParser::splitPlusArg_(
-    std::string s, std::string prefix,
+    const std::string& s, const std::string& prefix,
     std::map<SymbolId, std::string>& container) {
   std::istringstream f(s);
   std::string tmp;
   while (getline(f, tmp, '+')) {
-    if (tmp.size() && (tmp != prefix)) {
+    if (!tmp.empty() && (tmp != prefix)) {
       std::string def;
       std::string value;
       const size_t loc = tmp.find("=");
@@ -400,7 +401,7 @@ bool CommandLineParser::plus_arguments_(const std::string& s) {
   std::string incdir("+incdir+");
   std::string libext("+libext+");
   std::string define("+define+");
-  if (s.size() == 0) return false;
+  if (s.empty()) return false;
   if (s.at(0) != '+') return false;
   if (s.compare(0, incdir.size(), incdir) == 0) {
     splitPlusArg_(s, "incdir", m_includePaths);
@@ -1057,21 +1058,21 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       } else {
         m_sverilog = true;
       }
-    } else if (all_arguments[i].size() && all_arguments[i] == "--x-assign") {
+    } else if (!all_arguments[i].empty() && all_arguments[i] == "--x-assign") {
       Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
       Error err(ErrorDefinition::CMD_PLUS_ARG_IGNORED, loc);
       m_errors->addError(err);
       i++;
-    } else if (all_arguments[i].size() && all_arguments[i] == "--x-initial") {
+    } else if (!all_arguments[i].empty() && all_arguments[i] == "--x-initial") {
       Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
       Error err(ErrorDefinition::CMD_PLUS_ARG_IGNORED, loc);
       m_errors->addError(err);
       i++;
-    } else if (all_arguments[i].size() && all_arguments[i].at(0) == '+') {
+    } else if (!all_arguments[i].empty() && all_arguments[i].at(0) == '+') {
       Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
       Error err(ErrorDefinition::CMD_PLUS_ARG_IGNORED, loc);
       m_errors->addError(err);
-    } else if (all_arguments[i].size() && all_arguments[i].at(0) == '-') {
+    } else if (!all_arguments[i].empty() && all_arguments[i].at(0) == '-') {
       Location loc(mutableSymbolTable()->registerSymbol(all_arguments[i]));
       Error err(ErrorDefinition::CMD_MINUS_ARG_IGNORED, loc);
       m_errors->addError(err);

--- a/src/CommandLine/CommandLineParser.h
+++ b/src/CommandLine/CommandLineParser.h
@@ -190,9 +190,9 @@ class CommandLineParser final {
   bool plus_arguments_(const std::string& s);
   void processArgs_(std::vector<std::string>& args,
                     std::vector<std::string>& container);
-  void splitPlusArg_(std::string s, std::string prefix,
+  void splitPlusArg_(const std::string& s, const std::string& prefix,
                      std::vector<SymbolId>& container);
-  void splitPlusArg_(std::string s, std::string prefix,
+  void splitPlusArg_(const std::string& s, const std::string& prefix,
                      std::map<SymbolId, std::string>& container);
   bool checkCommandLine_();
   bool prepareCompilation_(int argc, const char** argv);

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -244,9 +244,9 @@ ModuleInstance* Design::findInstance(const std::string& path,
   return findInstance(vpath, scope);
 }
 
-ModuleInstance* Design::findInstance(std::vector<std::string>& path,
+ModuleInstance* Design::findInstance(const std::vector<std::string>& path,
                                      ModuleInstance* scope) const {
-  if (!path.size()) return nullptr;
+  if (path.empty()) return nullptr;
   if (scope) {
     ModuleInstance* res = findInstance_(path, scope);
     if (res) return res;
@@ -270,9 +270,9 @@ ModuleInstance* Design::findInstance(std::vector<std::string>& path,
   return nullptr;
 }
 
-ModuleInstance* Design::findInstance_(std::vector<std::string>& path,
+ModuleInstance* Design::findInstance_(const std::vector<std::string>& path,
                                       ModuleInstance* scope) const {
-  if (!path.size()) return nullptr;
+  if (path.empty()) return nullptr;
   if (scope == nullptr) return nullptr;
   if (path.size() == 1) {
     if (scope->getInstanceName() == path[0]) {
@@ -282,16 +282,15 @@ ModuleInstance* Design::findInstance_(std::vector<std::string>& path,
 
   for (unsigned int i = 0; i < scope->getNbChildren(); i++) {
     ModuleInstance* child = scope->getChildren(i);
-    if (path.size()) {
-      if (child->getInstanceName() == path[0]) {
-        if (path.size() == 1) {
-          return child;
-        } else {
-          std::vector<std::string> subpath = path;
-          subpath.erase(subpath.begin());
-          ModuleInstance* res = findInstance(subpath, child);
-          if (res) return res;
-        }
+    if (path.empty()) continue;
+    if (child->getInstanceName() == path[0]) {
+      if (path.size() == 1) {
+        return child;
+      } else {
+        std::vector<std::string> subpath = path;
+        subpath.erase(subpath.begin());
+        ModuleInstance* res = findInstance(subpath, child);
+        if (res) return res;
       }
     }
   }
@@ -318,7 +317,7 @@ Value* Design::getDefParamValue(const std::string& name) {
 
 DefParam* Design::getDefParam_(std::vector<std::string>& path,
                                DefParam* parent) const {
-  if (path.size() == 0) {
+  if (path.empty()) {
     return parent;
   }
   std::map<std::string, DefParam*>::iterator itr =
@@ -348,7 +347,7 @@ void Design::addDefParam(const std::string& name, const FileContent* fC,
 
 void Design::addDefParam_(std::vector<std::string>& path, const FileContent* fC,
                           NodeId nodeId, Value* value, DefParam* parent) {
-  if (path.size() == 0) {
+  if (path.empty()) {
     parent->setValue(value);
     parent->setLocation(fC, nodeId);
     return;
@@ -357,7 +356,7 @@ void Design::addDefParam_(std::vector<std::string>& path, const FileContent* fC,
       parent->getChildren().find(path[0]);
   if (itr != parent->getChildren().end()) {
     path.erase(path.begin());
-    if (path.size() == 0) {
+    if (path.empty()) {
       DefParam* previous = (*itr).second;
       if ((fC->getFileId(nodeId) !=
            previous->getLocation()->getFileId(previous->getNodeId())) ||
@@ -446,7 +445,7 @@ ClassDefinition* Design::getClassDefinition(const std::string& name) const {
 }
 
 void Design::orderPackages() {
-  if (m_orderedPackageNames.size() == 0) return;
+  if (m_orderedPackageNames.empty()) return;
   m_orderedPackageDefinitions.resize(m_orderedPackageNames.size());
   unsigned int index = 0;
   typedef std::map<std::string, int> MultiDefCount;

--- a/src/Design/Design.h
+++ b/src/Design/Design.h
@@ -122,7 +122,7 @@ class Design final {
 
   void checkDefParamUsage(DefParam* parent = nullptr);
 
-  ModuleInstance* findInstance(std::vector<std::string>& path,
+  ModuleInstance* findInstance(const std::vector<std::string>& path,
                                ModuleInstance* scope = nullptr) const;
 
   ModuleInstance* findInstance(const std::string& path,
@@ -182,7 +182,7 @@ class Design final {
   void orderPackages();
 
  private:
-  ModuleInstance* findInstance_(std::vector<std::string>& path,
+  ModuleInstance* findInstance_(const std::vector<std::string>& path,
                                 ModuleInstance* scope) const;
   void addDefParam_(std::vector<std::string>& path, const FileContent* fC,
                     NodeId nodeId, Value* value, DefParam* parent);

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -38,7 +38,7 @@
 namespace SURELOG {
 namespace fs = std::filesystem;
 NodeId FileContent::getRootNode() {
-  if (m_objects.size() == 0) {
+  if (m_objects.empty()) {
     return 0;
   }
   return m_objects[0].m_sibling;
@@ -262,7 +262,7 @@ unsigned short FileContent::EndColumn(NodeId index) const {
 }
 
 NodeId FileContent::sl_get(NodeId parent, VObjectType type) {
-  if (!m_objects.size()) return 0;
+  if (m_objects.empty()) return 0;
   if (parent > m_objects.size() - 1) return 0;
   VObject current = Object(parent);
   if (current.m_type == type) return parent;
@@ -279,7 +279,7 @@ NodeId FileContent::sl_get(NodeId parent, VObjectType type) {
 
 NodeId FileContent::sl_parent(NodeId parent, std::vector<VObjectType> types,
                               VObjectType& actualType) {
-  if (!m_objects.size()) return 0;
+  if (m_objects.empty()) return 0;
   if (parent > m_objects.size() - 1) return 0;
   VObject current = Object(parent);
   for (auto type : types)
@@ -301,7 +301,7 @@ NodeId FileContent::sl_parent(NodeId parent, std::vector<VObjectType> types,
 }
 
 NodeId FileContent::sl_parent(NodeId parent, VObjectType type) {
-  if (!m_objects.size()) return 0;
+  if (m_objects.empty()) return 0;
   if (parent > m_objects.size() - 1) return 0;
   VObject current = Object(parent);
   if (current.m_type == type) return parent;
@@ -318,7 +318,7 @@ NodeId FileContent::sl_parent(NodeId parent, VObjectType type) {
 
 std::vector<NodeId> FileContent::sl_get_all(NodeId parent, VObjectType type) {
   std::vector<NodeId> objects;
-  if (!m_objects.size()) return objects;
+  if (m_objects.empty()) return objects;
   if (parent > m_objects.size() - 1) return objects;
   VObject current = Object(parent);
   if (current.m_type == type) objects.push_back(parent);
@@ -336,7 +336,7 @@ std::vector<NodeId> FileContent::sl_get_all(NodeId parent, VObjectType type) {
 std::vector<NodeId> FileContent::sl_get_all(NodeId parent,
                                             std::vector<VObjectType>& types) {
   std::vector<NodeId> objects;
-  if (!m_objects.size()) return objects;
+  if (m_objects.empty()) return objects;
   if (parent > m_objects.size() - 1) return objects;
   VObject current = Object(parent);
   for (auto type : types) {
@@ -361,7 +361,7 @@ std::vector<NodeId> FileContent::sl_get_all(NodeId parent,
 }
 
 NodeId FileContent::sl_collect(NodeId parent, VObjectType type) const {
-  if (!m_objects.size()) return 0;
+  if (m_objects.empty()) return 0;
   if (parent > m_objects.size() - 1) return 0;
   VObject current = Object(parent);
   if (current.m_type == type) return parent;
@@ -383,7 +383,7 @@ NodeId FileContent::sl_collect(NodeId parent, VObjectType type) const {
 std::vector<NodeId> FileContent::sl_collect_all(NodeId parent, VObjectType type,
                                                 bool first) const {
   std::vector<NodeId> objects;
-  if (!m_objects.size()) return objects;
+  if (m_objects.empty()) return objects;
   if (parent > m_objects.size() - 1) return objects;
   VObject current = Object(parent);
   NodeId id = current.m_child;
@@ -391,7 +391,7 @@ std::vector<NodeId> FileContent::sl_collect_all(NodeId parent, VObjectType type,
   if (!id) return objects;
   std::stack<NodeId> stack;
   stack.push(id);
-  while (stack.size()) {
+  while (!stack.empty()) {
     id = stack.top();
     stack.pop();
     current = Object(id);
@@ -409,7 +409,7 @@ std::vector<NodeId> FileContent::sl_collect_all(NodeId parent,
                                                 std::vector<VObjectType>& types,
                                                 bool first) const {
   std::vector<NodeId> objects;
-  if (!m_objects.size()) return objects;
+  if (m_objects.empty()) return objects;
   if (parent > m_objects.size() - 1) return objects;
   VObject current = Object(parent);
   NodeId id = current.m_child;
@@ -417,7 +417,7 @@ std::vector<NodeId> FileContent::sl_collect_all(NodeId parent,
   if (!id) return objects;
   std::stack<NodeId> stack;
   stack.push(id);
-  while (stack.size()) {
+  while (!stack.empty()) {
     id = stack.top();
     stack.pop();
     current = Object(id);
@@ -439,7 +439,7 @@ std::vector<NodeId> FileContent::sl_collect_all(NodeId parent,
 NodeId FileContent::sl_collect(NodeId parent, VObjectType type,
                                VObjectType stopPoint) const {
   NodeId result = InvalidNodeId;
-  if (!m_objects.size()) return result;
+  if (m_objects.empty()) return result;
   if (parent > m_objects.size() - 1) return result;
   VObject current = Object(parent);
   NodeId id = current.m_child;
@@ -447,7 +447,7 @@ NodeId FileContent::sl_collect(NodeId parent, VObjectType type,
   if (!id) return result;
   std::stack<NodeId> stack;
   stack.push(id);
-  while (stack.size()) {
+  while (!stack.empty()) {
     id = stack.top();
     stack.pop();
     current = Object(id);
@@ -469,7 +469,7 @@ std::vector<NodeId> FileContent::sl_collect_all(
     NodeId parent, std::vector<VObjectType>& types,
     std::vector<VObjectType>& stopPoints, bool first) const {
   std::vector<NodeId> objects;
-  if (!m_objects.size()) return objects;
+  if (m_objects.empty()) return objects;
   if (parent > m_objects.size() - 1) return objects;
   VObject current = Object(parent);
   NodeId id = current.m_child;
@@ -477,7 +477,7 @@ std::vector<NodeId> FileContent::sl_collect_all(
   if (!id) return objects;
   std::stack<NodeId> stack;
   stack.push(id);
-  while (stack.size()) {
+  while (!stack.empty()) {
     id = stack.top();
     stack.pop();
     current = Object(id);
@@ -493,7 +493,7 @@ std::vector<NodeId> FileContent::sl_collect_all(
     if (current.m_sibling) stack.push(current.m_sibling);
 
     if (current.m_child) {
-      if (stopPoints.size()) {
+      if (!stopPoints.empty()) {
         bool stop = false;
         for (auto t : stopPoints) {
           if (t == current.m_type) {
@@ -529,8 +529,8 @@ bool FileContent::diffTree(NodeId root, const FileContent* oFc, NodeId oroot,
   std::stack<NodeId> stack2;
   stack1.push(id1);
   stack2.push(id2);
-  while (stack1.size()) {
-    if (!stack2.size()) return true;
+  while (!stack1.empty()) {
+    if (stack2.empty()) return true;
     id1 = stack1.top();
     id2 = stack2.top();
     stack1.pop();
@@ -552,8 +552,7 @@ bool FileContent::diffTree(NodeId root, const FileContent* oFc, NodeId oroot,
     if (current2.m_sibling) stack2.push(current2.m_sibling);
     if (current2.m_child) stack2.push(current2.m_child);
   }
-  if (stack2.size()) return true;
-  return false;
+  return !stack2.empty();
 }
 
 void FileContent::addDesignElement(const std::string& name,

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -75,7 +75,7 @@ bool CompileClass::compile() {
   if (tmp_container) {
     fullName = tmp_container->getName() + "::";
   }
-  if (names.size()) {
+  if (!names.empty()) {
     unsigned int index = names.size() - 1;
     while (1) {
       fullName += names[index];
@@ -159,7 +159,7 @@ bool CompileClass::compile() {
   stack.push(id);
   bool inFunction_body_declaration = false;
   bool inTask_body_declaration = false;
-  while (stack.size()) {
+  while (!stack.empty()) {
     bool skipGuts = false;
     id = stack.top();
     stack.pop();

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -562,7 +562,7 @@ constant* compileConst(const FileContent* fC, NodeId child, Serializer& s) {
         }
 
       } else {
-        if (value.size() && value[0] == '-') {
+        if (!value.empty() && value[0] == '-') {
           v = "INT:" + value;
           c->VpiConstType(vpiIntConst);
         } else {
@@ -769,7 +769,7 @@ any* CompileHelper::decodeHierPath(hier_path* path, bool& invalidValue,
                                    bool returnTypespec) {
   Serializer& s = compileDesign->getSerializer();
   std::string baseObject;
-  if (path->Path_elems()->size()) {
+  if (!path->Path_elems()->empty()) {
     any* firstElem = path->Path_elems()->at(0);
     baseObject = firstElem->VpiName();
   }
@@ -2699,7 +2699,7 @@ any* CompileHelper::hierarchicalSelector(
           if (tps->VpiName() == "default") {
             defaultPattern = (any*)tpatt->Pattern();
           }
-          if (elemName.size() && (tps->VpiName() == elemName)) {
+          if (!elemName.empty() && (tps->VpiName() == elemName)) {
             const any* patt = tpatt->Pattern();
             UHDM_OBJECT_TYPE pattType = patt->UhdmType();
             if (pattType == uhdmconstant) {
@@ -3391,7 +3391,7 @@ UHDM::any* CompileHelper::compileSelectExpression(
                     bit_select* s = (bit_select*)el;
                     const expr* index = s->VpiIndex();
                     std::string ind = index->VpiDecompile();
-                    if (ind.size() == 0) ind = index->VpiName();
+                    if (ind.empty()) ind = index->VpiName();
                     n += "[" + ind + "]";
                   }
                   hname += "." + n;
@@ -4508,7 +4508,7 @@ UHDM::any* CompileHelper::compileExpression(
                     }
                     if (param_ass->Lhs()->UhdmType() == uhdmparameter) {
                       const parameter* tp = (parameter*)param_ass->Lhs();
-                      if (tp->VpiImported() != "") {
+                      if (!tp->VpiImported().empty()) {
                         paramFromPackage = true;
                       }
                     }
@@ -6855,7 +6855,7 @@ UHDM::any* CompileHelper::compileComplexFuncCall(
         NodeId BitSelect = fC->Child(dotedName);
         if (dtype == VObjectType::slStringConst) {
           the_name += "." + fC->SymName(dotedName);
-          if (tmpName != "") {
+          if (!tmpName.empty()) {
             ref_obj* ref = s.MakeRef_obj();
             elems->push_back(ref);
             ref->VpiName(tmpName);
@@ -7006,7 +7006,7 @@ UHDM::any* CompileHelper::compileComplexFuncCall(
         if (dotedName) dotedName = fC->Sibling(dotedName);
       }
       if (is_hierarchical) {
-        if (tmpName != "") {
+        if (!tmpName.empty()) {
           ref_obj* ref = s.MakeRef_obj();
           elems->push_back(ref);
           ref->VpiName(tmpName);

--- a/src/DesignCompile/CompileFileContent.cpp
+++ b/src/DesignCompile/CompileFileContent.cpp
@@ -71,7 +71,7 @@ bool CompileFileContent::collectObjects_() {
   if (!id) return false;
   std::stack<NodeId> stack;
   stack.push(id);
-  while (stack.size()) {
+  while (!stack.empty()) {
     id = stack.top();
     stack.pop();
     current = fC->Object(id);
@@ -147,7 +147,7 @@ bool CompileFileContent::collectObjects_() {
 
     if (current.m_sibling) stack.push(current.m_sibling);
     if (current.m_child) {
-      if (stopPoints.size()) {
+      if (!stopPoints.empty()) {
         bool stop = false;
         for (auto t : stopPoints) {
           if (t == current.m_type) {

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -1678,7 +1678,7 @@ bool CompileHelper::compileAnsiPortDeclaration(DesignComponent* component,
       NodeId specParamId = 0;
       // Reuse last signal data type (if any)
       Signal* last = nullptr;
-      if (component->getPorts().size()) {
+      if (!component->getPorts().empty()) {
         last = component->getPorts().back();
         dataType = last->getType();
         packed = last->getPackedDimension();
@@ -2324,7 +2324,7 @@ bool CompileHelper::isMultidimensional(UHDM::typespec* ts,
     if (ttps == uhdmlogic_typespec) {
       logic_typespec* lts = (logic_typespec*)ts;
       if (component && valuedcomponenti_cast<Package*>(component)) {
-        if (lts->Ranges() && lts->Ranges()->size() > 0) isMultiDimension = true;
+        if (lts->Ranges() && !lts->Ranges()->empty()) isMultiDimension = true;
       } else {
         if (lts->Ranges() && lts->Ranges()->size() > 1) isMultiDimension = true;
       }
@@ -2566,7 +2566,7 @@ bool CompileHelper::compileParameterDeclaration(
               int optype = op->VpiOpType();
               if (optype == vpiAssignmentPatternOp || optype == vpiConcatOp) {
                 VectorOfany* operands = op->Operands();
-                if (operands && operands->size()) {
+                if (operands && !operands->empty()) {
                   if ((*operands)[0]->UhdmType() == uhdmref_obj) {
                     op->VpiReordered(true);
                     std::reverse(operands->begin(), operands->end());
@@ -2630,7 +2630,7 @@ bool CompileHelper::compileParameterDeclaration(
             int optype = op->VpiOpType();
             if (optype == vpiAssignmentPatternOp || optype == vpiConcatOp) {
               VectorOfany* operands = op->Operands();
-              if (operands && operands->size()) {
+              if (operands && !operands->empty()) {
                 if ((*operands)[0]->UhdmType() == uhdmref_obj) {
                   op->VpiReordered(true);
                   std::reverse(operands->begin(), operands->end());
@@ -2824,7 +2824,7 @@ UHDM::any* CompileHelper::compileTfCall(DesignComponent* component,
     }
     if (call == nullptr) call = s.MakeFunc_call();
   }
-  if (call->VpiName() == "") call->VpiName(name);
+  if (call->VpiName().empty()) call->VpiName(name);
 
   NodeId argListNode = fC->Sibling(tfNameNode);
   if (fC->Type(argListNode) == slAttribute_instance) {
@@ -2894,7 +2894,7 @@ VectorOfany* CompileHelper::compileTfCallArguments(
     }
     argumentNode = fC->Sibling(argumentNode);
   }
-  if (args.size()) {
+  if (!args.empty()) {
     if (io_decls) {
       for (io_decl* decl : *io_decls) {
         const std::string& name = decl->VpiName();

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -182,7 +182,7 @@ bool CompileModule::collectUdpObjects_() {
   stack.push(id);
   m_module->m_udpDefn = s.MakeUdp_defn();
   UHDM::udp_defn* defn = m_module->m_udpDefn;
-  while (stack.size()) {
+  while (!stack.empty()) {
     id = stack.top();
     stack.pop();
     current = fC->Object(id);
@@ -551,7 +551,7 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
     stack.push(id);
     VObjectType port_direction = VObjectType::slNoType;
 
-    while (stack.size()) {
+    while (!stack.empty()) {
       id = stack.top();
       if (endOfBlockId && (id == endOfBlockId)) {
         break;
@@ -816,7 +816,7 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
 
       if (current.m_sibling) stack.push(current.m_sibling);
       if (current.m_child && (!skipChildren)) {
-        if (stopPoints.size()) {
+        if (!stopPoints.empty()) {
           bool stop = false;
           for (auto t : stopPoints) {
             if (t == current.m_type) {
@@ -892,7 +892,7 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
     std::stack<NodeId> stack;
     stack.push(id);
     VObjectType port_direction = VObjectType::slNoType;
-    while (stack.size()) {
+    while (!stack.empty()) {
       id = stack.top();
       if (ParameterPortListId && (id == ParameterPortListId)) {
         ParameterPortListId = 0;
@@ -1177,7 +1177,7 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
 
       if (current.m_sibling) stack.push(current.m_sibling);
       if (current.m_child) {
-        if (stopPoints.size()) {
+        if (!stopPoints.empty()) {
           bool stop = false;
           for (auto t : stopPoints) {
             if (t == current.m_type) {

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -126,7 +126,7 @@ bool CompilePackage::collectObjects_(CollectType collectType) {
 
     std::stack<NodeId> stack;
     stack.push(id);
-    while (stack.size()) {
+    while (!stack.empty()) {
       id = stack.top();
       stack.pop();
       current = fC->Object(id);
@@ -290,7 +290,7 @@ bool CompilePackage::collectObjects_(CollectType collectType) {
 
       if (current.m_sibling) stack.push(current.m_sibling);
       if (current.m_child) {
-        if (stopPoints.size()) {
+        if (!stopPoints.empty()) {
           bool stop = false;
           for (auto t : stopPoints) {
             if (t == current.m_type) {

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -128,7 +128,7 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
   std::stack<NodeId> stack;
   stack.push(id);
   VObjectType port_direction = VObjectType::slNoType;
-  while (stack.size()) {
+  while (!stack.empty()) {
     id = stack.top();
     if (ParameterPortListId && (id == ParameterPortListId)) {
       ParameterPortListId = 0;
@@ -337,7 +337,7 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
 
     if (current.m_sibling) stack.push(current.m_sibling);
     if (current.m_child) {
-      if (stopPoints.size()) {
+      if (!stopPoints.empty()) {
         bool stop = false;
         for (auto t : stopPoints) {
           if (t == current.m_type) {

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -523,7 +523,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
       if (Statement) {
         VectorOfany* while_stmts = compileStmt(
             component, fC, Statement, compileDesign, do_while, instance);
-        if (while_stmts && while_stmts->size()) {
+        if (while_stmts && !while_stmts->empty()) {
           any* stmt = (*while_stmts)[0];
           do_while->VpiStmt(stmt);
           stmt->VpiParent(do_while);
@@ -550,7 +550,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
         if (Statement) {
           VectorOfany* while_stmts = compileStmt(
               component, fC, Statement, compileDesign, waitst, instance);
-          if (while_stmts && while_stmts->size()) {
+          if (while_stmts && !while_stmts->empty()) {
             any* stmt = (*while_stmts)[0];
             waitst->VpiStmt(stmt);
             stmt->VpiParent(waitst);
@@ -581,7 +581,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
           // If only
           VectorOfany* if_stmts =
               compileStmt(component, fC, Stmt, compileDesign, waitst, instance);
-          if (if_stmts && if_stmts->size()) {
+          if (if_stmts && !if_stmts->empty()) {
             any* stmt = (*if_stmts)[0];
             waitst->VpiStmt(stmt);
             stmt->VpiParent(waitst);
@@ -591,7 +591,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
           Stmt = fC->Sibling(Stmt);
           VectorOfany* if_stmts =
               compileStmt(component, fC, Stmt, compileDesign, waitst, instance);
-          if (if_stmts && if_stmts->size()) {
+          if (if_stmts && !if_stmts->empty()) {
             any* stmt = (*if_stmts)[0];
             waitst->VpiElseStmt(stmt);
             stmt->VpiParent(waitst);
@@ -600,7 +600,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
           // if else
           VectorOfany* if_stmts =
               compileStmt(component, fC, Stmt, compileDesign, waitst, instance);
-          if (if_stmts && if_stmts->size()) {
+          if (if_stmts && !if_stmts->empty()) {
             any* stmt = (*if_stmts)[0];
             waitst->VpiStmt(stmt);
             stmt->VpiParent(waitst);
@@ -609,7 +609,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
           Stmt = fC->Sibling(Else);
           VectorOfany* else_stmts =
               compileStmt(component, fC, Stmt, compileDesign, waitst, instance);
-          if (else_stmts && else_stmts->size()) {
+          if (else_stmts && !else_stmts->empty()) {
             any* stmt = (*else_stmts)[0];
             waitst->VpiElseStmt(stmt);
             stmt->VpiParent(waitst);

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -1527,7 +1527,7 @@ bool CompileHelper::isOverloaded(const UHDM::any* expr,
   std::stack<const any*> stack;
   const UHDM::any* tmp = expr;
   stack.push(tmp);
-  while (stack.size()) {
+  while (!stack.empty()) {
     tmp = stack.top();
     stack.pop();
     UHDM_OBJECT_TYPE type = tmp->UhdmType();

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -217,7 +217,7 @@ bool DesignElaboration::setupConfigurations_() {
     }
   }
   std::unordered_set<const Config*> configS;
-  while (configq.size()) {
+  while (!configq.empty()) {
     std::string configName = configq.front();
     configq.pop();
     Config* conf = configSet->getMutableConfigByName(configName);
@@ -386,7 +386,7 @@ bool DesignElaboration::identifyTopModules_() {
         if (!used) {
           bool isTop = true;
 
-          if (m_toplevelConfigModules.size()) {
+          if (!m_toplevelConfigModules.empty()) {
             isTop = false;
             if (m_toplevelConfigModules.find(topname) !=
                 m_toplevelConfigModules.end()) {
@@ -403,7 +403,7 @@ bool DesignElaboration::identifyTopModules_() {
                 element->m_line, 0, topid);
             if (itr == m_uniqueTopLevelModules.end()) {
               bool okModule = true;
-              if (userTopList.size()) {
+              if (!userTopList.empty()) {
                 if (userTopList.find(elemName) == userTopList.end())
                   okModule = false;
               }
@@ -474,7 +474,7 @@ bool DesignElaboration::identifyTopModules_() {
         }
       }
 
-      if (locations.size()) {
+      if (!locations.empty()) {
         Error err1(ErrorDefinition::ELAB_MULTIPLY_DEFINED_MODULE, loc1,
                    &locations);
         m_compileDesign->getCompiler()->getErrorContainer()->addError(err1);
@@ -673,7 +673,7 @@ void DesignElaboration::recurseInstanceLoop_(
     // This is where the real logic goes.
     // indexes[i] contain the value of the i-th index.
     for (unsigned int i = 0; i < indexes.size(); i++) {
-      if (instanceName.size()) {
+      if (!instanceName.empty()) {
         if (instanceName[instanceName.size() - 1] == ' ') {
           instanceName.erase(instanceName.end() - 1);
         }
@@ -942,7 +942,7 @@ void DesignElaboration::elaborateInstance_(
 
       std::vector<NodeId> blockIds =
           fC->sl_collect_all(subInstanceId, btypes, true);
-      if (blockIds.size()) {
+      if (!blockIds.empty()) {
         NodeId blockId = blockIds[0];
         NodeId blockNameId = fC->Child(blockId);
         if (fC->Type(blockNameId) == VObjectType::slStringConst) {
@@ -1193,7 +1193,7 @@ void DesignElaboration::elaborateInstance_(
                 if (fC->Type(If_generate_construct) ==
                     slIf_generate_construct) {
                   blockIds = fC->sl_collect_all(childId, btypes, true);
-                  if (blockIds.size()) {
+                  if (!blockIds.empty()) {
                     NodeId blockId = blockIds[0];
                     NodeId blockNameId = fC->Child(blockId);
                     if (fC->Type(blockNameId) == VObjectType::slStringConst) {
@@ -1216,7 +1216,7 @@ void DesignElaboration::elaborateInstance_(
 
             } else {  // if-else-if
               blockIds = fC->sl_collect_all(childId, btypes, true);
-              if (blockIds.size()) {
+              if (!blockIds.empty()) {
                 NodeId blockId = blockIds[0];
                 NodeId blockNameId = fC->Child(blockId);
                 if (fC->Type(blockNameId) == VObjectType::slStringConst) {
@@ -1381,7 +1381,7 @@ void DesignElaboration::elaborateInstance_(
           fC->sl_collect_all(subInstanceId, insttypes, true);
 
       NodeId hierInstId = InvalidNodeId;
-      if (hierInstIds.size()) hierInstId = hierInstIds[0];
+      if (!hierInstIds.empty()) hierInstId = hierInstIds[0];
 
       if (hierInstId == InvalidNodeId) continue;
 
@@ -2105,7 +2105,7 @@ void DesignElaboration::reduceUnnamedBlocks_() {
     queue.push(instance);
   }
 
-  while (queue.size()) {
+  while (!queue.empty()) {
     ModuleInstance* current = queue.front();
     queue.pop();
     if (current == nullptr) continue;
@@ -2208,7 +2208,7 @@ bool DesignElaboration::bindDataTypes_() {
   for (auto modNamePair : modules) {
     ModuleDefinition* mod = modNamePair.second;
     VObjectType compType = mod->getType();
-    if (mod->getFileContents().size() == 0) {
+    if (mod->getFileContents().empty()) {
       // Built-in primitive
     } else if (compType == VObjectType::slModule_declaration ||
                compType == VObjectType::slInterface_declaration ||
@@ -2250,7 +2250,7 @@ void DesignElaboration::createFileList_() {
   std::queue<ModuleInstance*> queue;
   std::set<const FileContent*> files;
   for (auto pack : design->getPackageDefinitions()) {
-    if (pack.second->getFileContents().size()) {
+    if (!pack.second->getFileContents().empty()) {
       if (pack.second->getFileContents()[0] != nullptr)
         files.insert(pack.second->getFileContents()[0]);
     }
@@ -2260,7 +2260,7 @@ void DesignElaboration::createFileList_() {
     queue.push(instance);
   }
 
-  while (queue.size()) {
+  while (!queue.empty()) {
     ModuleInstance* current = queue.front();
     DesignComponent* def = current->getDefinition();
     queue.pop();

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -431,7 +431,7 @@ const DataType* ElaborationStep::bindDataType_(
   SymbolTable* symbols = compiler->getSymbolTable();
   Design* design = compiler->getDesign();
   std::string libName = "work";
-  if (parent->getFileContents().size()) {
+  if (!parent->getFileContents().empty()) {
     libName = parent->getFileContents()[0]->getLibrary()->getName();
   }
   ClassNameClassDefinitionMultiMap classes = design->getClassDefinitions();
@@ -764,7 +764,7 @@ Variable* ElaborationStep::locateStaticVariable_(
   if (itr != m_staticVariables.end()) return (*itr).second;
   Variable* result = nullptr;
   Design* design = m_compileDesign->getCompiler()->getDesign();
-  if (var_chain.size() > 0) {
+  if (!var_chain.empty()) {
     Package* package = design->getPackage(var_chain[0]);
     if (package) {
       if (var_chain.size() > 1) {
@@ -821,7 +821,7 @@ Variable* ElaborationStep::locateStaticVariable_(
     }
   }
   if (result == nullptr) {
-    if (var_chain.size()) {
+    if (!var_chain.empty()) {
       const DataType* dtype =
           bindDataType_(var_chain[0], fC, id, parentComponent, errtype);
       if (dtype) {
@@ -1535,7 +1535,7 @@ any* ElaborationStep::makeVar_(DesignComponent* component, Signal* sig,
     }
 
     if (associative || queue || dynamic) {
-      if (unpackedDimensions->size()) {
+      if (!unpackedDimensions->empty()) {
         if (index == 0) {
           array_var->Ranges(unpackedDimensions);
         } else {

--- a/src/DesignCompile/Elaboration_test.cpp
+++ b/src/DesignCompile/Elaboration_test.cpp
@@ -51,7 +51,7 @@ TEST(Elaboration, ExprFromPpTree) {
   auto insts = design->getTopLevelModuleInstances();
   ModuleInstance* top = nullptr;
   DesignComponent* component = nullptr;
-  if (insts.size()) {
+  if (!insts.empty()) {
     top = insts.at(0);
     component = top->getDefinition();
   }
@@ -97,7 +97,7 @@ TEST(Elaboration, ExprFromText) {
   auto insts = design->getTopLevelModuleInstances();
   ModuleInstance* top = nullptr;
   DesignComponent* component = nullptr;
-  if (insts.size()) {
+  if (!insts.empty()) {
     top = insts.at(0);
     component = top->getDefinition();
   }
@@ -141,7 +141,7 @@ TEST(Elaboration, ExprUsePackage) {
   auto insts = design->getTopLevelModuleInstances();
   ModuleInstance* top = nullptr;
   DesignComponent* component = nullptr;
-  if (insts.size()) {
+  if (!insts.empty()) {
     top = insts.at(0);
     component = top->getDefinition();
   }
@@ -191,7 +191,7 @@ TEST(Elaboration, DollarBits) {
   endmodule // top)");
   auto insts = design->getTopLevelModuleInstances();
   ModuleInstance* top = nullptr;
-  if (insts.size()) {
+  if (!insts.empty()) {
     top = insts.at(0);
   }
   EXPECT_NE(top, nullptr);
@@ -267,10 +267,10 @@ TEST(Elaboration, ConcatHexa) {
   std::tie(design, fC, compileDesign) = eharness.elaborate(R"(
   module dut();
     localparam logic [31:0] JT = {
-      4'h0,     
-      16'h4F54, 
-      11'h426,  
-      1'b1      
+      4'h0,
+      16'h4F54,
+      11'h426,
+      1'b1
     };
   endmodule)");
   Compiler* compiler = compileDesign->getCompiler();
@@ -295,7 +295,7 @@ TEST(Elaboration, ParamSubstituteWhenConstant) {
   std::tie(design, fC, compileDesign) = eharness.elaborate(R"(
   package aes_pkg;
     parameter logic [7:0][3:0] X = 32'habcd;
-  endpackage 
+  endpackage
   module aes_cipher_core;
     import aes_pkg::*;
     parameter logic [7:0][3:0] P = X;
@@ -323,8 +323,8 @@ TEST(Elaboration, ParamSubstituteComplex) {
   std::tie(design, fC, compileDesign) = eharness.elaborate(R"(
 module top();
 
-typedef logic [0:4]       fmt_logic_t;  
-  
+typedef logic [0:4]       fmt_logic_t;
+
 typedef struct packed {
     int unsigned Width;
     logic        EnableVectors;
@@ -343,11 +343,11 @@ localparam fpu_features_t RV64D_Xsflt = '{
  localparam XLEN = 64;
 
 localparam IS_XLEN64  = (XLEN == 32) ? 1'b0 : 1'b1;
-localparam bit RVF = IS_XLEN64; 
+localparam bit RVF = IS_XLEN64;
 localparam bit RVD = IS_XLEN64;
-localparam bit XF16    = 1'b0; 
-localparam bit XF16ALT = 1'b0; 
-localparam bit XF8     = 1'b0; 
+localparam bit XF16    = 1'b0;
+localparam bit XF16ALT = 1'b0;
+localparam bit XF8     = 1'b0;
 localparam bit XFVEC   = 1'b0;
 
 localparam fpu_features_t FPU_FEATURES = '{
@@ -359,7 +359,7 @@ localparam fpu_features_t FPU_FEATURES = '{
     };
  parameter fpu_features_t   Features       = FPU_FEATURES;
  parameter fmt_logic_t      FpFmtMask     = Features.FpFmtMask;
- 
+
 localparam DEBUGME = FpFmtMask[0];
 
 endmodule

--- a/src/DesignCompile/ElaboratorHarness.cpp
+++ b/src/DesignCompile/ElaboratorHarness.cpp
@@ -39,7 +39,7 @@ std::tuple<Design*, FileContent*, CompileDesign*> ElaboratorHarness::elaborate(
   compiler->compile();
   Design* design = compiler->getDesign();
   FileContent* fC = nullptr;
-  if (compiler->getCompileSourceFiles().size()) {
+  if (!compiler->getCompileSourceFiles().empty()) {
     CompileSourceFile* csf = compiler->getCompileSourceFiles().at(0);
     ParseFile* pf = csf->getParser();
     fC = pf->getFileContent();

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -1198,7 +1198,7 @@ interface* NetlistElaboration::elab_interface_(
   VectorOfmodport* dest_modports = s.MakeModportVec();
   for (auto& orig_modport : orig_modports) {
     const std::string modportfullname = instName + "." + orig_modport.first;
-    if ((modPortName != "") && (modportfullname != modPortName)) continue;
+    if (!modPortName.empty() && (modportfullname != modPortName)) continue;
     modport* dest_modport = s.MakeModport();
     dest_modport->Interface(sm);
     dest_modport->VpiParent(sm);

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -196,7 +196,7 @@ bool TestbenchElaboration::checkForMultipleDefinition_() {
         }
       }
 
-      if (locations.size()) {
+      if (!locations.empty()) {
         Error err1(ErrorDefinition::COMP_MULTIPLY_DEFINED_CLASS, loc1,
                    &locations);
         errors->addError(err1);
@@ -494,7 +494,7 @@ bool TestbenchElaboration::bindSubRoutineCall_(ClassDefinition* classDefinition,
       }
     }
   }
-  if (var_chain.size() == 0) {
+  if (var_chain.empty()) {
     if (st->isSystemCall()) {
       validFunction = checkValidBuiltinClass_("system", function, stmt, design,
                                               datatypeName);
@@ -526,7 +526,7 @@ bool TestbenchElaboration::bindSubRoutineCall_(ClassDefinition* classDefinition,
     }
     std::string name;
     for (auto v : var_chain) name += v + ".";
-    if (name.size()) name = name.substr(0, name.size() - 1);
+    if (!name.empty()) name = name.substr(0, name.size() - 1);
     while (dtype && dtype->getDefinition()) {
       dtype = dtype->getDefinition();
     }
@@ -626,7 +626,7 @@ bool TestbenchElaboration::bindFunctionBodies_() {
       std::queue<Statement*> stmts;
       for (Statement* stmt : func.second->getStmts()) stmts.push(stmt);
 
-      while (stmts.size()) {
+      while (!stmts.empty()) {
         Statement* stmt = stmts.front();
         stmts.pop();
         for (Statement* stmt1 : stmt->getStatements()) stmts.push(stmt1);

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -93,7 +93,7 @@ bool UhdmChecker::registerFile(const FileContent* fC,
   RangesMap& uhdmCover = (*fileItr).second;
   bool skipModule = false;
   NodeId endModuleNode = 0;
-  while (stack.size()) {
+  while (!stack.empty()) {
     id = stack.top();
     stack.pop();
     current = fC->Object(id);

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -676,7 +676,7 @@ void mapLowConns(std::vector<Signal*>& orig_ports, Serializer& s,
 void writeClass(ClassDefinition* classDef, VectorOfclass_defn* dest_classes,
                 Serializer& s, UhdmWriter::ComponentMap& componentMap,
                 BaseClass* parent) {
-  if (classDef->getFileContents().size() &&
+  if (!classDef->getFileContents().empty() &&
       classDef->getType() == VObjectType::slClass_declaration) {
     const FileContent* fC = classDef->getFileContents()[0];
     class_defn* c = classDef->getUhdmDefinition();
@@ -714,8 +714,8 @@ void writeClass(ClassDefinition* classDef, VectorOfclass_defn* dest_classes,
     c->VpiParent(parent);
     dest_classes->push_back(c);
     const std::string& name = classDef->getName();
-    if (c->VpiName() == "") c->VpiName(name);
-    if (c->VpiFullName() == "") c->VpiFullName(name);
+    if (c->VpiName().empty()) c->VpiName(name);
+    if (c->VpiFullName().empty()) c->VpiFullName(name);
     c->Attributes(classDef->Attributes());
     if (fC) {
       // Builtin classes have no file
@@ -2035,7 +2035,7 @@ void UhdmWriter::writeInstance(ModuleDefinition* mod, ModuleInstance* instance,
       if (insttype == VObjectType::slModule_instantiation) {
         if (subModules == nullptr) subModules = s.MakeModuleVec();
         module* sm = s.MakeModule();
-        if (childDef && childDef->getFileContents().size() &&
+        if (childDef && !childDef->getFileContents().empty() &&
             compileDesign->getCompiler()->isLibraryFile(
                 childDef->getFileContents()[0]->getSymbolId())) {
           sm->VpiCellInstance(true);
@@ -2391,7 +2391,7 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
     VectorOfpackage* v2 = s.MakePackageVec();
     for (Package* pack : packages) {
       if (!pack) continue;
-      if (pack->getFileContents().size() &&
+      if (!pack->getFileContents().empty() &&
           pack->getType() == VObjectType::slPackage_declaration) {
         const FileContent* fC = pack->getFileContents()[0];
         package* p = (package*)pack->getUhdmInstance();
@@ -2419,7 +2419,7 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
     VectorOfprogram* uhdm_programs = s.MakeProgramVec();
     for (auto progNamePair : programs) {
       Program* prog = progNamePair.second;
-      if (prog->getFileContents().size() &&
+      if (!prog->getFileContents().empty() &&
           prog->getType() == VObjectType::slProgram_declaration) {
         const FileContent* fC = prog->getFileContents()[0];
         program* p = s.MakeProgram();
@@ -2444,7 +2444,7 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
     VectorOfinterface* uhdm_interfaces = s.MakeInterfaceVec();
     for (auto modNamePair : modules) {
       ModuleDefinition* mod = modNamePair.second;
-      if (mod->getFileContents().size() == 0) {
+      if (mod->getFileContents().empty()) {
         // Built-in primitive
       } else if (mod->getType() == VObjectType::slInterface_declaration) {
         const FileContent* fC = mod->getFileContents()[0];
@@ -2471,7 +2471,7 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
     VectorOfudp_defn* uhdm_udps = s.MakeUdp_defnVec();
     for (auto modNamePair : modules) {
       ModuleDefinition* mod = modNamePair.second;
-      if (mod->getFileContents().size() == 0) {
+      if (mod->getFileContents().empty()) {
         // Built-in primitive
       } else if (mod->getType() == VObjectType::slModule_declaration) {
         const FileContent* fC = mod->getFileContents()[0];
@@ -2514,7 +2514,7 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
     VectorOfclass_defn* v4 = s.MakeClass_defnVec();
     for (auto classNamePair : classes) {
       ClassDefinition* classDef = classNamePair.second;
-      if (classDef->getFileContents().size() &&
+      if (!classDef->getFileContents().empty() &&
           classDef->getType() == VObjectType::slClass_declaration) {
         class_defn* c = classDef->getUhdmDefinition();
         if (!c->VpiParent()) {
@@ -2617,7 +2617,7 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
           m_compileDesign->getCompiler()->getCommandLineParser()->muteStdout());
 
       std::cout << "====== UHDM =======\n";
-      if (restoredDesigns.size()) {
+      if (!restoredDesigns.empty()) {
         designHandle = restoredDesigns[0];
       }
       vpi_show_ids(

--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -367,7 +367,7 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
         std::string size = val;
         StringUtils::rtrim(size, '\'');
         int64_t intsize = 0;
-        if (size != "") intsize = std::strtoull(size.c_str(), 0, 10);
+        if (!size.empty()) intsize = std::strtoull(size.c_str(), 0, 10);
         if (strstr(val.c_str(), "'")) {
           uint64_t hex_value = 0;
           char base = 'h';
@@ -427,13 +427,13 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
               break;
           }
           if (intformat) {
-            if (size == "")
+            if (size.empty())
               value->set(hex_value, Value::Type::Integer, 0);
             else
               value->set(hex_value, Value::Type::Unsigned, intsize);
           }
         } else {
-          if (val.size() && (val[0] == '-')) {
+          if (!val.empty() && (val[0] == '-')) {
             int64_t i = std::strtoll(val.c_str(), 0, 10);
             value->set(i);
           } else {
@@ -667,7 +667,7 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
           Constant_expression = fC->Sibling(Constant_expression);
         }
         base = 'b';
-        if (svalue == "") {
+        if (svalue.empty()) {
           value->set((int64_t)0);
         } else {
           m_valueFactory.deleteValue(value);
@@ -1020,7 +1020,7 @@ Value* ExprBuilder::fromString(const std::string& value) {
           val->set((double)v);
         } else {
           int64_t v = std::strtoll(value_ptr, &end_parse_ptr, 10);
-          if (value_ptr != end_parse_ptr && value.size() && value[0] == '-') {
+          if (value_ptr != end_parse_ptr && !value.empty() && value[0] == '-') {
             val = m_valueFactory.newLValue();
             val->set(v, Value::Type::Integer, s);
           } else {
@@ -1053,7 +1053,7 @@ Value* ExprBuilder::fromString(const std::string& value) {
       val->set((double)v);
     } else {
       int64_t v = std::strtoll(value_ptr, &end_parse_ptr, 10);
-      if (value_ptr != end_parse_ptr && value.size() && value[0] == '-') {
+      if (value_ptr != end_parse_ptr && !value.empty() && value[0] == '-') {
         val = m_valueFactory.newLValue();
         val->set(v);
       } else {

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -182,7 +182,7 @@ bool ParseLibraryDef::parseConfigDefinition() {
     // Design clause
     std::vector<VObjectType> designStmt = {VObjectType::slDesign_statement};
     std::vector<NodeId> designs = fC->sl_collect_all(config, designStmt);
-    if (designs.size() == 0) {
+    if (designs.empty()) {
       // TODO: Error
     } else if (designs.size() > 1) {
       // TODO: Error
@@ -202,7 +202,7 @@ bool ParseLibraryDef::parseConfigDefinition() {
     // Default clause
     std::vector<VObjectType> defaultStmt = {VObjectType::slDefault_clause};
     std::vector<NodeId> defaults = fC->sl_collect_all(config, defaultStmt);
-    if (defaults.size() > 0) {
+    if (!defaults.empty()) {
       NodeId defaultClause = defaults[0];
       NodeId libList = fC->Sibling(defaultClause);
       if (fC->Type(libList) == VObjectType::slLiblist_clause) {

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -95,8 +95,8 @@ void AnalyzeFile::checkSLlineDirective_(std::string line, unsigned int lineNb) {
       m_includeFileInfo.push(info);
     } else if (type == IncludeFileInfo::POP) {
       // Pop
-      if (m_includeFileInfo.size()) m_includeFileInfo.pop();
-      if (m_includeFileInfo.size()) {
+      if (!m_includeFileInfo.empty()) m_includeFileInfo.pop();
+      if (!m_includeFileInfo.empty()) {
         m_includeFileInfo.top().m_sectionFile = info.m_sectionFile;
         m_includeFileInfo.top().m_originalLine = lineNb;
         m_includeFileInfo.top().m_sectionStartLine =
@@ -111,7 +111,7 @@ std::string AnalyzeFile::setSLlineDirective_(unsigned int lineNb,
                                              unsigned int& origFromLine,
                                              fs::path& origFile) {
   std::string result;
-  if (m_includeFileInfo.size()) {
+  if (!m_includeFileInfo.empty()) {
     result = "SLline ";
     origFile = m_clp->mutableSymbolTable()->getSymbol(
         m_includeFileInfo.top().m_sectionFile);
@@ -125,7 +125,7 @@ std::string AnalyzeFile::setSLlineDirective_(unsigned int lineNb,
     result += std::to_string(1);
     result += "\n";
   }
-  result = "";
+  result = "";  // BUG or intentional ?
   return result;
 }
 

--- a/src/SourceCompile/CompilationUnit.cpp
+++ b/src/SourceCompile/CompilationUnit.cpp
@@ -56,7 +56,7 @@ void CompilationUnit::recordTimeInfo(TimeInfo& info) {
 }
 
 TimeInfo& CompilationUnit::getTimeInfo(SymbolId fileId, unsigned int line) {
-  if (!m_timeInfo.size()) {
+  if (m_timeInfo.empty()) {
     return m_noTimeInfo;
   }
   for (int i = (int)m_timeInfo.size() - 1; i >= 0; i--) {
@@ -76,7 +76,7 @@ void CompilationUnit::recordDefaultNetType(NetTypeInfo& info) {
 
 VObjectType CompilationUnit::getDefaultNetType(SymbolId fileId,
                                                unsigned int line) {
-  if (!m_defaultNetTypes.size()) {
+  if (m_defaultNetTypes.empty()) {
     return slNetType_Wire;
   }
   for (int i = (int)m_defaultNetTypes.size() - 1; i >= 0; i--) {
@@ -91,7 +91,7 @@ VObjectType CompilationUnit::getDefaultNetType(SymbolId fileId,
 }
 
 void CompilationUnit::setCurrentTimeInfo(SymbolId fileId) {
-  if (!m_timeInfo.size()) {
+  if (m_timeInfo.empty()) {
     return;
   }
   TimeInfo info = m_timeInfo[m_timeInfo.size() - 1];

--- a/src/SourceCompile/CompileSourceFile.cpp
+++ b/src/SourceCompile/CompileSourceFile.cpp
@@ -260,7 +260,7 @@ bool CompileSourceFile::postPreprocess_() {
     return true;
   }
   std::string m_pp_result = m_pp->getPreProcessedFileContent();
-  if (m_text.size()) {
+  if (!m_text.empty()) {
     m_parser = new ParseFile(m_pp_result, this, m_compilationUnit,
                              m_library);  // unit test
   }

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -183,7 +183,7 @@ bool Compiler::ppinit_() {
     m_compilers.push_back(compiler);
   }
 
-  if (m_text.size()) {
+  if (!m_text.empty()) {
     Library* library = new Library("UnitTest", m_symbolTable);
     CompileSourceFile* compiler =
         new CompileSourceFile(0, m_commandLineParser, m_errors, this,

--- a/src/SourceCompile/ParseFile.cpp
+++ b/src/SourceCompile/ParseFile.cpp
@@ -173,7 +173,7 @@ void ParseFile::buildLineInfoCache_() {
   PreprocessFile* pp = getCompileSourceFile()->getPreprocessor();
   if (!pp) return;
   auto& infos = pp->getIncludeFileInfo();
-  if (infos.size()) {
+  if (!infos.empty()) {
     fileInfoCache.resize(pp->getSumLineCount() + 10);
     lineInfoCache.resize(pp->getSumLineCount() + 10);
     lineInfoCache[0] = 1;
@@ -230,7 +230,7 @@ SymbolId ParseFile::getFileId(unsigned int line) {
   PreprocessFile* pp = getCompileSourceFile()->getPreprocessor();
   if (!pp) return 0;
   auto& infos = pp->getIncludeFileInfo();
-  if (infos.size()) {
+  if (!infos.empty()) {
     if (!fileInfoCache.empty()) {
       if (line > fileInfoCache.size()) {
         SymbolId fileId = registerSymbol("CACHE OUT OF BOUND");
@@ -258,7 +258,7 @@ unsigned int ParseFile::getLineNb(unsigned int line) {
   PreprocessFile* pp = getCompileSourceFile()->getPreprocessor();
   if (!pp) return 0;
   auto& infos = pp->getIncludeFileInfo();
-  if (infos.size()) {
+  if (!infos.empty()) {
     if (!lineInfoCache.empty()) {
       if (line > lineInfoCache.size()) {
         SymbolId fileId = registerSymbol("CACHE OUT OF BOUND");
@@ -461,7 +461,7 @@ bool ParseFile::parse() {
   bool precompiled = false;
   if (prec->isFilePrecompiled(root)) precompiled = true;
 
-  if (m_children.size() == 0) {
+  if (m_children.empty()) {
     ParseCache cache(this);
 
     if (cache.restore()) {
@@ -490,7 +490,7 @@ bool ParseFile::parse() {
   }
 
   // This is not a parent Parser object
-  if (m_children.size() == 0) {
+  if (m_children.empty()) {
     // std::cout << std::endl << "Parsing " << getSymbol(m_ppFileId) << "
     // Line: " << m_offsetLine << std::endl << std::flush;
 
@@ -505,8 +505,8 @@ bool ParseFile::parse() {
   }
 
   // This is either a parent Parser object of this Parser object has no parent
-  if ((m_children.size() != 0) || (m_parent == nullptr)) {
-    if ((m_parent == nullptr) && (m_children.size() == 0)) {
+  if (!m_children.empty() || (m_parent == nullptr)) {
+    if ((m_parent == nullptr) && (m_children.empty())) {
       Timer tmr;
 
       m_listener = new SV3_1aTreeShapeListener(
@@ -538,7 +538,7 @@ bool ParseFile::parse() {
       }
     }
 
-    if (m_children.size() != 0) {
+    if (!m_children.empty()) {
       for (unsigned int i = 0; i < m_children.size(); i++) {
         if (m_children[i]->m_antlrParserHandler) {
           // Only visit the chunks that got re-parsed

--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
@@ -206,7 +206,7 @@ void SV3_1aPpTreeListenerHelper::checkMultiplyDefinedMacro(
 void SV3_1aPpTreeListenerHelper::setCurrentBranchActivity(
     unsigned int currentLine) {
   PreprocessFile::IfElseStack& stack = m_pp->getStack();
-  if (stack.size()) {
+  if (!stack.empty()) {
     int index = stack.size() - 1;
     bool checkPrev = true;
     while (checkPrev) {
@@ -256,7 +256,7 @@ bool SV3_1aPpTreeListenerHelper::isPreviousBranchActive() {
   PreprocessFile::IfElseStack& stack = m_pp->getStack();
   bool previousBranchActive = false;
   bool checkPrev = true;
-  if (stack.size() == 0) {
+  if (stack.empty()) {
     return false;
   }
   int index = stack.size() - 1;

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -687,7 +687,7 @@ void SV3_1aPpTreeShapeListener::enterLine_directive(
   std::string fileName;
   if (ctx->String()) fileName = StringUtils::unquoted(ctx->String()->getText());
   std::string number;
-  if (ctx->number().size()) number = ctx->number()[0]->getText();
+  if (!ctx->number().empty()) number = ctx->number()[0]->getText();
   SymbolId newFileId = getSymbolTable()->registerSymbol(fileName);
   if (ctx->number().size() > 1) {
     std::string type = ctx->number()[1]->getText();
@@ -1046,7 +1046,7 @@ void SV3_1aPpTreeShapeListener::enterEndif_directive(
   PreprocessFile::IfElseStack &stack = m_pp->getStack();
   std::pair<int, int> lineCol =
       ParseUtils::getLineColumn(m_pp->getTokenStream(), ctx);
-  if (stack.size()) {
+  if (!stack.empty()) {
     bool unroll = true;
     if (ctx->One_line_comment()) {
       addLineFiller(ctx);

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
@@ -120,7 +120,7 @@ void SV3_1aTreeShapeHelper::addNestedDesignElement(
   elem->m_timeInfo = m_pf->getCompilationUnit()->getTimeInfo(fileId, line);
   elem->m_defaultNetType =
       m_pf->getCompilationUnit()->getDefaultNetType(fileId, line);
-  if (m_nestedElements.size()) {
+  if (!m_nestedElements.empty()) {
     elem->m_timeInfo = m_nestedElements.top()->m_timeInfo;
     elem->m_parent = m_nestedElements.top()->m_uniqueId;
   }

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -192,8 +192,8 @@ void SV3_1aTreeShapeListener::exitSlline(SV3_1aParser::SllineContext *ctx) {
     m_includeFileInfo.push(info);
   } else if (type == IncludeFileInfo::POP) {
     // Pop
-    if (m_includeFileInfo.size()) m_includeFileInfo.pop();
-    if (m_includeFileInfo.size()) {
+    if (!m_includeFileInfo.empty()) m_includeFileInfo.pop();
+    if (!m_includeFileInfo.empty()) {
       m_includeFileInfo.top().m_sectionFile =
           m_pf->getSymbolTable()->registerSymbol(file);
       m_includeFileInfo.top().m_originalLine = lineCol.first /*+ m_lineOffset*/;
@@ -902,7 +902,7 @@ void SV3_1aTreeShapeListener::exitSystem_task_names(
   else if (ctx->ASSERT())
     addVObject((antlr4::ParserRuleContext *)ctx->ASSERT(), ident,
                VObjectType::slStringConst);
-  else if (ctx->Simple_identifier().size())
+  else if (!ctx->Simple_identifier().empty())
     addVObject((antlr4::ParserRuleContext *)ctx->Simple_identifier()[0], ident,
                VObjectType::slStringConst);
   else if (ctx->SIGNED())
@@ -1198,13 +1198,13 @@ void SV3_1aTreeShapeListener::exitPs_identifier(
     SV3_1aParser::Ps_identifierContext *ctx) {
   std::string ident;
   antlr4::ParserRuleContext *childCtx = nullptr;
-  if (ctx->Simple_identifier().size()) {
+  if (!ctx->Simple_identifier().empty()) {
     childCtx = (antlr4::ParserRuleContext *)ctx->Simple_identifier()[0];
     ident = ctx->Simple_identifier()[0]->getText();
     if (ctx->Simple_identifier().size() > 1) {
       ident += "::" + ctx->Simple_identifier()[1]->getText();
     }
-  } else if (ctx->Escaped_identifier().size()) {
+  } else if (!ctx->Escaped_identifier().empty()) {
     childCtx = (antlr4::ParserRuleContext *)ctx->Escaped_identifier()[0];
     ident = ctx->Escaped_identifier()[0]->getText();
     std::regex escaped(std::string(EscapeSequence) + std::string("(.*?)") +
@@ -1214,13 +1214,13 @@ void SV3_1aTreeShapeListener::exitPs_identifier(
       std::string var = match[1].str();
       ident = ident.replace(match.position(0), match.length(0), var);
     }
-  } else if (ctx->THIS().size()) {
+  } else if (!ctx->THIS().empty()) {
     childCtx = (antlr4::ParserRuleContext *)ctx->THIS()[0];
     ident = ctx->THIS()[0]->getText();
-  } else if (ctx->RANDOMIZE().size()) {
+  } else if (!ctx->RANDOMIZE().empty()) {
     childCtx = (antlr4::ParserRuleContext *)ctx->RANDOMIZE()[0];
     ident = ctx->RANDOMIZE()[0]->getText();
-  } else if (ctx->SAMPLE().size()) {
+  } else if (!ctx->SAMPLE().empty()) {
     childCtx = (antlr4::ParserRuleContext *)ctx->SAMPLE()[0];
     ident = ctx->SAMPLE()[0]->getText();
   } else if (ctx->DOLLAR_UNIT()) {
@@ -1382,7 +1382,7 @@ void SV3_1aTreeShapeListener::exitExpression(
     else
       addVObject((antlr4::ParserRuleContext *)ctx->BITW_AND(),
                  VObjectType::slBinOp_BitwAnd);
-  } else if (ctx->LOGICAL_AND().size()) {
+  } else if (!ctx->LOGICAL_AND().empty()) {
     addVObject((antlr4::ParserRuleContext *)ctx->LOGICAL_AND()[0],
                VObjectType::slBinOp_LogicAnd);
   } else if (ctx->LOGICAL_OR()) {
@@ -1549,7 +1549,7 @@ void SV3_1aTreeShapeListener::exitConstant_expression(
     else
       addVObject((antlr4::ParserRuleContext *)ctx->BITW_AND(),
                  VObjectType::slBinOp_BitwAnd);
-  } else if (ctx->LOGICAL_AND().size()) {
+  } else if (!ctx->LOGICAL_AND().empty()) {
     addVObject((antlr4::ParserRuleContext *)ctx->LOGICAL_AND()[0],
                VObjectType::slBinOp_LogicAnd);
   } else if (ctx->LOGICAL_OR()) {


### PR DESCRIPTION
…ontainers.

Depending on the container, this can also be more efficient, but mostly this
is to improve readability and express intent better.

https://clang.llvm.org/extra/clang-tidy/checks/readability-container-size-empty.html

Signed-off-by: Henner Zeller <h.zeller@acm.org>