### PR TITLE
Use const references in range loop if possible.

### DIFF
--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -32,6 +32,7 @@ Checks: >
     clang-diagnostic-inconsistent-missing-override,
     clang-diagnostic-unused-private-field,
     modernize-use-override,
+    performance-for-range-copy,
     readability-container-size-empty,
     readability-delete-null-pointer,
     readability-redundant-member-init,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -585,8 +585,6 @@ jobs:
 
   ClangTidy:
     runs-on: ubuntu-20.04
-    if: ${{github.event_name == 'pull_request'}}
-
     steps:
 
     - name: Cancel previous

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -264,7 +264,7 @@ bool PPCache::checkCacheIsValid_(const fs::path& cacheFileName) {
     auto defineList =
         m_pp->getCompileSourceFile()->getCommandLineParser()->getDefineList();
     std::vector<std::string> define_vec;
-    for (auto definePair : defineList) {
+    for (const auto& definePair : defineList) {
       std::string spath =
           m_pp->getSymbol(definePair.first) + "=" + definePair.second;
       define_vec.push_back(spath);

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -51,7 +51,7 @@ Design::~Design() {
   for (auto elem : m_fileContents) {
     delete elem.second;
   }
-  for (auto elem : m_moduleDefinitions) {
+  for (const auto& elem : m_moduleDefinitions) {
     delete elem.second;
   }
   for (auto elem : m_topLevelModuleInstances) {
@@ -60,10 +60,10 @@ Design::~Design() {
   for (auto elem : m_orderedPackageDefinitions) {
     delete elem;
   }
-  for (auto elem : m_programDefinitions) {
+  for (const auto& elem : m_programDefinitions) {
     delete elem.second;
   }
-  for (auto elem : m_uniqueClassDefinitions) {
+  for (const auto& elem : m_uniqueClassDefinitions) {
     delete elem.second;
   }
 }
@@ -165,13 +165,13 @@ std::string Design::reportInstanceTree() const {
       if (tmp) {
         ModuleInstance* inst = valuedcomponenti_cast<ModuleInstance*>(tmp);
         if (inst) {
-          for (auto ps : inst->getMappedValues()) {
+          for (const auto& ps : inst->getMappedValues()) {
             const std::string& name = ps.first;
             Value* val = ps.second.first;
             tree +=
                 std::string("    " + name + " = " + val->uhdmValue() + "\n");
           }
-          for (auto ps : inst->getComplexValues()) {
+          for (const auto& ps : inst->getComplexValues()) {
             const std::string& name = ps.first;
             tree += std::string("    " + name + " = " + "complex" + "\n");
           }
@@ -384,7 +384,7 @@ void Design::addDefParam_(std::vector<std::string>& path, const FileContent* fC,
 void Design::checkDefParamUsage(DefParam* parent) {
   if (parent == nullptr) {
     // Start by all the top defs of the trie
-    for (auto top : m_defParams) {
+    for (const auto& top : m_defParams) {
       checkDefParamUsage(top.second);
     }
   } else {
@@ -408,7 +408,7 @@ void Design::checkDefParamUsage(DefParam* parent) {
       Error err(ErrorDefinition::ELAB_UNMATCHED_DEFPARAM, loc);
       m_errors->addError(err);
     }
-    for (auto param : parent->getChildren()) {
+    for (const auto& param : parent->getChildren()) {
       checkDefParamUsage(param.second);
     }
   }
@@ -450,7 +450,7 @@ void Design::orderPackages() {
   unsigned int index = 0;
   typedef std::map<std::string, int> MultiDefCount;
   MultiDefCount multiDefCount;
-  for (auto packageName : m_orderedPackageNames) {
+  for (const auto& packageName : m_orderedPackageNames) {
     for (unsigned int i = 0; i < m_packageDefinitions.size(); i++) {
       PackageNamePackageDefinitionMultiMap::iterator pos =
           m_packageDefinitions.begin();

--- a/src/Design/DesignComponent.cpp
+++ b/src/Design/DesignComponent.cpp
@@ -65,8 +65,8 @@ void DesignComponent::addObject(VObjectType type, FileCNodeId object) {
   }
 }
 
-void DesignComponent::addNamedObject(std::string name, FileCNodeId object,
-                                     DesignComponent* def) {
+void DesignComponent::addNamedObject(const std::string& name,
+                                     FileCNodeId object, DesignComponent* def) {
   m_namedObjects.insert(std::make_pair(name, std::make_pair(object, def)));
 }
 
@@ -89,7 +89,7 @@ void DesignComponent::append(DesignComponent* comp) {
   for (auto& obj : comp->m_namedObjects) {
     addNamedObject(obj.first, obj.second.first, obj.second.second);
   }
-  for (auto dtype : comp->m_dataTypes)
+  for (const auto& dtype : comp->m_dataTypes)
     insertDataType(dtype.first, dtype.second);
 }
 

--- a/src/Design/DesignComponent.h
+++ b/src/Design/DesignComponent.h
@@ -94,7 +94,7 @@ class DesignComponent : public ValuedComponentI, public PortNetHolder {
   const std::vector<FileCNodeId>& getObjects(VObjectType type) const;
   void addObject(VObjectType type, FileCNodeId object);
 
-  void addNamedObject(std::string name, FileCNodeId object,
+  void addNamedObject(const std::string& name, FileCNodeId object,
                       DesignComponent* def = nullptr);
   std::map<std::string, std::pair<FileCNodeId, DesignComponent*>>&
   getNamedObjects() {

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -82,7 +82,7 @@ unsigned int FileContent::getSize() const { return m_objects.size(); }
 
 std::string FileContent::printSubTree(NodeId uniqueId) {
   std::string text;
-  for (auto s : collectSubTree(uniqueId)) {
+  for (const auto& s : collectSubTree(uniqueId)) {
     text += s + "\n";
   }
   return text;
@@ -164,13 +164,13 @@ std::vector<std::string> FileContent::collectSubTree(NodeId index) {
                                         GetDefinitionFile(index), m_fileId));
 
   if (m_objects[index].m_child) {
-    for (auto s : collectSubTree(m_objects[index].m_child)) {
+    for (const auto& s : collectSubTree(m_objects[index].m_child)) {
       text.push_back("    " + s);
     }
   }
 
   if (m_objects[index].m_sibling) {
-    for (auto s : collectSubTree(m_objects[index].m_sibling)) {
+    for (const auto& s : collectSubTree(m_objects[index].m_sibling)) {
       text.push_back(s);
     }
   }

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -118,7 +118,7 @@ bool CompileDesign::compile() {
 template <class ObjectType, class ObjectMapType, typename FunctorType>
 void CompileDesign::compileMT_(ObjectMapType& objects, int maxThreadCount) {
   if (maxThreadCount == 0) {
-    for (auto itr : objects) {
+    for (const auto& itr : objects) {
       FunctorType funct(this, itr.second, m_compiler->getDesign(),
                         m_symbolTables[0], m_errorContainers[0]);
       funct.operator()();
@@ -131,7 +131,7 @@ void CompileDesign::compileMT_(ObjectMapType& objects, int maxThreadCount) {
       jobSize[i] = 0;
     }
     std::vector<std::vector<ObjectType*>> jobArray(maxThreadCount);
-    for (auto mod : objects) {
+    for (const auto& mod : objects) {
       unsigned int size = mod.second->getSize();
       if (size == 0) size = 100;
       unsigned int newJobIndex = 0;
@@ -218,7 +218,7 @@ void CompileDesign::collectObjects_(Design::FileIdDesignContentMap& all_files,
         if (finalCollection) lib->addModuleDefinition(mod.second);
       }
     }
-    for (auto prog : fC->getProgramDefinitions()) {
+    for (const auto& prog : fC->getProgramDefinitions()) {
       design->addProgramDefinition(prog.first, prog.second);
     }
     for (auto pack : fC->getPackageDefinitions()) {
@@ -264,7 +264,7 @@ void CompileDesign::collectObjects_(Design::FileIdDesignContentMap& all_files,
     }
     for (auto def : fC->getClassDefinitions()) {
       design->addClassDefinition(def.first, def.second);
-      for (auto def1 : def.second->getClassMap()) {
+      for (const auto& def1 : def.second->getClassMap()) {
         design->addClassDefinition(def1.first, def1.second);
       }
     }
@@ -400,13 +400,13 @@ void decompile(ValuedComponentI* instance) {
         std::cout << "Mod: " << inst->getModuleName() << " "
                   << component->getFileContents()[0]->getFileName() << "\n";
 
-        for (auto ps : inst->getMappedValues()) {
+        for (const auto& ps : inst->getMappedValues()) {
           const std::string& name = ps.first;
           Value* val = ps.second.first;
           std::cout << std::string("    " + name + " = " + val->uhdmValue() +
                                    "\n");
         }
-        for (auto ps : inst->getComplexValues()) {
+        for (const auto& ps : inst->getComplexValues()) {
           const std::string& name = ps.first;
           std::cout << std::string("    " + name + " =  complex\n");
         }

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -3202,7 +3202,7 @@ any* CompileHelper::getValue(const std::string& name,
     }
   }
   if (component && (result == nullptr)) {
-    for (auto tp : component->getTypeDefMap()) {
+    for (const auto& tp : component->getTypeDefMap()) {
       TypeDef* tpd = tp.second;
       typespec* tps = tpd->getTypespec();
       if (tps && tps->UhdmType() == uhdmenum_typespec) {
@@ -5312,13 +5312,13 @@ bool CompileHelper::errorOnNegativeConstant(
           std::cout << "Mod: " << inst->getModuleName() << " "
                     << component->getFileContents()[0]->getFileName() << "\n";
 
-          for (auto ps : inst->getMappedValues()) {
+          for (const auto& ps : inst->getMappedValues()) {
             const std::string& name = ps.first;
             Value* val = ps.second.first;
             std::cout << std::string("    " + name + " = " + val->uhdmValue() +
                                      "\n");
           }
-          for (auto ps : inst->getComplexValues()) {
+          for (const auto& ps : inst->getComplexValues()) {
             const std::string& name = ps.first;
             std::cout << std::string("    " + name + " =  complex\n");
           }

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -266,7 +266,7 @@ bool DesignElaboration::setupConfigurations_() {
   }
 
   // Remove unused configs from set
-  for (auto name : unused) {
+  for (const auto& name : unused) {
     std::vector<Config>::iterator itr;
     for (itr = allConfigs.begin(); itr != allConfigs.end(); itr++) {
       if ((*itr).getName() == name) {
@@ -494,7 +494,7 @@ bool DesignElaboration::identifyTopModules_() {
 
   // User overrides
   if (!toplevelModuleFound) {
-    for (auto userM : userTopList) {
+    for (const auto& userM : userTopList) {
       bool found = false;
       for (auto file : all_files) {
         if (m_compileDesign->getCompiler()->isLibraryFile(file.first)) continue;
@@ -573,7 +573,7 @@ bool DesignElaboration::createBuiltinPrimitives_() {
 
 bool DesignElaboration::elaborateAllModules_(bool onlyTopLevel) {
   bool status = true;
-  for (auto topmodule : m_topLevelModules) {
+  for (const auto& topmodule : m_topLevelModules) {
     if (!elaborateModule_(topmodule.first, topmodule.second, onlyTopLevel)) {
       status = false;
     }
@@ -783,7 +783,7 @@ void DesignElaboration::elaborateInstance_(
   while (tmp) {
     if (tmp->getDefinition() == parentDef) {
       loopDetected = true;
-      for (auto pvalues : parent->getMappedValues()) {
+      for (const auto& pvalues : parent->getMappedValues()) {
         const std::string& name = pvalues.first;
         Value* pval = pvalues.second.first;
         Value* val = tmp->getValue(name, m_exprBuilder);
@@ -794,7 +794,7 @@ void DesignElaboration::elaborateInstance_(
           }
         }
       }
-      for (auto cvalues : parent->getComplexValues()) {
+      for (const auto& cvalues : parent->getComplexValues()) {
         const std::string& name = cvalues.first;
         UHDM::expr* pval = cvalues.second;
         UHDM::expr* val = tmp->getComplexValue(name);
@@ -827,7 +827,7 @@ void DesignElaboration::elaborateInstance_(
 
   // Apply DefParams
   Design* design = m_compileDesign->getCompiler()->getDesign();
-  for (auto name : params) {
+  for (const auto& name : params) {
     DefParam* defparam =
         design->getDefParam(parent->getFullPathName() + "." + name);
     if (defparam) {
@@ -1310,7 +1310,7 @@ void DesignElaboration::elaborateInstance_(
 
       std::vector<std::string> libs;
       if (config) {
-        for (auto lib : config->getDefaultLibs()) {
+        for (const auto& lib : config->getDefaultLibs()) {
           libs.push_back(lib);
         }
         libs.push_back(libName);
@@ -1318,7 +1318,7 @@ void DesignElaboration::elaborateInstance_(
         libs.push_back(libName);
       }
 
-      for (auto lib : libs) {
+      for (const auto& lib : libs) {
         modName = lib + "@" + mname;
         def = design->getComponentDefinition(modName);
         if (def) {
@@ -1343,7 +1343,7 @@ void DesignElaboration::elaborateInstance_(
             break;
           }
           case UseClause::UseLib: {
-            for (auto lib : use.getLibs()) {
+            for (const auto& lib : use.getLibs()) {
               modName = lib + "@" + mname;
               def = design->getComponentDefinition(modName);
               if (def) {
@@ -1405,7 +1405,7 @@ void DesignElaboration::elaborateInstance_(
               break;
             }
             case UseClause::UseLib: {
-              for (auto lib : use.getLibs()) {
+              for (const auto& lib : use.getLibs()) {
                 modName = lib + "@" + mname;
                 def = design->getComponentDefinition(modName);
                 if (def) {
@@ -2181,7 +2181,7 @@ bool DesignElaboration::bindDataTypes_(ModuleInstance* instance,
 bool DesignElaboration::bindPackagesDataTypes_() {
   Design* design = m_compileDesign->getCompiler()->getDesign();
   auto packages = design->getPackageDefinitions();
-  for (auto packNamePair : packages) {
+  for (const auto& packNamePair : packages) {
     Package* package = packNamePair.second;
     const FileContent* fC = package->getFileContents()[0];
     std::vector<Signal*>& ports = package->getPorts();  // Always empty
@@ -2195,7 +2195,7 @@ bool DesignElaboration::bindPackagesDataTypes_() {
 bool DesignElaboration::bindDataTypes_() {
   Design* design = m_compileDesign->getCompiler()->getDesign();
   auto packages = design->getPackageDefinitions();
-  for (auto packNamePair : packages) {
+  for (const auto& packNamePair : packages) {
     Package* package = packNamePair.second;
     const FileContent* fC = package->getFileContents()[0];
     std::vector<Signal*>& ports = package->getPorts();  // Always empty
@@ -2205,7 +2205,7 @@ bool DesignElaboration::bindDataTypes_() {
   }
 
   auto modules = design->getModuleDefinitions();
-  for (auto modNamePair : modules) {
+  for (const auto& modNamePair : modules) {
     ModuleDefinition* mod = modNamePair.second;
     VObjectType compType = mod->getType();
     if (mod->getFileContents().empty()) {
@@ -2235,7 +2235,7 @@ bool DesignElaboration::bindDataTypes_() {
     }
   }
   auto programs = design->getProgramDefinitions();
-  for (auto programPair : programs) {
+  for (const auto& programPair : programs) {
     Program* prog = programPair.second;
     const FileContent* fC = prog->getFileContents()[0];
     std::vector<Signal*>& ports = prog->getPorts();
@@ -2249,7 +2249,7 @@ void DesignElaboration::createFileList_() {
   Design* design = m_compileDesign->getCompiler()->getDesign();
   std::queue<ModuleInstance*> queue;
   std::set<const FileContent*> files;
-  for (auto pack : design->getPackageDefinitions()) {
+  for (const auto& pack : design->getPackageDefinitions()) {
     if (!pack.second->getFileContents().empty()) {
       if (pack.second->getFileContents()[0] != nullptr)
         files.insert(pack.second->getFileContents()[0]);
@@ -2295,7 +2295,7 @@ void DesignElaboration::createFileList_() {
       for (auto fC : files) {
         auto itr = ppFileName.find(fC->getFileName());
         if (itr != ppFileName.end()) {
-          for (auto f : (*itr).second) {
+          for (const auto& f : itr->second) {
             ofs << f << std::flush << std::endl;
           }
         }

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -89,39 +89,39 @@ bool ElaborationStep::bindTypedefs_() {
   std::map<std::string, typespec*> specs;
   for (auto file : design->getAllFileContents()) {
     FileContent* fC = file.second;
-    for (auto typed : fC->getTypeDefMap()) {
+    for (const auto& typed : fC->getTypeDefMap()) {
       TypeDef* typd = typed.second;
       defs.emplace_back(typd, fC);
     }
   }
 
-  for (auto package : design->getPackageDefinitions()) {
+  for (const auto& package : design->getPackageDefinitions()) {
     Package* pack = package.second;
-    for (auto typed : pack->getTypeDefMap()) {
+    for (const auto& typed : pack->getTypeDefMap()) {
       TypeDef* typd = typed.second;
       defs.emplace_back(typd, pack);
     }
   }
 
-  for (auto module : design->getModuleDefinitions()) {
+  for (const auto& module : design->getModuleDefinitions()) {
     ModuleDefinition* mod = module.second;
-    for (auto typed : mod->getTypeDefMap()) {
+    for (const auto& typed : mod->getTypeDefMap()) {
       TypeDef* typd = typed.second;
       defs.emplace_back(typd, mod);
     }
   }
 
-  for (auto program_def : design->getProgramDefinitions()) {
+  for (const auto& program_def : design->getProgramDefinitions()) {
     Program* program = program_def.second;
-    for (auto typed : program->getTypeDefMap()) {
+    for (const auto& typed : program->getTypeDefMap()) {
       TypeDef* typd = typed.second;
       defs.emplace_back(typd, program);
     }
   }
 
-  for (auto class_def : design->getClassDefinitions()) {
+  for (const auto& class_def : design->getClassDefinitions()) {
     ClassDefinition* classp = class_def.second;
-    for (auto typed : classp->getTypeDefMap()) {
+    for (const auto& typed : classp->getTypeDefMap()) {
       TypeDef* typd = typed.second;
       defs.emplace_back(typd, classp);
     }
@@ -305,7 +305,7 @@ bool ElaborationStep::bindTypedefs_() {
       }
     }
   }
-  for (auto module : design->getPackageDefinitions()) {
+  for (const auto& module : design->getPackageDefinitions()) {
     DesignComponent* comp = module.second;
     for (any* var : comp->getLateTypedefBinding()) {
       const typespec* orig = nullptr;
@@ -349,7 +349,7 @@ bool ElaborationStep::bindTypedefs_() {
       }
     }
   }
-  for (auto module : design->getModuleDefinitions()) {
+  for (const auto& module : design->getModuleDefinitions()) {
     DesignComponent* comp = module.second;
     for (any* var : comp->getLateTypedefBinding()) {
       const typespec* orig = nullptr;

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -133,7 +133,7 @@ bool NetlistElaboration::elab_parameters_(ModuleInstance* instance,
   VectorOfparam_assign* assigns = netlist->param_assigns();
   if (!mod) {
     if (param_port) return true;
-    for (auto mv : instance->getMappedValues()) {
+    for (const auto& mv : instance->getMappedValues()) {
       if (assigns == nullptr) {
         netlist->param_assigns(s.MakeParam_assignVec());
         assigns = netlist->param_assigns();
@@ -164,7 +164,7 @@ bool NetlistElaboration::elab_parameters_(ModuleInstance* instance,
   }
   if (mod->getParameters() != nullptr) {
     // Type params
-    for (auto nameParam : mod->getParameterMap()) {
+    for (const auto& nameParam : mod->getParameterMap()) {
       Parameter* sit = nameParam.second;
       elabTypeParameter_(mod, sit, instance);
     }
@@ -2069,7 +2069,7 @@ UHDM::any* NetlistElaboration::bind_net_(NodeId id, ModuleInstance* instance,
   if (instance && (result == nullptr)) {
     DesignComponent* component = instance->getDefinition();
     if (component) {
-      for (auto tp : component->getTypeDefMap()) {
+      for (const auto& tp : component->getTypeDefMap()) {
         TypeDef* tpd = tp.second;
         typespec* tps = tpd->getTypespec();
         if (tps && tps->UhdmType() == uhdmenum_typespec) {
@@ -2081,7 +2081,7 @@ UHDM::any* NetlistElaboration::bind_net_(NodeId id, ModuleInstance* instance,
           }
         }
       }
-      for (auto tp : component->getDataTypeMap()) {
+      for (const auto& tp : component->getDataTypeMap()) {
         const DataType* dt = tp.second;
         dt = dt->getActual();
         typespec* tps = dt->getTypespec();

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -525,7 +525,7 @@ bool TestbenchElaboration::bindSubRoutineCall_(ClassDefinition* classDefinition,
       return true;
     }
     std::string name;
-    for (auto v : var_chain) name += v + ".";
+    for (const auto& v : var_chain) name += v + ".";
     if (!name.empty()) name = name.substr(0, name.size() - 1);
     while (dtype && dtype->getDefinition()) {
       dtype = dtype->getDefinition();

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -430,7 +430,7 @@ bool UhdmChecker::reportHtml(CompileDesign* compileDesign,
     reportF.close();
     fileIndex++;
   }
-  for (auto covFile : orderedCoverageMap) {
+  for (const auto& covFile : orderedCoverageMap) {
     report << covFile.second << "\n";
   }
 
@@ -532,7 +532,7 @@ float UhdmChecker::reportCoverage(const fs::path& reportFile) {
   report << "\nOverall coverage: " << std::setprecision(3) << overallCoverage
          << "%\n";
   report << "\nOrdered coverage:\n";
-  for (auto covFile : coverageMap) {
+  for (const auto& covFile : coverageMap) {
     report << covFile.second.first << ":" << covFile.second.second << ": "
            << std::setprecision(3) << covFile.first << "% "
            << "\n";
@@ -652,7 +652,7 @@ bool UhdmChecker::check(const std::string& reportFile) {
   for (ModuleInstance* top : m_design->getTopLevelModuleInstances()) {
     collectUsedFileContents(files, moduleNames, top);
   }
-  for (auto packInfo : m_design->getPackageDefinitions()) {
+  for (const auto& packInfo : m_design->getPackageDefinitions()) {
     Package* pack = packInfo.second;
     for (auto file : pack->getFileContents()) {
       if (file) files.insert(file);

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -915,8 +915,8 @@ void UhdmWriter::writeModule(ModuleDefinition* mod, module* m, Serializer& s,
   }
 
   // ClockingBlocks
-  for (auto ctupple : mod->getClockingBlockMap()) {
-    ClockingBlock& cblock = ctupple.second;
+  for (const auto& ctupple : mod->getClockingBlockMap()) {
+    const ClockingBlock& cblock = ctupple.second;
     switch (cblock.getType()) {
       case ClockingBlock::Type::Default: {
         m->Default_clocking(cblock.getActual());
@@ -1050,8 +1050,8 @@ void UhdmWriter::writeInterface(ModuleDefinition* mod, interface* m,
   }
 
   // ClockingBlocks
-  for (auto ctupple : mod->getClockingBlockMap()) {
-    ClockingBlock& cblock = ctupple.second;
+  for (const auto& ctupple : mod->getClockingBlockMap()) {
+    const ClockingBlock& cblock = ctupple.second;
     switch (cblock.getType()) {
       case ClockingBlock::Type::Default: {
         m->Default_clocking(cblock.getActual());
@@ -1140,8 +1140,8 @@ void writeProgram(Program* mod, program* m, Serializer& s,
   }
 
   // ClockingBlocks
-  for (auto ctupple : mod->getClockingBlockMap()) {
-    ClockingBlock& cblock = ctupple.second;
+  for (const auto& ctupple : mod->getClockingBlockMap()) {
+    const ClockingBlock& cblock = ctupple.second;
     switch (cblock.getType()) {
       case ClockingBlock::Type::Default: {
         m->Default_clocking(cblock.getActual());
@@ -1383,8 +1383,8 @@ bool UhdmWriter::writeElabGenScope(Serializer& s, ModuleInstance* instance,
   }
 
   // ClockingBlocks
-  for (auto ctupple : mod->getClockingBlockMap()) {
-    ClockingBlock& cblock = ctupple.second;
+  for (const auto& ctupple : mod->getClockingBlockMap()) {
+    const ClockingBlock& cblock = ctupple.second;
     switch (cblock.getType()) {
       case ClockingBlock::Type::Default: {
         // No default clocking
@@ -1619,7 +1619,7 @@ void UhdmWriter::lateBinding(UHDM::Serializer& s, DesignComponent* mod,
             }
           }
         }
-        for (auto imp : importedPackages) {
+        for (const auto& imp : importedPackages) {
           if (n->VpiName() == std::string(imp + "::" + name)) {
             isTypespec = true;
             break;
@@ -1635,7 +1635,7 @@ void UhdmWriter::lateBinding(UHDM::Serializer& s, DesignComponent* mod,
       if (ref->Actual_group()) continue;
     }
     const FileContent* fC = mod->getFileContents()[0];
-    for (auto td : fC->getTypeDefMap()) {
+    for (const auto& td : fC->getTypeDefMap()) {
       const DataType* dt = td.second;
       while (dt) {
         typespec* n = dt->getTypespec();
@@ -2290,10 +2290,10 @@ void printUhdmStats(Serializer& s) {
   std::cout << "UHDM Objects Stats:\n";
   std::map<std::string, unsigned long> stats = s.ObjectStats();
   std::multimap<unsigned long, std::string> rstats;
-  for (auto stat : stats) {
+  for (const auto& stat : stats) {
     if (stat.second) rstats.insert(std::make_pair(stat.second, stat.first));
   }
-  for (auto stat : rstats) {
+  for (const auto& stat : rstats) {
     std::cout << stat.second << " " << stat.first << "\n";
   }
   std::cout << "\n";
@@ -2417,7 +2417,7 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
     // Programs
     auto programs = m_design->getProgramDefinitions();
     VectorOfprogram* uhdm_programs = s.MakeProgramVec();
-    for (auto progNamePair : programs) {
+    for (const auto& progNamePair : programs) {
       Program* prog = progNamePair.second;
       if (!prog->getFileContents().empty() &&
           prog->getType() == VObjectType::slProgram_declaration) {
@@ -2442,7 +2442,7 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
     // Interfaces
     auto modules = m_design->getModuleDefinitions();
     VectorOfinterface* uhdm_interfaces = s.MakeInterfaceVec();
-    for (auto modNamePair : modules) {
+    for (const auto& modNamePair : modules) {
       ModuleDefinition* mod = modNamePair.second;
       if (mod->getFileContents().empty()) {
         // Built-in primitive
@@ -2469,7 +2469,7 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
     VectorOfmodule* uhdm_modules = s.MakeModuleVec();
     // Udps
     VectorOfudp_defn* uhdm_udps = s.MakeUdp_defnVec();
-    for (auto modNamePair : modules) {
+    for (const auto& modNamePair : modules) {
       ModuleDefinition* mod = modNamePair.second;
       if (mod->getFileContents().empty()) {
         // Built-in primitive
@@ -2512,7 +2512,7 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
     // Classes
     auto classes = m_design->getClassDefinitions();
     VectorOfclass_defn* v4 = s.MakeClass_defnVec();
-    for (auto classNamePair : classes) {
+    for (const auto& classNamePair : classes) {
       ClassDefinition* classDef = classNamePair.second;
       if (!classDef->getFileContents().empty() &&
           classDef->getType() == VObjectType::slClass_declaration) {

--- a/src/ErrorReporting/Error.cpp
+++ b/src/ErrorReporting/Error.cpp
@@ -25,25 +25,26 @@
 
 using namespace SURELOG;
 
-Error::Error(ErrorDefinition::ErrorType errorId, Location& loc,
-             std::vector<Location>* extraLocs)
+Error::Error(ErrorDefinition::ErrorType errorId, const Location& loc,
+             const std::vector<Location>* extraLocs)
     : m_errorId(errorId), m_reported(false), m_waived(false) {
   m_locations.push_back(loc);
   if (extraLocs) {
-    for (auto loc : (*extraLocs)) m_locations.push_back(loc);
+    for (const auto& location : *extraLocs) m_locations.push_back(location);
   }
 }
 
-Error::Error(ErrorDefinition::ErrorType errorId, Location& loc, Location& extra)
+Error::Error(ErrorDefinition::ErrorType errorId, const Location& loc,
+             const Location& extra)
     : m_errorId(errorId), m_reported(false), m_waived(false) {
   m_locations.push_back(loc);
   m_locations.push_back(extra);
 }
 
 Error::Error(ErrorDefinition::ErrorType errorId,
-             std::vector<Location>& locations)
+             const std::vector<Location>& locations)
     : m_errorId(errorId), m_reported(false), m_waived(false) {
-  for (auto loc : (locations)) m_locations.push_back(loc);
+  for (const auto& location : locations) m_locations.push_back(location);
 }
 
 bool Error::operator==(const Error& rhs) const {
@@ -66,5 +67,3 @@ bool Error::operator<(const Error& rhs) const {
   }
   return false;
 }
-
-Error::~Error() {}

--- a/src/ErrorReporting/Error.h
+++ b/src/ErrorReporting/Error.h
@@ -33,13 +33,15 @@ namespace SURELOG {
 
 class ErrorContainer;
 
-class Error {
+class Error final {
  public:
   friend ErrorContainer;
-  Error(ErrorDefinition::ErrorType errorId, Location& loc,
-        std::vector<Location>* extraLocs = nullptr);
-  Error(ErrorDefinition::ErrorType errorId, Location& loc, Location& extra);
-  Error(ErrorDefinition::ErrorType errorId, std::vector<Location>& locations);
+  Error(ErrorDefinition::ErrorType errorId, const Location& loc,
+        const std::vector<Location>* extraLocs = nullptr);
+  Error(ErrorDefinition::ErrorType errorId, const Location& loc,
+        const Location& extra);
+  Error(ErrorDefinition::ErrorType errorId,
+        const std::vector<Location>& locations);
   Error(const Error& orig) = default;
 
   bool operator==(const Error& rhs) const;
@@ -48,7 +50,6 @@ class Error {
     bool operator()(const Error& e1, const Error& e2) const { return e1 < e2; }
   };
 
-  virtual ~Error();
   const std::vector<Location>& getLocations() const { return m_locations; }
   ErrorDefinition::ErrorType getType() const { return m_errorId; }
 

--- a/src/SourceCompile/CheckCompile.cpp
+++ b/src/SourceCompile/CheckCompile.cpp
@@ -133,7 +133,7 @@ bool CheckCompile::checkTimescale_() {
     }
   }
   if (timeUnitUsed && timeScaleUsed) {
-    for (auto loc : noTimeUnitLocs) {
+    for (const auto& loc : noTimeUnitLocs) {
       if (reportedMissingTimeunit.find(loc.m_object) ==
           reportedMissingTimeunit.end()) {
         reportedMissingTimeunit.insert(loc.m_object);

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -474,7 +474,7 @@ bool Compiler::createMultiProcessParser_() {
       }
 
       ofs << "add_custom_target(Parse ALL DEPENDS" << std::endl;
-      for (auto target : targets) {
+      for (const auto& target : targets) {
         ofs << target << std::endl;
       }
       ofs << ")" << std::endl;
@@ -485,7 +485,7 @@ bool Compiler::createMultiProcessParser_() {
         // Single child process
         fs::path fileList = directory / "parser_batch.txt";
         ofs.open(fileList);
-        for (auto line : batchProcessCommands) {
+        for (const auto& line : batchProcessCommands) {
           ofs << line << "\n";
         }
         ofs.close();

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -537,7 +537,7 @@ void PreprocessFile::recordMacro(const std::string& name, unsigned int line,
 
   if (m_debugMacro) {
     std::string body;
-    for (auto token : tokens) {
+    for (const auto& token : tokens) {
       body += token;
     }
     std::cout << "PP RECORDING MACRO: " << name << ": | " << body << " | "
@@ -594,7 +594,7 @@ void PreprocessFile::checkMacroArguments_(
     tok = StringUtils::replaceAll(tok, "`", "");
     tokenSet.insert(tok);
   }
-  for (auto s : argSet) {
+  for (const auto& s : argSet) {
     if (tokenSet.find(s) == tokenSet.end()) {
       Location loc(m_fileId, line, column, registerSymbol(s));
       Error err(ErrorDefinition::PP_MACRO_UNUSED_ARGUMENT, loc);
@@ -883,7 +883,7 @@ std::pair<bool, std::string> PreprocessFile::evaluateMacro_(
     return std::make_pair(true, "`" + name);
   }
   std::string body;
-  for (auto token : body_tokens) {
+  for (const auto& token : body_tokens) {
     body += token;
   }
   if (keyword && !actual_args.empty() && formal_args.empty()) {
@@ -934,7 +934,7 @@ std::pair<bool, std::string> PreprocessFile::evaluateMacro_(
       const fs::path fileName = getSymbol(m_fileId);
       std::cout << "PP BODY EXPANSION FOR " << name << " in : " << fileName
                 << std::endl;
-      for (auto arg : actual_args) {
+      for (const auto& arg : actual_args) {
         std::cout << "PP ARG: " << arg << "\n";
       }
     }
@@ -1067,7 +1067,7 @@ std::string PreprocessFile::getMacro(
   SymbolId macroId = registerSymbol(name);
   if (m_debugMacro) {
     std::cout << "PP CALL TO getMacro for " << name << "\n";
-    for (auto arg : arguments) {
+    for (const auto& arg : arguments) {
       std::cout << "PP ARG: " << arg << "\n";
     }
     instructions.print();

--- a/src/Testbench/ClassDefinition.cpp
+++ b/src/Testbench/ClassDefinition.cpp
@@ -55,7 +55,7 @@ unsigned int ClassDefinition::getSize() const {
 Property* ClassDefinition::getProperty(const std::string& name) const {
   PropertyMap::const_iterator itr = m_properties.find(name);
   if (itr == m_properties.end()) {
-    for (auto parent : getBaseClassMap()) {
+    for (const auto& parent : getBaseClassMap()) {
       if (parent.second) {
         const ClassDefinition* cparent =
             datatype_cast<const ClassDefinition*>(parent.second);
@@ -179,7 +179,7 @@ const DataType* ClassDefinition::getBaseDataType(
   const DataTypeMap& dataTypes = getDataTypeMap();
   DataTypeMap::const_iterator itr = dataTypes.find(name);
   if (itr == dataTypes.end()) {
-    for (auto parent : getBaseClassMap()) {
+    for (const auto& parent : getBaseClassMap()) {
       if (parent.second) {
         const ClassDefinition* cparent =
             datatype_cast<const ClassDefinition*>(parent.second);

--- a/src/Utils/FileUtils.cpp
+++ b/src/Utils/FileUtils.cpp
@@ -118,7 +118,7 @@ std::vector<SymbolId> FileUtils::collectFiles(const fs::path& dirPath,
                                               SymbolTable* symbols) {
   std::vector<SymbolId> result;
   if (fileIsDirectory(dirPath)) {
-    for (fs::directory_entry entry : fs::directory_iterator(dirPath)) {
+    for (const fs::directory_entry& entry : fs::directory_iterator(dirPath)) {
       const fs::path& filepath = entry.path();
       if (filepath.extension() == ext) {
         result.push_back(symbols->registerSymbol(filepath.string()));


### PR DESCRIPTION
For all places where copying the loop variable
would be non-trivial and we call const methods on it anyway.

https://clang.llvm.org/extra/clang-tidy/checks/performance-for-range-copy.html

Signed-off-by: Henner Zeller <h.zeller@acm.org>