### PR TITLE
Draft: Performance improvement around recursive definition of if statements

### DIFF
--- a/grammar/SV3_1aParser.g4
+++ b/grammar/SV3_1aParser.g4
@@ -1930,9 +1930,18 @@ conditional_generate_construct
       | case_generate_construct 
       ; 
 
-if_generate_construct : 
-      IF OPEN_PARENS constant_expression CLOSE_PARENS generate_block ( ELSE generate_block )? ; 
+if_generate_construct :
+      IF OPEN_PARENS constant_expression CLOSE_PARENS generate_block else_if_statements
+      ;
 
+else_if_statements :
+    ( else_if_construct )*;
+
+else_if_construct
+      : ELSE ( identifier COLUMN )? BEGIN ( COLUMN identifier )? (generate_block)* END ( COLUMN identifier )?
+      | ELSE IF OPEN_PARENS constant_expression CLOSE_PARENS generate_block
+      ;
+      
 case_generate_construct : 
       CASE OPEN_PARENS constant_expression CLOSE_PARENS case_generate_item  case_generate_item* ENDCASE ; 
 


### PR DESCRIPTION
@alaindargelas I have another performance improvement suggestion around the generate ifs. In the current version of the grammar it relies on a recursive definition of if else. After profiling Surelog and ANTLR I've found that these recursive definitions kill performance. Each level of rule indirection that is calling one rule from another is a very expensive operation in ANTLR. The generate ifs in the Google test case have over 100,000 if else if branches which makes this file pretty slow. 

In this PR I propose replacing the overly general grammar with a more tailored grammar that reduces the long rule chains that hurt performance. This will require a change in Surelog's ParseTree to AST code which I will take a look at, but if you can beat me to it @alaindargelas that would be ideal.

The grammar now relies on ()* which doesn't require adding a new context to the stack in ANTLR.

## Test Case
```systemverilog
module conditional_generate
    #(parameter OPERATION_TYPE = 0)
    (
        input  logic [31:0] a,
        input  logic [31:0] b,
        output logic [63:0] z
    );

    // The generate-endgenerate keywords are optional.
    // It is the act of doing a conditional operation
    // on a parameter that makes this a generate block.
    generate
        if (OPERATION_TYPE == 0) begin
            assign z = a + b;
        end
        else if (OPERATION_TYPE == 1) begin
            assign z = a - b;
        end
        else if (OPERATION_TYPE == 2) begin
            assign z = (a << 1) + b; // 2a+b
        end
        ... // Add a hundred thousand of these else if cases to match the google case
        else begin
            assign z = b - a;
        end
    endgenerate
endmodule: conditional_generate

```

## Bad Profile
![image](https://user-images.githubusercontent.com/3784748/158275238-27855754-ee0a-486e-b0aa-b882346f89ea.png)

## Old Version
![image](https://user-images.githubusercontent.com/3784748/158275530-a86d0bc8-3fd2-4cb1-8e0a-074a23f518b3.png)

## New Version

![image](https://user-images.githubusercontent.com/3784748/158275184-bbc5d527-1192-4219-9023-f08b9173b77b.png)
