### PR TITLE
Surelog optimization improvements.

### DIFF
--- a/include/Surelog/SourceCompile/CommonListenerHelper.h
+++ b/include/Surelog/SourceCompile/CommonListenerHelper.h
@@ -29,7 +29,7 @@
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <string>
-#include <unordered_map>
+#include <map>
 
 namespace antlr4 {
 class CommonTokenStream;
@@ -106,7 +106,7 @@ class CommonListenerHelper {
   FileContent* m_fileContent;
   antlr4::CommonTokenStream* const m_tokens;
 
-  typedef std::unordered_map<const antlr4::tree::ParseTree*, NodeId>
+  typedef std::map<const antlr4::tree::ParseTree*, NodeId>
       ContextToObjectMap;
   ContextToObjectMap m_contextToObjectMap;
 };


### PR DESCRIPTION
This change results in about a 16% speed up on Google internal benchmarks.

The root of the issue with unordered_map is that it gets resized many times. The reallocations, and rehashing waste a lot of cycles.

This is a recommit.

Signed-off-by: Ethan Mahintorabi <ethanmoon@google.com>