### PR TITLE
signal typespec for all signals

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -761,7 +761,7 @@
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/dbuild/bin/surelog",
-            "args": ["-parse", "tests/ScratchPad.sv", "-d", "inst", "-d", "ast", "-d", "uhdm", "-d", "vpi_ids", "-replay", "-nocache", "-nobuiltin", "-elabuhdm", "-PPa"],
+            "args": ["-parse", "tests/ScratchPad.sv", "-d", "inst", "-d", "ast", "-d", "uhdm", "-d", "vpi_ids", "-replay", "-nocache", "-nobuiltin", "-elabuhdm"],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -948,6 +948,14 @@ UHDM::typespec* CompileHelper::compileBuiltinTypespec(
       break;
     }
     default:
+      logic_typespec* var = s.MakeLogic_typespec();
+      var->Ranges(ranges);
+      var->VpiFile(fC->getFileName());
+      var->VpiLineNo(fC->Line(type));
+      var->VpiColumnNo(fC->Column(type));
+      var->VpiEndLineNo(fC->EndLine(type));
+      var->VpiEndColumnNo(fC->EndColumn(type));
+      result = var;
       break;
   }
   return result;
@@ -974,6 +982,9 @@ UHDM::typespec* CompileHelper::compileTypespec(
     if (fC->Type(Packed_dimension) != slPacked_dimension) Packed_dimension = 0;
   } else {
     Packed_dimension = fC->Sibling(type);
+    if (fC->Type(Packed_dimension) == slData_type_or_implicit) {
+      Packed_dimension = fC->Child(Packed_dimension);
+    }
   }
   bool isPacked = false;
   if (fC->Type(Packed_dimension) == slPacked_keyword) {
@@ -981,6 +992,10 @@ UHDM::typespec* CompileHelper::compileTypespec(
     isPacked = true;
   }
   if (fC->Type(Packed_dimension) == slStruct_union_member) {
+    Packed_dimension = fC->Sibling(Packed_dimension);
+  }
+  if (fC->Type(Packed_dimension) == slSigning_Signed ||
+      fC->Type(Packed_dimension) == slSigning_Unsigned) {
     Packed_dimension = fC->Sibling(Packed_dimension);
   }
   int size;
@@ -1184,6 +1199,18 @@ UHDM::typespec* CompileHelper::compileTypespec(
       break;
     }
     case VObjectType::slIntVec_TypeLogic:
+    case VObjectType::slNetType_Wire:
+    case VObjectType::slNetType_Supply0:
+    case VObjectType::slNetType_Supply1:
+    case VObjectType::slNetType_Tri0:
+    case VObjectType::slNetType_Tri1:
+    case VObjectType::slNetType_Tri:
+    case VObjectType::slNetType_TriAnd:
+    case VObjectType::slNetType_TriOr:
+    case VObjectType::slNetType_TriReg:
+    case VObjectType::slNetType_Uwire:
+    case VObjectType::slNetType_Wand:
+    case VObjectType::slNetType_Wor:
     case VObjectType::slIntVec_TypeReg:
     case VObjectType::slIntegerAtomType_Int:
     case VObjectType::slIntegerAtomType_Integer:

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -1465,7 +1465,7 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
     auto itr = tscache.find(typeSpecId);
     if (itr == tscache.end()) {
       tps = m_helper.compileTypespec(comp, fC, typeSpecId, m_compileDesign,
-                                     nullptr, child, true);
+                                     nullptr, child, true, true);
       tscache.insert(std::make_pair(typeSpecId, tps));
     } else {
       tps = (*itr).second;
@@ -1476,7 +1476,8 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
       auto itr = tscache.find(sig->getInterfaceTypeNameId());
       if (itr == tscache.end()) {
         tps = m_helper.compileTypespec(comp, fC, sig->getInterfaceTypeNameId(),
-                                       m_compileDesign, nullptr, child, true);
+                                       m_compileDesign, nullptr, child, true,
+                                       true);
         tscache.insert(std::make_pair(sig->getInterfaceTypeNameId(), tps));
       } else {
         tps = (*itr).second;
@@ -1565,7 +1566,9 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
           logicn->Attributes(sig->attributes());
           logicn->VpiSigned(sig->isSigned());
           logicn->VpiNetType(UhdmWriter::getVpiNetType(sig->getType()));
-          logicn->Ranges(packedDimensions);
+          // Move range to typespec for simple types
+          // logicn->Ranges(packedDimensions);
+          logicn->Typespec(tps);
           logicn->VpiName(signame);
           obj = logicn;
           logicn->Typespec(spec);
@@ -1597,7 +1600,9 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
           bit_var* logicn = s.MakeBit_var();
           logicn->Attributes(sig->attributes());
           logicn->VpiSigned(sig->isSigned());
-          logicn->Ranges(packedDimensions);
+          // Move range to typespec for simple types
+          // logicn->Ranges(packedDimensions);
+          logicn->Typespec(tps);
           logicn->VpiName(signame);
           obj = logicn;
           logicn->Typespec(spec);
@@ -1659,7 +1664,9 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
           logicn->Attributes(sig->attributes());
           logicn->VpiSigned(sig->isSigned());
           logicn->VpiNetType(UhdmWriter::getVpiNetType(sig->getType()));
-          logicn->Ranges(packedDimensions);
+          // Move range to typespec for simple types
+          // logicn->Ranges(packedDimensions);
+          logicn->Typespec(tps);
           logicn->VpiName(signame);
           obj = logicn;
           logicn->Typespec(spec);
@@ -1699,7 +1706,9 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
           bit_var* logicn = s.MakeBit_var();
           logicn->Attributes(sig->attributes());
           logicn->VpiSigned(sig->isSigned());
-          logicn->Ranges(packedDimensions);
+          logicn->Typespec(tps);
+          // Move range to typespec for simple types
+          // logicn->Ranges(packedDimensions);
           logicn->VpiName(signame);
           obj = logicn;
           logicn->Typespec(spec);
@@ -1725,7 +1734,9 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
         logicn->Attributes(sig->attributes());
         logicn->VpiSigned(sig->isSigned());
         logicn->VpiNetType(UhdmWriter::getVpiNetType(sig->getType()));
-        logicn->Ranges(packedDimensions);
+        logicn->Typespec(tps);
+        // Move range to typespec for simple types
+        // logicn->Ranges(packedDimensions);
         logicn->VpiName(signame);
         obj = logicn;
       }
@@ -1821,8 +1832,11 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
       logic_net* logicn = s.MakeLogic_net();
       logicn->VpiSigned(sig->isSigned());
       logicn->VpiNetType(UhdmWriter::getVpiNetType(sig->getType()));
-      logicn->Ranges(packedDimensions);
+      // Move range to typespec for simple types
+      // logicn->Ranges(packedDimensions);
+      logicn->Typespec(tps);
       logicn->Attributes(sig->attributes());
+      logicn->Typespec(tps);
       if (unpackedDimensions) {
         logicn->VpiLineNo(fC->Line(id));
         logicn->VpiColumnNo(fC->Column(id));
@@ -1999,7 +2013,7 @@ bool NetlistElaboration::elab_ports_nets_(
           if (itr == tscache.end()) {
             tps =
                 m_helper.compileTypespec(comp, fC, typeSpecId, m_compileDesign,
-                                         dest_port, instance, true);
+                                         dest_port, instance, true, true);
             tscache.insert(std::make_pair(typeSpecId, tps));
           } else {
             tps = (*itr).second;

--- a/tests/1364_2005/1364_2005.log
+++ b/tests/1364_2005/1364_2005.log
@@ -175,83 +175,85 @@ design: (work@main)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@main.foo), line:5:14, endln:5:17, parent:work@main
+    |vpiTypespec:
+    \_logic_typespec: , line:5:4, endln:5:7
+      |vpiRange:
+      \_range: , line:5:9, endln:5:12
+        |vpiLeftRange:
+        \_constant: , line:5:9, endln:5:10
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:5:11, endln:5:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:foo
     |vpiFullName:work@main.foo
     |vpiNetType:48
-    |vpiRange:
-    \_range: , line:5:9, endln:5:12
-      |vpiLeftRange:
-      \_constant: , line:5:9, endln:5:10
-        |vpiDecompile:3
-        |vpiSize:64
-        |UINT:3
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:5:11, endln:5:12
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@main.bar), line:5:19, endln:5:22, parent:work@main
+    |vpiTypespec:
+    \_logic_typespec: , line:5:4, endln:5:7
     |vpiName:bar
     |vpiFullName:work@main.bar
     |vpiNetType:48
-    |vpiRange:
-    \_range: , line:5:9, endln:5:12
-      |vpiLeftRange:
-      \_constant: , line:5:9, endln:5:10
-        |vpiDecompile:3
-        |vpiSize:64
-        |UINT:3
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:5:11, endln:5:12
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@main.adr), line:6:14, endln:6:17, parent:work@main
+    |vpiTypespec:
+    \_logic_typespec: , line:6:4, endln:6:7
+      |vpiRange:
+      \_range: , line:6:9, endln:6:12
+        |vpiLeftRange:
+        \_constant: , line:6:9, endln:6:10
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:6:11, endln:6:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:adr
     |vpiFullName:work@main.adr
     |vpiNetType:48
-    |vpiRange:
-    \_range: , line:6:9, endln:6:12
-      |vpiLeftRange:
-      \_constant: , line:6:9, endln:6:10
-        |vpiDecompile:1
-        |vpiSize:64
-        |UINT:1
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:6:11, endln:6:12
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@main.bit), line:8:13, endln:8:16, parent:work@main
+    |vpiTypespec:
+    \_logic_typespec: , line:8:4, endln:8:7
     |vpiName:bit
     |vpiFullName:work@main.bit
     |vpiNetType:48
   |vpiNet:
   \_logic_net: (work@main.rst), line:8:18, endln:8:21, parent:work@main
+    |vpiTypespec:
+    \_logic_typespec: , line:8:4, endln:8:7
     |vpiName:rst
     |vpiFullName:work@main.rst
     |vpiNetType:48
   |vpiNet:
   \_logic_net: (work@main.clk), line:8:23, endln:8:26, parent:work@main
+    |vpiTypespec:
+    \_logic_typespec: , line:8:4, endln:8:7
     |vpiName:clk
     |vpiFullName:work@main.clk
     |vpiNetType:48
   |vpiNet:
   \_logic_net: (work@main.load_enable), line:9:13, endln:9:24, parent:work@main
+    |vpiTypespec:
+    \_logic_typespec: , line:9:4, endln:9:7
     |vpiName:load_enable
     |vpiFullName:work@main.load_enable
     |vpiNetType:48
   |vpiNet:
   \_logic_net: (work@main.write_enable), line:9:26, endln:9:38, parent:work@main
+    |vpiTypespec:
+    \_logic_typespec: , line:9:4, endln:9:7
     |vpiName:write_enable
     |vpiFullName:work@main.write_enable
     |vpiNetType:48

--- a/tests/ArrayNet/ArrayNet.log
+++ b/tests/ArrayNet/ArrayNet.log
@@ -153,22 +153,24 @@ design: (work@memory)
                 |vpiConstType:9
             |vpiNet:
             \_logic_net: (work@memory.my_memory), line:2:11, endln:2:20, parent:work@memory.my_memory
+              |vpiTypespec:
+              \_logic_typespec: , line:2:1, endln:2:4
+                |vpiRange:
+                \_range: , line:2:6, endln:2:9
+                  |vpiLeftRange:
+                  \_constant: , line:2:6, endln:2:7
+                    |vpiDecompile:7
+                    |vpiSize:64
+                    |UINT:7
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:2:8, endln:2:9
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiFullName:work@memory.my_memory
               |vpiNetType:48
-              |vpiRange:
-              \_range: , line:2:6, endln:2:9
-                |vpiLeftRange:
-                \_constant: , line:2:6, endln:2:7
-                  |vpiDecompile:7
-                  |vpiSize:64
-                  |UINT:7
-                  |vpiConstType:9
-                |vpiRightRange:
-                \_constant: , line:2:8, endln:2:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-                  |vpiConstType:9
         |vpiName:$readmemh
 |uhdmtopModules:
 \_module: work@memory (work@memory) dut.sv:1:1: , endln:7:10

--- a/tests/ArrayVarName/ArrayVarName.log
+++ b/tests/ArrayVarName/ArrayVarName.log
@@ -320,6 +320,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:1:23, endln:1:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:1:19, endln:1:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:8:10
   |vpiContAssign:

--- a/tests/Attributes/Attributes.log
+++ b/tests/Attributes/Attributes.log
@@ -1475,6 +1475,8 @@ design: (work@foo)
           |vpiFullName:work@bar.clk
           |vpiActual:
           \_logic_net: (work@foo.bar_instance.clk), line:1:12, endln:1:15, parent:work@foo.bar_instance
+            |vpiTypespec:
+            \_logic_typespec: , line:2:10, endln:2:14
             |vpiName:clk
             |vpiFullName:work@foo.bar_instance.clk
             |vpiNetType:1
@@ -1486,6 +1488,8 @@ design: (work@foo)
           |vpiFullName:work@bar.rst
           |vpiActual:
           \_logic_net: (work@foo.bar_instance.rst), line:1:17, endln:1:20, parent:work@foo.bar_instance
+            |vpiTypespec:
+            \_logic_typespec: , line:3:10, endln:3:14
             |vpiName:rst
             |vpiFullName:work@foo.bar_instance.rst
             |vpiNetType:1
@@ -1504,6 +1508,8 @@ design: (work@foo)
             |vpiFullName:work@bar.out
             |vpiActual:
             \_logic_net: (work@foo.bar_instance.out), line:1:27, endln:1:30, parent:work@foo.bar_instance
+              |vpiTypespec:
+              \_logic_typespec: , line:5:10, endln:5:13
               |vpiName:out
               |vpiFullName:work@foo.bar_instance.out
               |vpiNetType:48
@@ -1519,6 +1525,8 @@ design: (work@foo)
               |vpiFullName:work@bar.inp
               |vpiActual:
               \_logic_net: (work@foo.bar_instance.inp), line:1:22, endln:1:25, parent:work@foo.bar_instance
+                |vpiTypespec:
+                \_logic_typespec: , line:4:10, endln:4:14
                 |vpiName:inp
                 |vpiFullName:work@foo.bar_instance.inp
                 |vpiNetType:1
@@ -1766,21 +1774,29 @@ design: (work@foo)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@foo.clk), line:13:12, endln:13:15, parent:work@foo
+    |vpiTypespec:
+    \_logic_typespec: , line:14:10, endln:14:14
     |vpiName:clk
     |vpiFullName:work@foo.clk
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@foo.rst), line:13:17, endln:13:20, parent:work@foo
+    |vpiTypespec:
+    \_logic_typespec: , line:15:10, endln:15:14
     |vpiName:rst
     |vpiFullName:work@foo.rst
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@foo.inp), line:13:22, endln:13:25, parent:work@foo
+    |vpiTypespec:
+    \_logic_typespec: , line:16:10, endln:16:14
     |vpiName:inp
     |vpiFullName:work@foo.inp
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@foo.out), line:13:27, endln:13:30, parent:work@foo
+    |vpiTypespec:
+    \_logic_typespec: , line:17:10, endln:17:14
     |vpiName:out
     |vpiFullName:work@foo.out
     |vpiNetType:1
@@ -1807,6 +1823,8 @@ design: (work@foo)
       |vpiFullName:work@foo.clk
       |vpiActual:
       \_logic_net: (work@foo.clk), line:13:12, endln:13:15, parent:work@foo
+    |vpiTypedef:
+    \_logic_typespec: , line:14:10, endln:14:14
     |vpiInstance:
     \_module: work@foo (work@foo) dut.sv:13:1: , endln:41:10
   |vpiPort:
@@ -1819,6 +1837,8 @@ design: (work@foo)
       |vpiFullName:work@foo.rst
       |vpiActual:
       \_logic_net: (work@foo.rst), line:13:17, endln:13:20, parent:work@foo
+    |vpiTypedef:
+    \_logic_typespec: , line:15:10, endln:15:14
     |vpiInstance:
     \_module: work@foo (work@foo) dut.sv:13:1: , endln:41:10
   |vpiPort:
@@ -1831,6 +1851,8 @@ design: (work@foo)
       |vpiFullName:work@foo.inp
       |vpiActual:
       \_logic_net: (work@foo.inp), line:13:22, endln:13:25, parent:work@foo
+    |vpiTypedef:
+    \_logic_typespec: , line:16:10, endln:16:14
     |vpiInstance:
     \_module: work@foo (work@foo) dut.sv:13:1: , endln:41:10
   |vpiPort:
@@ -1843,6 +1865,8 @@ design: (work@foo)
       |vpiFullName:work@foo.out
       |vpiActual:
       \_logic_net: (work@foo.out), line:13:27, endln:13:30, parent:work@foo
+    |vpiTypedef:
+    \_logic_typespec: , line:17:10, endln:17:14
     |vpiInstance:
     \_module: work@foo (work@foo) dut.sv:13:1: , endln:41:10
   |vpiProcess:
@@ -1998,6 +2022,8 @@ design: (work@foo)
         |vpiFullName:work@foo.bar_instance.clk
         |vpiActual:
         \_logic_net: (work@foo.bar_instance.clk), line:1:12, endln:1:15, parent:work@foo.bar_instance
+      |vpiTypedef:
+      \_logic_typespec: , line:2:10, endln:2:14
       |vpiInstance:
       \_module: work@bar (work@foo.bar_instance) dut.sv:19:3: , endln:19:105, parent:work@foo
       |vpiAttribute:
@@ -2020,6 +2046,8 @@ design: (work@foo)
         |vpiFullName:work@foo.bar_instance.rst
         |vpiActual:
         \_logic_net: (work@foo.bar_instance.rst), line:1:17, endln:1:20, parent:work@foo.bar_instance
+      |vpiTypedef:
+      \_logic_typespec: , line:3:10, endln:3:14
       |vpiInstance:
       \_module: work@bar (work@foo.bar_instance) dut.sv:19:3: , endln:19:105, parent:work@foo
     |vpiPort:
@@ -2038,6 +2066,8 @@ design: (work@foo)
         |vpiFullName:work@foo.bar_instance.inp
         |vpiActual:
         \_logic_net: (work@foo.bar_instance.inp), line:1:22, endln:1:25, parent:work@foo.bar_instance
+      |vpiTypedef:
+      \_logic_typespec: , line:4:10, endln:4:14
       |vpiInstance:
       \_module: work@bar (work@foo.bar_instance) dut.sv:19:3: , endln:19:105, parent:work@foo
       |vpiAttribute:

--- a/tests/Attributes2/Attributes2.log
+++ b/tests/Attributes2/Attributes2.log
@@ -745,6 +745,8 @@ design: (work@foo)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@foo.clk), line:8:12, endln:8:15, parent:work@foo
+    |vpiTypespec:
+    \_logic_typespec: , line:9:28, endln:9:32
     |vpiName:clk
     |vpiFullName:work@foo.clk
     |vpiNetType:1
@@ -762,6 +764,8 @@ design: (work@foo)
       |vpiFullName:work@foo.clk
       |vpiActual:
       \_logic_net: (work@foo.clk), line:8:12, endln:8:15, parent:work@foo
+    |vpiTypedef:
+    \_logic_typespec: , line:9:28, endln:9:32
     |vpiInstance:
     \_module: work@foo (work@foo) dut.sv:8:1: , endln:12:10
   |vpiModule:
@@ -773,6 +777,8 @@ design: (work@foo)
     |vpiDefLineNo:2
     |vpiNet:
     \_logic_net: (work@foo.bar_instance_1.clk), line:2:12, endln:2:15, parent:work@foo.bar_instance_1
+      |vpiTypespec:
+      \_logic_typespec: , line:3:10, endln:3:14
       |vpiName:clk
       |vpiFullName:work@foo.bar_instance_1.clk
       |vpiNetType:1
@@ -794,6 +800,8 @@ design: (work@foo)
         |vpiFullName:work@foo.bar_instance_1.clk
         |vpiActual:
         \_logic_net: (work@foo.bar_instance_1.clk), line:2:12, endln:2:15, parent:work@foo.bar_instance_1
+      |vpiTypedef:
+      \_logic_typespec: , line:3:10, endln:3:14
       |vpiInstance:
       \_module: work@bar (work@foo.bar_instance_1) dut.sv:11:3: , endln:11:55, parent:work@foo
       |vpiAttribute:

--- a/tests/BadLabel/BadLabel.log
+++ b/tests/BadLabel/BadLabel.log
@@ -436,6 +436,8 @@ design: (work@test)
           |vpiFullName:work@block_tb.name1.a
           |vpiActual:
           \_logic_net: (work@block_tb.a), line:61:6, endln:61:11, parent:work@block_tb
+            |vpiTypespec:
+            \_logic_typespec: , line:61:2, endln:61:5
             |vpiName:a
             |vpiFullName:work@block_tb.a
             |vpiNetType:48

--- a/tests/BiasValue/BiasValue.log
+++ b/tests/BiasValue/BiasValue.log
@@ -961,23 +961,25 @@ design: (work@bp_be_rec_to_fp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@bp_be_rec_to_fp.adjusted_exp), line:6:28, endln:6:40, parent:work@bp_be_rec_to_fp
+    |vpiTypespec:
+    \_logic_typespec: , line:6:3, endln:6:7
+      |vpiRange:
+      \_range: , line:6:9, endln:6:26
+        |vpiLeftRange:
+        \_constant: , line:6:9, endln:6:24
+          |vpiDecompile:8
+          |vpiSize:32
+          |UINT:8
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:6:25, endln:6:26
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:adjusted_exp
     |vpiFullName:work@bp_be_rec_to_fp.adjusted_exp
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:6:9, endln:6:26
-      |vpiLeftRange:
-      \_constant: , line:6:9, endln:6:24
-        |vpiDecompile:8
-        |vpiSize:32
-        |UINT:8
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:6:25, endln:6:26
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiContAssign:
   \_cont_assign: , line:6:28, endln:6:40, parent:work@bp_be_rec_to_fp

--- a/tests/BindStmt/BindStmt.log
+++ b/tests/BindStmt/BindStmt.log
@@ -648,6 +648,8 @@ design: (work@testbench)
       |vpiFullName:work@bp_me_nonsynth_lce_tracer2.b
       |vpiActual:
       \_logic_net: (work@testbench.u1.lce_tracer2.b), line:13:91, endln:13:92, parent:work@testbench.lce_tracer2
+        |vpiTypespec:
+        \_logic_typespec: , line:13:85, endln:13:90
         |vpiName:b
         |vpiFullName:work@testbench.u1.lce_tracer2.b
         |vpiNetType:36
@@ -657,6 +659,8 @@ design: (work@testbench)
       |vpiFullName:work@bp_me_nonsynth_lce_tracer2.a
       |vpiActual:
       \_logic_net: (work@testbench.u1.lce_tracer2.a), line:13:75, endln:13:76, parent:work@testbench.lce_tracer2
+        |vpiTypespec:
+        \_logic_typespec: , line:13:69, endln:13:74
         |vpiName:a
         |vpiFullName:work@testbench.u1.lce_tracer2.a
         |vpiNetType:36
@@ -730,6 +734,8 @@ design: (work@testbench)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@testbench.clk), line:25:31, endln:25:34, parent:work@testbench
+    |vpiTypespec:
+    \_logic_typespec: , line:25:25, endln:25:30
     |vpiName:clk
     |vpiFullName:work@testbench.clk
     |vpiNetType:36
@@ -744,6 +750,8 @@ design: (work@testbench)
       |vpiFullName:work@testbench.clk
       |vpiActual:
       \_logic_net: (work@testbench.clk), line:25:31, endln:25:34, parent:work@testbench
+    |vpiTypedef:
+    \_logic_typespec: , line:25:25, endln:25:30
     |vpiInstance:
     \_module: work@testbench (work@testbench) dut.sv:25:1: , endln:52:10
   |vpiModule:
@@ -775,11 +783,15 @@ design: (work@testbench)
     |vpiDefLineNo:1
     |vpiNet:
     \_logic_net: (work@testbench.u1.a), line:1:55, endln:1:56, parent:work@testbench.u1
+      |vpiTypespec:
+      \_logic_typespec: , line:1:49, endln:1:54
       |vpiName:a
       |vpiFullName:work@testbench.u1.a
       |vpiNetType:36
     |vpiNet:
     \_logic_net: (work@testbench.u1.b), line:1:71, endln:1:72, parent:work@testbench.u1
+      |vpiTypespec:
+      \_logic_typespec: , line:1:65, endln:1:70
       |vpiName:b
       |vpiFullName:work@testbench.u1.b
       |vpiNetType:36
@@ -799,6 +811,8 @@ design: (work@testbench)
         |vpiFullName:work@testbench.u1.a
         |vpiActual:
         \_logic_net: (work@testbench.u1.a), line:1:55, endln:1:56, parent:work@testbench.u1
+      |vpiTypedef:
+      \_logic_typespec: , line:1:49, endln:1:54
       |vpiInstance:
       \_module: work@bp_lce (work@testbench.u1) dut.sv:27:3: , endln:27:30, parent:work@testbench
     |vpiPort:
@@ -811,6 +825,8 @@ design: (work@testbench)
         |vpiFullName:work@testbench.u1.b
         |vpiActual:
         \_logic_net: (work@testbench.u1.b), line:1:71, endln:1:72, parent:work@testbench.u1
+      |vpiTypedef:
+      \_logic_typespec: , line:1:65, endln:1:70
       |vpiInstance:
       \_module: work@bp_lce (work@testbench.u1) dut.sv:27:3: , endln:27:30, parent:work@testbench
     |vpiContAssign:
@@ -856,11 +872,15 @@ design: (work@testbench)
       |vpiDefLineNo:8
       |vpiNet:
       \_logic_net: (work@testbench.u1.lce_tracer1.c), line:8:74, endln:8:75, parent:work@testbench.lce_tracer1
+        |vpiTypespec:
+        \_logic_typespec: , line:8:68, endln:8:73
         |vpiName:c
         |vpiFullName:work@testbench.u1.lce_tracer1.c
         |vpiNetType:36
       |vpiNet:
       \_logic_net: (work@testbench.u1.lce_tracer1.d), line:8:90, endln:8:91, parent:work@testbench.lce_tracer1
+        |vpiTypespec:
+        \_logic_typespec: , line:8:84, endln:8:89
         |vpiName:d
         |vpiFullName:work@testbench.u1.lce_tracer1.d
         |vpiNetType:36
@@ -886,6 +906,8 @@ design: (work@testbench)
           |vpiFullName:work@testbench.lce_tracer1.c
           |vpiActual:
           \_logic_net: (work@testbench.u1.lce_tracer1.c), line:8:74, endln:8:75, parent:work@testbench.lce_tracer1
+        |vpiTypedef:
+        \_logic_typespec: , line:8:68, endln:8:73
         |vpiInstance:
         \_module: work@bp_me_nonsynth_lce_tracer (work@testbench.lce_tracer1) dut.sv:34:13: , endln:36:41, parent:work@testbench.u1
       |vpiPort:
@@ -904,6 +926,8 @@ design: (work@testbench)
           |vpiFullName:work@testbench.lce_tracer1.d
           |vpiActual:
           \_logic_net: (work@testbench.u1.lce_tracer1.d), line:8:90, endln:8:91, parent:work@testbench.lce_tracer1
+        |vpiTypedef:
+        \_logic_typespec: , line:8:84, endln:8:89
         |vpiInstance:
         \_module: work@bp_me_nonsynth_lce_tracer (work@testbench.lce_tracer1) dut.sv:34:13: , endln:36:41, parent:work@testbench.u1
       |vpiContAssign:
@@ -962,6 +986,8 @@ design: (work@testbench)
       \_logic_net: (work@testbench.u1.lce_tracer2.b), line:13:91, endln:13:92, parent:work@testbench.lce_tracer2
       |vpiNet:
       \_logic_net: (work@testbench.u1.lce_tracer2.clk), line:13:106, endln:13:109, parent:work@testbench.lce_tracer2
+        |vpiTypespec:
+        \_logic_typespec: , line:13:100, endln:13:105
         |vpiName:clk
         |vpiFullName:work@testbench.u1.lce_tracer2.clk
         |vpiNetType:36
@@ -983,6 +1009,8 @@ design: (work@testbench)
           |vpiFullName:work@testbench.lce_tracer2.a
           |vpiActual:
           \_logic_net: (work@testbench.u1.lce_tracer2.a), line:13:75, endln:13:76, parent:work@testbench.lce_tracer2
+        |vpiTypedef:
+        \_logic_typespec: , line:13:69, endln:13:74
         |vpiInstance:
         \_module: work@bp_me_nonsynth_lce_tracer2 (work@testbench.lce_tracer2) dut.sv:40:13: , endln:42:31, parent:work@testbench.u1
       |vpiPort:
@@ -1001,6 +1029,8 @@ design: (work@testbench)
           |vpiFullName:work@testbench.lce_tracer2.b
           |vpiActual:
           \_logic_net: (work@testbench.u1.lce_tracer2.b), line:13:91, endln:13:92, parent:work@testbench.lce_tracer2
+        |vpiTypedef:
+        \_logic_typespec: , line:13:85, endln:13:90
         |vpiInstance:
         \_module: work@bp_me_nonsynth_lce_tracer2 (work@testbench.lce_tracer2) dut.sv:40:13: , endln:42:31, parent:work@testbench.u1
       |vpiPort:
@@ -1019,6 +1049,8 @@ design: (work@testbench)
           |vpiFullName:work@testbench.lce_tracer2.clk
           |vpiActual:
           \_logic_net: (work@testbench.u1.lce_tracer2.clk), line:13:106, endln:13:109, parent:work@testbench.lce_tracer2
+        |vpiTypedef:
+        \_logic_typespec: , line:13:100, endln:13:105
         |vpiInstance:
         \_module: work@bp_me_nonsynth_lce_tracer2 (work@testbench.lce_tracer2) dut.sv:40:13: , endln:42:31, parent:work@testbench.u1
       |vpiContAssign:
@@ -1087,11 +1119,15 @@ design: (work@testbench)
       |vpiDefLineNo:1
       |vpiNet:
       \_logic_net: (work@testbench.tt.u1.a), line:1:55, endln:1:56, parent:work@testbench.tt.u1
+        |vpiTypespec:
+        \_logic_typespec: , line:1:49, endln:1:54
         |vpiName:a
         |vpiFullName:work@testbench.tt.u1.a
         |vpiNetType:36
       |vpiNet:
       \_logic_net: (work@testbench.tt.u1.b), line:1:71, endln:1:72, parent:work@testbench.tt.u1
+        |vpiTypespec:
+        \_logic_typespec: , line:1:65, endln:1:70
         |vpiName:b
         |vpiFullName:work@testbench.tt.u1.b
         |vpiNetType:36
@@ -1107,6 +1143,8 @@ design: (work@testbench)
           |vpiFullName:work@testbench.tt.u1.a
           |vpiActual:
           \_logic_net: (work@testbench.tt.u1.a), line:1:55, endln:1:56, parent:work@testbench.tt.u1
+        |vpiTypedef:
+        \_logic_typespec: , line:1:49, endln:1:54
         |vpiInstance:
         \_module: work@bp_lce (work@testbench.tt.u1) dut.sv:21:2: , endln:21:29, parent:work@testbench.tt
       |vpiPort:
@@ -1119,6 +1157,8 @@ design: (work@testbench)
           |vpiFullName:work@testbench.tt.u1.b
           |vpiActual:
           \_logic_net: (work@testbench.tt.u1.b), line:1:71, endln:1:72, parent:work@testbench.tt.u1
+        |vpiTypedef:
+        \_logic_typespec: , line:1:65, endln:1:70
         |vpiInstance:
         \_module: work@bp_lce (work@testbench.tt.u1) dut.sv:21:2: , endln:21:29, parent:work@testbench.tt
       |vpiContAssign:
@@ -1164,11 +1204,15 @@ design: (work@testbench)
         |vpiDefLineNo:8
         |vpiNet:
         \_logic_net: (work@testbench.tt.u1.lce_tracer1.c), line:8:74, endln:8:75, parent:work@testbench.tt.lce_tracer1
+          |vpiTypespec:
+          \_logic_typespec: , line:8:68, endln:8:73
           |vpiName:c
           |vpiFullName:work@testbench.tt.u1.lce_tracer1.c
           |vpiNetType:36
         |vpiNet:
         \_logic_net: (work@testbench.tt.u1.lce_tracer1.d), line:8:90, endln:8:91, parent:work@testbench.tt.lce_tracer1
+          |vpiTypespec:
+          \_logic_typespec: , line:8:84, endln:8:89
           |vpiName:d
           |vpiFullName:work@testbench.tt.u1.lce_tracer1.d
           |vpiNetType:36
@@ -1190,6 +1234,8 @@ design: (work@testbench)
             |vpiFullName:work@testbench.tt.lce_tracer1.c
             |vpiActual:
             \_logic_net: (work@testbench.tt.u1.lce_tracer1.c), line:8:74, endln:8:75, parent:work@testbench.tt.lce_tracer1
+          |vpiTypedef:
+          \_logic_typespec: , line:8:68, endln:8:73
           |vpiInstance:
           \_module: work@bp_me_nonsynth_lce_tracer (work@testbench.tt.lce_tracer1) dut.sv:34:13: , endln:36:41, parent:work@testbench.tt.u1
         |vpiPort:
@@ -1208,6 +1254,8 @@ design: (work@testbench)
             |vpiFullName:work@testbench.tt.lce_tracer1.d
             |vpiActual:
             \_logic_net: (work@testbench.tt.u1.lce_tracer1.d), line:8:90, endln:8:91, parent:work@testbench.tt.lce_tracer1
+          |vpiTypedef:
+          \_logic_typespec: , line:8:84, endln:8:89
           |vpiInstance:
           \_module: work@bp_me_nonsynth_lce_tracer (work@testbench.tt.lce_tracer1) dut.sv:34:13: , endln:36:41, parent:work@testbench.tt.u1
         |vpiContAssign:
@@ -1262,16 +1310,22 @@ design: (work@testbench)
         |vpiDefLineNo:13
         |vpiNet:
         \_logic_net: (work@testbench.tt.u1.lce_tracer2.a), line:13:75, endln:13:76, parent:work@testbench.tt.lce_tracer2
+          |vpiTypespec:
+          \_logic_typespec: , line:13:69, endln:13:74
           |vpiName:a
           |vpiFullName:work@testbench.tt.u1.lce_tracer2.a
           |vpiNetType:36
         |vpiNet:
         \_logic_net: (work@testbench.tt.u1.lce_tracer2.b), line:13:91, endln:13:92, parent:work@testbench.tt.lce_tracer2
+          |vpiTypespec:
+          \_logic_typespec: , line:13:85, endln:13:90
           |vpiName:b
           |vpiFullName:work@testbench.tt.u1.lce_tracer2.b
           |vpiNetType:36
         |vpiNet:
         \_logic_net: (work@testbench.tt.u1.lce_tracer2.clk), line:13:106, endln:13:109, parent:work@testbench.tt.lce_tracer2
+          |vpiTypespec:
+          \_logic_typespec: , line:13:100, endln:13:105
           |vpiName:clk
           |vpiFullName:work@testbench.tt.u1.lce_tracer2.clk
           |vpiNetType:36
@@ -1293,6 +1347,8 @@ design: (work@testbench)
             |vpiFullName:work@testbench.tt.lce_tracer2.a
             |vpiActual:
             \_logic_net: (work@testbench.tt.u1.lce_tracer2.a), line:13:75, endln:13:76, parent:work@testbench.tt.lce_tracer2
+          |vpiTypedef:
+          \_logic_typespec: , line:13:69, endln:13:74
           |vpiInstance:
           \_module: work@bp_me_nonsynth_lce_tracer2 (work@testbench.tt.lce_tracer2) dut.sv:40:13: , endln:42:31, parent:work@testbench.tt.u1
         |vpiPort:
@@ -1311,6 +1367,8 @@ design: (work@testbench)
             |vpiFullName:work@testbench.tt.lce_tracer2.b
             |vpiActual:
             \_logic_net: (work@testbench.tt.u1.lce_tracer2.b), line:13:91, endln:13:92, parent:work@testbench.tt.lce_tracer2
+          |vpiTypedef:
+          \_logic_typespec: , line:13:85, endln:13:90
           |vpiInstance:
           \_module: work@bp_me_nonsynth_lce_tracer2 (work@testbench.tt.lce_tracer2) dut.sv:40:13: , endln:42:31, parent:work@testbench.tt.u1
         |vpiPort:
@@ -1329,6 +1387,8 @@ design: (work@testbench)
             |vpiFullName:work@testbench.tt.lce_tracer2.clk
             |vpiActual:
             \_logic_net: (work@testbench.tt.u1.lce_tracer2.clk), line:13:106, endln:13:109, parent:work@testbench.tt.lce_tracer2
+          |vpiTypedef:
+          \_logic_typespec: , line:13:100, endln:13:105
           |vpiInstance:
           \_module: work@bp_me_nonsynth_lce_tracer2 (work@testbench.tt.lce_tracer2) dut.sv:40:13: , endln:42:31, parent:work@testbench.tt.u1
         |vpiContAssign:

--- a/tests/BindStmt2/BindStmt2.log
+++ b/tests/BindStmt2/BindStmt2.log
@@ -1203,67 +1203,81 @@ design: (work@rv_dm)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@rv_dm.clk_i), line:5:30, endln:5:35, parent:work@rv_dm
+    |vpiTypespec:
+    \_logic_typespec: , line:5:10, endln:5:15
     |vpiName:clk_i
     |vpiFullName:work@rv_dm.clk_i
     |vpiNetType:36
   |vpiNet:
   \_logic_net: (work@rv_dm.rst_ni), line:6:30, endln:6:36, parent:work@rv_dm
+    |vpiTypespec:
+    \_logic_typespec: , line:6:10, endln:6:15
     |vpiName:rst_ni
     |vpiFullName:work@rv_dm.rst_ni
     |vpiNetType:36
   |vpiNet:
   \_logic_net: (work@rv_dm.testmode_i), line:9:30, endln:9:40, parent:work@rv_dm
+    |vpiTypespec:
+    \_logic_typespec: , line:9:10, endln:9:15
     |vpiName:testmode_i
     |vpiFullName:work@rv_dm.testmode_i
     |vpiNetType:36
   |vpiNet:
   \_logic_net: (work@rv_dm.ndmreset_o), line:10:30, endln:10:40, parent:work@rv_dm
+    |vpiTypespec:
+    \_logic_typespec: , line:10:10, endln:10:15
     |vpiName:ndmreset_o
     |vpiFullName:work@rv_dm.ndmreset_o
     |vpiNetType:36
   |vpiNet:
   \_logic_net: (work@rv_dm.dmactive_o), line:11:30, endln:11:40, parent:work@rv_dm
+    |vpiTypespec:
+    \_logic_typespec: , line:11:10, endln:11:15
     |vpiName:dmactive_o
     |vpiFullName:work@rv_dm.dmactive_o
     |vpiNetType:36
   |vpiNet:
   \_logic_net: (work@rv_dm.debug_req_o), line:12:30, endln:12:41, parent:work@rv_dm
+    |vpiTypespec:
+    \_logic_typespec: , line:12:10, endln:12:15
+      |vpiRange:
+      \_range: , line:12:17, endln:12:28
+        |vpiLeftRange:
+        \_constant: , line:12:17, endln:12:24
+          |vpiDecompile:0
+          |vpiSize:64
+          |INT:0
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:12:27, endln:12:28
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:debug_req_o
     |vpiFullName:work@rv_dm.debug_req_o
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:12:17, endln:12:28
-      |vpiLeftRange:
-      \_constant: , line:12:17, endln:12:24
-        |vpiDecompile:0
-        |vpiSize:64
-        |INT:0
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:12:27, endln:12:28
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@rv_dm.unavailable_i), line:13:30, endln:13:43, parent:work@rv_dm
+    |vpiTypespec:
+    \_logic_typespec: , line:13:10, endln:13:15
+      |vpiRange:
+      \_range: , line:13:17, endln:13:28
+        |vpiLeftRange:
+        \_constant: , line:13:17, endln:13:24
+          |vpiDecompile:0
+          |vpiSize:64
+          |INT:0
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:13:27, endln:13:28
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:unavailable_i
     |vpiFullName:work@rv_dm.unavailable_i
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:13:17, endln:13:28
-      |vpiLeftRange:
-      \_constant: , line:13:17, endln:13:24
-        |vpiDecompile:0
-        |vpiSize:64
-        |INT:0
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:13:27, endln:13:28
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (clk_i), line:5:30, endln:5:35, parent:work@rv_dm
@@ -1275,6 +1289,8 @@ design: (work@rv_dm)
       |vpiFullName:work@rv_dm.clk_i
       |vpiActual:
       \_logic_net: (work@rv_dm.clk_i), line:5:30, endln:5:35, parent:work@rv_dm
+    |vpiTypedef:
+    \_logic_typespec: , line:5:10, endln:5:15
     |vpiInstance:
     \_module: work@rv_dm (work@rv_dm) dut.sv:1:1: , endln:34:10
   |vpiPort:
@@ -1287,6 +1303,8 @@ design: (work@rv_dm)
       |vpiFullName:work@rv_dm.rst_ni
       |vpiActual:
       \_logic_net: (work@rv_dm.rst_ni), line:6:30, endln:6:36, parent:work@rv_dm
+    |vpiTypedef:
+    \_logic_typespec: , line:6:10, endln:6:15
     |vpiInstance:
     \_module: work@rv_dm (work@rv_dm) dut.sv:1:1: , endln:34:10
   |vpiPort:
@@ -1314,6 +1332,8 @@ design: (work@rv_dm)
       |vpiFullName:work@rv_dm.testmode_i
       |vpiActual:
       \_logic_net: (work@rv_dm.testmode_i), line:9:30, endln:9:40, parent:work@rv_dm
+    |vpiTypedef:
+    \_logic_typespec: , line:9:10, endln:9:15
     |vpiInstance:
     \_module: work@rv_dm (work@rv_dm) dut.sv:1:1: , endln:34:10
   |vpiPort:
@@ -1326,6 +1346,8 @@ design: (work@rv_dm)
       |vpiFullName:work@rv_dm.ndmreset_o
       |vpiActual:
       \_logic_net: (work@rv_dm.ndmreset_o), line:10:30, endln:10:40, parent:work@rv_dm
+    |vpiTypedef:
+    \_logic_typespec: , line:10:10, endln:10:15
     |vpiInstance:
     \_module: work@rv_dm (work@rv_dm) dut.sv:1:1: , endln:34:10
   |vpiPort:
@@ -1338,6 +1360,8 @@ design: (work@rv_dm)
       |vpiFullName:work@rv_dm.dmactive_o
       |vpiActual:
       \_logic_net: (work@rv_dm.dmactive_o), line:11:30, endln:11:40, parent:work@rv_dm
+    |vpiTypedef:
+    \_logic_typespec: , line:11:10, endln:11:15
     |vpiInstance:
     \_module: work@rv_dm (work@rv_dm) dut.sv:1:1: , endln:34:10
   |vpiPort:
@@ -1350,6 +1374,22 @@ design: (work@rv_dm)
       |vpiFullName:work@rv_dm.debug_req_o
       |vpiActual:
       \_logic_net: (work@rv_dm.debug_req_o), line:12:30, endln:12:41, parent:work@rv_dm
+    |vpiTypedef:
+    \_logic_typespec: , line:12:10, endln:12:15
+      |vpiRange:
+      \_range: , line:12:17, endln:12:28, parent:debug_req_o
+        |vpiLeftRange:
+        \_constant: , line:12:17, endln:12:24
+          |vpiDecompile:0
+          |vpiSize:64
+          |INT:0
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:12:27, endln:12:28
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@rv_dm (work@rv_dm) dut.sv:1:1: , endln:34:10
   |vpiPort:
@@ -1362,6 +1402,22 @@ design: (work@rv_dm)
       |vpiFullName:work@rv_dm.unavailable_i
       |vpiActual:
       \_logic_net: (work@rv_dm.unavailable_i), line:13:30, endln:13:43, parent:work@rv_dm
+    |vpiTypedef:
+    \_logic_typespec: , line:13:10, endln:13:15
+      |vpiRange:
+      \_range: , line:13:17, endln:13:28, parent:unavailable_i
+        |vpiLeftRange:
+        \_constant: , line:13:17, endln:13:24
+          |vpiDecompile:0
+          |vpiSize:64
+          |INT:0
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:13:27, endln:13:28
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@rv_dm (work@rv_dm) dut.sv:1:1: , endln:34:10
   |vpiPort:
@@ -1460,35 +1516,35 @@ design: (work@rv_dm)
     |vpiVariables:
     \_bit_var: (work@rv_dm.u_dmidpi.clk_i), line:40:21, endln:40:26, parent:u_dmidpi
       |vpiTypespec:
-      \_bit_typespec: 
+      \_bit_typespec: , line:40:10, endln:40:13
       |vpiName:clk_i
       |vpiFullName:work@rv_dm.u_dmidpi.clk_i
       |vpiVisibility:1
     |vpiVariables:
     \_bit_var: (work@rv_dm.u_dmidpi.rst_ni), line:41:21, endln:41:27, parent:u_dmidpi
       |vpiTypespec:
-      \_bit_typespec: 
+      \_bit_typespec: , line:41:10, endln:41:13
       |vpiName:rst_ni
       |vpiFullName:work@rv_dm.u_dmidpi.rst_ni
       |vpiVisibility:1
     |vpiVariables:
     \_bit_var: (work@rv_dm.u_dmidpi.dmi_req_valid), line:43:21, endln:43:34, parent:u_dmidpi
       |vpiTypespec:
-      \_bit_typespec: 
+      \_bit_typespec: , line:43:10, endln:43:13
       |vpiName:dmi_req_valid
       |vpiFullName:work@rv_dm.u_dmidpi.dmi_req_valid
       |vpiVisibility:1
     |vpiVariables:
     \_bit_var: (work@rv_dm.u_dmidpi.dmi_req_ready), line:44:21, endln:44:34, parent:u_dmidpi
       |vpiTypespec:
-      \_bit_typespec: 
+      \_bit_typespec: , line:44:10, endln:44:13
       |vpiName:dmi_req_ready
       |vpiFullName:work@rv_dm.u_dmidpi.dmi_req_ready
       |vpiVisibility:1
     |vpiVariables:
     \_bit_var: (work@rv_dm.u_dmidpi.dmi_req_addr), line:45:21, endln:45:33, parent:u_dmidpi
       |vpiTypespec:
-      \_bit_typespec: 
+      \_bit_typespec: , line:45:10, endln:45:13
         |vpiRange:
         \_range: , line:45:15, endln:45:18
           |vpiLeftRange:
@@ -1506,12 +1562,10 @@ design: (work@rv_dm)
       |vpiName:dmi_req_addr
       |vpiFullName:work@rv_dm.u_dmidpi.dmi_req_addr
       |vpiVisibility:1
-      |vpiRange:
-      \_range: , line:45:15, endln:45:18
     |vpiVariables:
     \_bit_var: (work@rv_dm.u_dmidpi.dmi_req_op), line:46:21, endln:46:31, parent:u_dmidpi
       |vpiTypespec:
-      \_bit_typespec: 
+      \_bit_typespec: , line:46:10, endln:46:13
         |vpiRange:
         \_range: , line:46:15, endln:46:18
           |vpiLeftRange:
@@ -1529,12 +1583,10 @@ design: (work@rv_dm)
       |vpiName:dmi_req_op
       |vpiFullName:work@rv_dm.u_dmidpi.dmi_req_op
       |vpiVisibility:1
-      |vpiRange:
-      \_range: , line:46:15, endln:46:18
     |vpiVariables:
     \_bit_var: (work@rv_dm.u_dmidpi.dmi_req_data), line:47:21, endln:47:33, parent:u_dmidpi
       |vpiTypespec:
-      \_bit_typespec: 
+      \_bit_typespec: , line:47:10, endln:47:13
         |vpiRange:
         \_range: , line:47:15, endln:47:19
           |vpiLeftRange:
@@ -1552,26 +1604,24 @@ design: (work@rv_dm)
       |vpiName:dmi_req_data
       |vpiFullName:work@rv_dm.u_dmidpi.dmi_req_data
       |vpiVisibility:1
-      |vpiRange:
-      \_range: , line:47:15, endln:47:19
     |vpiVariables:
     \_bit_var: (work@rv_dm.u_dmidpi.dmi_rsp_valid), line:48:21, endln:48:34, parent:u_dmidpi
       |vpiTypespec:
-      \_bit_typespec: 
+      \_bit_typespec: , line:48:10, endln:48:13
       |vpiName:dmi_rsp_valid
       |vpiFullName:work@rv_dm.u_dmidpi.dmi_rsp_valid
       |vpiVisibility:1
     |vpiVariables:
     \_bit_var: (work@rv_dm.u_dmidpi.dmi_rsp_ready), line:49:21, endln:49:34, parent:u_dmidpi
       |vpiTypespec:
-      \_bit_typespec: 
+      \_bit_typespec: , line:49:10, endln:49:13
       |vpiName:dmi_rsp_ready
       |vpiFullName:work@rv_dm.u_dmidpi.dmi_rsp_ready
       |vpiVisibility:1
     |vpiVariables:
     \_bit_var: (work@rv_dm.u_dmidpi.dmi_rsp_data), line:50:21, endln:50:33, parent:u_dmidpi
       |vpiTypespec:
-      \_bit_typespec: 
+      \_bit_typespec: , line:50:10, endln:50:13
         |vpiRange:
         \_range: , line:50:15, endln:50:19
           |vpiLeftRange:
@@ -1589,12 +1639,10 @@ design: (work@rv_dm)
       |vpiName:dmi_rsp_data
       |vpiFullName:work@rv_dm.u_dmidpi.dmi_rsp_data
       |vpiVisibility:1
-      |vpiRange:
-      \_range: , line:50:15, endln:50:19
     |vpiVariables:
     \_bit_var: (work@rv_dm.u_dmidpi.dmi_rsp_resp), line:51:21, endln:51:33, parent:u_dmidpi
       |vpiTypespec:
-      \_bit_typespec: 
+      \_bit_typespec: , line:51:10, endln:51:13
         |vpiRange:
         \_range: , line:51:15, endln:51:18
           |vpiLeftRange:
@@ -1612,12 +1660,10 @@ design: (work@rv_dm)
       |vpiName:dmi_rsp_resp
       |vpiFullName:work@rv_dm.u_dmidpi.dmi_rsp_resp
       |vpiVisibility:1
-      |vpiRange:
-      \_range: , line:51:15, endln:51:18
     |vpiVariables:
     \_bit_var: (work@rv_dm.u_dmidpi.dmi_rst_n), line:52:21, endln:52:30, parent:u_dmidpi
       |vpiTypespec:
-      \_bit_typespec: 
+      \_bit_typespec: , line:52:10, endln:52:13
       |vpiName:dmi_rst_n
       |vpiFullName:work@rv_dm.u_dmidpi.dmi_rst_n
       |vpiVisibility:1
@@ -1676,6 +1722,8 @@ design: (work@rv_dm)
         |vpiFullName:u_dmidpi.clk_i
         |vpiActual:
         \_bit_var: (work@rv_dm.u_dmidpi.clk_i), line:40:21, endln:40:26, parent:u_dmidpi
+      |vpiTypedef:
+      \_bit_typespec: , line:40:10, endln:40:13
       |vpiInstance:
       \_module: work@dmidpi (u_dmidpi) dut.sv:57:14: , endln:70:5, parent:work@rv_dm
     |vpiPort:
@@ -1688,6 +1736,8 @@ design: (work@rv_dm)
         |vpiFullName:u_dmidpi.rst_ni
         |vpiActual:
         \_bit_var: (work@rv_dm.u_dmidpi.rst_ni), line:41:21, endln:41:27, parent:u_dmidpi
+      |vpiTypedef:
+      \_bit_typespec: , line:41:10, endln:41:13
       |vpiInstance:
       \_module: work@dmidpi (u_dmidpi) dut.sv:57:14: , endln:70:5, parent:work@rv_dm
     |vpiPort:
@@ -1700,6 +1750,8 @@ design: (work@rv_dm)
         |vpiFullName:u_dmidpi.dmi_req_valid
         |vpiActual:
         \_bit_var: (work@rv_dm.u_dmidpi.dmi_req_valid), line:43:21, endln:43:34, parent:u_dmidpi
+      |vpiTypedef:
+      \_bit_typespec: , line:43:10, endln:43:13
       |vpiInstance:
       \_module: work@dmidpi (u_dmidpi) dut.sv:57:14: , endln:70:5, parent:work@rv_dm
     |vpiPort:
@@ -1712,6 +1764,8 @@ design: (work@rv_dm)
         |vpiFullName:u_dmidpi.dmi_req_ready
         |vpiActual:
         \_bit_var: (work@rv_dm.u_dmidpi.dmi_req_ready), line:44:21, endln:44:34, parent:u_dmidpi
+      |vpiTypedef:
+      \_bit_typespec: , line:44:10, endln:44:13
       |vpiInstance:
       \_module: work@dmidpi (u_dmidpi) dut.sv:57:14: , endln:70:5, parent:work@rv_dm
     |vpiPort:
@@ -1735,6 +1789,22 @@ design: (work@rv_dm)
         |vpiFullName:u_dmidpi.dmi_req_addr
         |vpiActual:
         \_bit_var: (work@rv_dm.u_dmidpi.dmi_req_addr), line:45:21, endln:45:33, parent:u_dmidpi
+      |vpiTypedef:
+      \_bit_typespec: , line:45:10, endln:45:13
+        |vpiRange:
+        \_range: , line:45:15, endln:45:18, parent:dmi_req_addr
+          |vpiLeftRange:
+          \_constant: , line:45:15, endln:45:16
+            |vpiDecompile:6
+            |vpiSize:64
+            |UINT:6
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:45:17, endln:45:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@dmidpi (u_dmidpi) dut.sv:57:14: , endln:70:5, parent:work@rv_dm
     |vpiPort:
@@ -1758,6 +1828,22 @@ design: (work@rv_dm)
         |vpiFullName:u_dmidpi.dmi_req_op
         |vpiActual:
         \_bit_var: (work@rv_dm.u_dmidpi.dmi_req_op), line:46:21, endln:46:31, parent:u_dmidpi
+      |vpiTypedef:
+      \_bit_typespec: , line:46:10, endln:46:13
+        |vpiRange:
+        \_range: , line:46:15, endln:46:18, parent:dmi_req_op
+          |vpiLeftRange:
+          \_constant: , line:46:15, endln:46:16
+            |vpiDecompile:1
+            |vpiSize:64
+            |UINT:1
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:46:17, endln:46:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@dmidpi (u_dmidpi) dut.sv:57:14: , endln:70:5, parent:work@rv_dm
     |vpiPort:
@@ -1781,6 +1867,22 @@ design: (work@rv_dm)
         |vpiFullName:u_dmidpi.dmi_req_data
         |vpiActual:
         \_bit_var: (work@rv_dm.u_dmidpi.dmi_req_data), line:47:21, endln:47:33, parent:u_dmidpi
+      |vpiTypedef:
+      \_bit_typespec: , line:47:10, endln:47:13
+        |vpiRange:
+        \_range: , line:47:15, endln:47:19, parent:dmi_req_data
+          |vpiLeftRange:
+          \_constant: , line:47:15, endln:47:17
+            |vpiDecompile:31
+            |vpiSize:64
+            |UINT:31
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:47:18, endln:47:19
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@dmidpi (u_dmidpi) dut.sv:57:14: , endln:70:5, parent:work@rv_dm
     |vpiPort:
@@ -1793,6 +1895,8 @@ design: (work@rv_dm)
         |vpiFullName:u_dmidpi.dmi_rsp_valid
         |vpiActual:
         \_bit_var: (work@rv_dm.u_dmidpi.dmi_rsp_valid), line:48:21, endln:48:34, parent:u_dmidpi
+      |vpiTypedef:
+      \_bit_typespec: , line:48:10, endln:48:13
       |vpiInstance:
       \_module: work@dmidpi (u_dmidpi) dut.sv:57:14: , endln:70:5, parent:work@rv_dm
     |vpiPort:
@@ -1805,6 +1909,8 @@ design: (work@rv_dm)
         |vpiFullName:u_dmidpi.dmi_rsp_ready
         |vpiActual:
         \_bit_var: (work@rv_dm.u_dmidpi.dmi_rsp_ready), line:49:21, endln:49:34, parent:u_dmidpi
+      |vpiTypedef:
+      \_bit_typespec: , line:49:10, endln:49:13
       |vpiInstance:
       \_module: work@dmidpi (u_dmidpi) dut.sv:57:14: , endln:70:5, parent:work@rv_dm
     |vpiPort:
@@ -1828,6 +1934,22 @@ design: (work@rv_dm)
         |vpiFullName:u_dmidpi.dmi_rsp_data
         |vpiActual:
         \_bit_var: (work@rv_dm.u_dmidpi.dmi_rsp_data), line:50:21, endln:50:33, parent:u_dmidpi
+      |vpiTypedef:
+      \_bit_typespec: , line:50:10, endln:50:13
+        |vpiRange:
+        \_range: , line:50:15, endln:50:19, parent:dmi_rsp_data
+          |vpiLeftRange:
+          \_constant: , line:50:15, endln:50:17
+            |vpiDecompile:31
+            |vpiSize:64
+            |UINT:31
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:50:18, endln:50:19
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@dmidpi (u_dmidpi) dut.sv:57:14: , endln:70:5, parent:work@rv_dm
     |vpiPort:
@@ -1851,6 +1973,22 @@ design: (work@rv_dm)
         |vpiFullName:u_dmidpi.dmi_rsp_resp
         |vpiActual:
         \_bit_var: (work@rv_dm.u_dmidpi.dmi_rsp_resp), line:51:21, endln:51:33, parent:u_dmidpi
+      |vpiTypedef:
+      \_bit_typespec: , line:51:10, endln:51:13
+        |vpiRange:
+        \_range: , line:51:15, endln:51:18, parent:dmi_rsp_resp
+          |vpiLeftRange:
+          \_constant: , line:51:15, endln:51:16
+            |vpiDecompile:1
+            |vpiSize:64
+            |UINT:1
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:51:17, endln:51:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@dmidpi (u_dmidpi) dut.sv:57:14: , endln:70:5, parent:work@rv_dm
     |vpiPort:
@@ -1869,6 +2007,8 @@ design: (work@rv_dm)
         |vpiFullName:u_dmidpi.dmi_rst_n
         |vpiActual:
         \_bit_var: (work@rv_dm.u_dmidpi.dmi_rst_n), line:52:21, endln:52:30, parent:u_dmidpi
+      |vpiTypedef:
+      \_bit_typespec: , line:52:10, endln:52:13
       |vpiInstance:
       \_module: work@dmidpi (u_dmidpi) dut.sv:57:14: , endln:70:5, parent:work@rv_dm
 |uhdmtopModules:

--- a/tests/BindVarsAndEnum/BindVarsAndEnum.log
+++ b/tests/BindVarsAndEnum/BindVarsAndEnum.log
@@ -940,7 +940,7 @@ design: (work@conditional_Fsm)
             |vpiActual:
             \_bit_var: (work@conditional_Fsm.reset), line:1:36, endln:1:41, parent:work@conditional_Fsm
               |vpiTypespec:
-              \_bit_typespec: 
+              \_bit_typespec: , line:1:32, endln:1:35
               |vpiName:reset
               |vpiFullName:work@conditional_Fsm.reset
               |vpiVisibility:1
@@ -976,7 +976,7 @@ design: (work@conditional_Fsm)
   |vpiVariables:
   \_bit_var: (work@conditional_Fsm.increment), line:2:13, endln:2:22, parent:work@conditional_Fsm
     |vpiTypespec:
-    \_bit_typespec: 
+    \_bit_typespec: , line:2:9, endln:2:12
     |vpiName:increment
     |vpiFullName:work@conditional_Fsm.increment
     |vpiVisibility:1
@@ -1014,6 +1014,8 @@ design: (work@conditional_Fsm)
       |vpiFullName:work@conditional_Fsm.reset
       |vpiActual:
       \_bit_var: (work@conditional_Fsm.reset), line:1:36, endln:1:41, parent:work@conditional_Fsm
+    |vpiTypedef:
+    \_bit_typespec: , line:1:32, endln:1:35
     |vpiInstance:
     \_module: work@conditional_Fsm (work@conditional_Fsm) dut.sv:1:1: , endln:18:10
   |vpiPort:
@@ -1026,6 +1028,8 @@ design: (work@conditional_Fsm)
       |vpiFullName:work@conditional_Fsm.increment
       |vpiActual:
       \_bit_var: (work@conditional_Fsm.increment), line:2:13, endln:2:22, parent:work@conditional_Fsm
+    |vpiTypedef:
+    \_bit_typespec: , line:2:9, endln:2:12
     |vpiInstance:
     \_module: work@conditional_Fsm (work@conditional_Fsm) dut.sv:1:1: , endln:18:10
   |vpiPort:
@@ -1038,6 +1042,9 @@ design: (work@conditional_Fsm)
       |vpiFullName:work@conditional_Fsm.count
       |vpiActual:
       \_int_var: (work@conditional_Fsm.count), line:3:14, endln:3:19, parent:work@conditional_Fsm
+    |vpiTypedef:
+    \_int_typespec: , line:3:10, endln:3:13
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@conditional_Fsm (work@conditional_Fsm) dut.sv:1:1: , endln:18:10
   |vpiProcess:

--- a/tests/Bindings/Bindings.log
+++ b/tests/Bindings/Bindings.log
@@ -2645,41 +2645,45 @@ design: (work@dut1)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@dut2.i), line:37:36, endln:37:37, parent:work@dut2
+    |vpiTypespec:
+    \_logic_typespec: , line:37:12, endln:37:35
+      |vpiRange:
+      \_range: , line:37:13, endln:37:34
+        |vpiLeftRange:
+        \_constant: , line:37:13, endln:37:30
+          |vpiDecompile:-1
+          |vpiSize:64
+          |INT:-1
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:37:33, endln:37:34
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:i
     |vpiFullName:work@dut2.i
-    |vpiRange:
-    \_range: , line:37:13, endln:37:34
-      |vpiLeftRange:
-      \_constant: , line:37:13, endln:37:30
-        |vpiDecompile:-1
-        |vpiSize:64
-        |INT:-1
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:37:33, endln:37:34
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@dut2.o), line:38:36, endln:38:37, parent:work@dut2
+    |vpiTypespec:
+    \_logic_typespec: , line:38:14, endln:38:19
+      |vpiRange:
+      \_range: , line:38:21, endln:38:34
+        |vpiLeftRange:
+        \_constant: , line:38:21, endln:38:30
+          |vpiDecompile:-1
+          |vpiSize:64
+          |INT:-1
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:38:33, endln:38:34
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:o
     |vpiFullName:work@dut2.o
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:38:21, endln:38:34
-      |vpiLeftRange:
-      \_constant: , line:38:21, endln:38:30
-        |vpiDecompile:-1
-        |vpiSize:64
-        |INT:-1
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:38:33, endln:38:34
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (i), line:37:36, endln:37:37, parent:work@dut2
@@ -2691,6 +2695,22 @@ design: (work@dut1)
       |vpiFullName:work@dut2.i
       |vpiActual:
       \_logic_net: (work@dut2.i), line:37:36, endln:37:37, parent:work@dut2
+    |vpiTypedef:
+    \_logic_typespec: , line:37:12, endln:37:35
+      |vpiRange:
+      \_range: , line:37:13, endln:37:34, parent:i
+        |vpiLeftRange:
+        \_constant: , line:37:13, endln:37:30
+          |vpiDecompile:-1
+          |vpiSize:64
+          |INT:-1
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:37:33, endln:37:34
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut2 (work@dut2) dut.sv:35:1: , endln:50:10
   |vpiPort:
@@ -2703,6 +2723,22 @@ design: (work@dut1)
       |vpiFullName:work@dut2.o
       |vpiActual:
       \_logic_net: (work@dut2.o), line:38:36, endln:38:37, parent:work@dut2
+    |vpiTypedef:
+    \_logic_typespec: , line:38:14, endln:38:19
+      |vpiRange:
+      \_range: , line:38:21, endln:38:34, parent:o
+        |vpiLeftRange:
+        \_constant: , line:38:21, endln:38:30
+          |vpiDecompile:-1
+          |vpiSize:64
+          |INT:-1
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:38:33, endln:38:34
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut2 (work@dut2) dut.sv:35:1: , endln:50:10
   |vpiGenScopeArray:
@@ -3303,23 +3339,25 @@ design: (work@dut1)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@dut5.shifted), line:96:23, endln:96:30, parent:work@dut5
+    |vpiTypespec:
+    \_logic_typespec: , line:96:4, endln:96:8
+      |vpiRange:
+      \_range: , line:96:10, endln:96:21
+        |vpiLeftRange:
+        \_constant: , line:96:10, endln:96:17
+          |vpiDecompile:-2
+          |vpiSize:64
+          |INT:-2
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:96:20, endln:96:21
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:shifted
     |vpiFullName:work@dut5.shifted
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:96:10, endln:96:21
-      |vpiLeftRange:
-      \_constant: , line:96:10, endln:96:17
-        |vpiDecompile:-2
-        |vpiSize:64
-        |INT:-2
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:96:20, endln:96:21
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (fill)
     |vpiName:fill

--- a/tests/BitComplex/BitComplex.log
+++ b/tests/BitComplex/BitComplex.log
@@ -453,6 +453,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:10:23, endln:10:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:10:19, endln:10:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:10:1: , endln:14:10
   |vpiContAssign:

--- a/tests/BitRanges/BitRanges.log
+++ b/tests/BitRanges/BitRanges.log
@@ -148,7 +148,7 @@ design: (work@top)
     |vpiReg:
     \_bit_var: (work@top.dmi_req_ram), line:3:21, endln:3:32, parent:work@top.dmi_req_ram
       |vpiTypespec:
-      \_bit_typespec: 
+      \_bit_typespec: , line:3:10, endln:3:13
         |vpiRange:
         \_range: , line:3:15, endln:3:18
           |vpiLeftRange:
@@ -165,11 +165,11 @@ design: (work@top)
             |vpiConstType:9
       |vpiFullName:work@top.dmi_req_ram
       |vpiRange:
-      \_range: , line:3:15, endln:3:18
+      \_range: , line:3:34, endln:3:39
   |vpiVariables:
   \_bit_var: (work@top.dmi_req_addr), line:4:21, endln:4:33, parent:work@top
     |vpiTypespec:
-    \_bit_typespec: 
+    \_bit_typespec: , line:4:10, endln:4:13
       |vpiRange:
       \_range: , line:4:15, endln:4:18
         |vpiLeftRange:
@@ -187,8 +187,6 @@ design: (work@top)
     |vpiName:dmi_req_addr
     |vpiFullName:work@top.dmi_req_addr
     |vpiVisibility:1
-    |vpiRange:
-    \_range: , line:4:15, endln:4:18
   |vpiDefName:work@top
   |vpiTop:1
   |vpiTopModule:1
@@ -202,6 +200,22 @@ design: (work@top)
       |vpiFullName:work@top.dmi_req_ram
       |vpiActual:
       \_array_var: (work@top.dmi_req_ram), line:3:21, endln:3:40, parent:work@top
+    |vpiTypedef:
+    \_bit_typespec: , line:3:10, endln:3:13
+      |vpiRange:
+      \_range: , line:3:15, endln:3:18, parent:dmi_req_ram
+        |vpiLeftRange:
+        \_constant: , line:3:15, endln:3:16
+          |vpiDecompile:6
+          |vpiSize:64
+          |UINT:6
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:3:17, endln:3:18
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:6:10
   |vpiPort:
@@ -214,6 +228,22 @@ design: (work@top)
       |vpiFullName:work@top.dmi_req_addr
       |vpiActual:
       \_bit_var: (work@top.dmi_req_addr), line:4:21, endln:4:33, parent:work@top
+    |vpiTypedef:
+    \_bit_typespec: , line:4:10, endln:4:13
+      |vpiRange:
+      \_range: , line:4:15, endln:4:18, parent:dmi_req_addr
+        |vpiLeftRange:
+        \_constant: , line:4:15, endln:4:16
+          |vpiDecompile:6
+          |vpiSize:64
+          |UINT:6
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:4:17, endln:4:18
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:6:10
 ===================

--- a/tests/BitSelectExpr/BitSelectExpr.log
+++ b/tests/BitSelectExpr/BitSelectExpr.log
@@ -242,6 +242,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:1:23, endln:1:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:1:19, endln:1:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:12:10
   |vpiContAssign:

--- a/tests/BitsArray/BitsArray.log
+++ b/tests/BitsArray/BitsArray.log
@@ -434,23 +434,25 @@ design: (work@top)
     |vpiDefLineNo:2
     |vpiNet:
     \_logic_net: (work@top.u_reg_status_key_init.we_i), line:5:28, endln:5:32, parent:work@top.u_reg_status_key_init
+      |vpiTypespec:
+      \_logic_typespec: , line:5:10, endln:5:15
+        |vpiRange:
+        \_range: , line:5:17, endln:5:26
+          |vpiLeftRange:
+          \_constant: , line:5:17, endln:5:22
+            |vpiDecompile:15
+            |vpiSize:64
+            |INT:15
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:5:25, endln:5:26
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:we_i
       |vpiFullName:work@top.u_reg_status_key_init.we_i
       |vpiNetType:36
-      |vpiRange:
-      \_range: , line:5:17, endln:5:26
-        |vpiLeftRange:
-        \_constant: , line:5:17, endln:5:22
-          |vpiDecompile:15
-          |vpiSize:64
-          |INT:15
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:5:25, endln:5:26
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:9:1: , endln:21:10
     |vpiPort:
@@ -494,6 +496,22 @@ design: (work@top)
         |vpiFullName:work@top.u_reg_status_key_init.we_i
         |vpiActual:
         \_logic_net: (work@top.u_reg_status_key_init.we_i), line:5:28, endln:5:32, parent:work@top.u_reg_status_key_init
+      |vpiTypedef:
+      \_logic_typespec: , line:5:10, endln:5:15
+        |vpiRange:
+        \_range: , line:5:17, endln:5:26, parent:we_i
+          |vpiLeftRange:
+          \_constant: , line:5:17, endln:5:22
+            |vpiDecompile:15
+            |vpiSize:64
+            |INT:15
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:5:25, endln:5:26
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@aes_reg_status (work@top.u_reg_status_key_init) dut.sv:15:4: , endln:19:6, parent:work@top
 |uhdmtopModules:

--- a/tests/BitsStructMember/BitsStructMember.log
+++ b/tests/BitsStructMember/BitsStructMember.log
@@ -351,33 +351,35 @@ design: (work@top)
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@top.kmac_mask_o), line:17:30, endln:17:41, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:17:9, endln:17:14
+      |vpiRange:
+      \_range: , line:17:16, endln:17:28
+        |vpiLeftRange:
+        \_operation: , line:17:16, endln:17:26
+          |vpiOpType:11
+          |vpiOperand:
+          \_ref_obj: (MsgWidth), line:17:16, endln:17:24
+            |vpiName:MsgWidth
+            |vpiActual:
+            \_logic_net: (MsgWidth)
+              |vpiName:MsgWidth
+              |vpiNetType:1
+          |vpiOperand:
+          \_constant: , line:17:25, endln:17:26
+            |vpiDecompile:1
+            |vpiSize:64
+            |UINT:1
+            |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:17:27, endln:17:28
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:kmac_mask_o
     |vpiFullName:work@top.kmac_mask_o
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:17:16, endln:17:28
-      |vpiLeftRange:
-      \_operation: , line:17:16, endln:17:26
-        |vpiOpType:11
-        |vpiOperand:
-        \_ref_obj: (MsgWidth), line:17:16, endln:17:24
-          |vpiName:MsgWidth
-          |vpiActual:
-          \_logic_net: (MsgWidth)
-            |vpiName:MsgWidth
-            |vpiNetType:1
-        |vpiOperand:
-        \_constant: , line:17:25, endln:17:26
-          |vpiDecompile:1
-          |vpiSize:64
-          |UINT:1
-          |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:17:27, endln:17:28
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (mux_sel)
   |vpiNet:
@@ -409,6 +411,31 @@ design: (work@top)
       |vpiFullName:work@top.kmac_mask_o
       |vpiActual:
       \_logic_net: (work@top.kmac_mask_o), line:17:30, endln:17:41, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:17:9, endln:17:14
+      |vpiRange:
+      \_range: , line:17:16, endln:17:28, parent:kmac_mask_o
+        |vpiLeftRange:
+        \_operation: , line:17:16, endln:17:26
+          |vpiOpType:11
+          |vpiOperand:
+          \_ref_obj: (work@top.kmac_mask_o.MsgWidth), line:17:16, endln:17:24, parent:kmac_mask_o
+            |vpiName:MsgWidth
+            |vpiFullName:work@top.kmac_mask_o.MsgWidth
+            |vpiActual:
+            \_logic_net: (MsgWidth)
+          |vpiOperand:
+          \_constant: , line:17:25, endln:17:26
+            |vpiDecompile:1
+            |vpiSize:64
+            |UINT:1
+            |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:17:27, endln:17:28
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:16:1: , endln:28:10
   |vpiProcess:

--- a/tests/Blackbox/Blackbox.log
+++ b/tests/Blackbox/Blackbox.log
@@ -152,10 +152,39 @@ design: (work@top)
           |vpiConstType:7
     |vpiNet:
     \_logic_net: (work@top.e), line:1:30, endln:1:31, parent:work@top.e
+      |vpiTypespec:
+      \_logic_typespec: , line:1:18, endln:1:23
+        |vpiRange:
+        \_range: , line:1:25, endln:1:28
+          |vpiLeftRange:
+          \_constant: , line:1:25, endln:1:26
+            |vpiDecompile:7
+            |vpiSize:64
+            |UINT:7
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:1:27, endln:1:28
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiFullName:work@top.e
       |vpiNetType:36
+  |vpiTopModule:1
+  |vpiPort:
+  \_port: (e), line:1:30, endln:1:31, parent:work@top
+    |vpiName:e
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@top.e), line:1:30, endln:1:31, parent:e
+      |vpiName:e
+      |vpiFullName:work@top.e
+      |vpiActual:
+      \_array_net: (work@top.e), line:1:30, endln:1:31, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:18, endln:1:23
       |vpiRange:
-      \_range: , line:1:25, endln:1:28
+      \_range: , line:1:25, endln:1:28, parent:e
         |vpiLeftRange:
         \_constant: , line:1:25, endln:1:26
           |vpiDecompile:7
@@ -168,17 +197,6 @@ design: (work@top)
           |vpiSize:64
           |UINT:0
           |vpiConstType:9
-  |vpiTopModule:1
-  |vpiPort:
-  \_port: (e), line:1:30, endln:1:31, parent:work@top
-    |vpiName:e
-    |vpiDirection:1
-    |vpiLowConn:
-    \_ref_obj: (work@top.e), line:1:30, endln:1:31, parent:e
-      |vpiName:e
-      |vpiFullName:work@top.e
-      |vpiActual:
-      \_array_net: (work@top.e), line:1:30, endln:1:31, parent:work@top
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:5:10
   |vpiModule:

--- a/tests/CarryTrans/CarryTrans.log
+++ b/tests/CarryTrans/CarryTrans.log
@@ -1604,16 +1604,22 @@ design: (work@carry_rtl)
     |vpiFullName:work@carry_gate.cout
   |vpiNet:
   \_logic_net: (work@carry_gate.x), line:11:6, endln:11:7, parent:work@carry_gate
+    |vpiTypespec:
+    \_logic_typespec: , line:11:1, endln:11:5
     |vpiName:x
     |vpiFullName:work@carry_gate.x
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@carry_gate.y), line:11:9, endln:11:10, parent:work@carry_gate
+    |vpiTypespec:
+    \_logic_typespec: , line:11:1, endln:11:5
     |vpiName:y
     |vpiFullName:work@carry_gate.y
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@carry_gate.z), line:11:12, endln:11:13, parent:work@carry_gate
+    |vpiTypespec:
+    \_logic_typespec: , line:11:1, endln:11:5
     |vpiName:z
     |vpiFullName:work@carry_gate.z
     |vpiNetType:1
@@ -1839,36 +1845,50 @@ design: (work@carry_rtl)
     |vpiFullName:work@carry_trans.cout
   |vpiNet:
   \_logic_net: (work@carry_trans.i1), line:20:6, endln:20:8, parent:work@carry_trans
+    |vpiTypespec:
+    \_logic_typespec: , line:20:1, endln:20:5
     |vpiName:i1
     |vpiFullName:work@carry_trans.i1
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@carry_trans.i2), line:20:10, endln:20:12, parent:work@carry_trans
+    |vpiTypespec:
+    \_logic_typespec: , line:20:1, endln:20:5
     |vpiName:i2
     |vpiFullName:work@carry_trans.i2
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@carry_trans.i3), line:20:14, endln:20:16, parent:work@carry_trans
+    |vpiTypespec:
+    \_logic_typespec: , line:20:1, endln:20:5
     |vpiName:i3
     |vpiFullName:work@carry_trans.i3
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@carry_trans.i4), line:20:18, endln:20:20, parent:work@carry_trans
+    |vpiTypespec:
+    \_logic_typespec: , line:20:1, endln:20:5
     |vpiName:i4
     |vpiFullName:work@carry_trans.i4
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@carry_trans.cn), line:20:22, endln:20:24, parent:work@carry_trans
+    |vpiTypespec:
+    \_logic_typespec: , line:20:1, endln:20:5
     |vpiName:cn
     |vpiFullName:work@carry_trans.cn
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@carry_trans.zero), line:22:6, endln:22:10, parent:work@carry_trans
+    |vpiTypespec:
+    \_logic_typespec: , line:22:1, endln:22:5
     |vpiName:zero
     |vpiFullName:work@carry_trans.zero
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@carry_trans.one), line:23:6, endln:23:9, parent:work@carry_trans
+    |vpiTypespec:
+    \_logic_typespec: , line:23:1, endln:23:5
     |vpiName:one
     |vpiFullName:work@carry_trans.one
     |vpiNetType:1

--- a/tests/CaseFullElab/CaseFullElab.log
+++ b/tests/CaseFullElab/CaseFullElab.log
@@ -1301,6 +1301,8 @@ design: (work@FSM)
             |vpiName:clock
             |vpiActual:
             \_logic_net: (work@FSM.clock), line:3:8, endln:3:13, parent:work@FSM
+              |vpiTypespec:
+              \_logic_typespec: , line:3:3, endln:3:7
               |vpiName:clock
               |vpiFullName:work@FSM.clock
               |vpiNetType:1
@@ -1312,6 +1314,8 @@ design: (work@FSM)
             |vpiName:keys
             |vpiActual:
             \_logic_net: (work@FSM.keys), line:3:15, endln:3:19, parent:work@FSM
+              |vpiTypespec:
+              \_logic_typespec: , line:3:3, endln:3:7
               |vpiName:keys
               |vpiFullName:work@FSM.keys
               |vpiNetType:1
@@ -1338,6 +1342,8 @@ design: (work@FSM)
                 |vpiFullName:work@FSM.FSM3.accelerate
                 |vpiActual:
                 \_logic_net: (work@FSM.accelerate), line:3:28, endln:3:38, parent:work@FSM
+                  |vpiTypespec:
+                  \_logic_typespec: , line:3:3, endln:3:7
                   |vpiName:accelerate
                   |vpiFullName:work@FSM.accelerate
                   |vpiNetType:1
@@ -1350,23 +1356,25 @@ design: (work@FSM)
                   |vpiFullName:work@FSM.FSM3.Speed
                   |vpiActual:
                   \_logic_net: (work@FSM.Speed), line:5:13, endln:5:18, parent:work@FSM
+                    |vpiTypespec:
+                    \_logic_typespec: , line:5:3, endln:5:6
+                      |vpiRange:
+                      \_range: , line:5:8, endln:5:11
+                        |vpiLeftRange:
+                        \_constant: , line:5:8, endln:5:9
+                          |vpiDecompile:3
+                          |vpiSize:64
+                          |UINT:3
+                          |vpiConstType:9
+                        |vpiRightRange:
+                        \_constant: , line:5:10, endln:5:11
+                          |vpiDecompile:0
+                          |vpiSize:64
+                          |UINT:0
+                          |vpiConstType:9
                     |vpiName:Speed
                     |vpiFullName:work@FSM.Speed
                     |vpiNetType:48
-                    |vpiRange:
-                    \_range: , line:5:8, endln:5:11
-                      |vpiLeftRange:
-                      \_constant: , line:5:8, endln:5:9
-                        |vpiDecompile:3
-                        |vpiSize:64
-                        |UINT:3
-                        |vpiConstType:9
-                      |vpiRightRange:
-                      \_constant: , line:5:10, endln:5:11
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-                        |vpiConstType:9
                 |vpiCaseItem:
                 \_case_item: , line:23:7, endln:23:29
                   |vpiExpr:
@@ -1418,6 +1426,8 @@ design: (work@FSM)
               |vpiFullName:work@FSM.FSM3.brake
               |vpiActual:
               \_logic_net: (work@FSM.brake), line:3:21, endln:3:26, parent:work@FSM
+                |vpiTypespec:
+                \_logic_typespec: , line:3:3, endln:3:7
                 |vpiName:brake
                 |vpiFullName:work@FSM.brake
                 |vpiNetType:1
@@ -1698,16 +1708,22 @@ design: (work@FSM)
   \_logic_net: (work@FSM.Speed), line:5:13, endln:5:18, parent:work@FSM
   |vpiNet:
   \_logic_net: (work@FSM.Ctrl1), line:7:7, endln:7:12, parent:work@FSM
+    |vpiTypespec:
+    \_logic_typespec: , line:7:3, endln:7:6
     |vpiName:Ctrl1
     |vpiFullName:work@FSM.Ctrl1
     |vpiNetType:48
   |vpiNet:
   \_logic_net: (work@FSM.Ctrl2), line:7:14, endln:7:19, parent:work@FSM
+    |vpiTypespec:
+    \_logic_typespec: , line:7:3, endln:7:6
     |vpiName:Ctrl2
     |vpiFullName:work@FSM.Ctrl2
     |vpiNetType:48
   |vpiNet:
   \_logic_net: (work@FSM.Ctrl3), line:7:21, endln:7:26, parent:work@FSM
+    |vpiTypespec:
+    \_logic_typespec: , line:7:3, endln:7:6
     |vpiName:Ctrl3
     |vpiFullName:work@FSM.Ctrl3
     |vpiNetType:48
@@ -1770,6 +1786,22 @@ design: (work@FSM)
       |vpiFullName:work@FSM.Speed
       |vpiActual:
       \_logic_net: (work@FSM.Speed), line:5:13, endln:5:18, parent:work@FSM
+    |vpiTypedef:
+    \_logic_typespec: , line:4:10, endln:4:15
+      |vpiRange:
+      \_range: , line:4:11, endln:4:14, parent:Speed
+        |vpiLeftRange:
+        \_constant: , line:4:11, endln:4:12
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:4:13, endln:4:14
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@FSM (work@FSM) top.sv:1:1: , endln:42:12
   |vpiProcess:

--- a/tests/CastPartSelect/CastPartSelect.log
+++ b/tests/CastPartSelect/CastPartSelect.log
@@ -817,23 +817,25 @@ design: (work@top)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.instr_rdata_i), line:1:32, endln:1:45, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:1:19, endln:1:24
+      |vpiRange:
+      \_range: , line:1:26, endln:1:30
+        |vpiLeftRange:
+        \_constant: , line:1:26, endln:1:28
+          |vpiDecompile:31
+          |vpiSize:64
+          |UINT:31
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:1:29, endln:1:30
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:instr_rdata_i
     |vpiFullName:work@top.instr_rdata_i
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:1:26, endln:1:30
-      |vpiLeftRange:
-      \_constant: , line:1:26, endln:1:28
-        |vpiDecompile:31
-        |vpiSize:64
-        |UINT:31
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:1:29, endln:1:30
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (CSR_MSTATUS)
   |vpiNet:
@@ -849,6 +851,22 @@ design: (work@top)
       |vpiFullName:work@top.instr_rdata_i
       |vpiActual:
       \_logic_net: (work@top.instr_rdata_i), line:1:32, endln:1:45, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:19, endln:1:24
+      |vpiRange:
+      \_range: , line:1:26, endln:1:30, parent:instr_rdata_i
+        |vpiLeftRange:
+        \_constant: , line:1:26, endln:1:28
+          |vpiDecompile:31
+          |vpiSize:64
+          |UINT:31
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:1:29, endln:1:30
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:10:10
   |vpiProcess:

--- a/tests/ClassFuncProto/ClassFuncProto.log
+++ b/tests/ClassFuncProto/ClassFuncProto.log
@@ -1100,6 +1100,9 @@ design: (work@toto)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@toto.d), line:50:5, endln:50:6, parent:work@toto
+    |vpiTypespec:
+    \_unsupported_typespec: (DD), line:50:2, endln:50:4
+      |vpiName:DD
     |vpiName:d
     |vpiFullName:work@toto.d
   |vpiClassDefn:

--- a/tests/ClockingSntx/ClockingSntx.log
+++ b/tests/ClockingSntx/ClockingSntx.log
@@ -378,23 +378,25 @@ design: (work@top)
         |vpiFullName:work@top.cmd_reg
         |vpiActual:
         \_logic_net: (work@top.cmd_reg), line:11:12, endln:11:19, parent:work@top
+          |vpiTypespec:
+          \_logic_typespec: , line:11:2, endln:11:5
+            |vpiRange:
+            \_range: , line:11:7, endln:11:10
+              |vpiLeftRange:
+              \_constant: , line:11:7, endln:11:8
+                |vpiDecompile:8
+                |vpiSize:64
+                |UINT:8
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:11:9, endln:11:10
+                |vpiDecompile:1
+                |vpiSize:64
+                |UINT:1
+                |vpiConstType:9
           |vpiName:cmd_reg
           |vpiFullName:work@top.cmd_reg
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:11:7, endln:11:10
-            |vpiLeftRange:
-            \_constant: , line:11:7, endln:11:8
-              |vpiDecompile:8
-              |vpiSize:64
-              |UINT:8
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:11:9, endln:11:10
-              |vpiDecompile:1
-              |vpiSize:64
-              |UINT:1
-              |vpiConstType:9
       |vpiOperand:
       \_constant: , line:25:33, endln:25:35
         |vpiDecompile:'X
@@ -407,22 +409,24 @@ design: (work@top)
       |vpiFullName:work@top.cmd
       |vpiActual:
       \_logic_net: (work@top.cmd), line:9:27, endln:9:30, parent:work@top
+        |vpiTypespec:
+        \_logic_typespec: , line:9:21, endln:9:26
+          |vpiRange:
+          \_range: , line:9:22, endln:9:25
+            |vpiLeftRange:
+            \_constant: , line:9:22, endln:9:23
+              |vpiDecompile:8
+              |vpiSize:64
+              |UINT:8
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:9:24, endln:9:25
+              |vpiDecompile:1
+              |vpiSize:64
+              |UINT:1
+              |vpiConstType:9
         |vpiName:cmd
         |vpiFullName:work@top.cmd
-        |vpiRange:
-        \_range: , line:9:22, endln:9:25
-          |vpiLeftRange:
-          \_constant: , line:9:22, endln:9:23
-            |vpiDecompile:8
-            |vpiSize:64
-            |UINT:8
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:9:24, endln:9:25
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
-            |vpiConstType:9
   |vpiClockingBlock:
   \_clocking_block: (mem), line:2:2, endln:4:13
     |vpiName:mem
@@ -552,24 +556,28 @@ design: (work@top)
   \_logic_net: (work@top.phi1), line:8:9, endln:8:13, parent:work@top
   |vpiNet:
   \_logic_net: (work@top.data), line:8:28, endln:8:32, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:8:21, endln:8:27
+      |vpiRange:
+      \_range: , line:8:22, endln:8:26
+        |vpiLeftRange:
+        \_constant: , line:8:22, endln:8:24
+          |vpiDecompile:15
+          |vpiSize:64
+          |UINT:15
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:8:25, endln:8:26
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:data
     |vpiFullName:work@top.data
-    |vpiRange:
-    \_range: , line:8:22, endln:8:26
-      |vpiLeftRange:
-      \_constant: , line:8:22, endln:8:24
-        |vpiDecompile:15
-        |vpiSize:64
-        |UINT:15
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:8:25, endln:8:26
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@top.write), line:8:47, endln:8:52, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:8:41, endln:8:46
     |vpiName:write
     |vpiFullName:work@top.write
     |vpiNetType:36
@@ -610,6 +618,22 @@ design: (work@top)
       |vpiFullName:work@top.data
       |vpiActual:
       \_logic_net: (work@top.data), line:8:28, endln:8:32, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:8:21, endln:8:27
+      |vpiRange:
+      \_range: , line:8:22, endln:8:26, parent:data
+        |vpiLeftRange:
+        \_constant: , line:8:22, endln:8:24
+          |vpiDecompile:15
+          |vpiSize:64
+          |UINT:15
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:8:25, endln:8:26
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:27:10
   |vpiPort:
@@ -622,6 +646,8 @@ design: (work@top)
       |vpiFullName:work@top.write
       |vpiActual:
       \_logic_net: (work@top.write), line:8:47, endln:8:52, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:8:41, endln:8:46
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:27:10
   |vpiPort:
@@ -646,6 +672,22 @@ design: (work@top)
       |vpiFullName:work@top.cmd
       |vpiActual:
       \_logic_net: (work@top.cmd), line:9:27, endln:9:30, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:9:21, endln:9:26
+      |vpiRange:
+      \_range: , line:9:22, endln:9:25, parent:cmd
+        |vpiLeftRange:
+        \_constant: , line:9:22, endln:9:23
+          |vpiDecompile:8
+          |vpiSize:64
+          |UINT:8
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:9:24, endln:9:25
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:27:10
   |vpiPort:

--- a/tests/ClogCast/ClogCast.log
+++ b/tests/ClogCast/ClogCast.log
@@ -1121,6 +1121,8 @@ design: (work@debug_rom)
           |vpiFullName:work@debug_rom.clk_i
           |vpiActual:
           \_logic_net: (work@debug_rom.clk_i), line:4:25, endln:4:30, parent:work@debug_rom
+            |vpiTypespec:
+            \_logic_typespec: , line:4:11, endln:4:16
             |vpiName:clk_i
             |vpiFullName:work@debug_rom.clk_i
             |vpiNetType:36
@@ -1135,6 +1137,8 @@ design: (work@debug_rom)
             |vpiFullName:work@debug_rom.req_i
             |vpiActual:
             \_logic_net: (work@debug_rom.req_i), line:5:25, endln:5:30, parent:work@debug_rom
+              |vpiTypespec:
+              \_logic_typespec: , line:5:11, endln:5:16
               |vpiName:req_i
               |vpiFullName:work@debug_rom.req_i
               |vpiNetType:36
@@ -1245,23 +1249,25 @@ design: (work@debug_rom)
           |vpiFullName:work@debug_rom.p_outmux.rdata_o
           |vpiActual:
           \_logic_net: (work@debug_rom.rdata_o), line:7:25, endln:7:32, parent:work@debug_rom
+            |vpiTypespec:
+            \_logic_typespec: , line:7:11, endln:7:16
+              |vpiRange:
+              \_range: , line:7:18, endln:7:22
+                |vpiLeftRange:
+                \_constant: , line:7:18, endln:7:20
+                  |vpiDecompile:63
+                  |vpiSize:64
+                  |UINT:63
+                  |vpiConstType:9
+                |vpiRightRange:
+                \_constant: , line:7:21, endln:7:22
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiName:rdata_o
             |vpiFullName:work@debug_rom.rdata_o
             |vpiNetType:36
-            |vpiRange:
-            \_range: , line:7:18, endln:7:22
-              |vpiLeftRange:
-              \_constant: , line:7:18, endln:7:20
-                |vpiDecompile:63
-                |vpiSize:64
-                |UINT:63
-                |vpiConstType:9
-              |vpiRightRange:
-              \_constant: , line:7:21, endln:7:22
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
       |vpiStmt:
       \_if_stmt: , line:46:6, endln:48:9, parent:work@debug_rom.p_outmux
         |vpiCondition:
@@ -1530,23 +1536,25 @@ design: (work@debug_rom)
   \_logic_net: (work@debug_rom.req_i), line:5:25, endln:5:30, parent:work@debug_rom
   |vpiNet:
   \_logic_net: (work@debug_rom.addr_i), line:6:25, endln:6:31, parent:work@debug_rom
+    |vpiTypespec:
+    \_logic_typespec: , line:6:11, endln:6:16
+      |vpiRange:
+      \_range: , line:6:18, endln:6:22
+        |vpiLeftRange:
+        \_constant: , line:6:18, endln:6:20
+          |vpiDecompile:63
+          |vpiSize:64
+          |UINT:63
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:6:21, endln:6:22
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:addr_i
     |vpiFullName:work@debug_rom.addr_i
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:6:18, endln:6:22
-      |vpiLeftRange:
-      \_constant: , line:6:18, endln:6:20
-        |vpiDecompile:63
-        |vpiSize:64
-        |UINT:63
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:6:21, endln:6:22
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@debug_rom.rdata_o), line:7:25, endln:7:32, parent:work@debug_rom
   |vpiTopModule:1
@@ -1560,6 +1568,8 @@ design: (work@debug_rom)
       |vpiFullName:work@debug_rom.clk_i
       |vpiActual:
       \_logic_net: (work@debug_rom.clk_i), line:4:25, endln:4:30, parent:work@debug_rom
+    |vpiTypedef:
+    \_logic_typespec: , line:4:11, endln:4:16
     |vpiInstance:
     \_module: work@debug_rom (work@debug_rom) dut.sv:3:2: , endln:51:11
   |vpiPort:
@@ -1572,6 +1582,8 @@ design: (work@debug_rom)
       |vpiFullName:work@debug_rom.req_i
       |vpiActual:
       \_logic_net: (work@debug_rom.req_i), line:5:25, endln:5:30, parent:work@debug_rom
+    |vpiTypedef:
+    \_logic_typespec: , line:5:11, endln:5:16
     |vpiInstance:
     \_module: work@debug_rom (work@debug_rom) dut.sv:3:2: , endln:51:11
   |vpiPort:
@@ -1584,6 +1596,22 @@ design: (work@debug_rom)
       |vpiFullName:work@debug_rom.addr_i
       |vpiActual:
       \_logic_net: (work@debug_rom.addr_i), line:6:25, endln:6:31, parent:work@debug_rom
+    |vpiTypedef:
+    \_logic_typespec: , line:6:11, endln:6:16
+      |vpiRange:
+      \_range: , line:6:18, endln:6:22, parent:addr_i
+        |vpiLeftRange:
+        \_constant: , line:6:18, endln:6:20
+          |vpiDecompile:63
+          |vpiSize:64
+          |UINT:63
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:6:21, endln:6:22
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@debug_rom (work@debug_rom) dut.sv:3:2: , endln:51:11
   |vpiPort:
@@ -1596,6 +1624,22 @@ design: (work@debug_rom)
       |vpiFullName:work@debug_rom.rdata_o
       |vpiActual:
       \_logic_net: (work@debug_rom.rdata_o), line:7:25, endln:7:32, parent:work@debug_rom
+    |vpiTypedef:
+    \_logic_typespec: , line:7:11, endln:7:16
+      |vpiRange:
+      \_range: , line:7:18, endln:7:22, parent:rdata_o
+        |vpiLeftRange:
+        \_constant: , line:7:18, endln:7:20
+          |vpiDecompile:63
+          |vpiSize:64
+          |UINT:63
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:7:21, endln:7:22
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@debug_rom (work@debug_rom) dut.sv:3:2: , endln:51:11
   |vpiProcess:

--- a/tests/ClogParam/ClogParam.log
+++ b/tests/ClogParam/ClogParam.log
@@ -456,6 +456,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:7:23, endln:7:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:7:19, endln:7:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:7:1: , endln:19:16
   |vpiModule:
@@ -542,6 +545,9 @@ design: (work@top)
         |vpiFullName:work@top.u_otp_ctrl_ecc_reg.a
         |vpiActual:
         \_int_var: (work@top.u_otp_ctrl_ecc_reg.a), line:1:36, endln:1:37, parent:work@top.u_otp_ctrl_ecc_reg
+      |vpiTypedef:
+      \_int_typespec: , line:1:32, endln:1:35
+        |vpiSigned:1
       |vpiInstance:
       \_module: work@otp_ctrl_ecc_reg (work@top.u_otp_ctrl_ecc_reg) dut.sv:15:4: , endln:18:14, parent:work@top
     |vpiContAssign:

--- a/tests/ComplexEscaped/ComplexEscaped.log
+++ b/tests/ComplexEscaped/ComplexEscaped.log
@@ -179,6 +179,8 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_string_var: (work@top.o), line:1:26, endln:1:27, parent:work@top
+    |vpiTypedef:
+    \_string_typespec: , line:1:19, endln:1:25
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:5:10
   |vpiProcess:

--- a/tests/ComplexParamOverload2/ComplexParamOverload2.log
+++ b/tests/ComplexParamOverload2/ComplexParamOverload2.log
@@ -863,6 +863,9 @@ design: (work@top)
             |vpiFullName:work@top.u_top.u_prim_pad_attr.u_submodule.o
             |vpiActual:
             \_int_var: (work@top.u_top.u_prim_pad_attr.u_submodule.o), line:24:34, endln:24:35, parent:work@top.u_top.u_prim_pad_attr.u_submodule
+          |vpiTypedef:
+          \_int_typespec: , line:24:30, endln:24:33
+            |vpiSigned:1
           |vpiInstance:
           \_module: work@prim_submodule (work@top.u_top.u_prim_pad_attr.u_submodule) dut.sv:38:4: , endln:42:6, parent:work@top.u_top.u_prim_pad_attr
         |vpiModule:
@@ -914,6 +917,9 @@ design: (work@top)
               |vpiFullName:work@top.u_top.u_prim_pad_attr.u_submodule.u_impl_generic.o
               |vpiActual:
               \_int_var: (work@top.u_top.u_prim_pad_attr.u_submodule.u_impl_generic.o), line:19:41, endln:19:42, parent:work@top.u_top.u_prim_pad_attr.u_submodule.u_impl_generic
+            |vpiTypedef:
+            \_int_typespec: , line:19:37, endln:19:40
+              |vpiSigned:1
             |vpiInstance:
             \_module: work@prim_generic_pad_attr (work@top.u_top.u_prim_pad_attr.u_submodule.u_impl_generic) dut.sv:27:4: , endln:31:6, parent:work@top.u_top.u_prim_pad_attr.u_submodule
           |vpiContAssign:

--- a/tests/ConcatWidth/ConcatWidth.log
+++ b/tests/ConcatWidth/ConcatWidth.log
@@ -978,6 +978,8 @@ design: (work@top)
           |vpiFullName:work@top.clk
           |vpiActual:
           \_logic_net: (work@top.clk), line:4:17, endln:4:20, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:4:11, endln:4:16
             |vpiName:clk
             |vpiFullName:work@top.clk
             |vpiNetType:36
@@ -1106,23 +1108,25 @@ design: (work@top)
       |vpiFullName:work@top.out
       |vpiActual:
       \_logic_net: (work@top.out), line:5:37, endln:5:40, parent:work@top
+        |vpiTypespec:
+        \_logic_typespec: , line:5:12, endln:5:17
+          |vpiRange:
+          \_range: , line:5:19, endln:5:35
+            |vpiLeftRange:
+            \_constant: , line:5:19, endln:5:31
+              |vpiDecompile:31
+              |vpiSize:64
+              |INT:31
+              |vpiConstType:7
+            |vpiRightRange:
+            \_constant: , line:5:34, endln:5:35
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:out
         |vpiFullName:work@top.out
         |vpiNetType:36
-        |vpiRange:
-        \_range: , line:5:19, endln:5:35
-          |vpiLeftRange:
-          \_constant: , line:5:19, endln:5:31
-            |vpiDecompile:31
-            |vpiSize:64
-            |INT:31
-            |vpiConstType:7
-          |vpiRightRange:
-          \_constant: , line:5:34, endln:5:35
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:1:1: , endln:18:10
   |vpiName:work@top
@@ -1168,6 +1172,8 @@ design: (work@top)
       |vpiFullName:work@top.clk
       |vpiActual:
       \_logic_net: (work@top.clk), line:4:17, endln:4:20, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:4:11, endln:4:16
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:18:10
   |vpiPort:
@@ -1180,6 +1186,22 @@ design: (work@top)
       |vpiFullName:work@top.out
       |vpiActual:
       \_logic_net: (work@top.out), line:5:37, endln:5:40, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:5:12, endln:5:17
+      |vpiRange:
+      \_range: , line:5:19, endln:5:35, parent:out
+        |vpiLeftRange:
+        \_constant: , line:5:19, endln:5:31
+          |vpiDecompile:31
+          |vpiSize:64
+          |INT:31
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:5:34, endln:5:35
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:18:10
   |vpiProcess:

--- a/tests/CondOpPrec/CondOpPred.log
+++ b/tests/CondOpPrec/CondOpPred.log
@@ -313,6 +313,8 @@ design: (work@top)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.o), line:8:17, endln:8:18, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:8:11, endln:8:16
     |vpiName:o
     |vpiFullName:work@top.o
     |vpiNetType:36
@@ -327,6 +329,8 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:8:17, endln:8:18, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:8:11, endln:8:16
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:5:1: , endln:17:10
   |vpiGenScopeArray:

--- a/tests/Connection/Connection.log
+++ b/tests/Connection/Connection.log
@@ -490,21 +490,29 @@ design: (work@top)
     |vpiDefLineNo:12
     |vpiNet:
     \_logic_net: (work@top.u_mie_csr.rd_const_conn), line:14:20, endln:14:33, parent:work@top.u_mie_csr
+      |vpiTypespec:
+      \_logic_typespec: , line:14:14, endln:14:19
       |vpiName:rd_const_conn
       |vpiFullName:work@top.u_mie_csr.rd_const_conn
       |vpiNetType:36
     |vpiNet:
     \_logic_net: (work@top.u_mie_csr.rd_impl_conn), line:15:21, endln:15:33, parent:work@top.u_mie_csr
+      |vpiTypespec:
+      \_logic_typespec: , line:15:15, endln:15:20
       |vpiName:rd_impl_conn
       |vpiFullName:work@top.u_mie_csr.rd_impl_conn
       |vpiNetType:36
     |vpiNet:
     \_logic_net: (work@top.u_mie_csr.rd_name_conn), line:15:35, endln:15:47, parent:work@top.u_mie_csr
+      |vpiTypespec:
+      \_logic_typespec: , line:15:15, endln:15:20
       |vpiName:rd_name_conn
       |vpiFullName:work@top.u_mie_csr.rd_name_conn
       |vpiNetType:36
     |vpiNet:
     \_logic_net: (work@top.u_mie_csr.rd_disconn), line:15:49, endln:15:59, parent:work@top.u_mie_csr
+      |vpiTypespec:
+      \_logic_typespec: , line:15:15, endln:15:20
       |vpiName:rd_disconn
       |vpiFullName:work@top.u_mie_csr.rd_disconn
       |vpiNetType:36
@@ -526,6 +534,8 @@ design: (work@top)
         |vpiFullName:work@top.u_mie_csr.rd_const_conn
         |vpiActual:
         \_logic_net: (work@top.u_mie_csr.rd_const_conn), line:14:20, endln:14:33, parent:work@top.u_mie_csr
+      |vpiTypedef:
+      \_logic_typespec: , line:14:14, endln:14:19
     |vpiPort:
     \_port: (rd_impl_conn), line:15:21, endln:15:33, parent:work@top.u_mie_csr
       |vpiName:rd_impl_conn
@@ -542,6 +552,8 @@ design: (work@top)
         |vpiFullName:work@top.u_mie_csr.rd_impl_conn
         |vpiActual:
         \_logic_net: (work@top.u_mie_csr.rd_impl_conn), line:15:21, endln:15:33, parent:work@top.u_mie_csr
+      |vpiTypedef:
+      \_logic_typespec: , line:15:15, endln:15:20
     |vpiPort:
     \_port: (rd_name_conn), line:15:35, endln:15:47, parent:work@top.u_mie_csr
       |vpiName:rd_name_conn
@@ -558,6 +570,8 @@ design: (work@top)
         |vpiFullName:work@top.u_mie_csr.rd_name_conn
         |vpiActual:
         \_logic_net: (work@top.u_mie_csr.rd_name_conn), line:15:35, endln:15:47, parent:work@top.u_mie_csr
+      |vpiTypedef:
+      \_logic_typespec: , line:15:15, endln:15:20
     |vpiPort:
     \_port: (rd_disconn), line:15:49, endln:15:59, parent:work@top.u_mie_csr
       |vpiName:rd_disconn
@@ -571,6 +585,8 @@ design: (work@top)
         |vpiFullName:work@top.u_mie_csr.rd_disconn
         |vpiActual:
         \_logic_net: (work@top.u_mie_csr.rd_disconn), line:15:49, endln:15:59, parent:work@top.u_mie_csr
+      |vpiTypedef:
+      \_logic_typespec: , line:15:15, endln:15:20
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ConstHighConn/ConstHighConn.log
+++ b/tests/ConstHighConn/ConstHighConn.log
@@ -133,6 +133,8 @@ design: (work@top)
       |vpiFullName:work@dut.o
       |vpiActual:
       \_logic_net: (work@top.d.o), line:1:26, endln:1:27, parent:work@top.d
+        |vpiTypespec:
+        \_logic_typespec: , line:1:20, endln:1:25
         |vpiName:o
         |vpiFullName:work@top.d.o
         |vpiNetType:36
@@ -160,6 +162,8 @@ design: (work@top)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.o), line:5:26, endln:5:27, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:5:20, endln:5:25
     |vpiName:o
     |vpiFullName:work@top.o
     |vpiNetType:36
@@ -174,6 +178,8 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:5:26, endln:5:27, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:5:20, endln:5:25
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:5:1: , endln:9:10
   |vpiModule:
@@ -203,6 +209,8 @@ design: (work@top)
         |vpiFullName:work@top.d.o
         |vpiActual:
         \_logic_net: (work@top.d.o), line:1:26, endln:1:27, parent:work@top.d
+      |vpiTypedef:
+      \_logic_typespec: , line:1:20, endln:1:25
       |vpiInstance:
       \_module: work@dut (work@top.d) dut.sv:7:4: , endln:7:21, parent:work@top
     |vpiContAssign:

--- a/tests/ContAssign/ContAssign.log
+++ b/tests/ContAssign/ContAssign.log
@@ -774,16 +774,22 @@ design: (work@top)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.ena), line:5:8, endln:5:11, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:5:3, endln:5:7
     |vpiName:ena
     |vpiFullName:work@top.ena
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@top.__debug_req_ready), line:7:13, endln:7:30, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:7:3, endln:7:7
     |vpiName:__debug_req_ready
     |vpiFullName:work@top.__debug_req_ready
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@top.toto), line:9:8, endln:9:12, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:9:3, endln:9:7
     |vpiName:toto
     |vpiFullName:work@top.toto
     |vpiNetType:1
@@ -828,6 +834,9 @@ design: (work@top)
           |vpiConstType:7
     |vpiNet:
     \_logic_net: (work@top.intf2), line:3:13, endln:3:18, parent:work@top.intf2
+      |vpiTypespec:
+      \_unsupported_typespec: (intf), line:3:8, endln:3:12
+        |vpiName:intf
       |vpiFullName:work@top.intf2
       |vpiNetType:1
   |vpiTopModule:1

--- a/tests/Context/Context.log
+++ b/tests/Context/Context.log
@@ -144,6 +144,9 @@ design: (work@top)
       |vpiFullName:work@top.a
       |vpiActual:
       \_int_var: (work@top.a), line:1:23, endln:1:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:1:19, endln:1:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:3:10
 ===================

--- a/tests/DecValue/DecValue.log
+++ b/tests/DecValue/DecValue.log
@@ -290,6 +290,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:1:23, endln:1:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:1:19, endln:1:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:7:10
   |vpiContAssign:

--- a/tests/DefaultNetType/DefaultNetType.log
+++ b/tests/DefaultNetType/DefaultNetType.log
@@ -537,6 +537,8 @@ design: (work@ok)
       |vpiFullName:work@bad1.a
       |vpiActual:
       \_logic_net: (work@bad1.a), line:15:5, endln:15:6, parent:work@bad1
+        |vpiTypespec:
+        \_logic_typespec: , line:15:1, endln:15:4
         |vpiName:a
         |vpiFullName:work@bad1.a
         |vpiNetType:48
@@ -748,6 +750,8 @@ design: (work@ok)
       |vpiFullName:work@ok.a
       |vpiActual:
       \_logic_net: (work@ok.a), line:4:5, endln:4:6, parent:work@ok
+        |vpiTypespec:
+        \_logic_typespec: , line:4:1, endln:4:4
         |vpiName:a
         |vpiFullName:work@ok.a
         |vpiNetType:48

--- a/tests/Delay2Param/Delay2Param.log
+++ b/tests/Delay2Param/Delay2Param.log
@@ -804,23 +804,25 @@ design: (work@iNToRecFN)
     |vpiDefLineNo:1
     |vpiNet:
     \_logic_net: (work@iNToRecFN.iNToRawFN.adjustedNormDist), line:3:29, endln:3:45, parent:work@iNToRecFN.iNToRawFN
+      |vpiTypespec:
+      \_logic_typespec: , line:3:5, endln:3:9
+        |vpiRange:
+        \_range: , line:3:11, endln:3:27
+          |vpiLeftRange:
+          \_constant: , line:3:12, endln:3:20
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:3:26, endln:3:27
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:adjustedNormDist
       |vpiFullName:work@iNToRecFN.iNToRawFN.adjustedNormDist
       |vpiNetType:1
-      |vpiRange:
-      \_range: , line:3:11, endln:3:27
-        |vpiLeftRange:
-        \_constant: , line:3:12, endln:3:20
-          |vpiDecompile:5
-          |vpiSize:64
-          |INT:5
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:3:26, endln:3:27
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@iNToRecFN.iNToRawFN.signedIn), line:1:44, endln:1:52, parent:work@iNToRecFN.iNToRawFN
       |vpiName:signedIn
@@ -946,42 +948,46 @@ design: (work@iNToRecFN)
     |vpiDefLineNo:6
     |vpiNet:
     \_logic_net: (work@iNToRecFN.iNToRawFN3.adjustedNormDist), line:9:29, endln:9:45, parent:work@iNToRecFN.iNToRawFN3
+      |vpiTypespec:
+      \_logic_typespec: , line:9:5, endln:9:9
+        |vpiRange:
+        \_range: , line:9:11, endln:9:27
+          |vpiLeftRange:
+          \_constant: , line:9:12, endln:9:20
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:9:26, endln:9:27
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:adjustedNormDist
       |vpiFullName:work@iNToRecFN.iNToRawFN3.adjustedNormDist
       |vpiNetType:1
-      |vpiRange:
-      \_range: , line:9:11, endln:9:27
-        |vpiLeftRange:
-        \_constant: , line:9:12, endln:9:20
-          |vpiDecompile:5
-          |vpiSize:64
-          |INT:5
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:9:26, endln:9:27
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@iNToRecFN.iNToRawFN3.adjustedNormDist2), line:10:30, endln:10:47, parent:work@iNToRecFN.iNToRawFN3
+      |vpiTypespec:
+      \_logic_typespec: , line:10:5, endln:10:9
+        |vpiRange:
+        \_range: , line:10:11, endln:10:28
+          |vpiLeftRange:
+          \_constant: , line:10:12, endln:10:21
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:10:27, endln:10:28
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:adjustedNormDist2
       |vpiFullName:work@iNToRecFN.iNToRawFN3.adjustedNormDist2
       |vpiNetType:1
-      |vpiRange:
-      \_range: , line:10:11, endln:10:28
-        |vpiLeftRange:
-        \_constant: , line:10:12, endln:10:21
-          |vpiDecompile:5
-          |vpiSize:64
-          |INT:5
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:10:27, endln:10:28
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@iNToRecFN.iNToRawFN3.signedIn), line:6:70, endln:6:78, parent:work@iNToRecFN.iNToRawFN3
       |vpiName:signedIn

--- a/tests/DelayAssign/DelayAssign.log
+++ b/tests/DelayAssign/DelayAssign.log
@@ -1657,6 +1657,8 @@ design: (work@SimDTM)
                   |vpiFullName:work@SimDTM.__debug_req_ready
                   |vpiActual:
                   \_logic_net: (work@SimDTM.__debug_req_ready), line:36:13, endln:36:30, parent:work@SimDTM
+                    |vpiTypespec:
+                    \_logic_typespec: , line:36:3, endln:36:7
                     |vpiName:__debug_req_ready
                     |vpiFullName:work@SimDTM.__debug_req_ready
                     |vpiNetType:1
@@ -1699,6 +1701,8 @@ design: (work@SimDTM)
                   |vpiFullName:work@SimDTM.__debug_resp_valid
                   |vpiActual:
                   \_logic_net: (work@SimDTM.__debug_resp_valid), line:37:13, endln:37:31, parent:work@SimDTM
+                    |vpiTypespec:
+                    \_logic_typespec: , line:37:3, endln:37:7
                     |vpiName:__debug_resp_valid
                     |vpiFullName:work@SimDTM.__debug_resp_valid
                     |vpiNetType:1
@@ -1714,46 +1718,50 @@ design: (work@SimDTM)
                   |vpiFullName:work@SimDTM.__debug_resp_bits_resp
                   |vpiActual:
                   \_logic_net: (work@SimDTM.__debug_resp_bits_resp), line:38:20, endln:38:42, parent:work@SimDTM
+                    |vpiTypespec:
+                    \_logic_typespec: , line:38:3, endln:38:7
+                      |vpiRange:
+                      \_range: , line:38:9, endln:38:13
+                        |vpiLeftRange:
+                        \_constant: , line:38:9, endln:38:11
+                          |vpiDecompile:31
+                          |vpiSize:64
+                          |UINT:31
+                          |vpiConstType:9
+                        |vpiRightRange:
+                        \_constant: , line:38:12, endln:38:13
+                          |vpiDecompile:0
+                          |vpiSize:64
+                          |UINT:0
+                          |vpiConstType:9
                     |vpiName:__debug_resp_bits_resp
                     |vpiFullName:work@SimDTM.__debug_resp_bits_resp
                     |vpiNetType:1
-                    |vpiRange:
-                    \_range: , line:38:9, endln:38:13
-                      |vpiLeftRange:
-                      \_constant: , line:38:9, endln:38:11
-                        |vpiDecompile:31
-                        |vpiSize:64
-                        |UINT:31
-                        |vpiConstType:9
-                      |vpiRightRange:
-                      \_constant: , line:38:12, endln:38:13
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-                        |vpiConstType:9
                 |vpiArgument:
                 \_ref_obj: (work@SimDTM.__debug_resp_bits_data), line:75:9, endln:75:31, parent:debug_tick
                   |vpiName:__debug_resp_bits_data
                   |vpiFullName:work@SimDTM.__debug_resp_bits_data
                   |vpiActual:
                   \_logic_net: (work@SimDTM.__debug_resp_bits_data), line:39:20, endln:39:42, parent:work@SimDTM
+                    |vpiTypespec:
+                    \_logic_typespec: , line:39:3, endln:39:7
+                      |vpiRange:
+                      \_range: , line:39:9, endln:39:13
+                        |vpiLeftRange:
+                        \_constant: , line:39:9, endln:39:11
+                          |vpiDecompile:31
+                          |vpiSize:64
+                          |UINT:31
+                          |vpiConstType:9
+                        |vpiRightRange:
+                        \_constant: , line:39:12, endln:39:13
+                          |vpiDecompile:0
+                          |vpiSize:64
+                          |UINT:0
+                          |vpiConstType:9
                     |vpiName:__debug_resp_bits_data
                     |vpiFullName:work@SimDTM.__debug_resp_bits_data
                     |vpiNetType:1
-                    |vpiRange:
-                    \_range: , line:39:9, endln:39:13
-                      |vpiLeftRange:
-                      \_constant: , line:39:9, endln:39:11
-                        |vpiDecompile:31
-                        |vpiSize:64
-                        |UINT:31
-                        |vpiConstType:9
-                      |vpiRightRange:
-                      \_constant: , line:39:12, endln:39:13
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-                        |vpiConstType:9
                 |vpiName:debug_tick
               |vpiLhs:
               \_ref_obj: (work@SimDTM.__exit), line:66:7, endln:66:13, parent:work@SimDTM
@@ -1818,22 +1826,24 @@ design: (work@SimDTM)
       |vpiFullName:work@SimDTM.debug_req_bits_addr
       |vpiActual:
       \_logic_net: (work@SimDTM.debug_req_bits_addr), line:22:17, endln:22:36, parent:work@SimDTM
+        |vpiTypespec:
+        \_logic_typespec: , line:22:10, endln:22:16
+          |vpiRange:
+          \_range: , line:22:12, endln:22:15
+            |vpiLeftRange:
+            \_constant: , line:22:12, endln:22:13
+              |vpiDecompile:6
+              |vpiSize:64
+              |UINT:6
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:22:14, endln:22:15
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:debug_req_bits_addr
         |vpiFullName:work@SimDTM.debug_req_bits_addr
-        |vpiRange:
-        \_range: , line:22:12, endln:22:15
-          |vpiLeftRange:
-          \_constant: , line:22:12, endln:22:13
-            |vpiDecompile:6
-            |vpiSize:64
-            |UINT:6
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:22:14, endln:22:15
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
   |vpiContAssign:
   \_cont_assign: , line:50:15, endln:50:59, parent:work@SimDTM
     |vpiDelay:
@@ -1868,22 +1878,24 @@ design: (work@SimDTM)
       |vpiFullName:work@SimDTM.debug_req_bits_op
       |vpiActual:
       \_logic_net: (work@SimDTM.debug_req_bits_op), line:23:17, endln:23:34, parent:work@SimDTM
+        |vpiTypespec:
+        \_logic_typespec: , line:23:10, endln:23:16
+          |vpiRange:
+          \_range: , line:23:12, endln:23:15
+            |vpiLeftRange:
+            \_constant: , line:23:12, endln:23:13
+              |vpiDecompile:1
+              |vpiSize:64
+              |UINT:1
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:23:14, endln:23:15
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:debug_req_bits_op
         |vpiFullName:work@SimDTM.debug_req_bits_op
-        |vpiRange:
-        \_range: , line:23:12, endln:23:15
-          |vpiLeftRange:
-          \_constant: , line:23:12, endln:23:13
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:23:14, endln:23:15
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
   |vpiContAssign:
   \_cont_assign: , line:51:15, endln:51:64, parent:work@SimDTM
     |vpiDelay:
@@ -1918,22 +1930,24 @@ design: (work@SimDTM)
       |vpiFullName:work@SimDTM.debug_req_bits_data
       |vpiActual:
       \_logic_net: (work@SimDTM.debug_req_bits_data), line:24:17, endln:24:36, parent:work@SimDTM
+        |vpiTypespec:
+        \_logic_typespec: , line:24:10, endln:24:16
+          |vpiRange:
+          \_range: , line:24:11, endln:24:15
+            |vpiLeftRange:
+            \_constant: , line:24:11, endln:24:13
+              |vpiDecompile:31
+              |vpiSize:64
+              |UINT:31
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:24:14, endln:24:15
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:debug_req_bits_data
         |vpiFullName:work@SimDTM.debug_req_bits_data
-        |vpiRange:
-        \_range: , line:24:11, endln:24:15
-          |vpiLeftRange:
-          \_constant: , line:24:11, endln:24:13
-            |vpiDecompile:31
-            |vpiSize:64
-            |UINT:31
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:24:14, endln:24:15
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
   |vpiContAssign:
   \_cont_assign: , line:52:15, endln:52:52, parent:work@SimDTM
     |vpiDelay:
@@ -1976,22 +1990,24 @@ design: (work@SimDTM)
       |vpiFullName:work@SimDTM.exit
       |vpiActual:
       \_logic_net: (work@SimDTM.exit), line:31:17, endln:31:21, parent:work@SimDTM
+        |vpiTypespec:
+        \_logic_typespec: , line:31:10, endln:31:16
+          |vpiRange:
+          \_range: , line:31:11, endln:31:15
+            |vpiLeftRange:
+            \_constant: , line:31:11, endln:31:13
+              |vpiDecompile:31
+              |vpiSize:64
+              |UINT:31
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:31:14, endln:31:15
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:exit
         |vpiFullName:work@SimDTM.exit
-        |vpiRange:
-        \_range: , line:31:11, endln:31:15
-          |vpiLeftRange:
-          \_constant: , line:31:11, endln:31:13
-            |vpiDecompile:31
-            |vpiSize:64
-            |UINT:31
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:31:14, endln:31:15
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@SimDTM (work@SimDTM) dut.sv:16:1: , endln:79:10
   |vpiName:work@SimDTM
@@ -2035,40 +2051,44 @@ design: (work@SimDTM)
   \_logic_net: (work@SimDTM.debug_resp_ready), line:27:17, endln:27:33, parent:work@SimDTM
   |vpiNet:
   \_logic_net: (work@SimDTM.debug_resp_bits_resp), line:28:17, endln:28:37, parent:work@SimDTM
+    |vpiTypespec:
+    \_logic_typespec: , line:28:10, endln:28:16
+      |vpiRange:
+      \_range: , line:28:12, endln:28:15
+        |vpiLeftRange:
+        \_constant: , line:28:12, endln:28:13
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:28:14, endln:28:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:debug_resp_bits_resp
     |vpiFullName:work@SimDTM.debug_resp_bits_resp
-    |vpiRange:
-    \_range: , line:28:12, endln:28:15
-      |vpiLeftRange:
-      \_constant: , line:28:12, endln:28:13
-        |vpiDecompile:1
-        |vpiSize:64
-        |UINT:1
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:28:14, endln:28:15
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@SimDTM.debug_resp_bits_data), line:29:17, endln:29:37, parent:work@SimDTM
+    |vpiTypespec:
+    \_logic_typespec: , line:29:10, endln:29:16
+      |vpiRange:
+      \_range: , line:29:11, endln:29:15
+        |vpiLeftRange:
+        \_constant: , line:29:11, endln:29:13
+          |vpiDecompile:31
+          |vpiSize:64
+          |UINT:31
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:29:14, endln:29:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:debug_resp_bits_data
     |vpiFullName:work@SimDTM.debug_resp_bits_data
-    |vpiRange:
-    \_range: , line:29:11, endln:29:15
-      |vpiLeftRange:
-      \_constant: , line:29:11, endln:29:13
-        |vpiDecompile:31
-        |vpiSize:64
-        |UINT:31
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:29:14, endln:29:15
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@SimDTM.exit), line:31:17, endln:31:21, parent:work@SimDTM
   |vpiNet:
@@ -2138,6 +2158,22 @@ design: (work@SimDTM)
       |vpiFullName:work@SimDTM.debug_req_bits_addr
       |vpiActual:
       \_logic_net: (work@SimDTM.debug_req_bits_addr), line:22:17, endln:22:36, parent:work@SimDTM
+    |vpiTypedef:
+    \_logic_typespec: , line:22:10, endln:22:16
+      |vpiRange:
+      \_range: , line:22:12, endln:22:15, parent:debug_req_bits_addr
+        |vpiLeftRange:
+        \_constant: , line:22:12, endln:22:13
+          |vpiDecompile:6
+          |vpiSize:64
+          |UINT:6
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:22:14, endln:22:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@SimDTM (work@SimDTM) dut.sv:16:1: , endln:79:10
   |vpiPort:
@@ -2150,6 +2186,22 @@ design: (work@SimDTM)
       |vpiFullName:work@SimDTM.debug_req_bits_op
       |vpiActual:
       \_logic_net: (work@SimDTM.debug_req_bits_op), line:23:17, endln:23:34, parent:work@SimDTM
+    |vpiTypedef:
+    \_logic_typespec: , line:23:10, endln:23:16
+      |vpiRange:
+      \_range: , line:23:12, endln:23:15, parent:debug_req_bits_op
+        |vpiLeftRange:
+        \_constant: , line:23:12, endln:23:13
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:23:14, endln:23:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@SimDTM (work@SimDTM) dut.sv:16:1: , endln:79:10
   |vpiPort:
@@ -2162,6 +2214,22 @@ design: (work@SimDTM)
       |vpiFullName:work@SimDTM.debug_req_bits_data
       |vpiActual:
       \_logic_net: (work@SimDTM.debug_req_bits_data), line:24:17, endln:24:36, parent:work@SimDTM
+    |vpiTypedef:
+    \_logic_typespec: , line:24:10, endln:24:16
+      |vpiRange:
+      \_range: , line:24:11, endln:24:15, parent:debug_req_bits_data
+        |vpiLeftRange:
+        \_constant: , line:24:11, endln:24:13
+          |vpiDecompile:31
+          |vpiSize:64
+          |UINT:31
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:24:14, endln:24:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@SimDTM (work@SimDTM) dut.sv:16:1: , endln:79:10
   |vpiPort:
@@ -2198,6 +2266,22 @@ design: (work@SimDTM)
       |vpiFullName:work@SimDTM.debug_resp_bits_resp
       |vpiActual:
       \_logic_net: (work@SimDTM.debug_resp_bits_resp), line:28:17, endln:28:37, parent:work@SimDTM
+    |vpiTypedef:
+    \_logic_typespec: , line:28:10, endln:28:16
+      |vpiRange:
+      \_range: , line:28:12, endln:28:15, parent:debug_resp_bits_resp
+        |vpiLeftRange:
+        \_constant: , line:28:12, endln:28:13
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:28:14, endln:28:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@SimDTM (work@SimDTM) dut.sv:16:1: , endln:79:10
   |vpiPort:
@@ -2210,6 +2294,22 @@ design: (work@SimDTM)
       |vpiFullName:work@SimDTM.debug_resp_bits_data
       |vpiActual:
       \_logic_net: (work@SimDTM.debug_resp_bits_data), line:29:17, endln:29:37, parent:work@SimDTM
+    |vpiTypedef:
+    \_logic_typespec: , line:29:10, endln:29:16
+      |vpiRange:
+      \_range: , line:29:11, endln:29:15, parent:debug_resp_bits_data
+        |vpiLeftRange:
+        \_constant: , line:29:11, endln:29:13
+          |vpiDecompile:31
+          |vpiSize:64
+          |UINT:31
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:29:14, endln:29:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@SimDTM (work@SimDTM) dut.sv:16:1: , endln:79:10
   |vpiPort:
@@ -2222,6 +2322,22 @@ design: (work@SimDTM)
       |vpiFullName:work@SimDTM.exit
       |vpiActual:
       \_logic_net: (work@SimDTM.exit), line:31:17, endln:31:21, parent:work@SimDTM
+    |vpiTypedef:
+    \_logic_typespec: , line:31:10, endln:31:16
+      |vpiRange:
+      \_range: , line:31:11, endln:31:15, parent:exit
+        |vpiLeftRange:
+        \_constant: , line:31:11, endln:31:13
+          |vpiDecompile:31
+          |vpiSize:64
+          |UINT:31
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:31:14, endln:31:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@SimDTM (work@SimDTM) dut.sv:16:1: , endln:79:10
   |vpiProcess:

--- a/tests/DollarBits/DollarBits.log
+++ b/tests/DollarBits/DollarBits.log
@@ -304,46 +304,50 @@ design: (work@dut)
       |vpiFullName:work@other.in
       |vpiActual:
       \_logic_net: (work@dut.oth.in), line:3:27, endln:3:29, parent:work@dut.oth
+        |vpiTypespec:
+        \_logic_typespec: , line:3:10, endln:3:15
+          |vpiRange:
+          \_range: , line:3:16, endln:3:25
+            |vpiLeftRange:
+            \_constant: , line:3:16, endln:3:21
+              |vpiDecompile:7
+              |vpiSize:64
+              |INT:7
+              |vpiConstType:7
+            |vpiRightRange:
+            \_constant: , line:3:24, endln:3:25
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:in
         |vpiFullName:work@dut.oth.in
         |vpiNetType:36
-        |vpiRange:
-        \_range: , line:3:16, endln:3:25
-          |vpiLeftRange:
-          \_constant: , line:3:16, endln:3:21
-            |vpiDecompile:7
-            |vpiSize:64
-            |INT:7
-            |vpiConstType:7
-          |vpiRightRange:
-          \_constant: , line:3:24, endln:3:25
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
     |vpiLhs:
     \_ref_obj: (work@other.out), line:4:11, endln:4:14
       |vpiName:out
       |vpiFullName:work@other.out
       |vpiActual:
       \_logic_net: (work@dut.oth.out), line:3:55, endln:3:58, parent:work@dut.oth
+        |vpiTypespec:
+        \_logic_typespec: , line:3:38, endln:3:43
+          |vpiRange:
+          \_range: , line:3:44, endln:3:53
+            |vpiLeftRange:
+            \_constant: , line:3:44, endln:3:49
+              |vpiDecompile:7
+              |vpiSize:64
+              |INT:7
+              |vpiConstType:7
+            |vpiRightRange:
+            \_constant: , line:3:52, endln:3:53
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:out
         |vpiFullName:work@dut.oth.out
         |vpiNetType:36
-        |vpiRange:
-        \_range: , line:3:44, endln:3:53
-          |vpiLeftRange:
-          \_constant: , line:3:44, endln:3:49
-            |vpiDecompile:7
-            |vpiSize:64
-            |INT:7
-            |vpiConstType:7
-          |vpiRightRange:
-          \_constant: , line:3:52, endln:3:53
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@dut (work@dut) dut.sv:7:1: , endln:9:10
   |vpiName:work@dut
@@ -351,42 +355,46 @@ design: (work@dut)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@dut.in), line:7:30, endln:7:32, parent:work@dut
+    |vpiTypespec:
+    \_logic_typespec: , line:7:19, endln:7:24
+      |vpiRange:
+      \_range: , line:7:25, endln:7:28
+        |vpiLeftRange:
+        \_constant: , line:7:25, endln:7:26
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:7:27, endln:7:28
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:in
     |vpiFullName:work@dut.in
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:7:25, endln:7:28
-      |vpiLeftRange:
-      \_constant: , line:7:25, endln:7:26
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:7:27, endln:7:28
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@dut.out), line:7:52, endln:7:55, parent:work@dut
+    |vpiTypespec:
+    \_logic_typespec: , line:7:41, endln:7:46
+      |vpiRange:
+      \_range: , line:7:47, endln:7:50
+        |vpiLeftRange:
+        \_constant: , line:7:47, endln:7:48
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:7:49, endln:7:50
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:out
     |vpiFullName:work@dut.out
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:7:47, endln:7:50
-      |vpiLeftRange:
-      \_constant: , line:7:47, endln:7:48
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:7:49, endln:7:50
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (in), line:7:30, endln:7:32, parent:work@dut
@@ -398,6 +406,22 @@ design: (work@dut)
       |vpiFullName:work@dut.in
       |vpiActual:
       \_logic_net: (work@dut.in), line:7:30, endln:7:32, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:7:19, endln:7:24
+      |vpiRange:
+      \_range: , line:7:25, endln:7:28, parent:in
+        |vpiLeftRange:
+        \_constant: , line:7:25, endln:7:26
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:7:27, endln:7:28
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:7:1: , endln:9:10
   |vpiPort:
@@ -410,6 +434,22 @@ design: (work@dut)
       |vpiFullName:work@dut.out
       |vpiActual:
       \_logic_net: (work@dut.out), line:7:52, endln:7:55, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:7:41, endln:7:46
+      |vpiRange:
+      \_range: , line:7:47, endln:7:50, parent:out
+        |vpiLeftRange:
+        \_constant: , line:7:47, endln:7:48
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:7:49, endln:7:50
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:7:1: , endln:9:10
   |vpiModule:
@@ -463,6 +503,22 @@ design: (work@dut)
         |vpiFullName:work@dut.oth.in
         |vpiActual:
         \_logic_net: (work@dut.oth.in), line:3:27, endln:3:29, parent:work@dut.oth
+      |vpiTypedef:
+      \_logic_typespec: , line:3:10, endln:3:15
+        |vpiRange:
+        \_range: , line:3:16, endln:3:25, parent:in
+          |vpiLeftRange:
+          \_constant: , line:3:16, endln:3:21
+            |vpiDecompile:7
+            |vpiSize:64
+            |INT:7
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:3:24, endln:3:25
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@other (work@dut.oth) dut.sv:8:4: , endln:8:57, parent:work@dut
     |vpiPort:
@@ -481,6 +537,22 @@ design: (work@dut)
         |vpiFullName:work@dut.oth.out
         |vpiActual:
         \_logic_net: (work@dut.oth.out), line:3:55, endln:3:58, parent:work@dut.oth
+      |vpiTypedef:
+      \_logic_typespec: , line:3:38, endln:3:43
+        |vpiRange:
+        \_range: , line:3:44, endln:3:53, parent:out
+          |vpiLeftRange:
+          \_constant: , line:3:44, endln:3:49
+            |vpiDecompile:7
+            |vpiSize:64
+            |INT:7
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:3:52, endln:3:53
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@other (work@dut.oth) dut.sv:8:4: , endln:8:57, parent:work@dut
     |vpiContAssign:

--- a/tests/DollarBitsUnary/DollarBitsUnary.log
+++ b/tests/DollarBitsUnary/DollarBitsUnary.log
@@ -294,23 +294,25 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:1:32, endln:1:33, parent:work@top
+        |vpiTypespec:
+        \_logic_typespec: , line:1:19, endln:1:24
+          |vpiRange:
+          \_range: , line:1:26, endln:1:30
+            |vpiLeftRange:
+            \_constant: , line:1:26, endln:1:28
+              |vpiDecompile:31
+              |vpiSize:64
+              |UINT:31
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:1:29, endln:1:30
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:o
         |vpiFullName:work@top.o
         |vpiNetType:36
-        |vpiRange:
-        \_range: , line:1:26, endln:1:30
-          |vpiLeftRange:
-          \_constant: , line:1:26, endln:1:28
-            |vpiDecompile:31
-            |vpiSize:64
-            |UINT:31
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:1:29, endln:1:30
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:1:1: , endln:9:10
   |vpiName:work@top
@@ -333,6 +335,22 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:1:32, endln:1:33, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:19, endln:1:24
+      |vpiRange:
+      \_range: , line:1:26, endln:1:30, parent:o
+        |vpiLeftRange:
+        \_constant: , line:1:26, endln:1:28
+          |vpiDecompile:31
+          |vpiSize:64
+          |UINT:31
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:1:29, endln:1:30
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:9:10
   |vpiContAssign:

--- a/tests/DollarRoot/DollarRoot.log
+++ b/tests/DollarRoot/DollarRoot.log
@@ -13628,6 +13628,8 @@ design: (work@top)
       |vpiFullName:work@top.b
       |vpiActual:
       \_logic_net: (work@top.b), line:1:25, endln:1:26, parent:work@top
+        |vpiTypespec:
+        \_logic_typespec: , line:1:19, endln:1:24
         |vpiName:b
         |vpiFullName:work@top.b
         |vpiNetType:36
@@ -13653,6 +13655,8 @@ design: (work@top)
   \_logic_net: (work@top.b), line:1:25, endln:1:26, parent:work@top
   |vpiNet:
   \_logic_net: (work@top.a), line:1:41, endln:1:42, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:1:35, endln:1:40
     |vpiName:a
     |vpiFullName:work@top.a
     |vpiNetType:36
@@ -13667,6 +13671,8 @@ design: (work@top)
       |vpiFullName:work@top.b
       |vpiActual:
       \_logic_net: (work@top.b), line:1:25, endln:1:26, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:19, endln:1:24
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:3:10
   |vpiPort:
@@ -13679,6 +13685,8 @@ design: (work@top)
       |vpiFullName:work@top.a
       |vpiActual:
       \_logic_net: (work@top.a), line:1:41, endln:1:42, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:35, endln:1:40
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:3:10
   |vpiContAssign:

--- a/tests/ElabParam/ElabParam.log
+++ b/tests/ElabParam/ElabParam.log
@@ -981,23 +981,25 @@ design: (work@dut)
             |vpiFullName:work@dut.a
             |vpiActual:
             \_logic_net: (work@dut.a), line:14:15, endln:14:16, parent:work@dut
+              |vpiTypespec:
+              \_logic_typespec: , line:14:4, endln:14:8
+                |vpiRange:
+                \_range: , line:14:10, endln:14:13
+                  |vpiLeftRange:
+                  \_constant: , line:14:10, endln:14:11
+                    |vpiDecompile:5
+                    |vpiSize:64
+                    |UINT:5
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:14:12, endln:14:13
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiName:a
               |vpiFullName:work@dut.a
               |vpiNetType:1
-              |vpiRange:
-              \_range: , line:14:10, endln:14:13
-                |vpiLeftRange:
-                \_constant: , line:14:10, endln:14:11
-                  |vpiDecompile:5
-                  |vpiSize:64
-                  |UINT:5
-                  |vpiConstType:9
-                |vpiRightRange:
-                \_constant: , line:14:12, endln:14:13
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-                  |vpiConstType:9
           |vpiOperand:
           \_constant: , line:17:25, endln:17:45
             |vpiDecompile:6'h03
@@ -1010,23 +1012,25 @@ design: (work@dut)
       |vpiFullName:work@dut.b
       |vpiActual:
       \_logic_net: (work@dut.b), line:15:14, endln:15:15, parent:work@dut
+        |vpiTypespec:
+        \_logic_typespec: , line:15:4, endln:15:7
+          |vpiRange:
+          \_range: , line:15:9, endln:15:12
+            |vpiLeftRange:
+            \_constant: , line:15:9, endln:15:10
+              |vpiDecompile:2
+              |vpiSize:64
+              |UINT:2
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:15:11, endln:15:12
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:b
         |vpiFullName:work@dut.b
         |vpiNetType:48
-        |vpiRange:
-        \_range: , line:15:9, endln:15:12
-          |vpiLeftRange:
-          \_constant: , line:15:9, endln:15:10
-            |vpiDecompile:2
-            |vpiSize:64
-            |UINT:2
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:15:11, endln:15:12
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@dut (work@dut) dut.sv:11:2: , endln:18:11
   |vpiName:work@dut
@@ -1047,6 +1051,22 @@ design: (work@dut)
       |vpiFullName:work@dut.a
       |vpiActual:
       \_logic_net: (work@dut.a), line:14:15, endln:14:16, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:12:10, endln:12:15
+      |vpiRange:
+      \_range: , line:12:11, endln:12:14, parent:a
+        |vpiLeftRange:
+        \_constant: , line:12:11, endln:12:12
+          |vpiDecompile:5
+          |vpiSize:64
+          |UINT:5
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:12:13, endln:12:14
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:11:2: , endln:18:11
   |vpiPort:
@@ -1059,6 +1079,22 @@ design: (work@dut)
       |vpiFullName:work@dut.b
       |vpiActual:
       \_logic_net: (work@dut.b), line:15:14, endln:15:15, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:13:11, endln:13:16
+      |vpiRange:
+      \_range: , line:13:12, endln:13:15, parent:b
+        |vpiLeftRange:
+        \_constant: , line:13:12, endln:13:13
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:13:14, endln:13:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:11:2: , endln:18:11
   |vpiContAssign:

--- a/tests/EvalFuncCont/EvalFuncCont.log
+++ b/tests/EvalFuncCont/EvalFuncCont.log
@@ -1152,23 +1152,25 @@ design: (work@t)
               |vpiFullName:work@t.z
               |vpiActual:
               \_logic_net: (work@t.z), line:18:23, endln:18:24, parent:work@t
+                |vpiTypespec:
+                \_logic_typespec: , line:18:4, endln:18:8
+                  |vpiRange:
+                  \_range: , line:18:10, endln:18:21
+                    |vpiLeftRange:
+                    \_constant: , line:18:10, endln:18:17
+                      |vpiDecompile:3
+                      |vpiSize:64
+                      |INT:3
+                      |vpiConstType:7
+                    |vpiRightRange:
+                    \_constant: , line:18:20, endln:18:21
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:z
                 |vpiFullName:work@t.z
                 |vpiNetType:1
-                |vpiRange:
-                \_range: , line:18:10, endln:18:21
-                  |vpiLeftRange:
-                  \_constant: , line:18:10, endln:18:17
-                    |vpiDecompile:3
-                    |vpiSize:64
-                    |INT:3
-                    |vpiConstType:7
-                  |vpiRightRange:
-                  \_constant: , line:18:20, endln:18:21
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
             |vpiName:$bits
           |vpiOperand:
           \_constant: , line:31:23, endln:31:24

--- a/tests/EvalFuncNamed/EvalFuncNamed.log
+++ b/tests/EvalFuncNamed/EvalFuncNamed.log
@@ -1547,41 +1547,45 @@ design: (work@t)
     |vpiFullName:work@t.i_clk
   |vpiNet:
   \_logic_net: (work@t.i_d), line:27:27, endln:27:30, parent:work@t
+    |vpiTypespec:
+    \_logic_typespec: , line:27:11, endln:27:25
+      |vpiRange:
+      \_range: , line:27:12, endln:27:24
+        |vpiLeftRange:
+        \_constant: , line:27:12, endln:27:20
+          |vpiDecompile:2
+          |vpiSize:64
+          |INT:2
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:27:23, endln:27:24
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:i_d
     |vpiFullName:work@t.i_d
-    |vpiRange:
-    \_range: , line:27:12, endln:27:24
-      |vpiLeftRange:
-      \_constant: , line:27:12, endln:27:20
-        |vpiDecompile:2
-        |vpiSize:64
-        |INT:2
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:27:23, endln:27:24
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@t.o_q), line:28:33, endln:28:36, parent:work@t
+    |vpiTypespec:
+    \_logic_typespec: , line:28:12, endln:28:17
+      |vpiRange:
+      \_range: , line:28:19, endln:28:31
+        |vpiLeftRange:
+        \_constant: , line:28:19, endln:28:27
+          |vpiDecompile:2
+          |vpiSize:64
+          |INT:2
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:28:30, endln:28:31
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:o_q
     |vpiFullName:work@t.o_q
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:28:19, endln:28:31
-      |vpiLeftRange:
-      \_constant: , line:28:19, endln:28:27
-        |vpiDecompile:2
-        |vpiSize:64
-        |INT:2
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:28:30, endln:28:31
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (i_clk), line:26:14, endln:26:19, parent:work@t
@@ -1605,6 +1609,22 @@ design: (work@t)
       |vpiFullName:work@t.i_d
       |vpiActual:
       \_logic_net: (work@t.i_d), line:27:27, endln:27:30, parent:work@t
+    |vpiTypedef:
+    \_logic_typespec: , line:27:11, endln:27:25
+      |vpiRange:
+      \_range: , line:27:12, endln:27:24, parent:i_d
+        |vpiLeftRange:
+        \_constant: , line:27:12, endln:27:20
+          |vpiDecompile:2
+          |vpiSize:64
+          |INT:2
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:27:23, endln:27:24
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@t (work@t) dut.sv:23:1: , endln:31:10
   |vpiPort:
@@ -1617,6 +1637,22 @@ design: (work@t)
       |vpiFullName:work@t.o_q
       |vpiActual:
       \_logic_net: (work@t.o_q), line:28:33, endln:28:36, parent:work@t
+    |vpiTypedef:
+    \_logic_typespec: , line:28:12, endln:28:17
+      |vpiRange:
+      \_range: , line:28:19, endln:28:31, parent:o_q
+        |vpiLeftRange:
+        \_constant: , line:28:19, endln:28:27
+          |vpiDecompile:2
+          |vpiSize:64
+          |INT:2
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:28:30, endln:28:31
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@t (work@t) dut.sv:23:1: , endln:31:10
 ===================

--- a/tests/FSM2Always/FSM2Always.log
+++ b/tests/FSM2Always/FSM2Always.log
@@ -1679,28 +1679,32 @@ design: (work@fsm_using_always)
             |vpiName:state
             |vpiActual:
             \_logic_net: (work@fsm_using_always.state), line:26:27, endln:26:32, parent:work@fsm_using_always
+              |vpiTypespec:
+              \_logic_typespec: , line:26:1, endln:26:4
+                |vpiRange:
+                \_range: , line:26:8, endln:26:16
+                  |vpiLeftRange:
+                  \_constant: , line:26:8, endln:26:12
+                    |vpiDecompile:2
+                    |vpiSize:64
+                    |INT:2
+                    |vpiConstType:7
+                  |vpiRightRange:
+                  \_constant: , line:26:15, endln:26:16
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiName:state
               |vpiFullName:work@fsm_using_always.state
               |vpiNetType:48
-              |vpiRange:
-              \_range: , line:26:8, endln:26:16
-                |vpiLeftRange:
-                \_constant: , line:26:8, endln:26:12
-                  |vpiDecompile:2
-                  |vpiSize:64
-                  |INT:2
-                  |vpiConstType:7
-                |vpiRightRange:
-                \_constant: , line:26:15, endln:26:16
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-                  |vpiConstType:9
           |vpiOperand:
           \_ref_obj: (req_0), line:29:20, endln:29:25
             |vpiName:req_0
             |vpiActual:
             \_logic_net: (work@fsm_using_always.req_0), line:19:21, endln:19:26, parent:work@fsm_using_always
+              |vpiTypespec:
+              \_logic_typespec: , line:19:1, endln:19:5
               |vpiName:req_0
               |vpiFullName:work@fsm_using_always.req_0
               |vpiNetType:1
@@ -1709,6 +1713,8 @@ design: (work@fsm_using_always)
           |vpiName:req_1
           |vpiActual:
           \_logic_net: (work@fsm_using_always.req_1), line:19:27, endln:19:32, parent:work@fsm_using_always
+            |vpiTypespec:
+            \_logic_typespec: , line:19:1, endln:19:5
             |vpiName:req_1
             |vpiFullName:work@fsm_using_always.req_1
             |vpiNetType:1
@@ -1732,23 +1738,25 @@ design: (work@fsm_using_always)
             |vpiFullName:work@fsm_using_always.FSM_COMBO.next_state
             |vpiActual:
             \_logic_net: (work@fsm_using_always.next_state), line:27:27, endln:27:37, parent:work@fsm_using_always
+              |vpiTypespec:
+              \_logic_typespec: , line:27:1, endln:27:4
+                |vpiRange:
+                \_range: , line:27:8, endln:27:16
+                  |vpiLeftRange:
+                  \_constant: , line:27:8, endln:27:12
+                    |vpiDecompile:2
+                    |vpiSize:64
+                    |INT:2
+                    |vpiConstType:7
+                  |vpiRightRange:
+                  \_constant: , line:27:15, endln:27:16
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiName:next_state
               |vpiFullName:work@fsm_using_always.next_state
               |vpiNetType:48
-              |vpiRange:
-              \_range: , line:27:8, endln:27:16
-                |vpiLeftRange:
-                \_constant: , line:27:8, endln:27:12
-                  |vpiDecompile:2
-                  |vpiSize:64
-                  |INT:2
-                  |vpiConstType:7
-                |vpiRightRange:
-                \_constant: , line:27:15, endln:27:16
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-                  |vpiConstType:9
         |vpiStmt:
         \_case_stmt: , line:32:2, endln:51:10, parent:work@fsm_using_always.FSM_COMBO
           |vpiCaseType:1
@@ -1993,6 +2001,8 @@ design: (work@fsm_using_always)
           |vpiFullName:work@fsm_using_always.clock
           |vpiActual:
           \_logic_net: (work@fsm_using_always.clock), line:19:9, endln:19:14, parent:work@fsm_using_always
+            |vpiTypespec:
+            \_logic_typespec: , line:19:1, endln:19:5
             |vpiName:clock
             |vpiFullName:work@fsm_using_always.clock
             |vpiNetType:1
@@ -2011,6 +2021,8 @@ design: (work@fsm_using_always)
               |vpiFullName:work@fsm_using_always.FSM_SEQ.reset
               |vpiActual:
               \_logic_net: (work@fsm_using_always.reset), line:19:15, endln:19:20, parent:work@fsm_using_always
+                |vpiTypespec:
+                \_logic_typespec: , line:19:1, endln:19:5
                 |vpiName:reset
                 |vpiFullName:work@fsm_using_always.reset
                 |vpiNetType:1
@@ -2113,6 +2125,8 @@ design: (work@fsm_using_always)
                 |vpiFullName:work@fsm_using_always.OUTPUT_LOGIC.gnt_0
                 |vpiActual:
                 \_logic_net: (work@fsm_using_always.gnt_0), line:21:9, endln:21:14, parent:work@fsm_using_always
+                  |vpiTypespec:
+                  \_logic_typespec: , line:21:1, endln:21:4
                   |vpiName:gnt_0
                   |vpiFullName:work@fsm_using_always.gnt_0
                   |vpiNetType:48
@@ -2134,6 +2148,8 @@ design: (work@fsm_using_always)
                 |vpiFullName:work@fsm_using_always.OUTPUT_LOGIC.gnt_1
                 |vpiActual:
                 \_logic_net: (work@fsm_using_always.gnt_1), line:21:15, endln:21:20, parent:work@fsm_using_always
+                  |vpiTypespec:
+                  \_logic_typespec: , line:21:1, endln:21:4
                   |vpiName:gnt_1
                   |vpiFullName:work@fsm_using_always.gnt_1
                   |vpiNetType:48

--- a/tests/FSMBsp13/FSMBsp13.log
+++ b/tests/FSMBsp13/FSMBsp13.log
@@ -7222,23 +7222,25 @@ design: (work@top)
               |vpiFullName:work@FSM1.SEQ.CurState
               |vpiActual:
               \_logic_net: (work@top.F1.CurState), line:11:17, endln:11:25, parent:work@top.F1
+                |vpiTypespec:
+                \_logic_typespec: , line:11:1, endln:11:4
+                  |vpiRange:
+                  \_range: , line:11:12, endln:11:15
+                    |vpiLeftRange:
+                    \_constant: , line:11:12, endln:11:13
+                      |vpiDecompile:3
+                      |vpiSize:64
+                      |UINT:3
+                      |vpiConstType:9
+                    |vpiRightRange:
+                    \_constant: , line:11:14, endln:11:15
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:CurState
                 |vpiFullName:work@top.F1.CurState
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:11:12, endln:11:15
-                  |vpiLeftRange:
-                  \_constant: , line:11:12, endln:11:13
-                    |vpiDecompile:3
-                    |vpiSize:64
-                    |UINT:3
-                    |vpiConstType:9
-                  |vpiRightRange:
-                  \_constant: , line:11:14, endln:11:15
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
           |vpiElseStmt:
           \_assignment: , line:18:5, endln:18:25
             |vpiOpType:82
@@ -7249,23 +7251,11 @@ design: (work@top)
               |vpiFullName:work@FSM1.SEQ.NextState
               |vpiActual:
               \_logic_net: (work@top.F1.NextState), line:11:27, endln:11:36, parent:work@top.F1
+                |vpiTypespec:
+                \_logic_typespec: , line:11:1, endln:11:4
                 |vpiName:NextState
                 |vpiFullName:work@top.F1.NextState
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:11:12, endln:11:15
-                  |vpiLeftRange:
-                  \_constant: , line:11:12, endln:11:13
-                    |vpiDecompile:3
-                    |vpiSize:64
-                    |UINT:3
-                    |vpiConstType:9
-                  |vpiRightRange:
-                  \_constant: , line:11:14, endln:11:15
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
             |vpiLhs:
             \_ref_obj: (work@FSM1.SEQ.CurState), line:18:5, endln:18:13
               |vpiName:CurState
@@ -7294,6 +7284,8 @@ design: (work@top)
           |vpiFullName:work@FSM1.Read
           |vpiActual:
           \_logic_net: (work@top.F1.Read), line:5:5, endln:5:9, parent:work@top.F1
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:Read
             |vpiFullName:work@top.F1.Read
             |vpiNetType:48
@@ -7313,6 +7305,8 @@ design: (work@top)
           |vpiFullName:work@FSM1.Write
           |vpiActual:
           \_logic_net: (work@top.F1.Write), line:5:11, endln:5:16, parent:work@top.F1
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:Write
             |vpiFullName:work@top.F1.Write
             |vpiNetType:48
@@ -7332,6 +7326,8 @@ design: (work@top)
           |vpiFullName:work@FSM1.Wait
           |vpiActual:
           \_logic_net: (work@top.F1.Wait), line:5:18, endln:5:22, parent:work@top.F1
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:Wait
             |vpiFullName:work@top.F1.Wait
             |vpiNetType:48
@@ -7351,6 +7347,8 @@ design: (work@top)
           |vpiFullName:work@FSM1.Delay
           |vpiActual:
           \_logic_net: (work@top.F1.Delay), line:5:24, endln:5:29, parent:work@top.F1
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:Delay
             |vpiFullName:work@top.F1.Delay
             |vpiNetType:48
@@ -9725,6 +9723,8 @@ design: (work@top)
             |vpiFullName:work@FSM2.SwitchCtrl.Ctrl1
             |vpiActual:
             \_logic_net: (work@top.F2.Ctrl1), line:10:5, endln:10:10, parent:work@top.F2
+              |vpiTypespec:
+              \_logic_typespec: , line:10:1, endln:10:4
               |vpiName:Ctrl1
               |vpiFullName:work@top.F2.Ctrl1
               |vpiNetType:48
@@ -9747,6 +9747,8 @@ design: (work@top)
             |vpiFullName:work@FSM2.SwitchCtrl.Ctrl2
             |vpiActual:
             \_logic_net: (work@top.F2.Ctrl2), line:10:11, endln:10:16, parent:work@top.F2
+              |vpiTypespec:
+              \_logic_typespec: , line:10:1, endln:10:4
               |vpiName:Ctrl2
               |vpiFullName:work@top.F2.Ctrl2
               |vpiNetType:48
@@ -9769,6 +9771,8 @@ design: (work@top)
             |vpiFullName:work@FSM2.SwitchCtrl.Ctrl3
             |vpiActual:
             \_logic_net: (work@top.F2.Ctrl3), line:10:17, endln:10:22, parent:work@top.F2
+              |vpiTypespec:
+              \_logic_typespec: , line:10:1, endln:10:4
               |vpiName:Ctrl3
               |vpiFullName:work@top.F2.Ctrl3
               |vpiNetType:48
@@ -9791,6 +9795,8 @@ design: (work@top)
             |vpiFullName:work@FSM2.SwitchCtrl.Ctrl4
             |vpiActual:
             \_logic_net: (work@top.F2.Ctrl4), line:10:23, endln:10:28, parent:work@top.F2
+              |vpiTypespec:
+              \_logic_typespec: , line:10:1, endln:10:4
               |vpiName:Ctrl4
               |vpiFullName:work@top.F2.Ctrl4
               |vpiNetType:48
@@ -9813,6 +9819,8 @@ design: (work@top)
             |vpiFullName:work@FSM2.SwitchCtrl.Ctrl5
             |vpiActual:
             \_logic_net: (work@top.F2.Ctrl5), line:10:29, endln:10:34, parent:work@top.F2
+              |vpiTypespec:
+              \_logic_typespec: , line:10:1, endln:10:4
               |vpiName:Ctrl5
               |vpiFullName:work@top.F2.Ctrl5
               |vpiNetType:48
@@ -9835,6 +9843,8 @@ design: (work@top)
             |vpiFullName:work@FSM2.SwitchCtrl.Ctrl6
             |vpiActual:
             \_logic_net: (work@top.F2.Ctrl6), line:10:35, endln:10:40, parent:work@top.F2
+              |vpiTypespec:
+              \_logic_typespec: , line:10:1, endln:10:4
               |vpiName:Ctrl6
               |vpiFullName:work@top.F2.Ctrl6
               |vpiNetType:48
@@ -9857,6 +9867,8 @@ design: (work@top)
             |vpiFullName:work@FSM2.SwitchCtrl.Ctrl7
             |vpiActual:
             \_logic_net: (work@top.F2.Ctrl7), line:10:41, endln:10:46, parent:work@top.F2
+              |vpiTypespec:
+              \_logic_typespec: , line:10:1, endln:10:4
               |vpiName:Ctrl7
               |vpiFullName:work@top.F2.Ctrl7
               |vpiNetType:48
@@ -10098,23 +10110,25 @@ design: (work@top)
           |vpiName:CurrentState
           |vpiActual:
           \_logic_net: (work@top.F2.CurrentState), line:8:11, endln:8:23, parent:work@top.F2
+            |vpiTypespec:
+            \_logic_typespec: , line:8:1, endln:8:4
+              |vpiRange:
+              \_range: , line:8:6, endln:8:9
+                |vpiLeftRange:
+                \_constant: , line:8:6, endln:8:7
+                  |vpiDecompile:3
+                  |vpiSize:64
+                  |UINT:3
+                  |vpiConstType:9
+                |vpiRightRange:
+                \_constant: , line:8:8, endln:8:9
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiName:CurrentState
             |vpiFullName:work@top.F2.CurrentState
             |vpiNetType:48
-            |vpiRange:
-            \_range: , line:8:6, endln:8:9
-              |vpiLeftRange:
-              \_constant: , line:8:6, endln:8:7
-                |vpiDecompile:3
-                |vpiSize:64
-                |UINT:3
-                |vpiConstType:9
-              |vpiRightRange:
-              \_constant: , line:8:8, endln:8:9
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
       |vpiStmt:
       \_named_begin: (work@FSM2.COMB), line:36:35, endln:113:4
         |vpiName:COMB
@@ -10133,23 +10147,11 @@ design: (work@top)
             |vpiFullName:work@FSM2.COMB.NextState
             |vpiActual:
             \_logic_net: (work@top.F2.NextState), line:8:25, endln:8:34, parent:work@top.F2
+              |vpiTypespec:
+              \_logic_typespec: , line:8:1, endln:8:4
               |vpiName:NextState
               |vpiFullName:work@top.F2.NextState
               |vpiNetType:48
-              |vpiRange:
-              \_range: , line:8:6, endln:8:9
-                |vpiLeftRange:
-                \_constant: , line:8:6, endln:8:7
-                  |vpiDecompile:3
-                  |vpiSize:64
-                  |UINT:3
-                  |vpiConstType:9
-                |vpiRightRange:
-                \_constant: , line:8:8, endln:8:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-                  |vpiConstType:9
         |vpiStmt:
         \_case_stmt: , line:38:3, endln:112:10, parent:work@FSM2.COMB
           |vpiCaseType:1
@@ -10961,23 +10963,25 @@ design: (work@top)
                 |vpiFullName:work@FSM2.OUT_LOGIC.y
                 |vpiActual:
                 \_logic_net: (work@top.F2.y), line:4:11, endln:4:12, parent:work@top.F2
+                  |vpiTypespec:
+                  \_logic_typespec: , line:4:1, endln:4:4
+                    |vpiRange:
+                    \_range: , line:4:6, endln:4:9
+                      |vpiLeftRange:
+                      \_constant: , line:4:6, endln:4:7
+                        |vpiDecompile:2
+                        |vpiSize:64
+                        |UINT:2
+                        |vpiConstType:9
+                      |vpiRightRange:
+                      \_constant: , line:4:8, endln:4:9
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:y
                   |vpiFullName:work@top.F2.y
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:4:6, endln:4:9
-                    |vpiLeftRange:
-                    \_constant: , line:4:6, endln:4:7
-                      |vpiDecompile:2
-                      |vpiSize:64
-                      |UINT:2
-                      |vpiConstType:9
-                    |vpiRightRange:
-                    \_constant: , line:4:8, endln:4:9
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
           |vpiCaseItem:
           \_case_item: , line:127:5, endln:127:14
             |vpiExpr:
@@ -11353,6 +11357,8 @@ design: (work@top)
           |vpiFullName:work@FSM3.Ctrl1
           |vpiActual:
           \_logic_net: (work@top.F3.Ctrl1), line:6:5, endln:6:10, parent:work@top.F3
+            |vpiTypespec:
+            \_logic_typespec: , line:6:1, endln:6:4
             |vpiName:Ctrl1
             |vpiFullName:work@top.F3.Ctrl1
             |vpiNetType:48
@@ -11372,6 +11378,8 @@ design: (work@top)
           |vpiFullName:work@FSM3.Ctrl2
           |vpiActual:
           \_logic_net: (work@top.F3.Ctrl2), line:6:12, endln:6:17, parent:work@top.F3
+            |vpiTypespec:
+            \_logic_typespec: , line:6:1, endln:6:4
             |vpiName:Ctrl2
             |vpiFullName:work@top.F3.Ctrl2
             |vpiNetType:48
@@ -11391,6 +11399,8 @@ design: (work@top)
           |vpiFullName:work@FSM3.Ctrl3
           |vpiActual:
           \_logic_net: (work@top.F3.Ctrl3), line:6:19, endln:6:24, parent:work@top.F3
+            |vpiTypespec:
+            \_logic_typespec: , line:6:1, endln:6:4
             |vpiName:Ctrl3
             |vpiFullName:work@top.F3.Ctrl3
             |vpiNetType:48
@@ -11450,23 +11460,25 @@ design: (work@top)
               |vpiFullName:work@FSM3.FSM3.Speed
               |vpiActual:
               \_logic_net: (work@top.F3.Speed), line:4:11, endln:4:16, parent:work@top.F3
+                |vpiTypespec:
+                \_logic_typespec: , line:4:1, endln:4:4
+                  |vpiRange:
+                  \_range: , line:4:6, endln:4:9
+                    |vpiLeftRange:
+                    \_constant: , line:4:6, endln:4:7
+                      |vpiDecompile:3
+                      |vpiSize:64
+                      |UINT:3
+                      |vpiConstType:9
+                    |vpiRightRange:
+                    \_constant: , line:4:8, endln:4:9
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:Speed
                 |vpiFullName:work@top.F3.Speed
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:4:6, endln:4:9
-                  |vpiLeftRange:
-                  \_constant: , line:4:6, endln:4:7
-                    |vpiDecompile:3
-                    |vpiSize:64
-                    |UINT:3
-                    |vpiConstType:9
-                  |vpiRightRange:
-                  \_constant: , line:4:8, endln:4:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
           |vpiElseStmt:
           \_if_else: , line:25:8, endln:46:19
             |vpiCondition:
@@ -12100,6 +12112,8 @@ design: (work@top)
           |vpiFullName:work@top.fsm1clk
           |vpiActual:
           \_logic_net: (work@top.fsm1clk), line:3:5, endln:3:12, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:3:1, endln:3:4
             |vpiName:fsm1clk
             |vpiFullName:work@top.fsm1clk
             |vpiNetType:48
@@ -12148,6 +12162,8 @@ design: (work@top)
           |vpiFullName:work@top.a
           |vpiActual:
           \_logic_net: (work@top.a), line:5:18, endln:5:19, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:a
             |vpiFullName:work@top.a
             |vpiNetType:48
@@ -12167,6 +12183,8 @@ design: (work@top)
           |vpiFullName:work@top.b
           |vpiActual:
           \_logic_net: (work@top.b), line:5:21, endln:5:22, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:b
             |vpiFullName:work@top.b
             |vpiNetType:48
@@ -12186,6 +12204,8 @@ design: (work@top)
           |vpiFullName:work@top.c
           |vpiActual:
           \_logic_net: (work@top.c), line:5:24, endln:5:25, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:c
             |vpiFullName:work@top.c
             |vpiNetType:48
@@ -12205,6 +12225,8 @@ design: (work@top)
           |vpiFullName:work@top.m
           |vpiActual:
           \_logic_net: (work@top.m), line:5:39, endln:5:40, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:m
             |vpiFullName:work@top.m
             |vpiNetType:48
@@ -12224,6 +12246,8 @@ design: (work@top)
           |vpiFullName:work@top.n
           |vpiActual:
           \_logic_net: (work@top.n), line:5:42, endln:5:43, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:n
             |vpiFullName:work@top.n
             |vpiNetType:48
@@ -12243,6 +12267,8 @@ design: (work@top)
           |vpiFullName:work@top.o
           |vpiActual:
           \_logic_net: (work@top.o), line:5:45, endln:5:46, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:o
             |vpiFullName:work@top.o
             |vpiNetType:48
@@ -12262,6 +12288,8 @@ design: (work@top)
           |vpiFullName:work@top.p
           |vpiActual:
           \_logic_net: (work@top.p), line:5:48, endln:5:49, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:p
             |vpiFullName:work@top.p
             |vpiNetType:48
@@ -12281,6 +12309,8 @@ design: (work@top)
           |vpiFullName:work@top.q
           |vpiActual:
           \_logic_net: (work@top.q), line:5:51, endln:5:52, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:q
             |vpiFullName:work@top.q
             |vpiNetType:48
@@ -12300,6 +12330,8 @@ design: (work@top)
           |vpiFullName:work@top.r
           |vpiActual:
           \_logic_net: (work@top.r), line:5:54, endln:5:55, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:r
             |vpiFullName:work@top.r
             |vpiNetType:48
@@ -12319,6 +12351,8 @@ design: (work@top)
           |vpiFullName:work@top.s
           |vpiActual:
           \_logic_net: (work@top.s), line:5:57, endln:5:58, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:s
             |vpiFullName:work@top.s
             |vpiNetType:48
@@ -12338,6 +12372,8 @@ design: (work@top)
           |vpiFullName:work@top.t
           |vpiActual:
           \_logic_net: (work@top.t), line:5:60, endln:5:61, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:t
             |vpiFullName:work@top.t
             |vpiNetType:48
@@ -12357,6 +12393,8 @@ design: (work@top)
           |vpiFullName:work@top.u
           |vpiActual:
           \_logic_net: (work@top.u), line:5:63, endln:5:64, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:u
             |vpiFullName:work@top.u
             |vpiNetType:48
@@ -12376,6 +12414,8 @@ design: (work@top)
           |vpiFullName:work@top.v
           |vpiActual:
           \_logic_net: (work@top.v), line:5:66, endln:5:67, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:v
             |vpiFullName:work@top.v
             |vpiNetType:48
@@ -12458,6 +12498,8 @@ design: (work@top)
                 |vpiFullName:work@top.accelerate
                 |vpiActual:
                 \_logic_net: (work@top.accelerate), line:5:27, endln:5:37, parent:work@top
+                  |vpiTypespec:
+                  \_logic_typespec: , line:5:1, endln:5:4
                   |vpiName:accelerate
                   |vpiFullName:work@top.accelerate
                   |vpiNetType:48
@@ -12786,6 +12828,8 @@ design: (work@top)
           |vpiFullName:work@top.fsm2clk
           |vpiActual:
           \_logic_net: (work@top.fsm2clk), line:3:14, endln:3:21, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:3:1, endln:3:4
             |vpiName:fsm2clk
             |vpiFullName:work@top.fsm2clk
             |vpiNetType:48
@@ -12837,6 +12881,8 @@ design: (work@top)
           |vpiFullName:work@top.fsm3clk
           |vpiActual:
           \_logic_net: (work@top.fsm3clk), line:3:23, endln:3:30, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:3:1, endln:3:4
             |vpiName:fsm3clk
             |vpiFullName:work@top.fsm3clk
             |vpiNetType:48
@@ -12885,6 +12931,8 @@ design: (work@top)
           |vpiFullName:work@top.SlowRam
           |vpiActual:
           \_logic_net: (work@top.SlowRam), line:3:41, endln:3:48, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:3:1, endln:3:4
             |vpiName:SlowRam
             |vpiFullName:work@top.SlowRam
             |vpiNetType:48
@@ -12933,6 +12981,8 @@ design: (work@top)
           |vpiFullName:work@top.fsm1rst
           |vpiActual:
           \_logic_net: (work@top.fsm1rst), line:3:32, endln:3:39, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:3:1, endln:3:4
             |vpiName:fsm1rst
             |vpiFullName:work@top.fsm1rst
             |vpiNetType:48
@@ -13022,6 +13072,8 @@ design: (work@top)
           |vpiFullName:work@top.fsm2rst
           |vpiActual:
           \_logic_net: (work@top.fsm2rst), line:3:50, endln:3:57, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:3:1, endln:3:4
             |vpiName:fsm2rst
             |vpiFullName:work@top.fsm2rst
             |vpiNetType:48
@@ -13108,6 +13160,8 @@ design: (work@top)
           |vpiFullName:work@top.ctrl
           |vpiActual:
           \_logic_net: (work@top.ctrl), line:4:5, endln:4:9, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:4:1, endln:4:4
             |vpiName:ctrl
             |vpiFullName:work@top.ctrl
             |vpiNetType:48
@@ -13188,6 +13242,8 @@ design: (work@top)
           |vpiFullName:work@top.keys
           |vpiActual:
           \_logic_net: (work@top.keys), line:5:5, endln:5:9, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:keys
             |vpiFullName:work@top.keys
             |vpiNetType:48
@@ -13207,6 +13263,8 @@ design: (work@top)
           |vpiFullName:work@top.brake
           |vpiActual:
           \_logic_net: (work@top.brake), line:5:11, endln:5:16, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:4
             |vpiName:brake
             |vpiFullName:work@top.brake
             |vpiNetType:48
@@ -13344,52 +13402,60 @@ design: (work@top)
   \_logic_net: (work@top.v), line:5:66, endln:5:67, parent:work@top
   |vpiNet:
   \_logic_net: (work@top.rd), line:7:6, endln:7:8, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:7:1, endln:7:5
     |vpiName:rd
     |vpiFullName:work@top.rd
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@top.wr), line:7:10, endln:7:12, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:7:1, endln:7:5
     |vpiName:wr
     |vpiFullName:work@top.wr
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@top.Fsm2Out), line:8:12, endln:8:19, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:8:1, endln:8:5
+      |vpiRange:
+      \_range: , line:8:7, endln:8:10
+        |vpiLeftRange:
+        \_constant: , line:8:7, endln:8:8
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:8:9, endln:8:10
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:Fsm2Out
     |vpiFullName:work@top.Fsm2Out
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:8:7, endln:8:10
-      |vpiLeftRange:
-      \_constant: , line:8:7, endln:8:8
-        |vpiDecompile:2
-        |vpiSize:64
-        |UINT:2
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:8:9, endln:8:10
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@top.speed), line:9:12, endln:9:17, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:9:1, endln:9:5
+      |vpiRange:
+      \_range: , line:9:7, endln:9:10
+        |vpiLeftRange:
+        \_constant: , line:9:7, endln:9:8
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:9:9, endln:9:10
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:speed
     |vpiFullName:work@top.speed
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:9:7, endln:9:10
-      |vpiLeftRange:
-      \_constant: , line:9:7, endln:9:8
-        |vpiDecompile:3
-        |vpiSize:64
-        |UINT:3
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:9:9, endln:9:10
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiProcess:
   \_initial: , line:29:1, endln:32:4, parent:work@top
@@ -17559,6 +17625,22 @@ design: (work@top)
         |vpiFullName:work@top.F2.y
         |vpiActual:
         \_logic_net: (work@top.F2.y), line:4:11, endln:4:12, parent:work@top.F2
+      |vpiTypedef:
+      \_logic_typespec: , line:3:8, endln:3:13
+        |vpiRange:
+        \_range: , line:3:9, endln:3:12, parent:y
+          |vpiLeftRange:
+          \_constant: , line:3:9, endln:3:10
+            |vpiDecompile:2
+            |vpiSize:64
+            |UINT:2
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:3:11, endln:3:12
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@FSM2 (work@top.F2) top.v:17:1: , endln:20:22, parent:work@top
     |vpiProcess:
@@ -18953,6 +19035,22 @@ design: (work@top)
         |vpiFullName:work@top.F3.Speed
         |vpiActual:
         \_logic_net: (work@top.F3.Speed), line:4:11, endln:4:16, parent:work@top.F3
+      |vpiTypedef:
+      \_logic_typespec: , line:3:8, endln:3:13
+        |vpiRange:
+        \_range: , line:3:9, endln:3:12, parent:Speed
+          |vpiLeftRange:
+          \_constant: , line:3:9, endln:3:10
+            |vpiDecompile:3
+            |vpiSize:64
+            |UINT:3
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:3:11, endln:3:12
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@FSM3 (work@top.F3) top.v:22:1: , endln:26:24, parent:work@top
     |vpiProcess:

--- a/tests/FSMFunction/FSMFunction.log
+++ b/tests/FSMFunction/FSMFunction.log
@@ -2180,6 +2180,8 @@ design: (work@fsm_using_function)
           |vpiFullName:work@fsm_using_function.clock
           |vpiActual:
           \_logic_net: (work@fsm_using_function.clock), line:19:9, endln:19:14, parent:work@fsm_using_function
+            |vpiTypespec:
+            \_logic_typespec: , line:19:1, endln:19:5
             |vpiName:clock
             |vpiFullName:work@fsm_using_function.clock
             |vpiNetType:1
@@ -2198,6 +2200,8 @@ design: (work@fsm_using_function)
               |vpiFullName:work@fsm_using_function.FSM_SEQ.reset
               |vpiActual:
               \_logic_net: (work@fsm_using_function.reset), line:19:15, endln:19:20, parent:work@fsm_using_function
+                |vpiTypespec:
+                \_logic_typespec: , line:19:1, endln:19:5
                 |vpiName:reset
                 |vpiFullName:work@fsm_using_function.reset
                 |vpiNetType:1
@@ -2223,23 +2227,25 @@ design: (work@fsm_using_function)
                 |vpiFullName:work@fsm_using_function.FSM_SEQ.state
                 |vpiActual:
                 \_logic_net: (work@fsm_using_function.state), line:26:27, endln:26:32, parent:work@fsm_using_function
+                  |vpiTypespec:
+                  \_logic_typespec: , line:26:1, endln:26:4
+                    |vpiRange:
+                    \_range: , line:26:8, endln:26:16
+                      |vpiLeftRange:
+                      \_constant: , line:26:8, endln:26:12
+                        |vpiDecompile:2
+                        |vpiSize:64
+                        |INT:2
+                        |vpiConstType:7
+                      |vpiRightRange:
+                      \_constant: , line:26:15, endln:26:16
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:state
                   |vpiFullName:work@fsm_using_function.state
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:26:8, endln:26:16
-                    |vpiLeftRange:
-                    \_constant: , line:26:8, endln:26:12
-                      |vpiDecompile:2
-                      |vpiSize:64
-                      |INT:2
-                      |vpiConstType:7
-                    |vpiRightRange:
-                    \_constant: , line:26:15, endln:26:16
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
               |vpiDelayControl:
               \_delay_control: , line:60:14, endln:60:16
                 |#1
@@ -2255,23 +2261,25 @@ design: (work@fsm_using_function)
                 |vpiFullName:work@fsm_using_function.FSM_SEQ.next_state
                 |vpiActual:
                 \_logic_net: (work@fsm_using_function.next_state), line:27:27, endln:27:37, parent:work@fsm_using_function
+                  |vpiTypespec:
+                  \_logic_typespec: , line:27:1, endln:27:5
+                    |vpiRange:
+                    \_range: , line:27:8, endln:27:16
+                      |vpiLeftRange:
+                      \_constant: , line:27:8, endln:27:12
+                        |vpiDecompile:2
+                        |vpiSize:64
+                        |INT:2
+                        |vpiConstType:7
+                      |vpiRightRange:
+                      \_constant: , line:27:15, endln:27:16
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:next_state
                   |vpiFullName:work@fsm_using_function.next_state
                   |vpiNetType:1
-                  |vpiRange:
-                  \_range: , line:27:8, endln:27:16
-                    |vpiLeftRange:
-                    \_constant: , line:27:8, endln:27:12
-                      |vpiDecompile:2
-                      |vpiSize:64
-                      |INT:2
-                      |vpiConstType:7
-                    |vpiRightRange:
-                    \_constant: , line:27:15, endln:27:16
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
               |vpiLhs:
               \_ref_obj: (work@fsm_using_function.FSM_SEQ.state), line:62:5, endln:62:10, parent:work@fsm_using_function.FSM_SEQ
                 |vpiName:state
@@ -2334,6 +2342,8 @@ design: (work@fsm_using_function)
                 |vpiFullName:work@fsm_using_function.OUTPUT_LOGIC.gnt_0
                 |vpiActual:
                 \_logic_net: (work@fsm_using_function.gnt_0), line:21:9, endln:21:14, parent:work@fsm_using_function
+                  |vpiTypespec:
+                  \_logic_typespec: , line:21:1, endln:21:4
                   |vpiName:gnt_0
                   |vpiFullName:work@fsm_using_function.gnt_0
                   |vpiNetType:48
@@ -2355,6 +2365,8 @@ design: (work@fsm_using_function)
                 |vpiFullName:work@fsm_using_function.OUTPUT_LOGIC.gnt_1
                 |vpiActual:
                 \_logic_net: (work@fsm_using_function.gnt_1), line:21:15, endln:21:20, parent:work@fsm_using_function
+                  |vpiTypespec:
+                  \_logic_typespec: , line:21:1, endln:21:4
                   |vpiName:gnt_1
                   |vpiFullName:work@fsm_using_function.gnt_1
                   |vpiNetType:48
@@ -2566,6 +2578,8 @@ design: (work@fsm_using_function)
         |vpiFullName:work@fsm_using_function.req_0
         |vpiActual:
         \_logic_net: (work@fsm_using_function.req_0), line:19:21, endln:19:26, parent:work@fsm_using_function
+          |vpiTypespec:
+          \_logic_typespec: , line:19:1, endln:19:5
           |vpiName:req_0
           |vpiFullName:work@fsm_using_function.req_0
           |vpiNetType:1
@@ -2575,6 +2589,8 @@ design: (work@fsm_using_function)
         |vpiFullName:work@fsm_using_function.req_1
         |vpiActual:
         \_logic_net: (work@fsm_using_function.req_1), line:19:27, endln:19:32, parent:work@fsm_using_function
+          |vpiTypespec:
+          \_logic_typespec: , line:19:1, endln:19:5
           |vpiName:req_1
           |vpiFullName:work@fsm_using_function.req_1
           |vpiNetType:1

--- a/tests/FSMSingleAlways/FSMSingleAlways.log
+++ b/tests/FSMSingleAlways/FSMSingleAlways.log
@@ -1435,6 +1435,8 @@ design: (work@fsm_using_single_always)
           |vpiFullName:work@fsm_using_single_always.clock
           |vpiActual:
           \_logic_net: (work@fsm_using_single_always.clock), line:20:9, endln:20:14, parent:work@fsm_using_single_always
+            |vpiTypespec:
+            \_logic_typespec: , line:20:1, endln:20:5
             |vpiName:clock
             |vpiFullName:work@fsm_using_single_always.clock
             |vpiNetType:1
@@ -1453,6 +1455,8 @@ design: (work@fsm_using_single_always)
               |vpiFullName:work@fsm_using_single_always.FSM.reset
               |vpiActual:
               \_logic_net: (work@fsm_using_single_always.reset), line:20:15, endln:20:20, parent:work@fsm_using_single_always
+                |vpiTypespec:
+                \_logic_typespec: , line:20:1, endln:20:5
                 |vpiName:reset
                 |vpiFullName:work@fsm_using_single_always.reset
                 |vpiNetType:1
@@ -1478,23 +1482,25 @@ design: (work@fsm_using_single_always)
                 |vpiFullName:work@fsm_using_single_always.FSM.state
                 |vpiActual:
                 \_logic_net: (work@fsm_using_single_always.state), line:27:27, endln:27:32, parent:work@fsm_using_single_always
+                  |vpiTypespec:
+                  \_logic_typespec: , line:27:1, endln:27:4
+                    |vpiRange:
+                    \_range: , line:27:8, endln:27:16
+                      |vpiLeftRange:
+                      \_constant: , line:27:8, endln:27:12
+                        |vpiDecompile:2
+                        |vpiSize:64
+                        |INT:2
+                        |vpiConstType:7
+                      |vpiRightRange:
+                      \_constant: , line:27:15, endln:27:16
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:state
                   |vpiFullName:work@fsm_using_single_always.state
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:27:8, endln:27:16
-                    |vpiLeftRange:
-                    \_constant: , line:27:8, endln:27:12
-                      |vpiDecompile:2
-                      |vpiSize:64
-                      |INT:2
-                      |vpiConstType:7
-                    |vpiRightRange:
-                    \_constant: , line:27:15, endln:27:16
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
               |vpiDelayControl:
               \_delay_control: , line:33:12, endln:33:14
                 |#1
@@ -1513,6 +1519,8 @@ design: (work@fsm_using_single_always)
                 |vpiFullName:work@fsm_using_single_always.FSM.gnt_0
                 |vpiActual:
                 \_logic_net: (work@fsm_using_single_always.gnt_0), line:22:9, endln:22:14, parent:work@fsm_using_single_always
+                  |vpiTypespec:
+                  \_logic_typespec: , line:22:1, endln:22:4
                   |vpiName:gnt_0
                   |vpiFullName:work@fsm_using_single_always.gnt_0
                   |vpiNetType:48
@@ -1531,6 +1539,8 @@ design: (work@fsm_using_single_always)
                 |vpiFullName:work@fsm_using_single_always.FSM.gnt_1
                 |vpiActual:
                 \_logic_net: (work@fsm_using_single_always.gnt_1), line:22:15, endln:22:20, parent:work@fsm_using_single_always
+                  |vpiTypespec:
+                  \_logic_typespec: , line:22:1, endln:22:4
                   |vpiName:gnt_1
                   |vpiFullName:work@fsm_using_single_always.gnt_1
                   |vpiNetType:48
@@ -1560,6 +1570,8 @@ design: (work@fsm_using_single_always)
                     |vpiFullName:work@fsm_using_single_always.FSM.req_0
                     |vpiActual:
                     \_logic_net: (work@fsm_using_single_always.req_0), line:20:21, endln:20:26, parent:work@fsm_using_single_always
+                      |vpiTypespec:
+                      \_logic_typespec: , line:20:1, endln:20:5
                       |vpiName:req_0
                       |vpiFullName:work@fsm_using_single_always.req_0
                       |vpiNetType:1
@@ -1614,6 +1626,8 @@ design: (work@fsm_using_single_always)
                       |vpiFullName:work@fsm_using_single_always.FSM.req_1
                       |vpiActual:
                       \_logic_net: (work@fsm_using_single_always.req_1), line:20:27, endln:20:32, parent:work@fsm_using_single_always
+                        |vpiTypespec:
+                        \_logic_typespec: , line:20:1, endln:20:5
                         |vpiName:req_1
                         |vpiFullName:work@fsm_using_single_always.req_1
                         |vpiNetType:1
@@ -1968,23 +1982,25 @@ design: (work@fsm_using_single_always)
   \_logic_net: (work@fsm_using_single_always.state), line:27:27, endln:27:32, parent:work@fsm_using_single_always
   |vpiNet:
   \_logic_net: (work@fsm_using_single_always.next_state), line:28:27, endln:28:37, parent:work@fsm_using_single_always
+    |vpiTypespec:
+    \_logic_typespec: , line:28:1, endln:28:4
+      |vpiRange:
+      \_range: , line:28:8, endln:28:16
+        |vpiLeftRange:
+        \_constant: , line:28:8, endln:28:12
+          |vpiDecompile:2
+          |vpiSize:64
+          |INT:2
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:28:15, endln:28:16
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:next_state
     |vpiFullName:work@fsm_using_single_always.next_state
     |vpiNetType:48
-    |vpiRange:
-    \_range: , line:28:8, endln:28:16
-      |vpiLeftRange:
-      \_constant: , line:28:8, endln:28:12
-        |vpiDecompile:2
-        |vpiSize:64
-        |INT:2
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:28:15, endln:28:16
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (clock), line:8:1, endln:8:6, parent:work@fsm_using_single_always

--- a/tests/FuncArgs/FuncArgs.log
+++ b/tests/FuncArgs/FuncArgs.log
@@ -731,23 +731,25 @@ design: (work@dut)
         |vpiFullName:work@dut.inp
         |vpiActual:
         \_logic_net: (work@dut.inp), line:2:26, endln:2:29, parent:work@dut
+          |vpiTypespec:
+          \_logic_typespec: , line:2:15, endln:2:19
+            |vpiRange:
+            \_range: , line:2:21, endln:2:24
+              |vpiLeftRange:
+              \_constant: , line:2:21, endln:2:22
+                |vpiDecompile:3
+                |vpiSize:64
+                |UINT:3
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:2:23, endln:2:24
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:inp
           |vpiFullName:work@dut.inp
           |vpiNetType:1
-          |vpiRange:
-          \_range: , line:2:21, endln:2:24
-            |vpiLeftRange:
-            \_constant: , line:2:21, endln:2:22
-              |vpiDecompile:3
-              |vpiSize:64
-              |UINT:3
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:2:23, endln:2:24
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
       |vpiArgument:
       \_constant: , line:23:34, endln:23:35, parent:pow_a
         |vpiDecompile:3
@@ -763,23 +765,25 @@ design: (work@dut)
       |vpiFullName:work@dut.out1
       |vpiActual:
       \_logic_net: (work@dut.out1), line:3:27, endln:3:31, parent:work@dut
+        |vpiTypespec:
+        \_logic_typespec: , line:3:16, endln:3:20
+          |vpiRange:
+          \_range: , line:3:22, endln:3:25
+            |vpiLeftRange:
+            \_constant: , line:3:22, endln:3:23
+              |vpiDecompile:3
+              |vpiSize:64
+              |UINT:3
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:3:24, endln:3:25
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:out1
         |vpiFullName:work@dut.out1
         |vpiNetType:1
-        |vpiRange:
-        \_range: , line:3:22, endln:3:25
-          |vpiLeftRange:
-          \_constant: , line:3:22, endln:3:23
-            |vpiDecompile:3
-            |vpiSize:64
-            |UINT:3
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:3:24, endln:3:25
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
   |vpiContAssign:
   \_cont_assign: , line:24:16, endln:24:34, parent:work@dut
     |vpiRhs:
@@ -805,23 +809,11 @@ design: (work@dut)
       |vpiFullName:work@dut.out2
       |vpiActual:
       \_logic_net: (work@dut.out2), line:3:33, endln:3:37, parent:work@dut
+        |vpiTypespec:
+        \_logic_typespec: , line:3:16, endln:3:20
         |vpiName:out2
         |vpiFullName:work@dut.out2
         |vpiNetType:1
-        |vpiRange:
-        \_range: , line:3:22, endln:3:25
-          |vpiLeftRange:
-          \_constant: , line:3:22, endln:3:23
-            |vpiDecompile:3
-            |vpiSize:64
-            |UINT:3
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:3:24, endln:3:25
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@dut (work@dut) dut.sv:1:1: , endln:25:10
   |vpiName:work@dut
@@ -1026,6 +1018,22 @@ design: (work@dut)
       |vpiFullName:work@dut.inp
       |vpiActual:
       \_logic_net: (work@dut.inp), line:2:26, endln:2:29, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:2:15, endln:2:19
+      |vpiRange:
+      \_range: , line:2:21, endln:2:24, parent:inp
+        |vpiLeftRange:
+        \_constant: , line:2:21, endln:2:22
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:2:23, endln:2:24
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:1:1: , endln:25:10
   |vpiPort:
@@ -1038,6 +1046,22 @@ design: (work@dut)
       |vpiFullName:work@dut.out1
       |vpiActual:
       \_logic_net: (work@dut.out1), line:3:27, endln:3:31, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:3:16, endln:3:20
+      |vpiRange:
+      \_range: , line:3:22, endln:3:25, parent:out1
+        |vpiLeftRange:
+        \_constant: , line:3:22, endln:3:23
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:3:24, endln:3:25
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:1:1: , endln:25:10
   |vpiPort:
@@ -1050,6 +1074,8 @@ design: (work@dut)
       |vpiFullName:work@dut.out2
       |vpiActual:
       \_logic_net: (work@dut.out2), line:3:33, endln:3:37, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:3:16, endln:3:20
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:1:1: , endln:25:10
   |vpiContAssign:

--- a/tests/FuncBindGen/FuncBindGen.log
+++ b/tests/FuncBindGen/FuncBindGen.log
@@ -430,6 +430,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:1:23, endln:1:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:1:19, endln:1:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:14:10
   |vpiGenScopeArray:

--- a/tests/FuncBinding/FuncBinding.log
+++ b/tests/FuncBinding/FuncBinding.log
@@ -486,7 +486,7 @@ design: (work@fsm_using_function)
           |vpiActual:
           \_bit_var: (work@fsm_using_function.clock), line:2:11, endln:2:16, parent:work@fsm_using_function
             |vpiTypespec:
-            \_bit_typespec: 
+            \_bit_typespec: , line:2:7, endln:2:10
             |vpiName:clock
             |vpiFullName:work@fsm_using_function.clock
             |vpiVisibility:1
@@ -516,7 +516,7 @@ design: (work@fsm_using_function)
               |vpiActual:
               \_bit_var: (work@fsm_using_function.req_0), line:4:11, endln:4:16, parent:work@fsm_using_function
                 |vpiTypespec:
-                \_bit_typespec: 
+                \_bit_typespec: , line:4:7, endln:4:10
                 |vpiName:req_0
                 |vpiFullName:work@fsm_using_function.req_0
                 |vpiVisibility:1
@@ -527,7 +527,7 @@ design: (work@fsm_using_function)
               |vpiActual:
               \_bit_var: (work@fsm_using_function.req_1), line:5:11, endln:5:16, parent:work@fsm_using_function
                 |vpiTypespec:
-                \_bit_typespec: 
+                \_bit_typespec: , line:5:7, endln:5:10
                 |vpiName:req_1
                 |vpiFullName:work@fsm_using_function.req_1
                 |vpiVisibility:1
@@ -581,7 +581,7 @@ design: (work@fsm_using_function)
               |vpiActual:
               \_bit_var: (work@fsm_using_function.reset), line:3:11, endln:3:16, parent:work@fsm_using_function
                 |vpiTypespec:
-                \_bit_typespec: 
+                \_bit_typespec: , line:3:7, endln:3:10
                 |vpiName:reset
                 |vpiFullName:work@fsm_using_function.reset
                 |vpiVisibility:1
@@ -648,14 +648,14 @@ design: (work@fsm_using_function)
   |vpiVariables:
   \_bit_var: (work@fsm_using_function.gnt_0), line:6:12, endln:6:17, parent:work@fsm_using_function
     |vpiTypespec:
-    \_bit_typespec: 
+    \_bit_typespec: , line:6:8, endln:6:11
     |vpiName:gnt_0
     |vpiFullName:work@fsm_using_function.gnt_0
     |vpiVisibility:1
   |vpiVariables:
   \_bit_var: (work@fsm_using_function.gnt_1), line:7:12, endln:7:17, parent:work@fsm_using_function
     |vpiTypespec:
-    \_bit_typespec: 
+    \_bit_typespec: , line:7:8, endln:7:11
     |vpiName:gnt_1
     |vpiFullName:work@fsm_using_function.gnt_1
     |vpiVisibility:1
@@ -947,6 +947,8 @@ design: (work@fsm_using_function)
       |vpiFullName:work@fsm_using_function.clock
       |vpiActual:
       \_bit_var: (work@fsm_using_function.clock), line:2:11, endln:2:16, parent:work@fsm_using_function
+    |vpiTypedef:
+    \_bit_typespec: , line:2:7, endln:2:10
     |vpiInstance:
     \_module: work@fsm_using_function (work@fsm_using_function) dut.sv:1:1: , endln:53:10
   |vpiPort:
@@ -959,6 +961,8 @@ design: (work@fsm_using_function)
       |vpiFullName:work@fsm_using_function.reset
       |vpiActual:
       \_bit_var: (work@fsm_using_function.reset), line:3:11, endln:3:16, parent:work@fsm_using_function
+    |vpiTypedef:
+    \_bit_typespec: , line:3:7, endln:3:10
     |vpiInstance:
     \_module: work@fsm_using_function (work@fsm_using_function) dut.sv:1:1: , endln:53:10
   |vpiPort:
@@ -971,6 +975,8 @@ design: (work@fsm_using_function)
       |vpiFullName:work@fsm_using_function.req_0
       |vpiActual:
       \_bit_var: (work@fsm_using_function.req_0), line:4:11, endln:4:16, parent:work@fsm_using_function
+    |vpiTypedef:
+    \_bit_typespec: , line:4:7, endln:4:10
     |vpiInstance:
     \_module: work@fsm_using_function (work@fsm_using_function) dut.sv:1:1: , endln:53:10
   |vpiPort:
@@ -983,6 +989,8 @@ design: (work@fsm_using_function)
       |vpiFullName:work@fsm_using_function.req_1
       |vpiActual:
       \_bit_var: (work@fsm_using_function.req_1), line:5:11, endln:5:16, parent:work@fsm_using_function
+    |vpiTypedef:
+    \_bit_typespec: , line:5:7, endln:5:10
     |vpiInstance:
     \_module: work@fsm_using_function (work@fsm_using_function) dut.sv:1:1: , endln:53:10
   |vpiPort:
@@ -995,6 +1003,8 @@ design: (work@fsm_using_function)
       |vpiFullName:work@fsm_using_function.gnt_0
       |vpiActual:
       \_bit_var: (work@fsm_using_function.gnt_0), line:6:12, endln:6:17, parent:work@fsm_using_function
+    |vpiTypedef:
+    \_bit_typespec: , line:6:8, endln:6:11
     |vpiInstance:
     \_module: work@fsm_using_function (work@fsm_using_function) dut.sv:1:1: , endln:53:10
   |vpiPort:
@@ -1007,6 +1017,8 @@ design: (work@fsm_using_function)
       |vpiFullName:work@fsm_using_function.gnt_1
       |vpiActual:
       \_bit_var: (work@fsm_using_function.gnt_1), line:7:12, endln:7:17, parent:work@fsm_using_function
+    |vpiTypedef:
+    \_bit_typespec: , line:7:8, endln:7:11
     |vpiInstance:
     \_module: work@fsm_using_function (work@fsm_using_function) dut.sv:1:1: , endln:53:10
   |vpiProcess:

--- a/tests/FuncBinding2/FuncBinding2.log
+++ b/tests/FuncBinding2/FuncBinding2.log
@@ -33,14 +33,14 @@
 [INF:UH0711] Decompiling UHDM...
 
 ====== UHDM =======
-design: (work@vend), id:58
+design: (work@vend), id:59
 |vpiElaborated:1
 |vpiName:work@vend
 |uhdmallModules:
-\_module: work@vend (work@vend), id:59 dut.sv:1:1: , endln:33:10, parent:work@vend, parID:58
+\_module: work@vend (work@vend), id:60 dut.sv:1:1: , endln:33:10, parent:work@vend, parID:59
   |vpiFullName:work@vend
   |vpiParameter:
-  \_parameter: (work@vend.s0), id:1, line:7:11, endln:7:13, parent:work@vend, parID:59
+  \_parameter: (work@vend.s0), id:1, line:7:11, endln:7:13, parent:work@vend, parID:60
     |BIN:00
     |vpiTypespec:
     \_int_typespec: , id:4
@@ -55,7 +55,7 @@ design: (work@vend), id:58
     |vpiName:s0
     |vpiFullName:work@vend.s0
   |vpiParamAssign:
-  \_param_assign: , id:2, line:7:11, endln:7:21, parent:work@vend, parID:59
+  \_param_assign: , id:2, line:7:11, endln:7:21, parent:work@vend, parID:60
     |vpiRhs:
     \_constant: , id:3, line:7:16, endln:7:21
       |vpiDecompile:2'b00
@@ -65,10 +65,10 @@ design: (work@vend), id:58
       \_int_typespec: , id:4
       |vpiConstType:3
     |vpiLhs:
-    \_parameter: (work@vend.s0), id:1, line:7:11, endln:7:13, parent:work@vend, parID:59
+    \_parameter: (work@vend.s0), id:1, line:7:11, endln:7:13, parent:work@vend, parID:60
   |vpiDefName:work@vend
   |vpiTaskFunc:
-  \_function: (work@vend.fsm), id:0, line:10:1, endln:26:12, parent:work@vend, parID:59
+  \_function: (work@vend.fsm), id:0, line:10:1, endln:26:12, parent:work@vend, parID:60
     |vpiName:fsm
     |vpiFullName:work@vend.fsm
     |vpiVariables:
@@ -145,7 +145,7 @@ design: (work@vend), id:58
                   |vpiName:fsm_coin
                   |vpiFullName:work@vend.fsm.fsm_coin
                   |vpiActual:
-                  \_logic_net: (fsm_coin), id:73
+                  \_logic_net: (fsm_coin), id:74
                     |vpiName:fsm_coin
                     |vpiNetType:1
                 |vpiOperand:
@@ -188,51 +188,51 @@ design: (work@vend), id:58
           |vpiName:fsm
           |vpiFullName:work@vend.fsm.fsm
           |vpiActual:
-          \_logic_var: (fsm), id:74, line:10:11, endln:10:14
+          \_logic_var: (fsm), id:75, line:10:11, endln:10:14
             |vpiName:fsm
             |vpiRange:
-            \_range: , id:75, line:10:11, endln:10:14, parent:fsm, parID:74
+            \_range: , id:76, line:10:11, endln:10:14, parent:fsm, parID:75
               |vpiLeftRange:
-              \_constant: , id:76, line:10:11, endln:10:12, parID:75
+              \_constant: , id:77, line:10:11, endln:10:12, parID:76
                 |vpiDecompile:2
                 |vpiSize:64
                 |UINT:2
                 |vpiConstType:9
               |vpiRightRange:
-              \_constant: , id:77, line:10:13, endln:10:14, parID:75
+              \_constant: , id:78, line:10:13, endln:10:14, parID:76
                 |vpiDecompile:0
                 |vpiSize:64
                 |UINT:0
                 |vpiConstType:9
     |vpiInstance:
-    \_module: work@vend (work@vend), id:59 dut.sv:1:1: , endln:33:10, parent:work@vend, parID:58
+    \_module: work@vend (work@vend), id:60 dut.sv:1:1: , endln:33:10, parent:work@vend, parID:59
   |vpiNet:
-  \_logic_net: (work@vend.newspaper), id:62, line:5:6, endln:5:15, parent:work@vend, parID:59
+  \_logic_net: (work@vend.newspaper), id:63, line:5:6, endln:5:15, parent:work@vend, parID:60
     |vpiName:newspaper
     |vpiFullName:work@vend.newspaper
     |vpiNetType:1
   |vpiNet:
-  \_logic_net: (work@vend.clock), id:64, line:1:13, endln:1:18, parent:work@vend, parID:59
+  \_logic_net: (work@vend.clock), id:65, line:1:13, endln:1:18, parent:work@vend, parID:60
     |vpiName:clock
     |vpiFullName:work@vend.clock
   |vpiPort:
-  \_port: (clock), id:60, line:1:13, endln:1:18, parent:work@vend, parID:59
+  \_port: (clock), id:61, line:1:13, endln:1:18, parent:work@vend, parID:60
     |vpiName:clock
     |vpiDirection:1
     |vpiLowConn:
-    \_ref_obj: , id:65
+    \_ref_obj: , id:66
       |vpiActual:
-      \_logic_net: (work@vend.clock), id:64, line:1:13, endln:1:18, parent:work@vend, parID:59
+      \_logic_net: (work@vend.clock), id:65, line:1:13, endln:1:18, parent:work@vend, parID:60
   |vpiPort:
-  \_port: (newspaper), id:61, line:1:20, endln:1:29, parent:work@vend, parID:59
+  \_port: (newspaper), id:62, line:1:20, endln:1:29, parent:work@vend, parID:60
     |vpiName:newspaper
     |vpiDirection:2
     |vpiLowConn:
-    \_ref_obj: , id:66
+    \_ref_obj: , id:67
       |vpiActual:
-      \_logic_net: (work@vend.newspaper), id:62, line:5:6, endln:5:15, parent:work@vend, parID:59
+      \_logic_net: (work@vend.newspaper), id:63, line:5:6, endln:5:15, parent:work@vend, parID:60
   |vpiProcess:
-  \_always: , id:38, line:28:1, endln:31:4, parent:work@vend, parID:59
+  \_always: , id:38, line:28:1, endln:31:4, parent:work@vend, parID:60
     |vpiStmt:
     \_event_control: , id:39, line:28:8, endln:28:24, parID:38
       |vpiCondition:
@@ -243,7 +243,7 @@ design: (work@vend), id:58
           |vpiName:clock
           |vpiFullName:work@vend.clock
           |vpiActual:
-          \_logic_net: (work@vend.clock), id:55, line:1:13, endln:1:18, parent:work@vend, parID:67
+          \_logic_net: (work@vend.clock), id:56, line:1:13, endln:1:18, parent:work@vend, parID:68
             |vpiName:clock
             |vpiFullName:work@vend.clock
       |vpiStmt:
@@ -258,42 +258,44 @@ design: (work@vend), id:58
               |vpiName:PRES_STATE
               |vpiFullName:work@vend.PRES_STATE
               |vpiActual:
-              \_logic_net: (PRES_STATE), id:78
+              \_logic_net: (PRES_STATE), id:79
                 |vpiName:PRES_STATE
                 |vpiNetType:1
             |vpiName:fsm
             |vpiFunction:
-            \_function: (work@vend.fsm), id:0, line:10:1, endln:26:12, parent:work@vend, parID:59
+            \_function: (work@vend.fsm), id:0, line:10:1, endln:26:12, parent:work@vend, parID:60
           |vpiLhs:
           \_ref_obj: (work@vend.newspaper), id:44, line:30:10, endln:30:19, parID:43
             |vpiName:newspaper
             |vpiFullName:work@vend.newspaper
             |vpiActual:
-            \_logic_net: (work@vend.newspaper), id:54, line:5:6, endln:5:15, parent:work@vend, parID:67
+            \_logic_net: (work@vend.newspaper), id:55, line:5:6, endln:5:15, parent:work@vend, parID:68
+              |vpiTypespec:
+              \_logic_typespec: , id:54, line:5:1, endln:5:5
               |vpiName:newspaper
               |vpiFullName:work@vend.newspaper
               |vpiNetType:1
     |vpiAlwaysType:1
 |uhdmtopModules:
-\_module: work@vend (work@vend), id:67 dut.sv:1:1: , endln:33:10
+\_module: work@vend (work@vend), id:68 dut.sv:1:1: , endln:33:10
   |vpiName:work@vend
   |vpiParameter:
-  \_parameter: (work@vend.s0), id:68, line:7:11, endln:7:13, parent:work@vend, parID:67
+  \_parameter: (work@vend.s0), id:69, line:7:11, endln:7:13, parent:work@vend, parID:68
     |BIN:00
     |vpiTypespec:
-    \_int_typespec: , id:69, parent:work@vend.s0, parID:68
+    \_int_typespec: , id:70, parent:work@vend.s0, parID:69
       |vpiRange:
-      \_range: , id:70, parID:69
+      \_range: , id:71, parID:70
         |vpiLeftRange:
-        \_constant: , id:71, parID:70
+        \_constant: , id:72, parID:71
           |INT:1
         |vpiRightRange:
-        \_constant: , id:72, parID:70
+        \_constant: , id:73, parID:71
           |INT:0
     |vpiName:s0
     |vpiFullName:work@vend.s0
   |vpiParamAssign:
-  \_param_assign: , id:51, line:7:11, endln:7:21, parent:work@vend, parID:67
+  \_param_assign: , id:51, line:7:11, endln:7:21, parent:work@vend, parID:68
     |vpiRhs:
     \_constant: , id:52, line:7:16, endln:7:21
       |vpiDecompile:2'b00
@@ -303,15 +305,15 @@ design: (work@vend), id:58
       \_int_typespec: , id:4
       |vpiConstType:3
     |vpiLhs:
-    \_parameter: (work@vend.s0), id:68, line:7:11, endln:7:13, parent:work@vend, parID:67
+    \_parameter: (work@vend.s0), id:69, line:7:11, endln:7:13, parent:work@vend, parID:68
   |vpiDefName:work@vend
   |vpiTop:1
   |vpiTaskFunc:
-  \_function: (work@vend.fsm), id:92, line:10:1, endln:26:12, parent:work@vend, parID:67
+  \_function: (work@vend.fsm), id:93, line:10:1, endln:26:12, parent:work@vend, parID:68
     |vpiName:fsm
     |vpiFullName:work@vend.fsm
     |vpiVariables:
-    \_logic_var: (work@vend.fsm.fsm_newspaper), id:94, line:12:1, endln:12:4, parent:work@vend.fsm, parID:92
+    \_logic_var: (work@vend.fsm.fsm_newspaper), id:95, line:12:1, endln:12:4, parent:work@vend.fsm, parID:93
       |vpiName:fsm_newspaper
       |vpiFullName:work@vend.fsm.fsm_newspaper
       |vpiAutomatic:1
@@ -319,148 +321,148 @@ design: (work@vend), id:58
     |vpiReturn:
     \_logic_var: , id:12, line:10:11, endln:10:14
     |vpiIODecl:
-    \_io_decl: (fsm_PRES_STATE), id:93, line:11:13, endln:11:27, parent:work@vend.fsm, parID:92
+    \_io_decl: (fsm_PRES_STATE), id:94, line:11:13, endln:11:27, parent:work@vend.fsm, parID:93
       |vpiDirection:1
       |vpiName:fsm_PRES_STATE
       |vpiTypedef:
       \_packed_array_typespec: , id:16, line:11:7, endln:11:12
     |vpiStmt:
-    \_begin: (work@vend.fsm), id:95, line:14:1, endln:25:4, parent:work@vend.fsm, parID:92
+    \_begin: (work@vend.fsm), id:96, line:14:1, endln:25:4, parent:work@vend.fsm, parID:93
       |vpiFullName:work@vend.fsm
       |vpiStmt:
-      \_case_stmt: , id:96, line:15:5, endln:23:12, parent:work@vend.fsm, parID:95
+      \_case_stmt: , id:97, line:15:5, endln:23:12, parent:work@vend.fsm, parID:96
         |vpiCaseType:1
         |vpiCondition:
-        \_ref_obj: (work@vend.fsm.fsm_PRES_STATE), id:97, line:15:11, endln:15:25, parID:96
+        \_ref_obj: (work@vend.fsm.fsm_PRES_STATE), id:98, line:15:11, endln:15:25, parID:97
           |vpiName:fsm_PRES_STATE
           |vpiFullName:work@vend.fsm.fsm_PRES_STATE
           |vpiActual:
-          \_io_decl: (fsm_PRES_STATE), id:93, line:11:13, endln:11:27, parent:work@vend.fsm, parID:92
+          \_io_decl: (fsm_PRES_STATE), id:94, line:11:13, endln:11:27, parent:work@vend.fsm, parID:93
         |vpiCaseItem:
-        \_case_item: , id:98, line:16:5, endln:22:8, parID:96
+        \_case_item: , id:99, line:16:5, endln:22:8, parID:97
           |vpiExpr:
-          \_ref_obj: (work@vend.fsm.s0), id:99, line:16:5, endln:16:7, parID:98
+          \_ref_obj: (work@vend.fsm.s0), id:100, line:16:5, endln:16:7, parID:99
             |vpiName:s0
             |vpiFullName:work@vend.fsm.s0
             |vpiActual:
             \_constant: , id:52, line:7:16, endln:7:21
           |vpiStmt:
-          \_begin: (work@vend.fsm), id:100, line:17:5, endln:22:8, parID:98
+          \_begin: (work@vend.fsm), id:101, line:17:5, endln:22:8, parID:99
             |vpiFullName:work@vend.fsm
             |vpiStmt:
-            \_if_stmt: , id:101, line:18:9, endln:21:16, parent:work@vend.fsm, parID:100
+            \_if_stmt: , id:102, line:18:9, endln:21:16, parent:work@vend.fsm, parID:101
               |vpiCondition:
-              \_operation: , id:102, line:18:13, endln:18:30, parID:101
+              \_operation: , id:103, line:18:13, endln:18:30, parID:102
                 |vpiOpType:14
                 |vpiOperand:
-                \_ref_obj: (work@vend.fsm.fsm_coin), id:103, line:18:13, endln:18:21, parID:102
+                \_ref_obj: (work@vend.fsm.fsm_coin), id:104, line:18:13, endln:18:21, parID:103
                   |vpiName:fsm_coin
                   |vpiFullName:work@vend.fsm.fsm_coin
                   |vpiActual:
-                  \_logic_net: (fsm_coin), id:73
+                  \_logic_net: (fsm_coin), id:74
                 |vpiOperand:
                 \_constant: , id:29, line:18:25, endln:18:30, parID:28
               |vpiStmt:
-              \_begin: (work@vend.fsm), id:104, line:19:13, endln:21:16, parID:101
+              \_begin: (work@vend.fsm), id:105, line:19:13, endln:21:16, parID:102
                 |vpiFullName:work@vend.fsm
                 |vpiStmt:
-                \_assignment: , id:105, line:20:17, endln:20:37, parent:work@vend.fsm, parID:104
+                \_assignment: , id:106, line:20:17, endln:20:37, parent:work@vend.fsm, parID:105
                   |vpiOpType:82
                   |vpiBlocking:1
                   |vpiRhs:
                   \_constant: , id:33, line:20:33, endln:20:37, parID:34
                   |vpiLhs:
-                  \_ref_obj: (work@vend.fsm.fsm_newspaper), id:106, line:20:17, endln:20:30, parID:105
+                  \_ref_obj: (work@vend.fsm.fsm_newspaper), id:107, line:20:17, endln:20:30, parID:106
                     |vpiName:fsm_newspaper
                     |vpiFullName:work@vend.fsm.fsm_newspaper
                     |vpiActual:
-                    \_logic_var: (work@vend.fsm.fsm_newspaper), id:94, line:12:1, endln:12:4, parent:work@vend.fsm, parID:92
+                    \_logic_var: (work@vend.fsm.fsm_newspaper), id:95, line:12:1, endln:12:4, parent:work@vend.fsm, parID:93
       |vpiStmt:
-      \_assignment: , id:107, line:24:1, endln:24:20, parent:work@vend.fsm, parID:95
+      \_assignment: , id:108, line:24:1, endln:24:20, parent:work@vend.fsm, parID:96
         |vpiOpType:82
         |vpiBlocking:1
         |vpiRhs:
-        \_ref_obj: (work@vend.fsm.fsm_newspaper), id:108, line:24:7, endln:24:20, parID:107
+        \_ref_obj: (work@vend.fsm.fsm_newspaper), id:109, line:24:7, endln:24:20, parID:108
           |vpiName:fsm_newspaper
           |vpiFullName:work@vend.fsm.fsm_newspaper
           |vpiActual:
-          \_logic_var: (work@vend.fsm.fsm_newspaper), id:94, line:12:1, endln:12:4, parent:work@vend.fsm, parID:92
+          \_logic_var: (work@vend.fsm.fsm_newspaper), id:95, line:12:1, endln:12:4, parent:work@vend.fsm, parID:93
         |vpiLhs:
-        \_ref_obj: (work@vend.fsm.fsm), id:109, line:24:1, endln:24:4, parID:107
+        \_ref_obj: (work@vend.fsm.fsm), id:110, line:24:1, endln:24:4, parID:108
           |vpiName:fsm
           |vpiFullName:work@vend.fsm.fsm
           |vpiActual:
           \_logic_var: , id:12, line:10:11, endln:10:14
     |vpiInstance:
-    \_module: work@vend (work@vend), id:67 dut.sv:1:1: , endln:33:10
+    \_module: work@vend (work@vend), id:68 dut.sv:1:1: , endln:33:10
   |vpiNet:
-  \_logic_net: (work@vend.newspaper), id:54, line:5:6, endln:5:15, parent:work@vend, parID:67
+  \_logic_net: (work@vend.newspaper), id:55, line:5:6, endln:5:15, parent:work@vend, parID:68
   |vpiNet:
-  \_logic_net: (work@vend.clock), id:55, line:1:13, endln:1:18, parent:work@vend, parID:67
+  \_logic_net: (work@vend.clock), id:56, line:1:13, endln:1:18, parent:work@vend, parID:68
   |vpiNet:
-  \_logic_net: (fsm_coin), id:73
+  \_logic_net: (fsm_coin), id:74
   |vpiNet:
-  \_logic_net: (PRES_STATE), id:78
+  \_logic_net: (PRES_STATE), id:79
   |vpiTopModule:1
   |vpiPort:
-  \_port: (clock), id:79, line:1:13, endln:1:18, parent:work@vend, parID:67
+  \_port: (clock), id:80, line:1:13, endln:1:18, parent:work@vend, parID:68
     |vpiName:clock
     |vpiDirection:1
     |vpiLowConn:
-    \_ref_obj: (work@vend.clock), id:80, line:1:13, endln:1:18, parent:clock, parID:79
+    \_ref_obj: (work@vend.clock), id:81, line:1:13, endln:1:18, parent:clock, parID:80
       |vpiName:clock
       |vpiFullName:work@vend.clock
       |vpiActual:
-      \_logic_net: (work@vend.clock), id:55, line:1:13, endln:1:18, parent:work@vend, parID:67
+      \_logic_net: (work@vend.clock), id:56, line:1:13, endln:1:18, parent:work@vend, parID:68
     |vpiInstance:
-    \_module: work@vend (work@vend), id:67 dut.sv:1:1: , endln:33:10
+    \_module: work@vend (work@vend), id:68 dut.sv:1:1: , endln:33:10
   |vpiPort:
-  \_port: (newspaper), id:81, line:1:20, endln:1:29, parent:work@vend, parID:67
+  \_port: (newspaper), id:82, line:1:20, endln:1:29, parent:work@vend, parID:68
     |vpiName:newspaper
     |vpiDirection:2
     |vpiLowConn:
-    \_ref_obj: (work@vend.newspaper), id:82, line:1:20, endln:1:29, parent:newspaper, parID:81
+    \_ref_obj: (work@vend.newspaper), id:83, line:1:20, endln:1:29, parent:newspaper, parID:82
       |vpiName:newspaper
       |vpiFullName:work@vend.newspaper
       |vpiActual:
-      \_logic_net: (work@vend.newspaper), id:54, line:5:6, endln:5:15, parent:work@vend, parID:67
+      \_logic_net: (work@vend.newspaper), id:55, line:5:6, endln:5:15, parent:work@vend, parID:68
     |vpiInstance:
-    \_module: work@vend (work@vend), id:67 dut.sv:1:1: , endln:33:10
+    \_module: work@vend (work@vend), id:68 dut.sv:1:1: , endln:33:10
   |vpiProcess:
-  \_always: , id:83, line:28:1, endln:31:4, parent:work@vend, parID:67
+  \_always: , id:84, line:28:1, endln:31:4, parent:work@vend, parID:68
     |vpiStmt:
-    \_event_control: , id:84, line:28:8, endln:28:24, parID:83
+    \_event_control: , id:85, line:28:8, endln:28:24, parID:84
       |vpiCondition:
-      \_operation: , id:85, line:28:10, endln:28:23, parID:84
+      \_operation: , id:86, line:28:10, endln:28:23, parID:85
         |vpiOpType:39
         |vpiOperand:
-        \_ref_obj: (work@vend.clock), id:86, line:28:18, endln:28:23, parID:85
+        \_ref_obj: (work@vend.clock), id:87, line:28:18, endln:28:23, parID:86
           |vpiName:clock
           |vpiFullName:work@vend.clock
           |vpiActual:
-          \_logic_net: (work@vend.clock), id:55, line:1:13, endln:1:18, parent:work@vend, parID:67
+          \_logic_net: (work@vend.clock), id:56, line:1:13, endln:1:18, parent:work@vend, parID:68
       |vpiStmt:
-      \_begin: (work@vend), id:87, line:29:1, endln:31:4, parID:84
+      \_begin: (work@vend), id:88, line:29:1, endln:31:4, parID:85
         |vpiFullName:work@vend
         |vpiStmt:
-        \_assign_stmt: , id:88, line:30:3, endln:30:37, parent:work@vend, parID:87
+        \_assign_stmt: , id:89, line:30:3, endln:30:37, parent:work@vend, parID:88
           |vpiRhs:
-          \_func_call: (fsm), id:89, line:30:22, endln:30:37, parID:88
+          \_func_call: (fsm), id:90, line:30:22, endln:30:37, parID:89
             |vpiArgument:
-            \_ref_obj: (work@vend.PRES_STATE), id:90, line:30:26, endln:30:36, parent:fsm, parID:89
+            \_ref_obj: (work@vend.PRES_STATE), id:91, line:30:26, endln:30:36, parent:fsm, parID:90
               |vpiName:PRES_STATE
               |vpiFullName:work@vend.PRES_STATE
               |vpiActual:
-              \_logic_net: (PRES_STATE), id:78
+              \_logic_net: (PRES_STATE), id:79
             |vpiName:fsm
             |vpiFunction:
-            \_function: (work@vend.fsm), id:0, line:10:1, endln:26:12, parent:work@vend, parID:59
+            \_function: (work@vend.fsm), id:0, line:10:1, endln:26:12, parent:work@vend, parID:60
           |vpiLhs:
-          \_ref_obj: (work@vend.newspaper), id:91, line:30:10, endln:30:19, parID:88
+          \_ref_obj: (work@vend.newspaper), id:92, line:30:10, endln:30:19, parID:89
             |vpiName:newspaper
             |vpiFullName:work@vend.newspaper
             |vpiActual:
-            \_logic_net: (work@vend.newspaper), id:54, line:5:6, endln:5:15, parent:work@vend, parID:67
+            \_logic_net: (work@vend.newspaper), id:55, line:5:6, endln:5:15, parent:work@vend, parID:68
     |vpiAlwaysType:1
 ===================
 [  FATAL] : 0

--- a/tests/FuncDef2/FuncDef2.log
+++ b/tests/FuncDef2/FuncDef2.log
@@ -14037,10 +14037,16 @@ design: (work@tnoc_vc_splitter)
     \_module: work@tnoc_vc_splitter (work@tnoc_vc_splitter) dut.sv:404:1: , endln:433:10
   |vpiNet:
   \_logic_net: (work@tnoc_vc_splitter.types), line:411:25, endln:411:30, parent:work@tnoc_vc_splitter
+    |vpiTypespec:
+    \_unsupported_typespec: (tnoc_types), line:411:3, endln:411:13
+      |vpiName:tnoc_types
     |vpiName:types
     |vpiFullName:work@tnoc_vc_splitter.types
   |vpiNet:
   \_logic_net: (work@tnoc_vc_splitter.receiver_if), line:412:25, endln:412:36, parent:work@tnoc_vc_splitter
+    |vpiTypespec:
+    \_unsupported_typespec: (tnoc_flit_if), line:412:3, endln:412:15
+      |vpiName:tnoc_flit_if
     |vpiName:receiver_if
     |vpiFullName:work@tnoc_vc_splitter.receiver_if
   |vpiArrayNet:
@@ -14072,6 +14078,9 @@ design: (work@tnoc_vc_splitter)
           |vpiConstType:7
     |vpiNet:
     \_logic_net: (work@tnoc_vc_splitter.sender_if), line:413:25, endln:413:34, parent:work@tnoc_vc_splitter.sender_if
+      |vpiTypespec:
+      \_unsupported_typespec: (tnoc_flit_if), line:413:3, endln:413:15
+        |vpiName:tnoc_flit_if
       |vpiFullName:work@tnoc_vc_splitter.sender_if
   |vpiTopModule:1
   |vpiPort:

--- a/tests/FuncNoArgs/FuncNoArgs.log
+++ b/tests/FuncNoArgs/FuncNoArgs.log
@@ -1363,23 +1363,25 @@ design: (work@my_opt_reduce_or)
     \_module: work@my_opt_reduce_or (work@my_opt_reduce_or) dut.sv:1:1: , endln:31:10
   |vpiNet:
   \_logic_net: (work@my_opt_reduce_or.tmp), line:28:37, endln:28:40, parent:work@my_opt_reduce_or
+    |vpiTypespec:
+    \_logic_typespec: , line:28:5, endln:28:8
+      |vpiRange:
+      \_range: , line:28:10, endln:28:35
+        |vpiLeftRange:
+        \_constant: , line:28:10, endln:28:31
+          |vpiDecompile:0
+          |vpiSize:64
+          |INT:0
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:28:34, endln:28:35
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:tmp
     |vpiFullName:work@my_opt_reduce_or.tmp
     |vpiNetType:48
-    |vpiRange:
-    \_range: , line:28:10, endln:28:35
-      |vpiLeftRange:
-      \_constant: , line:28:10, endln:28:31
-        |vpiDecompile:0
-        |vpiSize:64
-        |INT:0
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:28:34, endln:28:35
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
 ===================
 [  FATAL] : 0

--- a/tests/Gates/Gates.log
+++ b/tests/Gates/Gates.log
@@ -3490,6 +3490,8 @@ design: (work@gates)
           |vpiFullName:work@and_from_nand.X
           |vpiActual:
           \_logic_net: (work@and_from_nand.X), line:126:5, endln:126:6, parent:work@and_from_nand
+            |vpiTypespec:
+            \_logic_typespec: , line:126:1, endln:126:4
             |vpiName:X
             |vpiFullName:work@and_from_nand.X
             |vpiNetType:48
@@ -3499,6 +3501,8 @@ design: (work@gates)
           |vpiFullName:work@and_from_nand.Y
           |vpiActual:
           \_logic_net: (work@and_from_nand.Y), line:126:8, endln:126:9, parent:work@and_from_nand
+            |vpiTypespec:
+            \_logic_typespec: , line:126:1, endln:126:4
             |vpiName:Y
             |vpiFullName:work@and_from_nand.Y
             |vpiNetType:48
@@ -3508,6 +3512,8 @@ design: (work@gates)
           |vpiFullName:work@and_from_nand.F
           |vpiActual:
           \_logic_net: (work@and_from_nand.F), line:127:6, endln:127:7, parent:work@and_from_nand
+            |vpiTypespec:
+            \_logic_typespec: , line:127:1, endln:127:5
             |vpiName:F
             |vpiFullName:work@and_from_nand.F
             |vpiNetType:1
@@ -3673,6 +3679,8 @@ design: (work@gates)
           |vpiFullName:work@delay_example.b
           |vpiActual:
           \_logic_net: (work@delay_example.b), line:148:5, endln:148:6, parent:work@delay_example
+            |vpiTypespec:
+            \_logic_typespec: , line:148:1, endln:148:4
             |vpiName:b
             |vpiFullName:work@delay_example.b
             |vpiNetType:48
@@ -3682,6 +3690,8 @@ design: (work@gates)
           |vpiFullName:work@delay_example.c
           |vpiActual:
           \_logic_net: (work@delay_example.c), line:148:7, endln:148:8, parent:work@delay_example
+            |vpiTypespec:
+            \_logic_typespec: , line:148:1, endln:148:4
             |vpiName:c
             |vpiFullName:work@delay_example.c
             |vpiNetType:48
@@ -3691,6 +3701,8 @@ design: (work@gates)
           |vpiFullName:work@delay_example.out1
           |vpiActual:
           \_logic_net: (work@delay_example.out1), line:147:6, endln:147:10, parent:work@delay_example
+            |vpiTypespec:
+            \_logic_typespec: , line:147:1, endln:147:5
             |vpiName:out1
             |vpiFullName:work@delay_example.out1
             |vpiNetType:1
@@ -3700,6 +3712,8 @@ design: (work@gates)
           |vpiFullName:work@delay_example.out2
           |vpiActual:
           \_logic_net: (work@delay_example.out2), line:147:11, endln:147:15, parent:work@delay_example
+            |vpiTypespec:
+            \_logic_typespec: , line:147:1, endln:147:5
             |vpiName:out2
             |vpiFullName:work@delay_example.out2
             |vpiNetType:1
@@ -3709,6 +3723,8 @@ design: (work@gates)
           |vpiFullName:work@delay_example.out3
           |vpiActual:
           \_logic_net: (work@delay_example.out3), line:147:16, endln:147:20, parent:work@delay_example
+            |vpiTypespec:
+            \_logic_typespec: , line:147:1, endln:147:5
             |vpiName:out3
             |vpiFullName:work@delay_example.out3
             |vpiNetType:1
@@ -3718,6 +3734,8 @@ design: (work@gates)
           |vpiFullName:work@delay_example.out4
           |vpiActual:
           \_logic_net: (work@delay_example.out4), line:147:21, endln:147:25, parent:work@delay_example
+            |vpiTypespec:
+            \_logic_typespec: , line:147:1, endln:147:5
             |vpiName:out4
             |vpiFullName:work@delay_example.out4
             |vpiNetType:1
@@ -3727,6 +3745,8 @@ design: (work@gates)
           |vpiFullName:work@delay_example.out5
           |vpiActual:
           \_logic_net: (work@delay_example.out5), line:147:26, endln:147:30, parent:work@delay_example
+            |vpiTypespec:
+            \_logic_typespec: , line:147:1, endln:147:5
             |vpiName:out5
             |vpiFullName:work@delay_example.out5
             |vpiNetType:1
@@ -3736,6 +3756,8 @@ design: (work@gates)
           |vpiFullName:work@delay_example.out6
           |vpiActual:
           \_logic_net: (work@delay_example.out6), line:147:31, endln:147:35, parent:work@delay_example
+            |vpiTypespec:
+            \_logic_typespec: , line:147:1, endln:147:5
             |vpiName:out6
             |vpiFullName:work@delay_example.out6
             |vpiNetType:1
@@ -3878,6 +3900,8 @@ design: (work@gates)
           |vpiFullName:work@dff_from_nand.CLK
           |vpiActual:
           \_logic_net: (work@dff_from_nand.CLK), line:64:7, endln:64:10, parent:work@dff_from_nand
+            |vpiTypespec:
+            \_logic_typespec: , line:64:1, endln:64:4
             |vpiName:CLK
             |vpiFullName:work@dff_from_nand.CLK
             |vpiNetType:48
@@ -3887,6 +3911,8 @@ design: (work@gates)
           |vpiFullName:work@dff_from_nand.D
           |vpiActual:
           \_logic_net: (work@dff_from_nand.D), line:64:5, endln:64:6, parent:work@dff_from_nand
+            |vpiTypespec:
+            \_logic_typespec: , line:64:1, endln:64:4
             |vpiName:D
             |vpiFullName:work@dff_from_nand.D
             |vpiNetType:48
@@ -3896,6 +3922,8 @@ design: (work@gates)
           |vpiFullName:work@dff_from_nand.Q
           |vpiActual:
           \_logic_net: (work@dff_from_nand.Q), line:63:6, endln:63:7, parent:work@dff_from_nand
+            |vpiTypespec:
+            \_logic_typespec: , line:63:1, endln:63:5
             |vpiName:Q
             |vpiFullName:work@dff_from_nand.Q
             |vpiNetType:1
@@ -3905,6 +3933,8 @@ design: (work@gates)
           |vpiFullName:work@dff_from_nand.Q_BAR
           |vpiActual:
           \_logic_net: (work@dff_from_nand.Q_BAR), line:63:8, endln:63:13, parent:work@dff_from_nand
+            |vpiTypespec:
+            \_logic_typespec: , line:63:1, endln:63:5
             |vpiName:Q_BAR
             |vpiFullName:work@dff_from_nand.Q_BAR
             |vpiNetType:1
@@ -4087,6 +4117,8 @@ design: (work@gates)
           |vpiFullName:work@gates.in1
           |vpiActual:
           \_logic_net: (work@gates.in1), line:6:6, endln:6:9, parent:work@gates
+            |vpiTypespec:
+            \_logic_typespec: , line:6:1, endln:6:4
             |vpiName:in1
             |vpiFullName:work@gates.in1
             |vpiNetType:48
@@ -4096,6 +4128,8 @@ design: (work@gates)
           |vpiFullName:work@gates.in2
           |vpiActual:
           \_logic_net: (work@gates.in2), line:6:10, endln:6:13, parent:work@gates
+            |vpiTypespec:
+            \_logic_typespec: , line:6:1, endln:6:4
             |vpiName:in2
             |vpiFullName:work@gates.in2
             |vpiNetType:48
@@ -4105,6 +4139,8 @@ design: (work@gates)
           |vpiFullName:work@gates.in3
           |vpiActual:
           \_logic_net: (work@gates.in3), line:6:14, endln:6:17, parent:work@gates
+            |vpiTypespec:
+            \_logic_typespec: , line:6:1, endln:6:4
             |vpiName:in3
             |vpiFullName:work@gates.in3
             |vpiNetType:48
@@ -4114,6 +4150,8 @@ design: (work@gates)
           |vpiFullName:work@gates.in4
           |vpiActual:
           \_logic_net: (work@gates.in4), line:6:18, endln:6:21, parent:work@gates
+            |vpiTypespec:
+            \_logic_typespec: , line:6:1, endln:6:4
             |vpiName:in4
             |vpiFullName:work@gates.in4
             |vpiNetType:48
@@ -4123,6 +4161,8 @@ design: (work@gates)
           |vpiFullName:work@gates.out0
           |vpiActual:
           \_logic_net: (work@gates.out0), line:3:6, endln:3:10, parent:work@gates
+            |vpiTypespec:
+            \_logic_typespec: , line:3:1, endln:3:5
             |vpiName:out0
             |vpiFullName:work@gates.out0
             |vpiNetType:1
@@ -4132,6 +4172,8 @@ design: (work@gates)
           |vpiFullName:work@gates.out1
           |vpiActual:
           \_logic_net: (work@gates.out1), line:4:6, endln:4:10, parent:work@gates
+            |vpiTypespec:
+            \_logic_typespec: , line:4:1, endln:4:5
             |vpiName:out1
             |vpiFullName:work@gates.out1
             |vpiNetType:1
@@ -4141,6 +4183,8 @@ design: (work@gates)
           |vpiFullName:work@gates.out2
           |vpiActual:
           \_logic_net: (work@gates.out2), line:5:6, endln:5:10, parent:work@gates
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:5
             |vpiName:out2
             |vpiFullName:work@gates.out2
             |vpiNetType:1
@@ -4403,6 +4447,8 @@ design: (work@gates)
           |vpiFullName:work@mux_from_gates.c0
           |vpiActual:
           \_logic_net: (work@mux_from_gates.c0), line:86:5, endln:86:7, parent:work@mux_from_gates
+            |vpiTypespec:
+            \_logic_typespec: , line:86:1, endln:86:4
             |vpiName:c0
             |vpiFullName:work@mux_from_gates.c0
             |vpiNetType:48
@@ -4412,6 +4458,8 @@ design: (work@gates)
           |vpiFullName:work@mux_from_gates.c1
           |vpiActual:
           \_logic_net: (work@mux_from_gates.c1), line:86:8, endln:86:10, parent:work@mux_from_gates
+            |vpiTypespec:
+            \_logic_typespec: , line:86:1, endln:86:4
             |vpiName:c1
             |vpiFullName:work@mux_from_gates.c1
             |vpiNetType:48
@@ -4421,6 +4469,8 @@ design: (work@gates)
           |vpiFullName:work@mux_from_gates.c2
           |vpiActual:
           \_logic_net: (work@mux_from_gates.c2), line:86:11, endln:86:13, parent:work@mux_from_gates
+            |vpiTypespec:
+            \_logic_typespec: , line:86:1, endln:86:4
             |vpiName:c2
             |vpiFullName:work@mux_from_gates.c2
             |vpiNetType:48
@@ -4430,6 +4480,8 @@ design: (work@gates)
           |vpiFullName:work@mux_from_gates.c3
           |vpiActual:
           \_logic_net: (work@mux_from_gates.c3), line:86:14, endln:86:16, parent:work@mux_from_gates
+            |vpiTypespec:
+            \_logic_typespec: , line:86:1, endln:86:4
             |vpiName:c3
             |vpiFullName:work@mux_from_gates.c3
             |vpiNetType:48
@@ -4439,6 +4491,8 @@ design: (work@gates)
           |vpiFullName:work@mux_from_gates.A
           |vpiActual:
           \_logic_net: (work@mux_from_gates.A), line:86:17, endln:86:18, parent:work@mux_from_gates
+            |vpiTypespec:
+            \_logic_typespec: , line:86:1, endln:86:4
             |vpiName:A
             |vpiFullName:work@mux_from_gates.A
             |vpiNetType:48
@@ -4448,6 +4502,8 @@ design: (work@gates)
           |vpiFullName:work@mux_from_gates.B
           |vpiActual:
           \_logic_net: (work@mux_from_gates.B), line:86:19, endln:86:20, parent:work@mux_from_gates
+            |vpiTypespec:
+            \_logic_typespec: , line:86:1, endln:86:4
             |vpiName:B
             |vpiFullName:work@mux_from_gates.B
             |vpiNetType:48
@@ -4457,6 +4513,8 @@ design: (work@gates)
           |vpiFullName:work@mux_from_gates.Y
           |vpiActual:
           \_logic_net: (work@mux_from_gates.Y), line:87:6, endln:87:7, parent:work@mux_from_gates
+            |vpiTypespec:
+            \_logic_typespec: , line:87:1, endln:87:5
             |vpiName:Y
             |vpiFullName:work@mux_from_gates.Y
             |vpiNetType:1
@@ -4778,6 +4836,8 @@ design: (work@gates)
           |vpiFullName:work@n_in_primitive.in1
           |vpiActual:
           \_logic_net: (work@n_in_primitive.in1), line:181:5, endln:181:8, parent:work@n_in_primitive
+            |vpiTypespec:
+            \_logic_typespec: , line:181:1, endln:181:4
             |vpiName:in1
             |vpiFullName:work@n_in_primitive.in1
             |vpiNetType:48
@@ -4787,6 +4847,8 @@ design: (work@gates)
           |vpiFullName:work@n_in_primitive.in2
           |vpiActual:
           \_logic_net: (work@n_in_primitive.in2), line:181:9, endln:181:12, parent:work@n_in_primitive
+            |vpiTypespec:
+            \_logic_typespec: , line:181:1, endln:181:4
             |vpiName:in2
             |vpiFullName:work@n_in_primitive.in2
             |vpiNetType:48
@@ -4796,6 +4858,8 @@ design: (work@gates)
           |vpiFullName:work@n_in_primitive.in3
           |vpiActual:
           \_logic_net: (work@n_in_primitive.in3), line:181:13, endln:181:16, parent:work@n_in_primitive
+            |vpiTypespec:
+            \_logic_typespec: , line:181:1, endln:181:4
             |vpiName:in3
             |vpiFullName:work@n_in_primitive.in3
             |vpiNetType:48
@@ -4805,6 +4869,8 @@ design: (work@gates)
           |vpiFullName:work@n_in_primitive.in4
           |vpiActual:
           \_logic_net: (work@n_in_primitive.in4), line:181:17, endln:181:20, parent:work@n_in_primitive
+            |vpiTypespec:
+            \_logic_typespec: , line:181:1, endln:181:4
             |vpiName:in4
             |vpiFullName:work@n_in_primitive.in4
             |vpiNetType:48
@@ -4814,6 +4880,8 @@ design: (work@gates)
           |vpiFullName:work@n_in_primitive.out1
           |vpiActual:
           \_logic_net: (work@n_in_primitive.out1), line:180:6, endln:180:10, parent:work@n_in_primitive
+            |vpiTypespec:
+            \_logic_typespec: , line:180:1, endln:180:5
             |vpiName:out1
             |vpiFullName:work@n_in_primitive.out1
             |vpiNetType:1
@@ -4823,6 +4891,8 @@ design: (work@gates)
           |vpiFullName:work@n_in_primitive.out2
           |vpiActual:
           \_logic_net: (work@n_in_primitive.out2), line:180:11, endln:180:15, parent:work@n_in_primitive
+            |vpiTypespec:
+            \_logic_typespec: , line:180:1, endln:180:5
             |vpiName:out2
             |vpiFullName:work@n_in_primitive.out2
             |vpiNetType:1
@@ -4832,6 +4902,8 @@ design: (work@gates)
           |vpiFullName:work@n_in_primitive.out3
           |vpiActual:
           \_logic_net: (work@n_in_primitive.out3), line:180:16, endln:180:20, parent:work@n_in_primitive
+            |vpiTypespec:
+            \_logic_typespec: , line:180:1, endln:180:5
             |vpiName:out3
             |vpiFullName:work@n_in_primitive.out3
             |vpiNetType:1
@@ -5116,6 +5188,8 @@ design: (work@gates)
           |vpiFullName:work@transmission_gates.in
           |vpiActual:
           \_logic_net: (work@transmission_gates.in), line:31:22, endln:31:24, parent:work@transmission_gates
+            |vpiTypespec:
+            \_logic_typespec: , line:31:1, endln:31:4
             |vpiName:in
             |vpiFullName:work@transmission_gates.in
             |vpiNetType:48
@@ -5125,6 +5199,8 @@ design: (work@gates)
           |vpiFullName:work@transmission_gates.data_enable_low
           |vpiActual:
           \_logic_net: (work@transmission_gates.data_enable_low), line:31:5, endln:31:20, parent:work@transmission_gates
+            |vpiTypespec:
+            \_logic_typespec: , line:31:1, endln:31:4
             |vpiName:data_enable_low
             |vpiFullName:work@transmission_gates.data_enable_low
             |vpiNetType:48
@@ -5134,6 +5210,8 @@ design: (work@gates)
           |vpiFullName:work@transmission_gates.out1
           |vpiActual:
           \_logic_net: (work@transmission_gates.out1), line:32:16, endln:32:20, parent:work@transmission_gates
+            |vpiTypespec:
+            \_logic_typespec: , line:32:1, endln:32:5
             |vpiName:out1
             |vpiFullName:work@transmission_gates.out1
             |vpiNetType:1
@@ -5143,6 +5221,8 @@ design: (work@gates)
           |vpiFullName:work@transmission_gates.out2
           |vpiActual:
           \_logic_net: (work@transmission_gates.out2), line:32:22, endln:32:26, parent:work@transmission_gates
+            |vpiTypespec:
+            \_logic_typespec: , line:32:1, endln:32:5
             |vpiName:out2
             |vpiFullName:work@transmission_gates.out2
             |vpiNetType:1
@@ -5152,6 +5232,8 @@ design: (work@gates)
           |vpiFullName:work@transmission_gates.data_bus
           |vpiActual:
           \_logic_net: (work@transmission_gates.data_bus), line:32:6, endln:32:14, parent:work@transmission_gates
+            |vpiTypespec:
+            \_logic_typespec: , line:32:1, endln:32:5
             |vpiName:data_bus
             |vpiFullName:work@transmission_gates.data_bus
             |vpiNetType:1
@@ -5770,31 +5852,43 @@ design: (work@gates)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@switch_primitives.net1), line:54:7, endln:54:11, parent:work@switch_primitives
+    |vpiTypespec:
+    \_logic_typespec: , line:54:1, endln:54:5
     |vpiName:net1
     |vpiFullName:work@switch_primitives.net1
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@switch_primitives.net2), line:54:13, endln:54:17, parent:work@switch_primitives
+    |vpiTypespec:
+    \_logic_typespec: , line:54:1, endln:54:5
     |vpiName:net2
     |vpiFullName:work@switch_primitives.net2
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@switch_primitives.net3), line:54:19, endln:54:23, parent:work@switch_primitives
+    |vpiTypespec:
+    \_logic_typespec: , line:54:1, endln:54:5
     |vpiName:net3
     |vpiFullName:work@switch_primitives.net3
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@switch_primitives.net4), line:55:7, endln:55:11, parent:work@switch_primitives
+    |vpiTypespec:
+    \_logic_typespec: , line:55:1, endln:55:5
     |vpiName:net4
     |vpiFullName:work@switch_primitives.net4
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@switch_primitives.net5), line:55:13, endln:55:17, parent:work@switch_primitives
+    |vpiTypespec:
+    \_logic_typespec: , line:55:1, endln:55:5
     |vpiName:net5
     |vpiFullName:work@switch_primitives.net5
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@switch_primitives.net6), line:55:19, endln:55:23, parent:work@switch_primitives
+    |vpiTypespec:
+    \_logic_typespec: , line:55:1, endln:55:5
     |vpiName:net6
     |vpiFullName:work@switch_primitives.net6
     |vpiNetType:1
@@ -6768,6 +6862,8 @@ design: (work@gates)
   \_logic_net: (work@and_from_nand.F), line:127:6, endln:127:7, parent:work@and_from_nand
   |vpiNet:
   \_logic_net: (work@and_from_nand.W), line:127:9, endln:127:10, parent:work@and_from_nand
+    |vpiTypespec:
+    \_logic_typespec: , line:127:1, endln:127:5
     |vpiName:W
     |vpiFullName:work@and_from_nand.W
     |vpiNetType:1
@@ -7819,46 +7915,64 @@ design: (work@gates)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@n_out_primitive.out), line:210:6, endln:210:9, parent:work@n_out_primitive
+    |vpiTypespec:
+    \_logic_typespec: , line:210:1, endln:210:5
     |vpiName:out
     |vpiFullName:work@n_out_primitive.out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@n_out_primitive.out_0), line:210:10, endln:210:15, parent:work@n_out_primitive
+    |vpiTypespec:
+    \_logic_typespec: , line:210:1, endln:210:5
     |vpiName:out_0
     |vpiFullName:work@n_out_primitive.out_0
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@n_out_primitive.out_1), line:210:16, endln:210:21, parent:work@n_out_primitive
+    |vpiTypespec:
+    \_logic_typespec: , line:210:1, endln:210:5
     |vpiName:out_1
     |vpiFullName:work@n_out_primitive.out_1
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@n_out_primitive.out_2), line:210:22, endln:210:27, parent:work@n_out_primitive
+    |vpiTypespec:
+    \_logic_typespec: , line:210:1, endln:210:5
     |vpiName:out_2
     |vpiFullName:work@n_out_primitive.out_2
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@n_out_primitive.out_3), line:210:28, endln:210:33, parent:work@n_out_primitive
+    |vpiTypespec:
+    \_logic_typespec: , line:210:1, endln:210:5
     |vpiName:out_3
     |vpiFullName:work@n_out_primitive.out_3
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@n_out_primitive.out_a), line:210:34, endln:210:39, parent:work@n_out_primitive
+    |vpiTypespec:
+    \_logic_typespec: , line:210:1, endln:210:5
     |vpiName:out_a
     |vpiFullName:work@n_out_primitive.out_a
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@n_out_primitive.out_b), line:210:40, endln:210:45, parent:work@n_out_primitive
+    |vpiTypespec:
+    \_logic_typespec: , line:210:1, endln:210:5
     |vpiName:out_b
     |vpiFullName:work@n_out_primitive.out_b
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@n_out_primitive.out_c), line:210:46, endln:210:51, parent:work@n_out_primitive
+    |vpiTypespec:
+    \_logic_typespec: , line:210:1, endln:210:5
     |vpiName:out_c
     |vpiFullName:work@n_out_primitive.out_c
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@n_out_primitive.in), line:211:6, endln:211:8, parent:work@n_out_primitive
+    |vpiTypespec:
+    \_logic_typespec: , line:211:1, endln:211:5
     |vpiName:in
     |vpiFullName:work@n_out_primitive.in
     |vpiNetType:1
@@ -7995,11 +8109,15 @@ design: (work@gates)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@half_adder.Sum), line:222:19, endln:222:22, parent:work@half_adder
+    |vpiTypespec:
+    \_logic_typespec: , line:224:9, endln:224:13
     |vpiName:Sum
     |vpiFullName:work@half_adder.Sum
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@half_adder.Carry), line:222:24, endln:222:29, parent:work@half_adder
+    |vpiTypespec:
+    \_logic_typespec: , line:224:9, endln:224:13
     |vpiName:Carry
     |vpiFullName:work@half_adder.Carry
     |vpiNetType:1
@@ -8022,6 +8140,8 @@ design: (work@gates)
       |vpiFullName:work@half_adder.Sum
       |vpiActual:
       \_logic_net: (work@half_adder.Sum), line:222:19, endln:222:22, parent:work@half_adder
+    |vpiTypedef:
+    \_logic_typespec: , line:224:9, endln:224:13
     |vpiInstance:
     \_module: work@half_adder (work@half_adder) dut.sv:222:1: , endln:227:10
   |vpiPort:
@@ -8034,6 +8154,8 @@ design: (work@gates)
       |vpiFullName:work@half_adder.Carry
       |vpiActual:
       \_logic_net: (work@half_adder.Carry), line:222:24, endln:222:29, parent:work@half_adder
+    |vpiTypedef:
+    \_logic_typespec: , line:224:9, endln:224:13
     |vpiInstance:
     \_module: work@half_adder (work@half_adder) dut.sv:222:1: , endln:227:10
   |vpiPort:
@@ -8147,61 +8269,39 @@ design: (work@gates)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@gate_array.out), line:232:12, endln:232:15, parent:work@gate_array
+    |vpiTypespec:
+    \_logic_typespec: , line:232:1, endln:232:5
+      |vpiRange:
+      \_range: , line:232:7, endln:232:10
+        |vpiLeftRange:
+        \_constant: , line:232:7, endln:232:8
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:232:9, endln:232:10
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:out
     |vpiFullName:work@gate_array.out
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:232:7, endln:232:10
-      |vpiLeftRange:
-      \_constant: , line:232:7, endln:232:8
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:232:9, endln:232:10
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@gate_array.in1), line:232:17, endln:232:20, parent:work@gate_array
+    |vpiTypespec:
+    \_logic_typespec: , line:232:1, endln:232:5
     |vpiName:in1
     |vpiFullName:work@gate_array.in1
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:232:7, endln:232:10
-      |vpiLeftRange:
-      \_constant: , line:232:7, endln:232:8
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:232:9, endln:232:10
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@gate_array.in2), line:232:22, endln:232:25, parent:work@gate_array
+    |vpiTypespec:
+    \_logic_typespec: , line:232:1, endln:232:5
     |vpiName:in2
     |vpiFullName:work@gate_array.in2
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:232:7, endln:232:10
-      |vpiLeftRange:
-      \_constant: , line:232:7, endln:232:8
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:232:9, endln:232:10
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPrimitiveArray:
   \_gate_array: (work@gate_array.n_gate), line:233:1, endln:233:36

--- a/tests/GenNet/GenNet.log
+++ b/tests/GenNet/GenNet.log
@@ -391,22 +391,24 @@ design: (work@dut)
     |vpiDefLineNo:1
     |vpiNet:
     \_logic_net: (work@dut.m1.q), line:5:18, endln:5:19, parent:work@dut.m1
+      |vpiTypespec:
+      \_logic_typespec: , line:5:9, endln:5:17
+        |vpiRange:
+        \_range: , line:5:10, endln:5:16
+          |vpiLeftRange:
+          \_constant: , line:5:10, endln:5:12
+            |vpiDecompile:31
+            |vpiSize:64
+            |INT:31
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:5:15, endln:5:16
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:q
       |vpiFullName:work@dut.m1.q
-      |vpiRange:
-      \_range: , line:5:10, endln:5:16
-        |vpiLeftRange:
-        \_constant: , line:5:10, endln:5:12
-          |vpiDecompile:31
-          |vpiSize:64
-          |INT:31
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:5:15, endln:5:16
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:17:1: , endln:23:10
     |vpiPort:
@@ -419,6 +421,22 @@ design: (work@dut)
         |vpiFullName:work@dut.m1.q
         |vpiActual:
         \_logic_net: (work@dut.m1.q), line:5:18, endln:5:19, parent:work@dut.m1
+      |vpiTypedef:
+      \_logic_typespec: , line:5:9, endln:5:17
+        |vpiRange:
+        \_range: , line:5:10, endln:5:16, parent:q
+          |vpiLeftRange:
+          \_constant: , line:5:10, endln:5:12
+            |vpiDecompile:31
+            |vpiSize:64
+            |INT:31
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:5:15, endln:5:16
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@prim_subreg_arb (work@dut.m1) dut.sv:19:2: , endln:22:9, parent:work@dut
     |vpiGenScopeArray:

--- a/tests/GenScopeFullName/GenScopeFullName.log
+++ b/tests/GenScopeFullName/GenScopeFullName.log
@@ -229,6 +229,8 @@ design: (work@dut)
         |vpiDefLineNo:12
         |vpiNet:
         \_logic_net: (work@dut.gen_modules[0].module_in_genscope.b), line:12:33, endln:12:34, parent:work@dut.gen_modules[0].module_in_genscope
+          |vpiTypespec:
+          \_logic_typespec: , line:12:27, endln:12:32
           |vpiName:b
           |vpiFullName:work@dut.gen_modules[0].module_in_genscope.b
           |vpiNetType:36
@@ -256,6 +258,8 @@ design: (work@dut)
             |vpiFullName:work@dut.gen_modules[0].module_in_genscope.b
             |vpiActual:
             \_logic_net: (work@dut.gen_modules[0].module_in_genscope.b), line:12:33, endln:12:34, parent:work@dut.gen_modules[0].module_in_genscope
+          |vpiTypedef:
+          \_logic_typespec: , line:12:27, endln:12:32
           |vpiInstance:
           \_module: work@ibex_counter (work@dut.gen_modules[0].module_in_genscope) dut.sv:5:7: , endln:5:49, parent:work@dut.gen_modules[0]
 ===================

--- a/tests/GenScopeHierPath/GenScopeHierPath.log
+++ b/tests/GenScopeHierPath/GenScopeHierPath.log
@@ -1304,6 +1304,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:44:23, endln:44:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:44:19, endln:44:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:44:1: , endln:53:10
   |vpiGenScopeArray:
@@ -1414,6 +1417,9 @@ design: (work@top)
             |vpiFullName:work@top.gen_dio_attr[0].u_prim_pad_attr.b
             |vpiActual:
             \_int_var: (work@top.gen_dio_attr[0].u_prim_pad_attr.b), line:32:33, endln:32:34, parent:work@top.gen_dio_attr[0].u_prim_pad_attr
+          |vpiTypedef:
+          \_int_typespec: , line:32:29, endln:32:32
+            |vpiSigned:1
           |vpiInstance:
           \_module: work@prim_pad_attr (work@top.gen_dio_attr[0].u_prim_pad_attr) dut.sv:49:6: , endln:51:31, parent:work@top.gen_dio_attr[0]
         |vpiGenScopeArray:
@@ -1516,6 +1522,9 @@ design: (work@top)
                   |vpiFullName:work@top.gen_dio_attr[0].u_prim_pad_attr.gen_generic.u_impl_generic.a
                   |vpiActual:
                   \_int_var: (work@top.gen_dio_attr[0].u_prim_pad_attr.gen_generic.u_impl_generic.a), line:23:41, endln:23:42, parent:work@top.gen_dio_attr[0].u_prim_pad_attr.gen_generic.u_impl_generic
+                |vpiTypedef:
+                \_int_typespec: , line:23:37, endln:23:40
+                  |vpiSigned:1
                 |vpiInstance:
                 \_module: work@prim_generic_pad_attr (work@top.gen_dio_attr[0].u_prim_pad_attr.gen_generic.u_impl_generic) dut.sv:37:7: , endln:39:31, parent:work@top.gen_dio_attr[0].u_prim_pad_attr.gen_generic
               |vpiGenScopeArray:
@@ -1647,6 +1656,9 @@ design: (work@top)
             |vpiFullName:work@top.gen_dio_attr[1].u_prim_pad_attr.b
             |vpiActual:
             \_int_var: (work@top.gen_dio_attr[1].u_prim_pad_attr.b), line:32:33, endln:32:34, parent:work@top.gen_dio_attr[1].u_prim_pad_attr
+          |vpiTypedef:
+          \_int_typespec: , line:32:29, endln:32:32
+            |vpiSigned:1
           |vpiInstance:
           \_module: work@prim_pad_attr (work@top.gen_dio_attr[1].u_prim_pad_attr) dut.sv:49:6: , endln:51:31, parent:work@top.gen_dio_attr[1]
         |vpiGenScopeArray:
@@ -1749,6 +1761,9 @@ design: (work@top)
                   |vpiFullName:work@top.gen_dio_attr[1].u_prim_pad_attr.gen_generic.u_impl_generic.a
                   |vpiActual:
                   \_int_var: (work@top.gen_dio_attr[1].u_prim_pad_attr.gen_generic.u_impl_generic.a), line:23:41, endln:23:42, parent:work@top.gen_dio_attr[1].u_prim_pad_attr.gen_generic.u_impl_generic
+                |vpiTypedef:
+                \_int_typespec: , line:23:37, endln:23:40
+                  |vpiSigned:1
                 |vpiInstance:
                 \_module: work@prim_generic_pad_attr (work@top.gen_dio_attr[1].u_prim_pad_attr.gen_generic.u_impl_generic) dut.sv:37:7: , endln:39:31, parent:work@top.gen_dio_attr[1].u_prim_pad_attr.gen_generic
               |vpiGenScopeArray:
@@ -1880,6 +1895,9 @@ design: (work@top)
             |vpiFullName:work@top.gen_dio_attr[2].u_prim_pad_attr.b
             |vpiActual:
             \_int_var: (work@top.gen_dio_attr[2].u_prim_pad_attr.b), line:32:33, endln:32:34, parent:work@top.gen_dio_attr[2].u_prim_pad_attr
+          |vpiTypedef:
+          \_int_typespec: , line:32:29, endln:32:32
+            |vpiSigned:1
           |vpiInstance:
           \_module: work@prim_pad_attr (work@top.gen_dio_attr[2].u_prim_pad_attr) dut.sv:49:6: , endln:51:31, parent:work@top.gen_dio_attr[2]
         |vpiGenScopeArray:
@@ -1982,6 +2000,9 @@ design: (work@top)
                   |vpiFullName:work@top.gen_dio_attr[2].u_prim_pad_attr.gen_generic.u_impl_generic.a
                   |vpiActual:
                   \_int_var: (work@top.gen_dio_attr[2].u_prim_pad_attr.gen_generic.u_impl_generic.a), line:23:41, endln:23:42, parent:work@top.gen_dio_attr[2].u_prim_pad_attr.gen_generic.u_impl_generic
+                |vpiTypedef:
+                \_int_typespec: , line:23:37, endln:23:40
+                  |vpiSigned:1
                 |vpiInstance:
                 \_module: work@prim_generic_pad_attr (work@top.gen_dio_attr[2].u_prim_pad_attr.gen_generic.u_impl_generic) dut.sv:37:7: , endln:39:31, parent:work@top.gen_dio_attr[2].u_prim_pad_attr.gen_generic
               |vpiGenScopeArray:
@@ -2113,6 +2134,9 @@ design: (work@top)
             |vpiFullName:work@top.gen_dio_attr[3].u_prim_pad_attr.b
             |vpiActual:
             \_int_var: (work@top.gen_dio_attr[3].u_prim_pad_attr.b), line:32:33, endln:32:34, parent:work@top.gen_dio_attr[3].u_prim_pad_attr
+          |vpiTypedef:
+          \_int_typespec: , line:32:29, endln:32:32
+            |vpiSigned:1
           |vpiInstance:
           \_module: work@prim_pad_attr (work@top.gen_dio_attr[3].u_prim_pad_attr) dut.sv:49:6: , endln:51:31, parent:work@top.gen_dio_attr[3]
         |vpiGenScopeArray:
@@ -2215,6 +2239,9 @@ design: (work@top)
                   |vpiFullName:work@top.gen_dio_attr[3].u_prim_pad_attr.gen_generic.u_impl_generic.a
                   |vpiActual:
                   \_int_var: (work@top.gen_dio_attr[3].u_prim_pad_attr.gen_generic.u_impl_generic.a), line:23:41, endln:23:42, parent:work@top.gen_dio_attr[3].u_prim_pad_attr.gen_generic.u_impl_generic
+                |vpiTypedef:
+                \_int_typespec: , line:23:37, endln:23:40
+                  |vpiSigned:1
                 |vpiInstance:
                 \_module: work@prim_generic_pad_attr (work@top.gen_dio_attr[3].u_prim_pad_attr.gen_generic.u_impl_generic) dut.sv:37:7: , endln:39:31, parent:work@top.gen_dio_attr[3].u_prim_pad_attr.gen_generic
               |vpiGenScopeArray:

--- a/tests/GenerateBlock/GenerateBlock.log
+++ b/tests/GenerateBlock/GenerateBlock.log
@@ -247,23 +247,25 @@ design: (work@gen_test9)
       |vpiFullName:work@gen_test9.x
       |vpiActual:
       \_logic_net: (work@gen_test9.x), line:5:36, endln:5:37, parent:work@gen_test9
+        |vpiTypespec:
+        \_logic_typespec: , line:5:25, endln:5:29
+          |vpiRange:
+          \_range: , line:5:31, endln:5:34
+            |vpiLeftRange:
+            \_constant: , line:5:31, endln:5:32
+              |vpiDecompile:1
+              |vpiSize:64
+              |UINT:1
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:5:33, endln:5:34
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:x
         |vpiFullName:work@gen_test9.x
         |vpiNetType:1
-        |vpiRange:
-        \_range: , line:5:31, endln:5:34
-          |vpiLeftRange:
-          \_constant: , line:5:31, endln:5:32
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:5:33, endln:5:34
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@gen_test9 (work@gen_test9) dut.sv:1:1: , endln:15:10
   |vpiName:work@gen_test9
@@ -271,63 +273,69 @@ design: (work@gen_test9)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@gen_test9.w), line:2:20, endln:2:21, parent:work@gen_test9
+    |vpiTypespec:
+    \_logic_typespec: , line:2:9, endln:2:13
+      |vpiRange:
+      \_range: , line:2:15, endln:2:18
+        |vpiLeftRange:
+        \_constant: , line:2:15, endln:2:16
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:2:17, endln:2:18
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:w
     |vpiFullName:work@gen_test9.w
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:2:15, endln:2:18
-      |vpiLeftRange:
-      \_constant: , line:2:15, endln:2:16
-        |vpiDecompile:1
-        |vpiSize:64
-        |UINT:1
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:2:17, endln:2:18
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@gen_test9.x), line:5:36, endln:5:37, parent:work@gen_test9
   |vpiNet:
   \_logic_net: (work@gen_test9.y), line:7:44, endln:7:45, parent:work@gen_test9
+    |vpiTypespec:
+    \_logic_typespec: , line:7:33, endln:7:37
+      |vpiRange:
+      \_range: , line:7:39, endln:7:42
+        |vpiLeftRange:
+        \_constant: , line:7:39, endln:7:40
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:7:41, endln:7:42
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:y
     |vpiFullName:work@gen_test9.y
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:7:39, endln:7:42
-      |vpiLeftRange:
-      \_constant: , line:7:39, endln:7:40
-        |vpiDecompile:1
-        |vpiSize:64
-        |UINT:1
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:7:41, endln:7:42
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@gen_test9.z), line:10:44, endln:10:45, parent:work@gen_test9
+    |vpiTypespec:
+    \_logic_typespec: , line:10:33, endln:10:37
+      |vpiRange:
+      \_range: , line:10:39, endln:10:42
+        |vpiLeftRange:
+        \_constant: , line:10:39, endln:10:40
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:10:41, endln:10:42
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:z
     |vpiFullName:work@gen_test9.z
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:10:39, endln:10:42
-      |vpiLeftRange:
-      \_constant: , line:10:39, endln:10:40
-        |vpiDecompile:1
-        |vpiSize:64
-        |UINT:1
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:10:41, endln:10:42
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiContAssign:
   \_cont_assign: , line:2:20, endln:2:21, parent:work@gen_test9

--- a/tests/GenerateInterface/GenerateInterface.log
+++ b/tests/GenerateInterface/GenerateInterface.log
@@ -1440,22 +1440,24 @@ design: (work@top)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top2.pins), line:34:61, endln:34:65, parent:work@top2
+    |vpiTypespec:
+    \_logic_typespec: , line:34:49, endln:34:60
+      |vpiRange:
+      \_range: , line:34:50, endln:34:59
+        |vpiLeftRange:
+        \_constant: , line:34:50, endln:34:55
+          |vpiDecompile:1
+          |vpiSize:64
+          |INT:1
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:34:58, endln:34:59
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:pins
     |vpiFullName:work@top2.pins
-    |vpiRange:
-    \_range: , line:34:50, endln:34:59
-      |vpiLeftRange:
-      \_constant: , line:34:50, endln:34:55
-        |vpiDecompile:1
-        |vpiSize:64
-        |INT:1
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:34:58, endln:34:59
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (pins), line:34:61, endln:34:65, parent:work@top2
@@ -1467,6 +1469,22 @@ design: (work@top)
       |vpiFullName:work@top2.pins
       |vpiActual:
       \_logic_net: (work@top2.pins), line:34:61, endln:34:65, parent:work@top2
+    |vpiTypedef:
+    \_logic_typespec: , line:34:49, endln:34:60
+      |vpiRange:
+      \_range: , line:34:50, endln:34:59, parent:pins
+        |vpiLeftRange:
+        \_constant: , line:34:50, endln:34:55
+          |vpiDecompile:1
+          |vpiSize:64
+          |INT:1
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:34:58, endln:34:59
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiInterface:
   \_interface: work@pins_if (work@top2.intf) top.sv:35:1: , endln:35:39, parent:work@top2
     |vpiName:intf
@@ -1533,22 +1551,24 @@ design: (work@top)
     |vpiDefLineNo:22
     |vpiNet:
     \_logic_net: (work@top2.intf.pins), line:23:21, endln:23:25, parent:work@top2.intf
+      |vpiTypespec:
+      \_logic_typespec: , line:23:9, endln:23:20
+        |vpiRange:
+        \_range: , line:23:10, endln:23:19
+          |vpiLeftRange:
+          \_constant: , line:23:10, endln:23:15
+            |vpiDecompile:1
+            |vpiSize:64
+            |INT:1
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:23:18, endln:23:19
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:pins
       |vpiFullName:work@top2.intf.pins
-      |vpiRange:
-      \_range: , line:23:10, endln:23:19
-        |vpiLeftRange:
-        \_constant: , line:23:10, endln:23:15
-          |vpiDecompile:1
-          |vpiSize:64
-          |INT:1
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:23:18, endln:23:19
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiInstance:
     \_module: work@top2 (work@top2) top.sv:34:1: , endln:43:10
     |vpiPort:
@@ -1567,6 +1587,22 @@ design: (work@top)
         |vpiFullName:work@top2.intf.pins
         |vpiActual:
         \_logic_net: (work@top2.intf.pins), line:23:21, endln:23:25, parent:work@top2.intf
+      |vpiTypedef:
+      \_logic_typespec: , line:23:9, endln:23:20
+        |vpiRange:
+        \_range: , line:23:10, endln:23:19, parent:pins
+          |vpiLeftRange:
+          \_constant: , line:23:10, endln:23:15
+            |vpiDecompile:1
+            |vpiSize:64
+            |INT:1
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:23:18, endln:23:19
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
     |vpiGenScopeArray:
     \_gen_scope_array: (work@top2.intf.each_pin_intf[0]), line:28:40, endln:30:8, parent:work@top2.intf
       |vpiName:each_pin_intf[0]

--- a/tests/GenerateModule/GenerateModule.log
+++ b/tests/GenerateModule/GenerateModule.log
@@ -1576,40 +1576,44 @@ design: (work@small_test)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.a), line:21:24, endln:21:25, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:21:18, endln:21:23
+      |vpiRange:
+      \_range: , line:21:19, endln:21:22
+        |vpiLeftRange:
+        \_constant: , line:21:19, endln:21:20
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:21:21, endln:21:22
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:a
     |vpiFullName:work@top.a
-    |vpiRange:
-    \_range: , line:21:19, endln:21:22
-      |vpiLeftRange:
-      \_constant: , line:21:19, endln:21:20
-        |vpiDecompile:2
-        |vpiSize:64
-        |UINT:2
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:21:21, endln:21:22
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@top.b), line:21:40, endln:21:41, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:21:34, endln:21:39
+      |vpiRange:
+      \_range: , line:21:35, endln:21:38
+        |vpiLeftRange:
+        \_constant: , line:21:35, endln:21:36
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:21:37, endln:21:38
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:b
     |vpiFullName:work@top.b
-    |vpiRange:
-    \_range: , line:21:35, endln:21:38
-      |vpiLeftRange:
-      \_constant: , line:21:35, endln:21:36
-        |vpiDecompile:2
-        |vpiSize:64
-        |UINT:2
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:21:37, endln:21:38
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (a), line:21:24, endln:21:25, parent:work@top
@@ -1621,6 +1625,22 @@ design: (work@small_test)
       |vpiFullName:work@top.a
       |vpiActual:
       \_logic_net: (work@top.a), line:21:24, endln:21:25, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:21:18, endln:21:23
+      |vpiRange:
+      \_range: , line:21:19, endln:21:22, parent:a
+        |vpiLeftRange:
+        \_constant: , line:21:19, endln:21:20
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:21:21, endln:21:22
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (b), line:21:40, endln:21:41, parent:work@top
     |vpiName:b
@@ -1631,6 +1651,22 @@ design: (work@small_test)
       |vpiFullName:work@top.b
       |vpiActual:
       \_logic_net: (work@top.b), line:21:40, endln:21:41, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:21:34, endln:21:39
+      |vpiRange:
+      \_range: , line:21:35, endln:21:38, parent:b
+        |vpiLeftRange:
+        \_constant: , line:21:35, endln:21:36
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:21:37, endln:21:38
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiGenScopeArray:
   \_gen_scope_array: (work@top.genblk1[0]), line:23:30, endln:25:6, parent:work@top
     |vpiName:genblk1[0]

--- a/tests/GenerateUnnamed/GenerateUnnamed.log
+++ b/tests/GenerateUnnamed/GenerateUnnamed.log
@@ -1477,16 +1477,22 @@ design: (work@test1)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@test1.a), line:3:8, endln:3:9, parent:work@test1
+    |vpiTypespec:
+    \_logic_typespec: , line:3:3, endln:3:7
     |vpiName:a
     |vpiFullName:work@test1.a
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@test1.b), line:3:11, endln:3:12, parent:work@test1
+    |vpiTypespec:
+    \_logic_typespec: , line:3:3, endln:3:7
     |vpiName:b
     |vpiFullName:work@test1.b
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@test1.c), line:3:14, endln:3:15, parent:work@test1
+    |vpiTypespec:
+    \_logic_typespec: , line:3:3, endln:3:7
     |vpiName:c
     |vpiFullName:work@test1.c
     |vpiNetType:1
@@ -1704,16 +1710,22 @@ design: (work@test1)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@test2.a), line:62:8, endln:62:9, parent:work@test2
+    |vpiTypespec:
+    \_logic_typespec: , line:62:3, endln:62:7
     |vpiName:a
     |vpiFullName:work@test2.a
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@test2.b), line:62:11, endln:62:12, parent:work@test2
+    |vpiTypespec:
+    \_logic_typespec: , line:62:3, endln:62:7
     |vpiName:b
     |vpiFullName:work@test2.b
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@test2.c), line:62:14, endln:62:15, parent:work@test2
+    |vpiTypespec:
+    \_logic_typespec: , line:62:3, endln:62:7
     |vpiName:c
     |vpiFullName:work@test2.c
     |vpiNetType:1

--- a/tests/HierPathBind/HierPathBind.log
+++ b/tests/HierPathBind/HierPathBind.log
@@ -183,6 +183,8 @@ design: (work@top)
       |vpiFullName:work@dut.o
       |vpiActual:
       \_logic_net: (work@top.d.o), line:1:26, endln:1:27, parent:work@top.d
+        |vpiTypespec:
+        \_logic_typespec: , line:1:20, endln:1:25
         |vpiName:o
         |vpiFullName:work@top.d.o
         |vpiNetType:36
@@ -240,6 +242,8 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:5:26, endln:5:27, parent:work@top
+        |vpiTypespec:
+        \_logic_typespec: , line:5:20, endln:5:25
         |vpiName:o
         |vpiFullName:work@top.o
         |vpiNetType:36
@@ -269,6 +273,8 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:5:26, endln:5:27, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:5:20, endln:5:25
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:5:1: , endln:15:10
   |vpiContAssign:
@@ -330,6 +336,8 @@ design: (work@top)
         |vpiFullName:work@top.d.o
         |vpiActual:
         \_logic_net: (work@top.d.o), line:1:26, endln:1:27, parent:work@top.d
+      |vpiTypedef:
+      \_logic_typespec: , line:1:20, endln:1:25
       |vpiInstance:
       \_module: work@dut (work@top.d) dut.sv:12:4: , endln:12:33, parent:work@top
     |vpiContAssign:

--- a/tests/IODataTypes/IODataTypes.log
+++ b/tests/IODataTypes/IODataTypes.log
@@ -191,7 +191,8 @@ design: (work@dff_diffDataTypes)
   |vpiVariables:
   \_byte_var: (work@dff_diffDataTypes.b), line:3:12, endln:3:13, parent:work@dff_diffDataTypes
     |vpiTypespec:
-    \_byte_typespec: 
+    \_byte_typespec: , line:3:7, endln:3:11
+      |vpiSigned:1
     |vpiName:b
     |vpiFullName:work@dff_diffDataTypes.b
     |vpiSigned:1
@@ -241,6 +242,9 @@ design: (work@dff_diffDataTypes)
       |vpiFullName:work@dff_diffDataTypes.a
       |vpiActual:
       \_int_var: (work@dff_diffDataTypes.a), line:2:11, endln:2:12, parent:work@dff_diffDataTypes
+    |vpiTypedef:
+    \_int_typespec: , line:2:7, endln:2:10
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@dff_diffDataTypes (work@dff_diffDataTypes) dut.sv:1:1: , endln:9:10
   |vpiPort:
@@ -253,6 +257,9 @@ design: (work@dff_diffDataTypes)
       |vpiFullName:work@dff_diffDataTypes.b
       |vpiActual:
       \_byte_var: (work@dff_diffDataTypes.b), line:3:12, endln:3:13, parent:work@dff_diffDataTypes
+    |vpiTypedef:
+    \_byte_typespec: , line:3:7, endln:3:11
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@dff_diffDataTypes (work@dff_diffDataTypes) dut.sv:1:1: , endln:9:10
   |vpiPort:
@@ -265,6 +272,9 @@ design: (work@dff_diffDataTypes)
       |vpiFullName:work@dff_diffDataTypes.c
       |vpiActual:
       \_short_int_var: (work@dff_diffDataTypes.c), line:4:16, endln:4:17, parent:work@dff_diffDataTypes
+    |vpiTypedef:
+    \_short_int_typespec: , line:4:7, endln:4:15
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@dff_diffDataTypes (work@dff_diffDataTypes) dut.sv:1:1: , endln:9:10
   |vpiPort:
@@ -277,6 +287,9 @@ design: (work@dff_diffDataTypes)
       |vpiFullName:work@dff_diffDataTypes.d
       |vpiActual:
       \_long_int_var: (work@dff_diffDataTypes.d), line:5:15, endln:5:16, parent:work@dff_diffDataTypes
+    |vpiTypedef:
+    \_long_int_typespec: , line:5:7, endln:5:14
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@dff_diffDataTypes (work@dff_diffDataTypes) dut.sv:1:1: , endln:9:10
   |vpiPort:
@@ -289,6 +302,9 @@ design: (work@dff_diffDataTypes)
       |vpiFullName:work@dff_diffDataTypes.e
       |vpiActual:
       \_integer_var: (work@dff_diffDataTypes.e), line:6:15, endln:6:16, parent:work@dff_diffDataTypes
+    |vpiTypedef:
+    \_integer_typespec: , line:6:7, endln:6:14
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@dff_diffDataTypes (work@dff_diffDataTypes) dut.sv:1:1: , endln:9:10
   |vpiPort:
@@ -301,6 +317,9 @@ design: (work@dff_diffDataTypes)
       |vpiFullName:work@dff_diffDataTypes.f
       |vpiActual:
       \_short_int_var: (work@dff_diffDataTypes.f), line:7:23, endln:7:24, parent:work@dff_diffDataTypes
+    |vpiTypedef:
+    \_short_int_typespec: , line:7:7, endln:7:15
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@dff_diffDataTypes (work@dff_diffDataTypes) dut.sv:1:1: , endln:9:10
 ===================

--- a/tests/Iff/Iff.log
+++ b/tests/Iff/Iff.log
@@ -188,6 +188,8 @@ design: (work@block_tb)
             |vpiFullName:work@block_tb.clk
             |vpiActual:
             \_logic_net: (work@block_tb.clk), line:2:7, endln:2:10, parent:work@block_tb
+              |vpiTypespec:
+              \_logic_typespec: , line:2:2, endln:2:6
               |vpiName:clk
               |vpiFullName:work@block_tb.clk
               |vpiNetType:1
@@ -200,6 +202,8 @@ design: (work@block_tb)
               |vpiFullName:work@block_tb.en
               |vpiActual:
               \_logic_net: (work@block_tb.en), line:3:7, endln:3:9, parent:work@block_tb
+                |vpiTypespec:
+                \_logic_typespec: , line:3:2, endln:3:6
                 |vpiName:en
                 |vpiFullName:work@block_tb.en
                 |vpiNetType:1
@@ -218,6 +222,8 @@ design: (work@block_tb)
           |vpiFullName:work@block_tb.a
           |vpiActual:
           \_logic_net: (work@block_tb.a), line:4:7, endln:4:8, parent:work@block_tb
+            |vpiTypespec:
+            \_logic_typespec: , line:4:2, endln:4:6
             |vpiName:a
             |vpiFullName:work@block_tb.a
             |vpiNetType:1
@@ -227,6 +233,8 @@ design: (work@block_tb)
           |vpiFullName:work@block_tb.y
           |vpiActual:
           \_logic_net: (work@block_tb.y), line:5:6, endln:5:7, parent:work@block_tb
+            |vpiTypespec:
+            \_logic_typespec: , line:5:2, endln:5:5
             |vpiName:y
             |vpiFullName:work@block_tb.y
             |vpiNetType:48

--- a/tests/IllegalZeroValue/IllegalZeroValue.log
+++ b/tests/IllegalZeroValue/IllegalZeroValue.log
@@ -111,6 +111,8 @@ design: (work@test)
           |vpiConstType:7
     |vpiNet:
     \_logic_net: (work@test.illegal), line:3:5, endln:3:12, parent:work@test.illegal
+      |vpiTypespec:
+      \_logic_typespec: , line:3:1, endln:3:4
       |vpiFullName:work@test.illegal
       |vpiNetType:48
   |vpiTopModule:1

--- a/tests/Implicit/Implicit.log
+++ b/tests/Implicit/Implicit.log
@@ -108,128 +108,136 @@ n<> u<74> t<Top_level_rule> l<2:1> el<10:1>
 [INF:UH0711] Decompiling UHDM...
 
 ====== UHDM =======
-design: (work@dff_from_nand), id:17
+design: (work@dff_from_nand), id:18
 |vpiElaborated:1
 |vpiName:work@dff_from_nand
 |uhdmallModules:
-\_module: work@dff_from_nand (work@dff_from_nand), id:18 dut.sv:2:1: , endln:8:10, parent:work@dff_from_nand, parID:17
+\_module: work@dff_from_nand (work@dff_from_nand), id:19 dut.sv:2:1: , endln:8:10, parent:work@dff_from_nand, parID:18
   |vpiFullName:work@dff_from_nand
   |vpiDefName:work@dff_from_nand
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.Q), id:19, line:3:6, endln:3:7, parent:work@dff_from_nand, parID:18
+  \_logic_net: (work@dff_from_nand.Q), id:20, line:3:6, endln:3:7, parent:work@dff_from_nand, parID:19
     |vpiName:Q
     |vpiFullName:work@dff_from_nand.Q
     |vpiNetType:1
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.Q_BAR), id:20, line:3:8, endln:3:13, parent:work@dff_from_nand, parID:18
+  \_logic_net: (work@dff_from_nand.Q_BAR), id:21, line:3:8, endln:3:13, parent:work@dff_from_nand, parID:19
     |vpiName:Q_BAR
     |vpiFullName:work@dff_from_nand.Q_BAR
     |vpiNetType:1
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.D), id:21, line:4:6, endln:4:7, parent:work@dff_from_nand, parID:18
+  \_logic_net: (work@dff_from_nand.D), id:22, line:4:6, endln:4:7, parent:work@dff_from_nand, parID:19
     |vpiName:D
     |vpiFullName:work@dff_from_nand.D
     |vpiNetType:48
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.CLK), id:22, line:4:8, endln:4:11, parent:work@dff_from_nand, parID:18
+  \_logic_net: (work@dff_from_nand.CLK), id:23, line:4:8, endln:4:11, parent:work@dff_from_nand, parID:19
     |vpiName:CLK
     |vpiFullName:work@dff_from_nand.CLK
     |vpiNetType:48
 |uhdmtopModules:
-\_module: work@dff_from_nand (work@dff_from_nand), id:23 dut.sv:2:1: , endln:8:10
+\_module: work@dff_from_nand (work@dff_from_nand), id:24 dut.sv:2:1: , endln:8:10
   |vpiName:work@dff_from_nand
   |vpiDefName:work@dff_from_nand
   |vpiTop:1
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.Q), id:0, line:3:6, endln:3:7, parent:work@dff_from_nand, parID:23
+  \_logic_net: (work@dff_from_nand.Q), id:1, line:3:6, endln:3:7, parent:work@dff_from_nand, parID:24
+    |vpiTypespec:
+    \_logic_typespec: , id:0, line:3:1, endln:3:5
     |vpiName:Q
     |vpiFullName:work@dff_from_nand.Q
     |vpiNetType:1
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.Q_BAR), id:1, line:3:8, endln:3:13, parent:work@dff_from_nand, parID:23
+  \_logic_net: (work@dff_from_nand.Q_BAR), id:2, line:3:8, endln:3:13, parent:work@dff_from_nand, parID:24
+    |vpiTypespec:
+    \_logic_typespec: , id:0, line:3:1, endln:3:5
     |vpiName:Q_BAR
     |vpiFullName:work@dff_from_nand.Q_BAR
     |vpiNetType:1
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.D), id:3, line:4:6, endln:4:7, parent:work@dff_from_nand, parID:23
+  \_logic_net: (work@dff_from_nand.D), id:4, line:4:6, endln:4:7, parent:work@dff_from_nand, parID:24
+    |vpiTypespec:
+    \_logic_typespec: , id:3, line:4:1, endln:4:4
     |vpiName:D
     |vpiFullName:work@dff_from_nand.D
     |vpiNetType:48
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.CLK), id:4, line:4:8, endln:4:11, parent:work@dff_from_nand, parID:23
+  \_logic_net: (work@dff_from_nand.CLK), id:5, line:4:8, endln:4:11, parent:work@dff_from_nand, parID:24
+    |vpiTypespec:
+    \_logic_typespec: , id:3, line:4:1, endln:4:4
     |vpiName:CLK
     |vpiFullName:work@dff_from_nand.CLK
     |vpiNetType:48
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.X), id:7, line:6:10, endln:6:11, parent:work@dff_from_nand, parID:23
+  \_logic_net: (work@dff_from_nand.X), id:8, line:6:10, endln:6:11, parent:work@dff_from_nand, parID:24
     |vpiName:X
     |vpiFullName:work@dff_from_nand.X
     |vpiNetType:1
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.X_BAR), id:14, line:7:6, endln:7:11, parent:work@dff_from_nand, parID:23
+  \_logic_net: (work@dff_from_nand.X_BAR), id:15, line:7:6, endln:7:11, parent:work@dff_from_nand, parID:24
     |vpiName:X_BAR
     |vpiFullName:work@dff_from_nand.X_BAR
     |vpiNetType:1
   |vpiTopModule:1
   |vpiPrimitive:
-  \_gate: work@nand (work@dff_from_nand.U1), id:24, line:6:1, endln:6:20, parent:work@dff_from_nand, parID:23
+  \_gate: work@nand (work@dff_from_nand.U1), id:25, line:6:1, endln:6:20, parent:work@dff_from_nand, parID:24
     |vpiDefName:work@nand
     |vpiName:U1
     |vpiFullName:work@dff_from_nand.U1
     |vpiPrimType:2
     |vpiPrimTerm:
-    \_prim_term: , id:25, line:6:10, endln:6:11, parent:work@dff_from_nand.U1, parID:24
+    \_prim_term: , id:26, line:6:10, endln:6:11, parent:work@dff_from_nand.U1, parID:25
       |vpiDirection:2
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.X), id:6, line:6:10, endln:6:11, parent:work@dff_from_nand.U1, parID:24
+      \_ref_obj: (work@dff_from_nand.X), id:7, line:6:10, endln:6:11, parent:work@dff_from_nand.U1, parID:25
         |vpiName:X
         |vpiFullName:work@dff_from_nand.X
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.X), id:7, line:6:10, endln:6:11, parent:work@dff_from_nand, parID:23
+        \_logic_net: (work@dff_from_nand.X), id:8, line:6:10, endln:6:11, parent:work@dff_from_nand, parID:24
     |vpiPrimTerm:
-    \_prim_term: , id:26, line:6:12, endln:6:13, parent:work@dff_from_nand.U1, parID:24
+    \_prim_term: , id:27, line:6:12, endln:6:13, parent:work@dff_from_nand.U1, parID:25
       |vpiDirection:1
       |vpiTermIndex:1
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.D), id:9, line:6:12, endln:6:13, parent:work@dff_from_nand.U1, parID:24
+      \_ref_obj: (work@dff_from_nand.D), id:10, line:6:12, endln:6:13, parent:work@dff_from_nand.U1, parID:25
         |vpiName:D
         |vpiFullName:work@dff_from_nand.D
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.D), id:3, line:4:6, endln:4:7, parent:work@dff_from_nand, parID:23
+        \_logic_net: (work@dff_from_nand.D), id:4, line:4:6, endln:4:7, parent:work@dff_from_nand, parID:24
     |vpiPrimTerm:
-    \_prim_term: , id:27, line:6:14, endln:6:17, parent:work@dff_from_nand.U1, parID:24
+    \_prim_term: , id:28, line:6:14, endln:6:17, parent:work@dff_from_nand.U1, parID:25
       |vpiDirection:1
       |vpiTermIndex:2
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.CLK), id:11, line:6:14, endln:6:17, parent:work@dff_from_nand.U1, parID:24
+      \_ref_obj: (work@dff_from_nand.CLK), id:12, line:6:14, endln:6:17, parent:work@dff_from_nand.U1, parID:25
         |vpiName:CLK
         |vpiFullName:work@dff_from_nand.CLK
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.CLK), id:4, line:4:8, endln:4:11, parent:work@dff_from_nand, parID:23
+        \_logic_net: (work@dff_from_nand.CLK), id:5, line:4:8, endln:4:11, parent:work@dff_from_nand, parID:24
   |vpiPrimitive:
-  \_gate: work@not (work@dff_from_nand.), id:28, line:7:1, endln:7:16, parent:work@dff_from_nand, parID:23
+  \_gate: work@not (work@dff_from_nand.), id:29, line:7:1, endln:7:16, parent:work@dff_from_nand, parID:24
     |vpiDefName:work@not
     |vpiFullName:work@dff_from_nand.
     |vpiPrimType:8
     |vpiPrimTerm:
-    \_prim_term: , id:29, line:7:6, endln:7:11, parent:work@dff_from_nand., parID:28
+    \_prim_term: , id:30, line:7:6, endln:7:11, parent:work@dff_from_nand., parID:29
       |vpiDirection:2
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.X_BAR), id:13, line:7:6, endln:7:11, parent:work@dff_from_nand., parID:28
+      \_ref_obj: (work@dff_from_nand.X_BAR), id:14, line:7:6, endln:7:11, parent:work@dff_from_nand., parID:29
         |vpiName:X_BAR
         |vpiFullName:work@dff_from_nand.X_BAR
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.X_BAR), id:14, line:7:6, endln:7:11, parent:work@dff_from_nand, parID:23
+        \_logic_net: (work@dff_from_nand.X_BAR), id:15, line:7:6, endln:7:11, parent:work@dff_from_nand, parID:24
     |vpiPrimTerm:
-    \_prim_term: , id:30, line:7:13, endln:7:14, parent:work@dff_from_nand., parID:28
+    \_prim_term: , id:31, line:7:13, endln:7:14, parent:work@dff_from_nand., parID:29
       |vpiDirection:1
       |vpiTermIndex:1
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.X), id:16, line:7:13, endln:7:14, parent:work@dff_from_nand., parID:28
+      \_ref_obj: (work@dff_from_nand.X), id:17, line:7:13, endln:7:14, parent:work@dff_from_nand., parID:29
         |vpiName:X
         |vpiFullName:work@dff_from_nand.X
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.X), id:7, line:6:10, endln:6:11, parent:work@dff_from_nand, parID:23
+        \_logic_net: (work@dff_from_nand.X), id:8, line:6:10, endln:6:11, parent:work@dff_from_nand, parID:24
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ImplicitParam/ImplicitParam.log
+++ b/tests/ImplicitParam/ImplicitParam.log
@@ -247,6 +247,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:1:23, endln:1:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:1:19, endln:1:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:4:10
 ===================

--- a/tests/ImplicitPort/ImplicitPort.log
+++ b/tests/ImplicitPort/ImplicitPort.log
@@ -753,67 +753,60 @@ design: (work@add)
         |vpiFullName:work@add.a
         |vpiActual:
         \_logic_net: (work@add.a), line:2:16, endln:2:17, parent:work@add
+          |vpiTypespec:
+          \_logic_typespec: , line:2:9, endln:2:15
+            |vpiRange:
+            \_range: , line:2:10, endln:2:14
+              |vpiLeftRange:
+              \_constant: , line:2:10, endln:2:12
+                |vpiDecompile:31
+                |vpiSize:64
+                |UINT:31
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:2:13, endln:2:14
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:a
           |vpiFullName:work@add.a
-          |vpiRange:
-          \_range: , line:2:10, endln:2:14
-            |vpiLeftRange:
-            \_constant: , line:2:10, endln:2:12
-              |vpiDecompile:31
-              |vpiSize:64
-              |UINT:31
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:2:13, endln:2:14
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
       |vpiOperand:
       \_ref_obj: (work@add.b), line:5:18, endln:5:19
         |vpiName:b
         |vpiFullName:work@add.b
         |vpiActual:
         \_logic_net: (work@add.b), line:2:18, endln:2:19, parent:work@add
+          |vpiTypespec:
+          \_logic_typespec: , line:2:9, endln:2:15
           |vpiName:b
           |vpiFullName:work@add.b
-          |vpiRange:
-          \_range: , line:2:10, endln:2:14
-            |vpiLeftRange:
-            \_constant: , line:2:10, endln:2:12
-              |vpiDecompile:31
-              |vpiSize:64
-              |UINT:31
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:2:13, endln:2:14
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
     |vpiLhs:
     \_ref_obj: (work@add.sum), line:5:8, endln:5:11
       |vpiName:sum
       |vpiFullName:work@add.sum
       |vpiActual:
       \_logic_net: (work@add.sum), line:3:24, endln:3:27, parent:work@add
+        |vpiTypespec:
+        \_int_typespec: , line:3:10, endln:3:16
+          |vpiSigned:1
+          |vpiRange:
+          \_range: , line:3:18, endln:3:22
+            |vpiLeftRange:
+            \_constant: , line:3:18, endln:3:20
+              |vpiDecompile:31
+              |vpiSize:64
+              |UINT:31
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:3:21, endln:3:22
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:sum
         |vpiFullName:work@add.sum
         |vpiSigned:1
-        |vpiRange:
-        \_range: , line:3:18, endln:3:22
-          |vpiLeftRange:
-          \_constant: , line:3:18, endln:3:20
-            |vpiDecompile:31
-            |vpiSize:64
-            |UINT:31
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:3:21, endln:3:22
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@add (work@add) dut.sv:1:1: , endln:6:10
   |vpiName:work@add
@@ -836,6 +829,22 @@ design: (work@add)
       |vpiFullName:work@add.a
       |vpiActual:
       \_logic_net: (work@add.a), line:2:16, endln:2:17, parent:work@add
+    |vpiTypedef:
+    \_logic_typespec: , line:2:9, endln:2:15
+      |vpiRange:
+      \_range: , line:2:10, endln:2:14, parent:a
+        |vpiLeftRange:
+        \_constant: , line:2:10, endln:2:12
+          |vpiDecompile:31
+          |vpiSize:64
+          |UINT:31
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:2:13, endln:2:14
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@add (work@add) dut.sv:1:1: , endln:6:10
   |vpiPort:
@@ -848,6 +857,8 @@ design: (work@add)
       |vpiFullName:work@add.b
       |vpiActual:
       \_logic_net: (work@add.b), line:2:18, endln:2:19, parent:work@add
+    |vpiTypedef:
+    \_logic_typespec: , line:2:9, endln:2:15
     |vpiInstance:
     \_module: work@add (work@add) dut.sv:1:1: , endln:6:10
   |vpiPort:
@@ -860,6 +871,23 @@ design: (work@add)
       |vpiFullName:work@add.sum
       |vpiActual:
       \_logic_net: (work@add.sum), line:3:24, endln:3:27, parent:work@add
+    |vpiTypedef:
+    \_int_typespec: , line:3:10, endln:3:16
+      |vpiSigned:1
+      |vpiRange:
+      \_range: , line:3:18, endln:3:22, parent:sum
+        |vpiLeftRange:
+        \_constant: , line:3:18, endln:3:20
+          |vpiDecompile:31
+          |vpiSize:64
+          |UINT:31
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:3:21, endln:3:22
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@add (work@add) dut.sv:1:1: , endln:6:10
   |vpiContAssign:

--- a/tests/ImplicitPorts2/ImplicitPorts2.log
+++ b/tests/ImplicitPorts2/ImplicitPorts2.log
@@ -211,11 +211,15 @@ design: (work@implicit)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@implicit.clk), line:2:7, endln:2:10, parent:work@implicit
+    |vpiTypespec:
+    \_logic_typespec: , line:2:3, endln:2:6
     |vpiName:clk
     |vpiFullName:work@implicit.clk
     |vpiNetType:48
   |vpiNet:
   \_logic_net: (work@implicit.q), line:3:8, endln:3:9, parent:work@implicit
+    |vpiTypespec:
+    \_logic_typespec: , line:3:3, endln:3:7
     |vpiName:q
     |vpiFullName:work@implicit.q
     |vpiNetType:1
@@ -229,6 +233,8 @@ design: (work@implicit)
     |vpiDefLineNo:11
     |vpiNet:
     \_logic_net: (work@implicit.u0.q), line:14:7, endln:14:8, parent:work@implicit.u0
+      |vpiTypespec:
+      \_logic_typespec: , line:14:3, endln:14:6
       |vpiName:q
       |vpiFullName:work@implicit.u0.q
       |vpiNetType:48

--- a/tests/ImportedTypespec/ImportedTypespec.log
+++ b/tests/ImportedTypespec/ImportedTypespec.log
@@ -322,6 +322,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:6:23, endln:6:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:6:19, endln:6:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:6:1: , endln:10:10
   |vpiContAssign:

--- a/tests/IndexPartSel/IndexPartSel.log
+++ b/tests/IndexPartSel/IndexPartSel.log
@@ -287,61 +287,67 @@ design: (work@dut)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@dut.hw2reg_wrap), line:3:14, endln:3:25, parent:work@dut
+    |vpiTypespec:
+    \_logic_typespec: , line:3:1, endln:3:5
+      |vpiRange:
+      \_range: , line:3:7, endln:3:12
+        |vpiLeftRange:
+        \_constant: , line:3:7, endln:3:10
+          |vpiDecompile:220
+          |vpiSize:64
+          |UINT:220
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:3:11, endln:3:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:hw2reg_wrap
     |vpiFullName:work@dut.hw2reg_wrap
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:3:7, endln:3:12
-      |vpiLeftRange:
-      \_constant: , line:3:7, endln:3:10
-        |vpiDecompile:220
-        |vpiSize:64
-        |UINT:220
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:3:11, endln:3:12
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@dut.notworking_indexed_part_select), line:4:14, endln:4:44, parent:work@dut
+    |vpiTypespec:
+    \_logic_typespec: , line:4:1, endln:4:5
+      |vpiRange:
+      \_range: , line:4:7, endln:4:12
+        |vpiLeftRange:
+        \_constant: , line:4:7, endln:4:10
+          |vpiDecompile:237
+          |vpiSize:64
+          |UINT:237
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:4:11, endln:4:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:notworking_indexed_part_select
     |vpiFullName:work@dut.notworking_indexed_part_select
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:4:7, endln:4:12
-      |vpiLeftRange:
-      \_constant: , line:4:7, endln:4:10
-        |vpiDecompile:237
-        |vpiSize:64
-        |UINT:237
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:4:11, endln:4:12
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@dut.working_bitselect), line:5:13, endln:5:30, parent:work@dut
+    |vpiTypespec:
+    \_logic_typespec: , line:5:1, endln:5:5
+      |vpiRange:
+      \_range: , line:5:7, endln:5:11
+        |vpiLeftRange:
+        \_constant: , line:5:7, endln:5:9
+          |vpiDecompile:10
+          |vpiSize:64
+          |UINT:10
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:5:10, endln:5:11
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:working_bitselect
     |vpiFullName:work@dut.working_bitselect
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:5:7, endln:5:11
-      |vpiLeftRange:
-      \_constant: , line:5:7, endln:5:9
-        |vpiDecompile:10
-        |vpiSize:64
-        |UINT:10
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:5:10, endln:5:11
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiContAssign:
   \_cont_assign: , line:6:8, endln:6:49, parent:work@dut

--- a/tests/InsideOp/InsideOp.log
+++ b/tests/InsideOp/InsideOp.log
@@ -499,6 +499,9 @@ design: (work@top)
       |vpiFullName:work@top.out
       |vpiActual:
       \_int_var: (work@top.out), line:22:16, endln:22:19, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:22:12, endln:22:15
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:17:1: , endln:38:10
   |vpiGenScopeArray:

--- a/tests/InterfAlways/InterfAlways.log
+++ b/tests/InterfAlways/InterfAlways.log
@@ -197,6 +197,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:7:23, endln:7:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:7:19, endln:7:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:7:1: , endln:9:10
   |vpiInterface:
@@ -228,6 +231,9 @@ design: (work@top)
         |vpiFullName:work@top.u_sw.x
         |vpiActual:
         \_int_var: (work@top.u_sw.x), line:1:40, endln:1:41, parent:work@top.u_sw
+      |vpiTypedef:
+      \_int_typespec: , line:1:36, endln:1:39
+        |vpiSigned:1
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/InterfHierPath/InterfHierPath.log
+++ b/tests/InterfHierPath/InterfHierPath.log
@@ -155,23 +155,25 @@ design: (work@or_ex)
       |vpiFullName:work@or_ex.a
       |vpiActual:
       \_logic_net: (work@or_ex.a), line:9:22, endln:9:23, parent:work@or_ex
+        |vpiTypespec:
+        \_logic_typespec: , line:9:11, endln:9:16
+          |vpiRange:
+          \_range: , line:9:17, endln:9:20
+            |vpiLeftRange:
+            \_constant: , line:9:17, endln:9:18
+              |vpiDecompile:3
+              |vpiSize:64
+              |UINT:3
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:9:19, endln:9:20
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:a
         |vpiFullName:work@or_ex.a
         |vpiNetType:36
-        |vpiRange:
-        \_range: , line:9:17, endln:9:20
-          |vpiLeftRange:
-          \_constant: , line:9:17, endln:9:18
-            |vpiDecompile:3
-            |vpiSize:64
-            |UINT:3
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:9:19, endln:9:20
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
     |vpiLhs:
     \_hier_path: (lg.a), line:14:10, endln:14:14
       |vpiName:lg.a
@@ -199,6 +201,22 @@ design: (work@or_ex)
       |vpiFullName:work@or_ex.a
       |vpiActual:
       \_logic_net: (work@or_ex.a), line:9:22, endln:9:23, parent:work@or_ex
+    |vpiTypedef:
+    \_logic_typespec: , line:9:11, endln:9:16
+      |vpiRange:
+      \_range: , line:9:17, endln:9:20, parent:a
+        |vpiLeftRange:
+        \_constant: , line:9:17, endln:9:18
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:9:19, endln:9:20
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@or_ex (work@or_ex) dut.sv:8:1: , endln:16:10
   |vpiInterface:

--- a/tests/InterfaceElab/InterfaceElab.log
+++ b/tests/InterfaceElab/InterfaceElab.log
@@ -356,6 +356,8 @@ design: (work@testharness)
       |vpiDefLineNo:2
       |vpiNet:
       \_logic_net: (work@testharness.i_peripherals.reg_bus.clk_i), line:6:15, endln:6:20, parent:work@testharness.i_peripherals.reg_bus
+        |vpiTypespec:
+        \_logic_typespec: , line:6:9, endln:6:14
         |vpiName:clk_i
         |vpiFullName:work@testharness.i_peripherals.reg_bus.clk_i
         |vpiNetType:36
@@ -386,6 +388,8 @@ design: (work@testharness)
           |vpiFullName:work@testharness.i_peripherals.reg_bus.clk_i
           |vpiActual:
           \_logic_net: (work@testharness.i_peripherals.reg_bus.clk_i), line:6:15, endln:6:20, parent:work@testharness.i_peripherals.reg_bus
+        |vpiTypedef:
+        \_logic_typespec: , line:6:9, endln:6:14
     |vpiModule:
     \_module: work@apb_to_reg (work@testharness.i_peripherals.i_apb_to_reg) dut.sv:27:1: , endln:27:44, parent:work@testharness.i_peripherals
       |vpiName:i_apb_to_reg

--- a/tests/InterfaceModPort/InterfaceModPort.log
+++ b/tests/InterfaceModPort/InterfaceModPort.log
@@ -2480,6 +2480,8 @@ design: (work@interface_modports)
             |vpiName:clk
             |vpiExpr:
             \_logic_net: (clk), line:26:30, endln:26:33
+              |vpiTypespec:
+              \_logic_typespec: , line:26:25, endln:26:29
               |vpiName:clk
               |vpiNetType:1
           |vpiIODecl:
@@ -2632,6 +2634,8 @@ design: (work@interface_modports)
     |vpiDefLineNo:26
     |vpiNet:
     \_logic_net: (work@interface_modports.miff.clk), line:26:30, endln:26:33, parent:work@interface_modports.miff
+      |vpiTypespec:
+      \_logic_typespec: , line:26:25, endln:26:29
       |vpiName:clk
       |vpiFullName:work@interface_modports.miff.clk
       |vpiNetType:1
@@ -2772,6 +2776,8 @@ design: (work@interface_modports)
         |vpiFullName:work@interface_modports.miff.clk
         |vpiActual:
         \_logic_net: (work@interface_modports.miff.clk), line:26:30, endln:26:33, parent:work@interface_modports.miff
+      |vpiTypedef:
+      \_logic_typespec: , line:26:25, endln:26:29
   |vpiModule:
   \_module: work@memory_ctrl (work@interface_modports.U_ctrl) top.v:120:1: , endln:120:26, parent:work@interface_modports
     |vpiName:U_ctrl
@@ -2812,6 +2818,8 @@ design: (work@interface_modports)
             |vpiName:clk
             |vpiExpr:
             \_logic_net: (clk), line:26:30, endln:26:33
+              |vpiTypespec:
+              \_logic_typespec: , line:26:25, endln:26:29
               |vpiName:clk
               |vpiNetType:1
           |vpiIODecl:
@@ -3152,6 +3160,8 @@ design: (work@interface_modports)
             |vpiName:clk
             |vpiExpr:
             \_logic_net: (clk), line:26:30, endln:26:33
+              |vpiTypespec:
+              \_logic_typespec: , line:26:25, endln:26:29
               |vpiName:clk
               |vpiNetType:1
           |vpiIODecl:

--- a/tests/Inverter/Inverter.log
+++ b/tests/Inverter/Inverter.log
@@ -170,6 +170,8 @@ design: (work@top)
         |vpiFullName:work@inverter.a
         |vpiActual:
         \_logic_net: (work@top.i1.a), line:8:13, endln:8:14, parent:work@top.i1
+          |vpiTypespec:
+          \_logic_typespec: , line:8:8, endln:8:12
           |vpiName:a
           |vpiFullName:work@top.i1.a
           |vpiNetType:1
@@ -179,6 +181,8 @@ design: (work@top)
       |vpiFullName:work@inverter.b
       |vpiActual:
       \_logic_net: (work@top.i1.b), line:9:14, endln:9:15, parent:work@top.i1
+        |vpiTypespec:
+        \_logic_typespec: , line:9:9, endln:9:13
         |vpiName:b
         |vpiFullName:work@top.i1.b
         |vpiNetType:1
@@ -219,11 +223,15 @@ design: (work@top)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.a), line:1:23, endln:1:24, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:1:18, endln:1:22
     |vpiName:a
     |vpiFullName:work@top.a
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@top.b), line:2:14, endln:2:15, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:2:9, endln:2:13
     |vpiName:b
     |vpiFullName:work@top.b
     |vpiNetType:1
@@ -243,6 +251,8 @@ design: (work@top)
       |vpiFullName:work@top.a
       |vpiActual:
       \_logic_net: (work@top.a), line:1:23, endln:1:24, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:18, endln:1:22
   |vpiPort:
   \_port: (b), line:2:14, endln:2:15, parent:work@top
     |vpiName:b
@@ -253,6 +263,8 @@ design: (work@top)
       |vpiFullName:work@top.b
       |vpiActual:
       \_logic_net: (work@top.b), line:2:14, endln:2:15, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:2:9, endln:2:13
   |vpiModule:
   \_module: work@inverter (work@top.i1) dut.sv:3:3: , endln:3:22, parent:work@top
     |vpiName:i1
@@ -282,6 +294,8 @@ design: (work@top)
         |vpiFullName:work@top.i1.a
         |vpiActual:
         \_logic_net: (work@top.i1.a), line:8:13, endln:8:14, parent:work@top.i1
+      |vpiTypedef:
+      \_logic_typespec: , line:8:8, endln:8:12
     |vpiPort:
     \_port: (b), line:9:14, endln:9:15, parent:work@top.i1
       |vpiName:b
@@ -298,6 +312,8 @@ design: (work@top)
         |vpiFullName:work@top.i1.b
         |vpiActual:
         \_logic_net: (work@top.i1.b), line:9:14, endln:9:15, parent:work@top.i1
+      |vpiTypedef:
+      \_logic_typespec: , line:9:9, endln:9:13
   |vpiModule:
   \_module: work@inverter (work@top.i2) dut.sv:4:3: , endln:4:22, parent:work@top
     |vpiName:i2
@@ -307,11 +323,15 @@ design: (work@top)
     |vpiDefLineNo:7
     |vpiNet:
     \_logic_net: (work@top.i2.a), line:8:13, endln:8:14, parent:work@top.i2
+      |vpiTypespec:
+      \_logic_typespec: , line:8:8, endln:8:12
       |vpiName:a
       |vpiFullName:work@top.i2.a
       |vpiNetType:1
     |vpiNet:
     \_logic_net: (work@top.i2.b), line:9:14, endln:9:15, parent:work@top.i2
+      |vpiTypespec:
+      \_logic_typespec: , line:9:9, endln:9:13
       |vpiName:b
       |vpiFullName:work@top.i2.b
       |vpiNetType:1
@@ -333,6 +353,8 @@ design: (work@top)
         |vpiFullName:work@top.i2.a
         |vpiActual:
         \_logic_net: (work@top.i2.a), line:8:13, endln:8:14, parent:work@top.i2
+      |vpiTypedef:
+      \_logic_typespec: , line:8:8, endln:8:12
     |vpiPort:
     \_port: (b), line:9:14, endln:9:15, parent:work@top.i2
       |vpiName:b
@@ -349,6 +371,8 @@ design: (work@top)
         |vpiFullName:work@top.i2.b
         |vpiActual:
         \_logic_net: (work@top.i2.b), line:9:14, endln:9:15, parent:work@top.i2
+      |vpiTypedef:
+      \_logic_typespec: , line:9:9, endln:9:13
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/JKFlipflop/JKFlipflop.log
+++ b/tests/JKFlipflop/JKFlipflop.log
@@ -484,6 +484,8 @@ design: (work@JKFlipflop)
               |vpiFullName:work@D_Flipflop.q
               |vpiActual:
               \_logic_net: (work@JKFlipflop.dff.q), line:9:33, endln:9:34, parent:work@JKFlipflop.dff
+                |vpiTypespec:
+                \_logic_typespec: , line:11:12, endln:11:15
                 |vpiName:q
                 |vpiFullName:work@JKFlipflop.dff.q
                 |vpiNetType:48
@@ -628,6 +630,8 @@ design: (work@JKFlipflop)
       |vpiFullName:work@JKFlipflop.w
       |vpiActual:
       \_logic_net: (work@JKFlipflop.w), line:4:8, endln:4:9, parent:work@JKFlipflop
+        |vpiTypespec:
+        \_logic_typespec: , line:4:3, endln:4:7
         |vpiName:w
         |vpiFullName:work@JKFlipflop.w
         |vpiNetType:1

--- a/tests/LocalParam/LocalParam.log
+++ b/tests/LocalParam/LocalParam.log
@@ -966,16 +966,22 @@ design: (work@top)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.i), line:1:24, endln:1:25, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:1:19, endln:1:23
     |vpiName:i
     |vpiFullName:work@top.i
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@top.o1), line:1:38, endln:1:40, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:1:34, endln:1:37
     |vpiName:o1
     |vpiFullName:work@top.o1
     |vpiNetType:48
   |vpiNet:
   \_logic_net: (work@top.o2), line:1:53, endln:1:55, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:1:49, endln:1:52
     |vpiName:o2
     |vpiFullName:work@top.o2
     |vpiNetType:48
@@ -990,6 +996,8 @@ design: (work@top)
       |vpiFullName:work@top.i
       |vpiActual:
       \_logic_net: (work@top.i), line:1:24, endln:1:25, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:19, endln:1:23
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:4:10
   |vpiPort:
@@ -1002,6 +1010,8 @@ design: (work@top)
       |vpiFullName:work@top.o1
       |vpiActual:
       \_logic_net: (work@top.o1), line:1:38, endln:1:40, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:34, endln:1:37
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:4:10
   |vpiPort:
@@ -1014,6 +1024,8 @@ design: (work@top)
       |vpiFullName:work@top.o2
       |vpiActual:
       \_logic_net: (work@top.o2), line:1:53, endln:1:55, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:49, endln:1:52
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:4:10
   |vpiModule:
@@ -1067,11 +1079,15 @@ design: (work@top)
     |vpiDefLineNo:6
     |vpiNet:
     \_logic_net: (work@top.asgn0.inp), line:6:53, endln:6:56, parent:work@top.asgn0
+      |vpiTypespec:
+      \_logic_typespec: , line:6:48, endln:6:52
       |vpiName:inp
       |vpiFullName:work@top.asgn0.inp
       |vpiNetType:1
     |vpiNet:
     \_logic_net: (work@top.asgn0.out), line:6:69, endln:6:72, parent:work@top.asgn0
+      |vpiTypespec:
+      \_logic_typespec: , line:6:65, endln:6:68
       |vpiName:out
       |vpiFullName:work@top.asgn0.out
       |vpiNetType:48
@@ -1093,6 +1109,8 @@ design: (work@top)
         |vpiFullName:work@top.asgn0.inp
         |vpiActual:
         \_logic_net: (work@top.asgn0.inp), line:6:53, endln:6:56, parent:work@top.asgn0
+      |vpiTypedef:
+      \_logic_typespec: , line:6:48, endln:6:52
       |vpiInstance:
       \_module: work@assigner (work@top.asgn0) dut.sv:2:3: , endln:2:51, parent:work@top
     |vpiPort:
@@ -1111,6 +1129,8 @@ design: (work@top)
         |vpiFullName:work@top.asgn0.out
         |vpiActual:
         \_logic_net: (work@top.asgn0.out), line:6:69, endln:6:72, parent:work@top.asgn0
+      |vpiTypedef:
+      \_logic_typespec: , line:6:65, endln:6:68
       |vpiInstance:
       \_module: work@assigner (work@top.asgn0) dut.sv:2:3: , endln:2:51, parent:work@top
     |vpiGenScopeArray:
@@ -1185,11 +1205,15 @@ design: (work@top)
     |vpiDefLineNo:6
     |vpiNet:
     \_logic_net: (work@top.asgn1.inp), line:6:53, endln:6:56, parent:work@top.asgn1
+      |vpiTypespec:
+      \_logic_typespec: , line:6:48, endln:6:52
       |vpiName:inp
       |vpiFullName:work@top.asgn1.inp
       |vpiNetType:1
     |vpiNet:
     \_logic_net: (work@top.asgn1.out), line:6:69, endln:6:72, parent:work@top.asgn1
+      |vpiTypespec:
+      \_logic_typespec: , line:6:65, endln:6:68
       |vpiName:out
       |vpiFullName:work@top.asgn1.out
       |vpiNetType:48
@@ -1211,6 +1235,8 @@ design: (work@top)
         |vpiFullName:work@top.asgn1.inp
         |vpiActual:
         \_logic_net: (work@top.asgn1.inp), line:6:53, endln:6:56, parent:work@top.asgn1
+      |vpiTypedef:
+      \_logic_typespec: , line:6:48, endln:6:52
       |vpiInstance:
       \_module: work@assigner (work@top.asgn1) dut.sv:3:3: , endln:3:51, parent:work@top
     |vpiPort:
@@ -1229,6 +1255,8 @@ design: (work@top)
         |vpiFullName:work@top.asgn1.out
         |vpiActual:
         \_logic_net: (work@top.asgn1.out), line:6:69, endln:6:72, parent:work@top.asgn1
+      |vpiTypedef:
+      \_logic_typespec: , line:6:65, endln:6:68
       |vpiInstance:
       \_module: work@assigner (work@top.asgn1) dut.sv:3:3: , endln:3:51, parent:work@top
     |vpiGenScopeArray:

--- a/tests/LogicSize/LogicSize.log
+++ b/tests/LogicSize/LogicSize.log
@@ -198,6 +198,8 @@ design: (work@top)
       |vpiFullName:work@dut.a
       |vpiActual:
       \_logic_net: (work@top.u_dut.a), line:1:25, endln:1:26, parent:work@top.u_dut
+        |vpiTypespec:
+        \_logic_typespec: , line:1:19, endln:1:24
         |vpiName:a
         |vpiFullName:work@top.u_dut.a
         |vpiNetType:36
@@ -263,6 +265,8 @@ design: (work@top)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.o), line:6:25, endln:6:26, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:6:19, endln:6:24
     |vpiName:o
     |vpiFullName:work@top.o
     |vpiNetType:36
@@ -277,6 +281,8 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:6:25, endln:6:26, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:6:19, endln:6:24
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:6:1: , endln:13:10
   |vpiModule:
@@ -326,6 +332,8 @@ design: (work@top)
         |vpiFullName:work@top.u_dut.a
         |vpiActual:
         \_logic_net: (work@top.u_dut.a), line:1:25, endln:1:26, parent:work@top.u_dut
+      |vpiTypedef:
+      \_logic_typespec: , line:1:19, endln:1:24
       |vpiInstance:
       \_module: work@dut (work@top.u_dut) dut.sv:8:4: , endln:12:6, parent:work@top
     |vpiContAssign:

--- a/tests/MBAdder/MBadder.log
+++ b/tests/MBAdder/MBadder.log
@@ -462,44 +462,34 @@ design: (work@MultibitAdder)
           |vpiFullName:work@MultibitAdder.a
           |vpiActual:
           \_logic_net: (work@MultibitAdder.a), line:1:22, endln:1:23, parent:work@MultibitAdder
+            |vpiTypespec:
+            \_logic_typespec: , line:2:8, endln:2:13
+              |vpiRange:
+              \_range: , line:2:9, endln:2:12
+                |vpiLeftRange:
+                \_constant: , line:2:9, endln:2:10
+                  |vpiDecompile:3
+                  |vpiSize:64
+                  |UINT:3
+                  |vpiConstType:9
+                |vpiRightRange:
+                \_constant: , line:2:11, endln:2:12
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiName:a
             |vpiFullName:work@MultibitAdder.a
-            |vpiRange:
-            \_range: , line:2:9, endln:2:12
-              |vpiLeftRange:
-              \_constant: , line:2:9, endln:2:10
-                |vpiDecompile:3
-                |vpiSize:64
-                |UINT:3
-                |vpiConstType:9
-              |vpiRightRange:
-              \_constant: , line:2:11, endln:2:12
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
         |vpiOperand:
         \_ref_obj: (work@MultibitAdder.b), line:6:22, endln:6:23
           |vpiName:b
           |vpiFullName:work@MultibitAdder.b
           |vpiActual:
           \_logic_net: (work@MultibitAdder.b), line:1:24, endln:1:25, parent:work@MultibitAdder
+            |vpiTypespec:
+            \_logic_typespec: , line:2:8, endln:2:13
             |vpiName:b
             |vpiFullName:work@MultibitAdder.b
-            |vpiRange:
-            \_range: , line:2:9, endln:2:12
-              |vpiLeftRange:
-              \_constant: , line:2:9, endln:2:10
-                |vpiDecompile:3
-                |vpiSize:64
-                |UINT:3
-                |vpiConstType:9
-              |vpiRightRange:
-              \_constant: , line:2:11, endln:2:12
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
       |vpiOperand:
       \_ref_obj: (work@MultibitAdder.cin), line:6:24, endln:6:27
         |vpiName:cin
@@ -525,22 +515,24 @@ design: (work@MultibitAdder)
         |vpiFullName:work@MultibitAdder.sum
         |vpiActual:
         \_logic_net: (work@MultibitAdder.sum), line:1:30, endln:1:33, parent:work@MultibitAdder
+          |vpiTypespec:
+          \_logic_typespec: , line:4:9, endln:4:14
+            |vpiRange:
+            \_range: , line:4:10, endln:4:13
+              |vpiLeftRange:
+              \_constant: , line:4:10, endln:4:11
+                |vpiDecompile:3
+                |vpiSize:64
+                |UINT:3
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:4:12, endln:4:13
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sum
           |vpiFullName:work@MultibitAdder.sum
-          |vpiRange:
-          \_range: , line:4:10, endln:4:13
-            |vpiLeftRange:
-            \_constant: , line:4:10, endln:4:11
-              |vpiDecompile:3
-              |vpiSize:64
-              |UINT:3
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:4:12, endln:4:13
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
 |uhdmtopModules:
 \_module: work@MultibitAdder (work@MultibitAdder) dut.sv:1:1: , endln:7:10
   |vpiName:work@MultibitAdder
@@ -567,6 +559,22 @@ design: (work@MultibitAdder)
       |vpiFullName:work@MultibitAdder.a
       |vpiActual:
       \_logic_net: (work@MultibitAdder.a), line:1:22, endln:1:23, parent:work@MultibitAdder
+    |vpiTypedef:
+    \_logic_typespec: , line:2:8, endln:2:13
+      |vpiRange:
+      \_range: , line:2:9, endln:2:12, parent:a
+        |vpiLeftRange:
+        \_constant: , line:2:9, endln:2:10
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:2:11, endln:2:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@MultibitAdder (work@MultibitAdder) dut.sv:1:1: , endln:7:10
   |vpiPort:
@@ -579,6 +587,8 @@ design: (work@MultibitAdder)
       |vpiFullName:work@MultibitAdder.b
       |vpiActual:
       \_logic_net: (work@MultibitAdder.b), line:1:24, endln:1:25, parent:work@MultibitAdder
+    |vpiTypedef:
+    \_logic_typespec: , line:2:8, endln:2:13
     |vpiInstance:
     \_module: work@MultibitAdder (work@MultibitAdder) dut.sv:1:1: , endln:7:10
   |vpiPort:
@@ -603,6 +613,22 @@ design: (work@MultibitAdder)
       |vpiFullName:work@MultibitAdder.sum
       |vpiActual:
       \_logic_net: (work@MultibitAdder.sum), line:1:30, endln:1:33, parent:work@MultibitAdder
+    |vpiTypedef:
+    \_logic_typespec: , line:4:9, endln:4:14
+      |vpiRange:
+      \_range: , line:4:10, endln:4:13, parent:sum
+        |vpiLeftRange:
+        \_constant: , line:4:10, endln:4:11
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:4:12, endln:4:13
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@MultibitAdder (work@MultibitAdder) dut.sv:1:1: , endln:7:10
   |vpiPort:

--- a/tests/ModPortHighConn/ModPortHighConn.log
+++ b/tests/ModPortHighConn/ModPortHighConn.log
@@ -106,42 +106,32 @@ design: (work@top)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.topA), line:6:16, endln:6:20, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:6:5, endln:6:9
+      |vpiRange:
+      \_range: , line:6:11, endln:6:14
+        |vpiLeftRange:
+        \_constant: , line:6:11, endln:6:12
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:6:13, endln:6:14
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:topA
     |vpiFullName:work@top.topA
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:6:11, endln:6:14
-      |vpiLeftRange:
-      \_constant: , line:6:11, endln:6:12
-        |vpiDecompile:1
-        |vpiSize:64
-        |UINT:1
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:6:13, endln:6:14
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@top.topB), line:6:22, endln:6:26, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:6:5, endln:6:9
     |vpiName:topB
     |vpiFullName:work@top.topB
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:6:11, endln:6:14
-      |vpiLeftRange:
-      \_constant: , line:6:11, endln:6:12
-        |vpiDecompile:1
-        |vpiSize:64
-        |UINT:1
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:6:13, endln:6:14
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiModule:
   \_module: work@moduleA (work@top.instanceA) dut.sv:7:5: , endln:7:57, parent:work@top

--- a/tests/ModPortRange/ModPortRange.log
+++ b/tests/ModPortRange/ModPortRange.log
@@ -283,6 +283,8 @@ design: (work@range_itf_port)
         |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@range_itf_port.my_port2), line:11:17, endln:11:25, parent:work@range_itf_port.my_port2
+      |vpiTypespec:
+      \_logic_typespec: , line:11:11, endln:11:16
       |vpiFullName:work@range_itf_port.my_port2
       |vpiNetType:36
   |vpiTopModule:1
@@ -342,6 +344,8 @@ design: (work@range_itf_port)
       |vpiFullName:work@range_itf_port.my_port2
       |vpiActual:
       \_array_net: (work@range_itf_port.my_port2), line:11:17, endln:11:25, parent:work@range_itf_port
+    |vpiTypedef:
+    \_logic_typespec: , line:11:11, endln:11:16
     |vpiInstance:
     \_module: work@range_itf_port (work@range_itf_port) dut.sv:9:1: , endln:13:10
 |uhdmtopModules:
@@ -370,6 +374,8 @@ design: (work@range_itf_port)
             |vpiName:clk
             |vpiExpr:
             \_logic_net: (clk), line:17:30, endln:17:33
+              |vpiTypespec:
+              \_logic_typespec: , line:17:25, endln:17:29
               |vpiName:clk
               |vpiNetType:1
           |vpiInterface:
@@ -403,6 +409,8 @@ design: (work@range_itf_port)
           |vpiName:clk
           |vpiExpr:
           \_logic_net: (clk), line:17:30, endln:17:33
+            |vpiTypespec:
+            \_logic_typespec: , line:17:25, endln:17:29
             |vpiName:clk
             |vpiNetType:1
         |vpiInterface:

--- a/tests/ModPortTest/ModPortTest.log
+++ b/tests/ModPortTest/ModPortTest.log
@@ -555,6 +555,8 @@ design: (work@dff0_test)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@dff0_test.n1), line:4:7, endln:4:17, parent:work@dff0_test
+    |vpiTypespec:
+    \_logic_typespec: , line:4:3, endln:4:6
     |vpiName:n1
     |vpiFullName:work@dff0_test.n1
     |vpiNetType:48
@@ -615,6 +617,8 @@ design: (work@dff0_test)
             |vpiName:clk
             |vpiExpr:
             \_logic_net: (clk), line:29:30, endln:29:33
+              |vpiTypespec:
+              \_logic_typespec: , line:29:25, endln:29:29
               |vpiName:clk
               |vpiNetType:1
           |vpiInterface:
@@ -646,6 +650,9 @@ design: (work@dff0_test)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@memory_ctrl2.t), line:51:4, endln:51:5, parent:work@memory_ctrl2
+    |vpiTypespec:
+    \_unsupported_typespec: (DD), line:51:1, endln:51:3
+      |vpiName:DD
     |vpiName:t
     |vpiFullName:work@memory_ctrl2.t
   |vpiTopModule:1
@@ -665,6 +672,8 @@ design: (work@dff0_test)
           |vpiName:clk
           |vpiExpr:
           \_logic_net: (clk), line:29:30, endln:29:33
+            |vpiTypespec:
+            \_logic_typespec: , line:29:25, endln:29:29
             |vpiName:clk
             |vpiNetType:1
         |vpiInterface:

--- a/tests/MultContAssign/MultContAssign.log
+++ b/tests/MultContAssign/MultContAssign.log
@@ -876,6 +876,8 @@ design: (work@top)
       |vpiFullName:work@top2.two
       |vpiActual:
       \_logic_net: (work@top2.two), line:58:9, endln:58:12, parent:work@top2
+        |vpiTypespec:
+        \_logic_typespec: , line:58:3, endln:58:8
         |vpiName:two
         |vpiFullName:work@top2.two
         |vpiNetType:13
@@ -950,6 +952,8 @@ design: (work@top)
       |vpiFullName:work@wandwor_test0.X
       |vpiActual:
       \_logic_net: (work@wandwor_test0.X), line:48:29, endln:48:30, parent:work@wandwor_test0
+        |vpiTypespec:
+        \_logic_typespec: , line:50:9, endln:50:12
         |vpiName:X
         |vpiFullName:work@wandwor_test0.X
         |vpiNetType:3
@@ -1294,6 +1298,8 @@ design: (work@top)
       |vpiFullName:work@wandwor_test0.X
       |vpiActual:
       \_logic_net: (work@wandwor_test0.X), line:48:29, endln:48:30, parent:work@wandwor_test0
+    |vpiTypedef:
+    \_logic_typespec: , line:50:9, endln:50:12
     |vpiInstance:
     \_module: work@wandwor_test0 (work@wandwor_test0) dut.sv:48:1: , endln:54:10
   |vpiContAssign:

--- a/tests/MultiConcatValueSize/MultiConcatValueSize.log
+++ b/tests/MultiConcatValueSize/MultiConcatValueSize.log
@@ -1906,6 +1906,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:52:23, endln:52:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:52:19, endln:52:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:52:1: , endln:60:10
   |vpiModule:
@@ -2283,6 +2286,9 @@ design: (work@top)
         |vpiFullName:work@top.u_sub.c
         |vpiActual:
         \_int_var: (work@top.u_sub.c), line:41:27, endln:41:28, parent:work@top.u_sub
+      |vpiTypedef:
+      \_int_typespec: , line:41:23, endln:41:26
+        |vpiSigned:1
       |vpiInstance:
       \_module: work@sub_top (work@top.u_sub) dut.sv:57:4: , endln:59:19, parent:work@top
     |vpiGenScopeArray:
@@ -2393,6 +2399,9 @@ design: (work@top)
               |vpiFullName:work@top.u_sub.gen_dio_attr[0].u_prim_pad_attr.b
               |vpiActual:
               \_int_var: (work@top.u_sub.gen_dio_attr[0].u_prim_pad_attr.b), line:30:33, endln:30:34, parent:work@top.u_sub.gen_dio_attr[0].u_prim_pad_attr
+            |vpiTypedef:
+            \_int_typespec: , line:30:29, endln:30:32
+              |vpiSigned:1
             |vpiInstance:
             \_module: work@prim_pad_attr (work@top.u_sub.gen_dio_attr[0].u_prim_pad_attr) dut.sv:46:6: , endln:48:31, parent:work@top.u_sub.gen_dio_attr[0]
           |vpiGenScopeArray:
@@ -2495,6 +2504,9 @@ design: (work@top)
                     |vpiFullName:work@top.u_sub.gen_dio_attr[0].u_prim_pad_attr.gen_generic.u_impl_generic.a
                     |vpiActual:
                     \_int_var: (work@top.u_sub.gen_dio_attr[0].u_prim_pad_attr.gen_generic.u_impl_generic.a), line:22:41, endln:22:42, parent:work@top.u_sub.gen_dio_attr[0].u_prim_pad_attr.gen_generic.u_impl_generic
+                  |vpiTypedef:
+                  \_int_typespec: , line:22:37, endln:22:40
+                    |vpiSigned:1
                   |vpiInstance:
                   \_module: work@prim_generic_pad_attr (work@top.u_sub.gen_dio_attr[0].u_prim_pad_attr.gen_generic.u_impl_generic) dut.sv:35:7: , endln:37:31, parent:work@top.u_sub.gen_dio_attr[0].u_prim_pad_attr.gen_generic
                 |vpiGenScopeArray:

--- a/tests/NoParamSubs/NoParamSubs.log
+++ b/tests/NoParamSubs/NoParamSubs.log
@@ -261,23 +261,25 @@ design: (work@top)
       |vpiFullName:work@dut.a
       |vpiActual:
       \_logic_net: (work@top.u_dut.a), line:1:31, endln:1:32, parent:work@top.u_dut
+        |vpiTypespec:
+        \_logic_typespec: , line:1:19, endln:1:24
+          |vpiRange:
+          \_range: , line:1:26, endln:1:29
+            |vpiLeftRange:
+            \_constant: , line:1:26, endln:1:27
+              |vpiDecompile:1
+              |vpiSize:64
+              |UINT:1
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:1:28, endln:1:29
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:a
         |vpiFullName:work@top.u_dut.a
         |vpiNetType:36
-        |vpiRange:
-        \_range: , line:1:26, endln:1:29
-          |vpiLeftRange:
-          \_constant: , line:1:26, endln:1:27
-            |vpiDecompile:1
-            |vpiSize:64
-            |UINT:1
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:1:28, endln:1:29
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:6:1: , endln:13:10, parent:work@top
   |vpiFullName:work@top
@@ -397,23 +399,25 @@ design: (work@top)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.o), line:6:31, endln:6:32, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:6:19, endln:6:24
+      |vpiRange:
+      \_range: , line:6:26, endln:6:29
+        |vpiLeftRange:
+        \_constant: , line:6:26, endln:6:27
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:6:28, endln:6:29
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:o
     |vpiFullName:work@top.o
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:6:26, endln:6:29
-      |vpiLeftRange:
-      \_constant: , line:6:26, endln:6:27
-        |vpiDecompile:1
-        |vpiSize:64
-        |UINT:1
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:6:28, endln:6:29
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (o), line:6:31, endln:6:32, parent:work@top
@@ -425,6 +429,22 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:6:31, endln:6:32, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:6:19, endln:6:24
+      |vpiRange:
+      \_range: , line:6:26, endln:6:29, parent:o
+        |vpiLeftRange:
+        \_constant: , line:6:26, endln:6:27
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:6:28, endln:6:29
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:6:1: , endln:13:10
   |vpiModule:
@@ -488,6 +508,22 @@ design: (work@top)
         |vpiFullName:work@top.u_dut.a
         |vpiActual:
         \_logic_net: (work@top.u_dut.a), line:1:31, endln:1:32, parent:work@top.u_dut
+      |vpiTypedef:
+      \_logic_typespec: , line:1:19, endln:1:24
+        |vpiRange:
+        \_range: , line:1:26, endln:1:29, parent:a
+          |vpiLeftRange:
+          \_constant: , line:1:26, endln:1:27
+            |vpiDecompile:1
+            |vpiSize:64
+            |UINT:1
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:1:28, endln:1:29
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@dut (work@top.u_dut) dut.sv:8:4: , endln:12:6, parent:work@top
     |vpiContAssign:

--- a/tests/OneAnd/OneAnd.log
+++ b/tests/OneAnd/OneAnd.log
@@ -663,6 +663,8 @@ design: (work@and_tb)
           |vpiFullName:work@and_tb.o
           |vpiActual:
           \_logic_net: (work@and_tb.o), line:1:28, endln:1:29, parent:work@and_tb
+            |vpiTypespec:
+            \_logic_typespec: , line:1:22, endln:1:27
             |vpiName:o
             |vpiFullName:work@and_tb.o
             |vpiNetType:36
@@ -1081,6 +1083,8 @@ design: (work@and_tb)
         |vpiFullName:work@dut.a
         |vpiActual:
         \_logic_net: (work@and_tb.dut1.a), line:1:24, endln:1:25, parent:work@and_tb.dut1
+          |vpiTypespec:
+          \_logic_typespec: , line:1:18, endln:1:23
           |vpiName:a
           |vpiFullName:work@and_tb.dut1.a
           |vpiNetType:36
@@ -1090,6 +1094,8 @@ design: (work@and_tb)
         |vpiFullName:work@dut.b
         |vpiActual:
         \_logic_net: (work@and_tb.dut1.b), line:1:39, endln:1:40, parent:work@and_tb.dut1
+          |vpiTypespec:
+          \_logic_typespec: , line:1:33, endln:1:38
           |vpiName:b
           |vpiFullName:work@and_tb.dut1.b
           |vpiNetType:36
@@ -1099,6 +1105,8 @@ design: (work@and_tb)
       |vpiFullName:work@dut.o
       |vpiActual:
       \_logic_net: (work@and_tb.dut1.o), line:1:55, endln:1:56, parent:work@and_tb.dut1
+        |vpiTypespec:
+        \_logic_typespec: , line:1:49, endln:1:54
         |vpiName:o
         |vpiFullName:work@and_tb.dut1.o
         |vpiNetType:36
@@ -1124,6 +1132,8 @@ design: (work@and_tb)
       |vpiFullName:work@and_tb.o
       |vpiActual:
       \_logic_net: (work@and_tb.o), line:1:28, endln:1:29, parent:work@and_tb
+    |vpiTypedef:
+    \_logic_typespec: , line:1:22, endln:1:27
     |vpiInstance:
     \_module: work@and_tb (work@and_tb) tb.v:1:1: , endln:30:10
   |vpiProcess:
@@ -1468,6 +1478,8 @@ design: (work@and_tb)
         |vpiFullName:work@and_tb.dut1.a
         |vpiActual:
         \_logic_net: (work@and_tb.dut1.a), line:1:24, endln:1:25, parent:work@and_tb.dut1
+      |vpiTypedef:
+      \_logic_typespec: , line:1:18, endln:1:23
       |vpiInstance:
       \_module: work@dut (work@and_tb.dut1) tb.v:28:3: , endln:28:19, parent:work@and_tb
     |vpiPort:
@@ -1486,6 +1498,8 @@ design: (work@and_tb)
         |vpiFullName:work@and_tb.dut1.b
         |vpiActual:
         \_logic_net: (work@and_tb.dut1.b), line:1:39, endln:1:40, parent:work@and_tb.dut1
+      |vpiTypedef:
+      \_logic_typespec: , line:1:33, endln:1:38
       |vpiInstance:
       \_module: work@dut (work@and_tb.dut1) tb.v:28:3: , endln:28:19, parent:work@and_tb
     |vpiPort:
@@ -1504,6 +1518,8 @@ design: (work@and_tb)
         |vpiFullName:work@and_tb.dut1.o
         |vpiActual:
         \_logic_net: (work@and_tb.dut1.o), line:1:55, endln:1:56, parent:work@and_tb.dut1
+      |vpiTypedef:
+      \_logic_typespec: , line:1:49, endln:1:54
       |vpiInstance:
       \_module: work@dut (work@and_tb.dut1) tb.v:28:3: , endln:28:19, parent:work@and_tb
     |vpiContAssign:

--- a/tests/OneClock/OneClock.log
+++ b/tests/OneClock/OneClock.log
@@ -64,6 +64,8 @@ design: (work@tb)
           |vpiFullName:work@tb.clk
           |vpiActual:
           \_logic_net: (work@tb.clk), line:3:7, endln:3:10, parent:work@tb
+            |vpiTypespec:
+            \_logic_typespec: , line:3:3, endln:3:6
             |vpiName:clk
             |vpiFullName:work@tb.clk
             |vpiNetType:48

--- a/tests/OneDivider/OneDivider.log
+++ b/tests/OneDivider/OneDivider.log
@@ -95,6 +95,8 @@ design: (work@tb)
             |vpiName:clk
             |vpiActual:
             \_logic_net: (work@tb.dut1.clk), line:2:24, endln:2:27, parent:work@tb.dut1
+              |vpiTypespec:
+              \_logic_typespec: , line:2:18, endln:2:23
               |vpiName:clk
               |vpiFullName:work@tb.dut1.clk
               |vpiNetType:36
@@ -106,6 +108,8 @@ design: (work@tb)
             |vpiName:rstn
             |vpiActual:
             \_logic_net: (work@tb.dut1.rstn), line:1:24, endln:1:28, parent:work@tb.dut1
+              |vpiTypespec:
+              \_logic_typespec: , line:1:18, endln:1:23
               |vpiName:rstn
               |vpiFullName:work@tb.dut1.rstn
               |vpiNetType:36
@@ -135,6 +139,8 @@ design: (work@tb)
             |vpiFullName:work@dut.div
             |vpiActual:
             \_logic_net: (work@tb.dut1.div), line:3:23, endln:3:26, parent:work@tb.dut1
+              |vpiTypespec:
+              \_logic_typespec: , line:3:19, endln:3:22
               |vpiName:div
               |vpiFullName:work@tb.dut1.div
               |vpiNetType:48
@@ -199,6 +205,8 @@ design: (work@tb)
           |vpiName:clk
           |vpiActual:
           \_logic_net: (work@tb.clk), line:2:7, endln:2:10, parent:work@tb
+            |vpiTypespec:
+            \_logic_typespec: , line:2:3, endln:2:6
             |vpiName:clk
             |vpiFullName:work@tb.clk
             |vpiNetType:48
@@ -398,6 +406,8 @@ design: (work@tb)
         |vpiFullName:work@tb.dut1.rstn
         |vpiActual:
         \_logic_net: (work@tb.dut1.rstn), line:1:24, endln:1:28, parent:work@tb.dut1
+      |vpiTypedef:
+      \_logic_typespec: , line:1:18, endln:1:23
     |vpiPort:
     \_port: (clk), line:2:24, endln:2:27, parent:work@tb.dut1
       |vpiName:clk
@@ -414,6 +424,8 @@ design: (work@tb)
         |vpiFullName:work@tb.dut1.clk
         |vpiActual:
         \_logic_net: (work@tb.dut1.clk), line:2:24, endln:2:27, parent:work@tb.dut1
+      |vpiTypedef:
+      \_logic_typespec: , line:2:18, endln:2:23
     |vpiPort:
     \_port: (div), line:3:23, endln:3:26, parent:work@tb.dut1
       |vpiName:div
@@ -430,6 +442,8 @@ design: (work@tb)
         |vpiFullName:work@tb.dut1.div
         |vpiActual:
         \_logic_net: (work@tb.dut1.div), line:3:23, endln:3:26, parent:work@tb.dut1
+      |vpiTypedef:
+      \_logic_typespec: , line:3:19, endln:3:22
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/OneFF/OneFF.log
+++ b/tests/OneFF/OneFF.log
@@ -146,6 +146,8 @@ design: (work@tb)
               |vpiFullName:work@dut.q
               |vpiActual:
               \_logic_net: (work@tb.dut1.q), line:5:26, endln:5:27, parent:work@tb.dut1
+                |vpiTypespec:
+                \_logic_typespec: , line:5:22, endln:5:25
                 |vpiName:q
                 |vpiFullName:work@tb.dut1.q
                 |vpiNetType:48
@@ -225,6 +227,8 @@ design: (work@tb)
           |vpiFullName:work@tb.clk
           |vpiActual:
           \_logic_net: (work@tb.clk), line:3:7, endln:3:10, parent:work@tb
+            |vpiTypespec:
+            \_logic_typespec: , line:3:3, endln:3:6
             |vpiName:clk
             |vpiFullName:work@tb.clk
             |vpiNetType:48
@@ -234,6 +238,8 @@ design: (work@tb)
           |vpiFullName:work@tb.o
           |vpiActual:
           \_logic_net: (work@tb.o), line:6:7, endln:6:8, parent:work@tb
+            |vpiTypespec:
+            \_logic_typespec: , line:6:3, endln:6:6
             |vpiName:o
             |vpiFullName:work@tb.o
             |vpiNetType:48
@@ -613,6 +619,8 @@ design: (work@tb)
         |vpiFullName:work@tb.dut1.q
         |vpiActual:
         \_logic_net: (work@tb.dut1.q), line:5:26, endln:5:27, parent:work@tb.dut1
+      |vpiTypedef:
+      \_logic_typespec: , line:5:22, endln:5:25
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/OneImport/OneImport.log
+++ b/tests/OneImport/OneImport.log
@@ -446,23 +446,25 @@ design: (work@dut)
             |vpiFullName:work@dut.a
             |vpiActual:
             \_logic_net: (work@dut.a), line:16:14, endln:16:15, parent:work@dut
+              |vpiTypespec:
+              \_logic_typespec: , line:16:3, endln:16:7
+                |vpiRange:
+                \_range: , line:16:9, endln:16:12
+                  |vpiLeftRange:
+                  \_constant: , line:16:9, endln:16:10
+                    |vpiDecompile:5
+                    |vpiSize:64
+                    |UINT:5
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:16:11, endln:16:12
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiName:a
               |vpiFullName:work@dut.a
               |vpiNetType:1
-              |vpiRange:
-              \_range: , line:16:9, endln:16:12
-                |vpiLeftRange:
-                \_constant: , line:16:9, endln:16:10
-                  |vpiDecompile:5
-                  |vpiSize:64
-                  |UINT:5
-                  |vpiConstType:9
-                |vpiRightRange:
-                \_constant: , line:16:11, endln:16:12
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-                  |vpiConstType:9
           |vpiOperand:
           \_ref_obj: (work@dut.OPCODE_LOAD), line:19:23, endln:19:34
             |vpiName:OPCODE_LOAD
@@ -475,23 +477,25 @@ design: (work@dut)
       |vpiFullName:work@dut.b
       |vpiActual:
       \_logic_net: (work@dut.b), line:17:13, endln:17:14, parent:work@dut
+        |vpiTypespec:
+        \_logic_typespec: , line:17:3, endln:17:6
+          |vpiRange:
+          \_range: , line:17:8, endln:17:11
+            |vpiLeftRange:
+            \_constant: , line:17:8, endln:17:9
+              |vpiDecompile:2
+              |vpiSize:64
+              |UINT:2
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:17:10, endln:17:11
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:b
         |vpiFullName:work@dut.b
         |vpiNetType:48
-        |vpiRange:
-        \_range: , line:17:8, endln:17:11
-          |vpiLeftRange:
-          \_constant: , line:17:8, endln:17:9
-            |vpiDecompile:2
-            |vpiSize:64
-            |UINT:2
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:17:10, endln:17:11
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@dut (work@dut) dut.sv:11:1: , endln:20:10
   |vpiName:work@dut
@@ -544,6 +548,22 @@ design: (work@dut)
       |vpiFullName:work@dut.a
       |vpiActual:
       \_logic_net: (work@dut.a), line:16:14, endln:16:15, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:14:9, endln:14:14
+      |vpiRange:
+      \_range: , line:14:10, endln:14:13, parent:a
+        |vpiLeftRange:
+        \_constant: , line:14:10, endln:14:11
+          |vpiDecompile:5
+          |vpiSize:64
+          |UINT:5
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:14:12, endln:14:13
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:11:1: , endln:20:10
   |vpiPort:
@@ -556,6 +576,22 @@ design: (work@dut)
       |vpiFullName:work@dut.b
       |vpiActual:
       \_logic_net: (work@dut.b), line:17:13, endln:17:14, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:15:10, endln:15:15
+      |vpiRange:
+      \_range: , line:15:11, endln:15:14, parent:b
+        |vpiLeftRange:
+        \_constant: , line:15:11, endln:15:12
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:15:13, endln:15:14
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:11:1: , endln:20:10
   |vpiContAssign:

--- a/tests/OneNet/OneNet.log
+++ b/tests/OneNet/OneNet.log
@@ -71,6 +71,8 @@ design: (work@dut)
       |vpiFullName:work@dut.i
       |vpiActual:
       \_logic_net: (work@dut.i), line:1:24, endln:1:25, parent:work@dut
+        |vpiTypespec:
+        \_logic_typespec: , line:1:19, endln:1:23
         |vpiName:i
         |vpiFullName:work@dut.i
         |vpiNetType:1
@@ -80,6 +82,8 @@ design: (work@dut)
       |vpiFullName:work@dut.o
       |vpiActual:
       \_logic_net: (work@dut.o), line:1:38, endln:1:39, parent:work@dut
+        |vpiTypespec:
+        \_logic_typespec: , line:1:34, endln:1:37
         |vpiName:o
         |vpiFullName:work@dut.o
         |vpiNetType:48
@@ -103,6 +107,8 @@ design: (work@dut)
       |vpiFullName:work@dut.i
       |vpiActual:
       \_logic_net: (work@dut.i), line:1:24, endln:1:25, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:1:19, endln:1:23
   |vpiPort:
   \_port: (o), line:1:38, endln:1:39, parent:work@dut
     |vpiName:o
@@ -113,6 +119,8 @@ design: (work@dut)
       |vpiFullName:work@dut.o
       |vpiActual:
       \_logic_net: (work@dut.o), line:1:38, endln:1:39, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:1:34, endln:1:37
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/OneNetInterf/OneNetInterf.log
+++ b/tests/OneNetInterf/OneNetInterf.log
@@ -137,6 +137,8 @@ design: (work@dut)
           |vpiFullName:work@TESTBENCH.drive
           |vpiActual:
           \_logic_net: (work@tb.tb.drive), line:1:50, endln:1:55, parent:work@tb.tb
+            |vpiTypespec:
+            \_logic_typespec: , line:1:46, endln:1:49
             |vpiName:drive
             |vpiFullName:work@tb.tb.drive
             |vpiNetType:48
@@ -146,6 +148,8 @@ design: (work@dut)
           |vpiFullName:work@TESTBENCH.observe
           |vpiActual:
           \_logic_net: (work@tb.tb.observe), line:1:30, endln:1:37, parent:work@tb.tb
+            |vpiTypespec:
+            \_logic_typespec: , line:1:25, endln:1:29
             |vpiName:observe
             |vpiFullName:work@tb.tb.observe
             |vpiNetType:1
@@ -333,6 +337,8 @@ design: (work@dut)
       |vpiFullName:work@SUB.inp
       |vpiActual:
       \_logic_net: (work@dut.middle1.sub1.inp), line:14:24, endln:14:27, parent:work@dut.middle1.sub1
+        |vpiTypespec:
+        \_logic_typespec: , line:14:19, endln:14:23
         |vpiName:inp
         |vpiFullName:work@dut.middle1.sub1.inp
         |vpiNetType:1
@@ -342,6 +348,8 @@ design: (work@dut)
       |vpiFullName:work@SUB.out
       |vpiActual:
       \_logic_net: (work@dut.middle1.sub1.out), line:14:40, endln:14:43, parent:work@dut.middle1.sub1
+        |vpiTypespec:
+        \_logic_typespec: , line:14:36, endln:14:39
         |vpiName:out
         |vpiFullName:work@dut.middle1.sub1.out
         |vpiNetType:48
@@ -412,11 +420,15 @@ design: (work@dut)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@dut.i), line:2:24, endln:2:25, parent:work@dut
+    |vpiTypespec:
+    \_logic_typespec: , line:2:19, endln:2:23
     |vpiName:i
     |vpiFullName:work@dut.i
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@dut.o), line:2:38, endln:2:39, parent:work@dut
+    |vpiTypespec:
+    \_logic_typespec: , line:2:34, endln:2:37
     |vpiName:o
     |vpiFullName:work@dut.o
     |vpiNetType:48
@@ -431,6 +443,8 @@ design: (work@dut)
       |vpiFullName:work@dut.i
       |vpiActual:
       \_logic_net: (work@dut.i), line:2:24, endln:2:25, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:2:19, endln:2:23
   |vpiPort:
   \_port: (o), line:2:38, endln:2:39, parent:work@dut
     |vpiName:o
@@ -441,6 +455,8 @@ design: (work@dut)
       |vpiFullName:work@dut.o
       |vpiActual:
       \_logic_net: (work@dut.o), line:2:38, endln:2:39, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:2:34, endln:2:37
   |vpiInterface:
   \_interface: work@ConnectTB (work@dut.conntb) dut.v:3:3: , endln:3:41, parent:work@dut
     |vpiName:conntb
@@ -450,11 +466,15 @@ design: (work@dut)
     |vpiDefLineNo:7
     |vpiNet:
     \_logic_net: (work@dut.conntb.con_i), line:7:33, endln:7:38, parent:work@dut.conntb
+      |vpiTypespec:
+      \_logic_typespec: , line:7:28, endln:7:32
       |vpiName:con_i
       |vpiFullName:work@dut.conntb.con_i
       |vpiNetType:1
     |vpiNet:
     \_logic_net: (work@dut.conntb.con_o), line:7:51, endln:7:56, parent:work@dut.conntb
+      |vpiTypespec:
+      \_logic_typespec: , line:7:47, endln:7:50
       |vpiName:con_o
       |vpiFullName:work@dut.conntb.con_o
       |vpiNetType:48
@@ -476,6 +496,8 @@ design: (work@dut)
         |vpiFullName:work@dut.conntb.con_i
         |vpiActual:
         \_logic_net: (work@dut.conntb.con_i), line:7:33, endln:7:38, parent:work@dut.conntb
+      |vpiTypedef:
+      \_logic_typespec: , line:7:28, endln:7:32
     |vpiPort:
     \_port: (con_o), line:7:51, endln:7:56, parent:work@dut.conntb
       |vpiName:con_o
@@ -492,6 +514,8 @@ design: (work@dut)
         |vpiFullName:work@dut.conntb.con_o
         |vpiActual:
         \_logic_net: (work@dut.conntb.con_o), line:7:51, endln:7:56, parent:work@dut.conntb
+      |vpiTypedef:
+      \_logic_typespec: , line:7:47, endln:7:50
   |vpiModule:
   \_module: work@middle (work@dut.middle1) dut.v:4:3: , endln:4:26, parent:work@dut
     |vpiName:middle1
@@ -554,6 +578,8 @@ design: (work@dut)
           |vpiFullName:work@dut.middle1.sub1.inp
           |vpiActual:
           \_logic_net: (work@dut.middle1.sub1.inp), line:14:24, endln:14:27, parent:work@dut.middle1.sub1
+        |vpiTypedef:
+        \_logic_typespec: , line:14:19, endln:14:23
       |vpiPort:
       \_port: (out), line:14:40, endln:14:43, parent:work@dut.middle1.sub1
         |vpiName:out
@@ -575,6 +601,8 @@ design: (work@dut)
           |vpiFullName:work@dut.middle1.sub1.out
           |vpiActual:
           \_logic_net: (work@dut.middle1.sub1.out), line:14:40, endln:14:43, parent:work@dut.middle1.sub1
+        |vpiTypedef:
+        \_logic_typespec: , line:14:36, endln:14:39
 |uhdmtopModules:
 \_module: work@tb (work@tb) tb.v:14:1: , endln:19:10
   |vpiName:work@tb
@@ -612,6 +640,8 @@ design: (work@dut)
         |vpiFullName:work@tb.tb.observe
         |vpiActual:
         \_logic_net: (work@tb.tb.observe), line:1:30, endln:1:37, parent:work@tb.tb
+      |vpiTypedef:
+      \_logic_typespec: , line:1:25, endln:1:29
     |vpiPort:
     \_port: (drive), line:1:50, endln:1:55, parent:work@tb.tb
       |vpiName:drive
@@ -631,13 +661,19 @@ design: (work@dut)
         |vpiFullName:work@tb.tb.drive
         |vpiActual:
         \_logic_net: (work@tb.tb.drive), line:1:50, endln:1:55, parent:work@tb.tb
+      |vpiTypedef:
+      \_logic_typespec: , line:1:46, endln:1:49
   |vpiNet:
   \_logic_net: (work@tb.i), line:15:8, endln:15:9, parent:work@tb
+    |vpiTypespec:
+    \_logic_typespec: , line:15:3, endln:15:7
     |vpiName:i
     |vpiFullName:work@tb.i
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@tb.o), line:15:10, endln:15:11, parent:work@tb
+    |vpiTypespec:
+    \_logic_typespec: , line:15:3, endln:15:7
     |vpiName:o
     |vpiFullName:work@tb.o
     |vpiNetType:1
@@ -651,11 +687,15 @@ design: (work@dut)
     |vpiDefLineNo:7
     |vpiNet:
     \_logic_net: (work@tb.conntb.con_i), line:7:33, endln:7:38, parent:work@tb.conntb
+      |vpiTypespec:
+      \_logic_typespec: , line:7:28, endln:7:32
       |vpiName:con_i
       |vpiFullName:work@tb.conntb.con_i
       |vpiNetType:1
     |vpiNet:
     \_logic_net: (work@tb.conntb.con_o), line:7:51, endln:7:56, parent:work@tb.conntb
+      |vpiTypespec:
+      \_logic_typespec: , line:7:47, endln:7:50
       |vpiName:con_o
       |vpiFullName:work@tb.conntb.con_o
       |vpiNetType:48
@@ -677,6 +717,8 @@ design: (work@dut)
         |vpiFullName:work@tb.conntb.con_i
         |vpiActual:
         \_logic_net: (work@tb.conntb.con_i), line:7:33, endln:7:38, parent:work@tb.conntb
+      |vpiTypedef:
+      \_logic_typespec: , line:7:28, endln:7:32
     |vpiPort:
     \_port: (con_o), line:7:51, endln:7:56, parent:work@tb.conntb
       |vpiName:con_o
@@ -693,6 +735,8 @@ design: (work@dut)
         |vpiFullName:work@tb.conntb.con_o
         |vpiActual:
         \_logic_net: (work@tb.conntb.con_o), line:7:51, endln:7:56, parent:work@tb.conntb
+      |vpiTypedef:
+      \_logic_typespec: , line:7:47, endln:7:50
   |vpiModule:
   \_module: work@middle (work@tb.dut1) tb.v:17:3: , endln:17:23, parent:work@tb
     |vpiName:dut1
@@ -730,11 +774,15 @@ design: (work@dut)
       |vpiDefLineNo:14
       |vpiNet:
       \_logic_net: (work@tb.dut1.sub1.inp), line:14:24, endln:14:27, parent:work@tb.dut1.sub1
+        |vpiTypespec:
+        \_logic_typespec: , line:14:19, endln:14:23
         |vpiName:inp
         |vpiFullName:work@tb.dut1.sub1.inp
         |vpiNetType:1
       |vpiNet:
       \_logic_net: (work@tb.dut1.sub1.out), line:14:40, endln:14:43, parent:work@tb.dut1.sub1
+        |vpiTypespec:
+        \_logic_typespec: , line:14:36, endln:14:39
         |vpiName:out
         |vpiFullName:work@tb.dut1.sub1.out
         |vpiNetType:48
@@ -761,6 +809,8 @@ design: (work@dut)
           |vpiFullName:work@tb.dut1.sub1.inp
           |vpiActual:
           \_logic_net: (work@tb.dut1.sub1.inp), line:14:24, endln:14:27, parent:work@tb.dut1.sub1
+        |vpiTypedef:
+        \_logic_typespec: , line:14:19, endln:14:23
       |vpiPort:
       \_port: (out), line:14:40, endln:14:43, parent:work@tb.dut1.sub1
         |vpiName:out
@@ -782,6 +832,8 @@ design: (work@dut)
           |vpiFullName:work@tb.dut1.sub1.out
           |vpiActual:
           \_logic_net: (work@tb.dut1.sub1.out), line:14:40, endln:14:43, parent:work@tb.dut1.sub1
+        |vpiTypedef:
+        \_logic_typespec: , line:14:36, endln:14:39
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/OneNetModPort/OneNetModPort.log
+++ b/tests/OneNetModPort/OneNetModPort.log
@@ -333,6 +333,8 @@ design: (work@TOP)
       |vpiFullName:work@SUB.inp
       |vpiActual:
       \_logic_net: (work@TOP.dut1.middle1.sub1.inp), line:26:24, endln:26:27, parent:work@TOP.dut1.middle1.sub1
+        |vpiTypespec:
+        \_logic_typespec: , line:26:19, endln:26:23
         |vpiName:inp
         |vpiFullName:work@TOP.dut1.middle1.sub1.inp
         |vpiNetType:1
@@ -342,6 +344,8 @@ design: (work@TOP)
       |vpiFullName:work@SUB.out
       |vpiActual:
       \_logic_net: (work@TOP.dut1.middle1.sub1.out), line:26:40, endln:26:43, parent:work@TOP.dut1.middle1.sub1
+        |vpiTypespec:
+        \_logic_typespec: , line:26:36, endln:26:39
         |vpiName:out
         |vpiFullName:work@TOP.dut1.middle1.sub1.out
         |vpiNetType:48
@@ -387,6 +391,8 @@ design: (work@TOP)
       |vpiFullName:work@dut.i
       |vpiActual:
       \_logic_net: (work@TOP.dut1.i), line:2:24, endln:2:25, parent:work@TOP.dut1
+        |vpiTypespec:
+        \_logic_typespec: , line:2:19, endln:2:23
         |vpiName:i
         |vpiFullName:work@TOP.dut1.i
         |vpiNetType:1
@@ -416,6 +422,8 @@ design: (work@TOP)
       |vpiFullName:work@dut.o
       |vpiActual:
       \_logic_net: (work@TOP.dut1.o), line:2:38, endln:2:39, parent:work@TOP.dut1
+        |vpiTypespec:
+        \_logic_typespec: , line:2:34, endln:2:37
         |vpiName:o
         |vpiFullName:work@TOP.dut1.o
         |vpiNetType:48
@@ -602,6 +610,8 @@ design: (work@TOP)
         |vpiFullName:work@TOP.dut1.i
         |vpiActual:
         \_logic_net: (work@TOP.dut1.i), line:2:24, endln:2:25, parent:work@TOP.dut1
+      |vpiTypedef:
+      \_logic_typespec: , line:2:19, endln:2:23
     |vpiPort:
     \_port: (o), line:2:38, endln:2:39, parent:work@TOP.dut1
       |vpiName:o
@@ -621,6 +631,8 @@ design: (work@TOP)
         |vpiFullName:work@TOP.dut1.o
         |vpiActual:
         \_logic_net: (work@TOP.dut1.o), line:2:38, endln:2:39, parent:work@TOP.dut1
+      |vpiTypedef:
+      \_logic_typespec: , line:2:34, endln:2:37
     |vpiInterface:
     \_interface: work@ConnectTB (work@TOP.dut1.conntb) dut.v:5:3: , endln:5:22, parent:work@TOP.dut1
       |vpiName:conntb
@@ -787,6 +799,8 @@ design: (work@TOP)
             |vpiFullName:work@TOP.dut1.middle1.sub1.inp
             |vpiActual:
             \_logic_net: (work@TOP.dut1.middle1.sub1.inp), line:26:24, endln:26:27, parent:work@TOP.dut1.middle1.sub1
+          |vpiTypedef:
+          \_logic_typespec: , line:26:19, endln:26:23
         |vpiPort:
         \_port: (out), line:26:40, endln:26:43, parent:work@TOP.dut1.middle1.sub1
           |vpiName:out
@@ -808,6 +822,8 @@ design: (work@TOP)
             |vpiFullName:work@TOP.dut1.middle1.sub1.out
             |vpiActual:
             \_logic_net: (work@TOP.dut1.middle1.sub1.out), line:26:40, endln:26:43, parent:work@TOP.dut1.middle1.sub1
+          |vpiTypedef:
+          \_logic_typespec: , line:26:36, endln:26:39
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/OneNetModPortGeneric/OneNetModPortGeneric.log
+++ b/tests/OneNetModPortGeneric/OneNetModPortGeneric.log
@@ -382,6 +382,8 @@ design: (work@TOP)
       |vpiFullName:work@SUB.inp
       |vpiActual:
       \_logic_net: (work@TOP.dut1.middle1.sub1.inp), line:26:24, endln:26:27, parent:work@TOP.dut1.middle1.sub1
+        |vpiTypespec:
+        \_logic_typespec: , line:26:19, endln:26:23
         |vpiName:inp
         |vpiFullName:work@TOP.dut1.middle1.sub1.inp
         |vpiNetType:1
@@ -391,6 +393,8 @@ design: (work@TOP)
       |vpiFullName:work@SUB.out
       |vpiActual:
       \_logic_net: (work@TOP.dut1.middle1.sub1.out), line:26:40, endln:26:43, parent:work@TOP.dut1.middle1.sub1
+        |vpiTypespec:
+        \_logic_typespec: , line:26:36, endln:26:39
         |vpiName:out
         |vpiFullName:work@TOP.dut1.middle1.sub1.out
         |vpiNetType:48
@@ -436,6 +440,8 @@ design: (work@TOP)
       |vpiFullName:work@dut.i
       |vpiActual:
       \_logic_net: (work@TOP.dut1.i), line:2:24, endln:2:25, parent:work@TOP.dut1
+        |vpiTypespec:
+        \_logic_typespec: , line:2:19, endln:2:23
         |vpiName:i
         |vpiFullName:work@TOP.dut1.i
         |vpiNetType:1
@@ -465,6 +471,8 @@ design: (work@TOP)
       |vpiFullName:work@dut.o
       |vpiActual:
       \_logic_net: (work@TOP.dut1.o), line:2:38, endln:2:39, parent:work@TOP.dut1
+        |vpiTypespec:
+        \_logic_typespec: , line:2:34, endln:2:37
         |vpiName:o
         |vpiFullName:work@TOP.dut1.o
         |vpiNetType:48
@@ -638,6 +646,8 @@ design: (work@TOP)
         |vpiFullName:work@TOP.dut1.i
         |vpiActual:
         \_logic_net: (work@TOP.dut1.i), line:2:24, endln:2:25, parent:work@TOP.dut1
+      |vpiTypedef:
+      \_logic_typespec: , line:2:19, endln:2:23
     |vpiPort:
     \_port: (o), line:2:38, endln:2:39, parent:work@TOP.dut1
       |vpiName:o
@@ -657,6 +667,8 @@ design: (work@TOP)
         |vpiFullName:work@TOP.dut1.o
         |vpiActual:
         \_logic_net: (work@TOP.dut1.o), line:2:38, endln:2:39, parent:work@TOP.dut1
+      |vpiTypedef:
+      \_logic_typespec: , line:2:34, endln:2:37
     |vpiInterface:
     \_interface: work@ConnectTB (work@TOP.dut1.conntb) dut.v:5:3: , endln:5:22, parent:work@TOP.dut1
       |vpiName:conntb
@@ -793,6 +805,8 @@ design: (work@TOP)
             |vpiFullName:work@TOP.dut1.middle1.sub1.inp
             |vpiActual:
             \_logic_net: (work@TOP.dut1.middle1.sub1.inp), line:26:24, endln:26:27, parent:work@TOP.dut1.middle1.sub1
+          |vpiTypedef:
+          \_logic_typespec: , line:26:19, endln:26:23
         |vpiPort:
         \_port: (out), line:26:40, endln:26:43, parent:work@TOP.dut1.middle1.sub1
           |vpiName:out
@@ -814,6 +828,8 @@ design: (work@TOP)
             |vpiFullName:work@TOP.dut1.middle1.sub1.out
             |vpiActual:
             \_logic_net: (work@TOP.dut1.middle1.sub1.out), line:26:40, endln:26:43, parent:work@TOP.dut1.middle1.sub1
+          |vpiTypedef:
+          \_logic_typespec: , line:26:36, endln:26:39
   |vpiModule:
   \_module: work@OBSERVER (work@TOP.obs) tb.v:19:3: , endln:19:32, parent:work@TOP
     |vpiName:obs

--- a/tests/OneNetNonAnsi/OneNetNonAnsi.log
+++ b/tests/OneNetNonAnsi/OneNetNonAnsi.log
@@ -75,6 +75,8 @@ design: (work@tb)
       |vpiFullName:work@dut.i
       |vpiActual:
       \_logic_net: (work@tb.dut1.i), line:4:8, endln:4:9, parent:work@tb.dut1
+        |vpiTypespec:
+        \_logic_typespec: , line:4:3, endln:4:7
         |vpiName:i
         |vpiFullName:work@tb.dut1.i
         |vpiNetType:1
@@ -84,6 +86,8 @@ design: (work@tb)
       |vpiFullName:work@dut.o
       |vpiActual:
       \_logic_net: (work@tb.dut1.o), line:5:7, endln:5:8, parent:work@tb.dut1
+        |vpiTypespec:
+        \_logic_typespec: , line:5:3, endln:5:6
         |vpiName:o
         |vpiFullName:work@tb.dut1.o
         |vpiNetType:48

--- a/tests/OneNetRange/OneNetRange.log
+++ b/tests/OneNetRange/OneNetRange.log
@@ -171,46 +171,50 @@ design: (work@TOP)
           |vpiFullName:work@TESTBENCH.drive
           |vpiActual:
           \_logic_net: (work@TOP.tb.drive), line:1:98, endln:1:103, parent:work@TOP.tb
+            |vpiTypespec:
+            \_logic_typespec: , line:1:82, endln:1:85
+              |vpiRange:
+              \_range: , line:1:87, endln:1:96
+                |vpiLeftRange:
+                \_constant: , line:1:87, endln:1:92
+                  |vpiDecompile:15
+                  |vpiSize:64
+                  |INT:15
+                  |vpiConstType:7
+                |vpiRightRange:
+                \_constant: , line:1:95, endln:1:96
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiName:drive
             |vpiFullName:work@TOP.tb.drive
             |vpiNetType:48
-            |vpiRange:
-            \_range: , line:1:87, endln:1:96
-              |vpiLeftRange:
-              \_constant: , line:1:87, endln:1:92
-                |vpiDecompile:15
-                |vpiSize:64
-                |INT:15
-                |vpiConstType:7
-              |vpiRightRange:
-              \_constant: , line:1:95, endln:1:96
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
         |vpiArgument:
         \_ref_obj: (work@TESTBENCH.observe), line:5:53, endln:5:60, parent:$monitor
           |vpiName:observe
           |vpiFullName:work@TESTBENCH.observe
           |vpiActual:
           \_logic_net: (work@TOP.tb.observe), line:1:66, endln:1:73, parent:work@TOP.tb
+            |vpiTypespec:
+            \_logic_typespec: , line:1:49, endln:1:53
+              |vpiRange:
+              \_range: , line:1:55, endln:1:64
+                |vpiLeftRange:
+                \_constant: , line:1:55, endln:1:60
+                  |vpiDecompile:15
+                  |vpiSize:64
+                  |INT:15
+                  |vpiConstType:7
+                |vpiRightRange:
+                \_constant: , line:1:63, endln:1:64
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiName:observe
             |vpiFullName:work@TOP.tb.observe
             |vpiNetType:1
-            |vpiRange:
-            \_range: , line:1:55, endln:1:64
-              |vpiLeftRange:
-              \_constant: , line:1:55, endln:1:60
-                |vpiDecompile:15
-                |vpiSize:64
-                |INT:15
-                |vpiConstType:7
-              |vpiRightRange:
-              \_constant: , line:1:63, endln:1:64
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
         |vpiName:$monitor
       |vpiStmt:
       \_assignment: , line:6:5, endln:6:16, parent:work@TESTBENCH
@@ -414,46 +418,50 @@ design: (work@TOP)
       |vpiFullName:work@SUB.inp
       |vpiActual:
       \_logic_net: (work@TOP.dut1.middle1.sub1.inp), line:15:59, endln:15:62, parent:work@TOP.dut1.middle1.sub1
+        |vpiTypespec:
+        \_logic_typespec: , line:15:42, endln:15:46
+          |vpiRange:
+          \_range: , line:15:48, endln:15:57
+            |vpiLeftRange:
+            \_constant: , line:15:48, endln:15:53
+              |vpiDecompile:15
+              |vpiSize:64
+              |INT:15
+              |vpiConstType:7
+            |vpiRightRange:
+            \_constant: , line:15:56, endln:15:57
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:inp
         |vpiFullName:work@TOP.dut1.middle1.sub1.inp
         |vpiNetType:1
-        |vpiRange:
-        \_range: , line:15:48, endln:15:57
-          |vpiLeftRange:
-          \_constant: , line:15:48, endln:15:53
-            |vpiDecompile:15
-            |vpiSize:64
-            |INT:15
-            |vpiConstType:7
-          |vpiRightRange:
-          \_constant: , line:15:56, endln:15:57
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
     |vpiLhs:
     \_ref_obj: (work@SUB.out), line:16:10, endln:16:13
       |vpiName:out
       |vpiFullName:work@SUB.out
       |vpiActual:
       \_logic_net: (work@TOP.dut1.middle1.sub1.out), line:15:87, endln:15:90, parent:work@TOP.dut1.middle1.sub1
+        |vpiTypespec:
+        \_logic_typespec: , line:15:71, endln:15:74
+          |vpiRange:
+          \_range: , line:15:76, endln:15:85
+            |vpiLeftRange:
+            \_constant: , line:15:76, endln:15:81
+              |vpiDecompile:15
+              |vpiSize:64
+              |INT:15
+              |vpiConstType:7
+            |vpiRightRange:
+            \_constant: , line:15:84, endln:15:85
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:out
         |vpiFullName:work@TOP.dut1.middle1.sub1.out
         |vpiNetType:48
-        |vpiRange:
-        \_range: , line:15:76, endln:15:85
-          |vpiLeftRange:
-          \_constant: , line:15:76, endln:15:81
-            |vpiDecompile:15
-            |vpiSize:64
-            |INT:15
-            |vpiConstType:7
-          |vpiRightRange:
-          \_constant: , line:15:84, endln:15:85
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmallModules:
 \_module: work@TOP (work@TOP) tb.v:16:1: , endln:23:10, parent:work@TOP
   |vpiFullName:work@TOP
@@ -627,6 +635,22 @@ design: (work@TOP)
         |vpiFullName:work@TOP.tb.observe
         |vpiActual:
         \_logic_net: (work@TOP.tb.observe), line:1:66, endln:1:73, parent:work@TOP.tb
+      |vpiTypedef:
+      \_logic_typespec: , line:1:49, endln:1:53
+        |vpiRange:
+        \_range: , line:1:55, endln:1:64, parent:observe
+          |vpiLeftRange:
+          \_constant: , line:1:55, endln:1:60
+            |vpiDecompile:15
+            |vpiSize:64
+            |INT:15
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:1:63, endln:1:64
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
     |vpiPort:
     \_port: (drive), line:1:98, endln:1:103, parent:work@TOP.tb
       |vpiName:drive
@@ -646,44 +670,64 @@ design: (work@TOP)
         |vpiFullName:work@TOP.tb.drive
         |vpiActual:
         \_logic_net: (work@TOP.tb.drive), line:1:98, endln:1:103, parent:work@TOP.tb
+      |vpiTypedef:
+      \_logic_typespec: , line:1:82, endln:1:85
+        |vpiRange:
+        \_range: , line:1:87, endln:1:96, parent:drive
+          |vpiLeftRange:
+          \_constant: , line:1:87, endln:1:92
+            |vpiDecompile:15
+            |vpiSize:64
+            |INT:15
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:1:95, endln:1:96
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@TOP.i), line:18:20, endln:18:21, parent:work@TOP
+    |vpiTypespec:
+    \_logic_typespec: , line:18:3, endln:18:7
+      |vpiRange:
+      \_range: , line:18:9, endln:18:18
+        |vpiLeftRange:
+        \_constant: , line:18:9, endln:18:14
+          |vpiDecompile:15
+          |vpiSize:64
+          |INT:15
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:18:17, endln:18:18
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:i
     |vpiFullName:work@TOP.i
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:18:9, endln:18:18
-      |vpiLeftRange:
-      \_constant: , line:18:9, endln:18:14
-        |vpiDecompile:15
-        |vpiSize:64
-        |INT:15
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:18:17, endln:18:18
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@TOP.o), line:19:20, endln:19:21, parent:work@TOP
+    |vpiTypespec:
+    \_logic_typespec: , line:19:3, endln:19:7
+      |vpiRange:
+      \_range: , line:19:9, endln:19:18
+        |vpiLeftRange:
+        \_constant: , line:19:9, endln:19:14
+          |vpiDecompile:15
+          |vpiSize:64
+          |INT:15
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:19:17, endln:19:18
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:o
     |vpiFullName:work@TOP.o
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:19:9, endln:19:18
-      |vpiLeftRange:
-      \_constant: , line:19:9, endln:19:14
-        |vpiDecompile:15
-        |vpiSize:64
-        |INT:15
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:19:17, endln:19:18
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiInterface:
   \_interface: work@ConnectTB (work@TOP.conntb) tb.v:20:3: , endln:20:50, parent:work@TOP
@@ -714,42 +758,46 @@ design: (work@TOP)
     |vpiDefLineNo:8
     |vpiNet:
     \_logic_net: (work@TOP.conntb.con_i), line:8:68, endln:8:73, parent:work@TOP.conntb
+      |vpiTypespec:
+      \_logic_typespec: , line:8:51, endln:8:55
+        |vpiRange:
+        \_range: , line:8:57, endln:8:66
+          |vpiLeftRange:
+          \_constant: , line:8:57, endln:8:62
+            |vpiDecompile:15
+            |vpiSize:64
+            |INT:15
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:8:65, endln:8:66
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:con_i
       |vpiFullName:work@TOP.conntb.con_i
       |vpiNetType:1
-      |vpiRange:
-      \_range: , line:8:57, endln:8:66
-        |vpiLeftRange:
-        \_constant: , line:8:57, endln:8:62
-          |vpiDecompile:15
-          |vpiSize:64
-          |INT:15
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:8:65, endln:8:66
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@TOP.conntb.con_o), line:8:98, endln:8:103, parent:work@TOP.conntb
+      |vpiTypespec:
+      \_logic_typespec: , line:8:82, endln:8:85
+        |vpiRange:
+        \_range: , line:8:87, endln:8:96
+          |vpiLeftRange:
+          \_constant: , line:8:87, endln:8:92
+            |vpiDecompile:15
+            |vpiSize:64
+            |INT:15
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:8:95, endln:8:96
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:con_o
       |vpiFullName:work@TOP.conntb.con_o
       |vpiNetType:48
-      |vpiRange:
-      \_range: , line:8:87, endln:8:96
-        |vpiLeftRange:
-        \_constant: , line:8:87, endln:8:92
-          |vpiDecompile:15
-          |vpiSize:64
-          |INT:15
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:8:95, endln:8:96
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiInstance:
     \_module: work@TOP (work@TOP) tb.v:16:1: , endln:23:10
     |vpiPort:
@@ -768,6 +816,22 @@ design: (work@TOP)
         |vpiFullName:work@TOP.conntb.con_i
         |vpiActual:
         \_logic_net: (work@TOP.conntb.con_i), line:8:68, endln:8:73, parent:work@TOP.conntb
+      |vpiTypedef:
+      \_logic_typespec: , line:8:51, endln:8:55
+        |vpiRange:
+        \_range: , line:8:57, endln:8:66, parent:con_i
+          |vpiLeftRange:
+          \_constant: , line:8:57, endln:8:62
+            |vpiDecompile:15
+            |vpiSize:64
+            |INT:15
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:8:65, endln:8:66
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
     |vpiPort:
     \_port: (con_o), line:8:98, endln:8:103, parent:work@TOP.conntb
       |vpiName:con_o
@@ -784,6 +848,22 @@ design: (work@TOP)
         |vpiFullName:work@TOP.conntb.con_o
         |vpiActual:
         \_logic_net: (work@TOP.conntb.con_o), line:8:98, endln:8:103, parent:work@TOP.conntb
+      |vpiTypedef:
+      \_logic_typespec: , line:8:82, endln:8:85
+        |vpiRange:
+        \_range: , line:8:87, endln:8:96, parent:con_o
+          |vpiLeftRange:
+          \_constant: , line:8:87, endln:8:92
+            |vpiDecompile:15
+            |vpiSize:64
+            |INT:15
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:8:95, endln:8:96
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
   |vpiModule:
   \_module: work@dut (work@TOP.dut1) tb.v:21:3: , endln:21:57, parent:work@TOP
     |vpiName:dut1
@@ -813,42 +893,46 @@ design: (work@TOP)
     |vpiDefLineNo:2
     |vpiNet:
     \_logic_net: (work@TOP.dut1.i), line:2:59, endln:2:60, parent:work@TOP.dut1
+      |vpiTypespec:
+      \_logic_typespec: , line:2:42, endln:2:46
+        |vpiRange:
+        \_range: , line:2:48, endln:2:57
+          |vpiLeftRange:
+          \_constant: , line:2:48, endln:2:53
+            |vpiDecompile:15
+            |vpiSize:64
+            |INT:15
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:2:56, endln:2:57
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:i
       |vpiFullName:work@TOP.dut1.i
       |vpiNetType:1
-      |vpiRange:
-      \_range: , line:2:48, endln:2:57
-        |vpiLeftRange:
-        \_constant: , line:2:48, endln:2:53
-          |vpiDecompile:15
-          |vpiSize:64
-          |INT:15
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:2:56, endln:2:57
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@TOP.dut1.o), line:2:85, endln:2:86, parent:work@TOP.dut1
+      |vpiTypespec:
+      \_logic_typespec: , line:2:69, endln:2:72
+        |vpiRange:
+        \_range: , line:2:74, endln:2:83
+          |vpiLeftRange:
+          \_constant: , line:2:74, endln:2:79
+            |vpiDecompile:15
+            |vpiSize:64
+            |INT:15
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:2:82, endln:2:83
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:o
       |vpiFullName:work@TOP.dut1.o
       |vpiNetType:48
-      |vpiRange:
-      \_range: , line:2:74, endln:2:83
-        |vpiLeftRange:
-        \_constant: , line:2:74, endln:2:79
-          |vpiDecompile:15
-          |vpiSize:64
-          |INT:15
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:2:82, endln:2:83
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiInstance:
     \_module: work@TOP (work@TOP) tb.v:16:1: , endln:23:10
     |vpiPort:
@@ -870,6 +954,22 @@ design: (work@TOP)
         |vpiFullName:work@TOP.dut1.i
         |vpiActual:
         \_logic_net: (work@TOP.dut1.i), line:2:59, endln:2:60, parent:work@TOP.dut1
+      |vpiTypedef:
+      \_logic_typespec: , line:2:42, endln:2:46
+        |vpiRange:
+        \_range: , line:2:48, endln:2:57, parent:i
+          |vpiLeftRange:
+          \_constant: , line:2:48, endln:2:53
+            |vpiDecompile:15
+            |vpiSize:64
+            |INT:15
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:2:56, endln:2:57
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
     |vpiPort:
     \_port: (o), line:2:85, endln:2:86, parent:work@TOP.dut1
       |vpiName:o
@@ -889,6 +989,22 @@ design: (work@TOP)
         |vpiFullName:work@TOP.dut1.o
         |vpiActual:
         \_logic_net: (work@TOP.dut1.o), line:2:85, endln:2:86, parent:work@TOP.dut1
+      |vpiTypedef:
+      \_logic_typespec: , line:2:69, endln:2:72
+        |vpiRange:
+        \_range: , line:2:74, endln:2:83, parent:o
+          |vpiLeftRange:
+          \_constant: , line:2:74, endln:2:79
+            |vpiDecompile:15
+            |vpiSize:64
+            |INT:15
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:2:82, endln:2:83
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
     |vpiInterface:
     \_interface: work@ConnectTB (work@TOP.dut1.conntb) dut.v:3:3: , endln:3:58, parent:work@TOP.dut1
       |vpiName:conntb
@@ -918,42 +1034,46 @@ design: (work@TOP)
       |vpiDefLineNo:8
       |vpiNet:
       \_logic_net: (work@TOP.dut1.conntb.con_i), line:8:68, endln:8:73, parent:work@TOP.dut1.conntb
+        |vpiTypespec:
+        \_logic_typespec: , line:8:51, endln:8:55
+          |vpiRange:
+          \_range: , line:8:57, endln:8:66
+            |vpiLeftRange:
+            \_constant: , line:8:57, endln:8:62
+              |vpiDecompile:15
+              |vpiSize:64
+              |INT:15
+              |vpiConstType:7
+            |vpiRightRange:
+            \_constant: , line:8:65, endln:8:66
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:con_i
         |vpiFullName:work@TOP.dut1.conntb.con_i
         |vpiNetType:1
-        |vpiRange:
-        \_range: , line:8:57, endln:8:66
-          |vpiLeftRange:
-          \_constant: , line:8:57, endln:8:62
-            |vpiDecompile:15
-            |vpiSize:64
-            |INT:15
-            |vpiConstType:7
-          |vpiRightRange:
-          \_constant: , line:8:65, endln:8:66
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
       |vpiNet:
       \_logic_net: (work@TOP.dut1.conntb.con_o), line:8:98, endln:8:103, parent:work@TOP.dut1.conntb
+        |vpiTypespec:
+        \_logic_typespec: , line:8:82, endln:8:85
+          |vpiRange:
+          \_range: , line:8:87, endln:8:96
+            |vpiLeftRange:
+            \_constant: , line:8:87, endln:8:92
+              |vpiDecompile:15
+              |vpiSize:64
+              |INT:15
+              |vpiConstType:7
+            |vpiRightRange:
+            \_constant: , line:8:95, endln:8:96
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:con_o
         |vpiFullName:work@TOP.dut1.conntb.con_o
         |vpiNetType:48
-        |vpiRange:
-        \_range: , line:8:87, endln:8:96
-          |vpiLeftRange:
-          \_constant: , line:8:87, endln:8:92
-            |vpiDecompile:15
-            |vpiSize:64
-            |INT:15
-            |vpiConstType:7
-          |vpiRightRange:
-          \_constant: , line:8:95, endln:8:96
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
       |vpiInstance:
       \_module: work@dut (work@TOP.dut1) tb.v:21:3: , endln:21:57, parent:work@TOP
       |vpiPort:
@@ -972,6 +1092,22 @@ design: (work@TOP)
           |vpiFullName:work@TOP.dut1.conntb.con_i
           |vpiActual:
           \_logic_net: (work@TOP.dut1.conntb.con_i), line:8:68, endln:8:73, parent:work@TOP.dut1.conntb
+        |vpiTypedef:
+        \_logic_typespec: , line:8:51, endln:8:55
+          |vpiRange:
+          \_range: , line:8:57, endln:8:66, parent:con_i
+            |vpiLeftRange:
+            \_constant: , line:8:57, endln:8:62
+              |vpiDecompile:15
+              |vpiSize:64
+              |INT:15
+              |vpiConstType:7
+            |vpiRightRange:
+            \_constant: , line:8:65, endln:8:66
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
       |vpiPort:
       \_port: (con_o), line:8:98, endln:8:103, parent:work@TOP.dut1.conntb
         |vpiName:con_o
@@ -988,6 +1124,22 @@ design: (work@TOP)
           |vpiFullName:work@TOP.dut1.conntb.con_o
           |vpiActual:
           \_logic_net: (work@TOP.dut1.conntb.con_o), line:8:98, endln:8:103, parent:work@TOP.dut1.conntb
+        |vpiTypedef:
+        \_logic_typespec: , line:8:82, endln:8:85
+          |vpiRange:
+          \_range: , line:8:87, endln:8:96, parent:con_o
+            |vpiLeftRange:
+            \_constant: , line:8:87, endln:8:92
+              |vpiDecompile:15
+              |vpiSize:64
+              |INT:15
+              |vpiConstType:7
+            |vpiRightRange:
+            \_constant: , line:8:95, endln:8:96
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
     |vpiModule:
     \_module: work@middle (work@TOP.dut1.middle1) dut.v:4:3: , endln:4:43, parent:work@TOP.dut1
       |vpiName:middle1
@@ -1090,6 +1242,22 @@ design: (work@TOP)
             |vpiFullName:work@TOP.dut1.middle1.sub1.inp
             |vpiActual:
             \_logic_net: (work@TOP.dut1.middle1.sub1.inp), line:15:59, endln:15:62, parent:work@TOP.dut1.middle1.sub1
+          |vpiTypedef:
+          \_logic_typespec: , line:15:42, endln:15:46
+            |vpiRange:
+            \_range: , line:15:48, endln:15:57, parent:inp
+              |vpiLeftRange:
+              \_constant: , line:15:48, endln:15:53
+                |vpiDecompile:15
+                |vpiSize:64
+                |INT:15
+                |vpiConstType:7
+              |vpiRightRange:
+              \_constant: , line:15:56, endln:15:57
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
         |vpiPort:
         \_port: (out), line:15:87, endln:15:90, parent:work@TOP.dut1.middle1.sub1
           |vpiName:out
@@ -1111,6 +1279,22 @@ design: (work@TOP)
             |vpiFullName:work@TOP.dut1.middle1.sub1.out
             |vpiActual:
             \_logic_net: (work@TOP.dut1.middle1.sub1.out), line:15:87, endln:15:90, parent:work@TOP.dut1.middle1.sub1
+          |vpiTypedef:
+          \_logic_typespec: , line:15:71, endln:15:74
+            |vpiRange:
+            \_range: , line:15:76, endln:15:85, parent:out
+              |vpiLeftRange:
+              \_constant: , line:15:76, endln:15:81
+                |vpiDecompile:15
+                |vpiSize:64
+                |INT:15
+                |vpiConstType:7
+              |vpiRightRange:
+              \_constant: , line:15:84, endln:15:85
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/PackFuncParent/PackFuncParent.log
+++ b/tests/PackFuncParent/PackFuncParent.log
@@ -479,23 +479,25 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:13:32, endln:13:33, parent:work@top
+        |vpiTypespec:
+        \_logic_typespec: , line:13:19, endln:13:24
+          |vpiRange:
+          \_range: , line:13:26, endln:13:30
+            |vpiLeftRange:
+            \_constant: , line:13:26, endln:13:28
+              |vpiDecompile:15
+              |vpiSize:64
+              |UINT:15
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:13:29, endln:13:30
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:o
         |vpiFullName:work@top.o
         |vpiNetType:36
-        |vpiRange:
-        \_range: , line:13:26, endln:13:30
-          |vpiLeftRange:
-          \_constant: , line:13:26, endln:13:28
-            |vpiDecompile:15
-            |vpiSize:64
-            |UINT:15
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:13:29, endln:13:30
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:13:1: , endln:15:10
   |vpiName:work@top
@@ -514,6 +516,22 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:13:32, endln:13:33, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:13:19, endln:13:24
+      |vpiRange:
+      \_range: , line:13:26, endln:13:30, parent:o
+        |vpiLeftRange:
+        \_constant: , line:13:26, endln:13:28
+          |vpiDecompile:15
+          |vpiSize:64
+          |UINT:15
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:13:29, endln:13:30
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:13:1: , endln:15:10
   |vpiContAssign:

--- a/tests/PackImport/PackImport.log
+++ b/tests/PackImport/PackImport.log
@@ -238,23 +238,25 @@ design: (work@top)
     |vpiFullName:work@top.clk_i
   |vpiNet:
   \_logic_net: (work@top.o1), line:18:45, endln:18:47, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:18:32, endln:18:37
+      |vpiRange:
+      \_range: , line:18:39, endln:18:43
+        |vpiLeftRange:
+        \_constant: , line:18:39, endln:18:41
+          |vpiDecompile:31
+          |vpiSize:64
+          |UINT:31
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:18:42, endln:18:43
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:o1
     |vpiFullName:work@top.o1
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:18:39, endln:18:43
-      |vpiLeftRange:
-      \_constant: , line:18:39, endln:18:41
-        |vpiDecompile:31
-        |vpiSize:64
-        |UINT:31
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:18:42, endln:18:43
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (clk_i), line:18:18, endln:18:23, parent:work@top
@@ -276,6 +278,22 @@ design: (work@top)
       |vpiFullName:work@top.o1
       |vpiActual:
       \_logic_net: (work@top.o1), line:18:45, endln:18:47, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:18:32, endln:18:37
+      |vpiRange:
+      \_range: , line:18:39, endln:18:43, parent:o1
+        |vpiLeftRange:
+        \_constant: , line:18:39, endln:18:41
+          |vpiDecompile:31
+          |vpiSize:64
+          |UINT:31
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:18:42, endln:18:43
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/PackageBind/PackageBind.log
+++ b/tests/PackageBind/PackageBind.log
@@ -354,6 +354,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_integer_var: (work@top.o), line:12:27, endln:12:28, parent:work@top
+    |vpiTypedef:
+    \_integer_typespec: , line:12:19, endln:12:26
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:12:1: , endln:14:10
   |vpiContAssign:

--- a/tests/PackedArrayStruct/PackedArrayStruct.log
+++ b/tests/PackedArrayStruct/PackedArrayStruct.log
@@ -199,23 +199,25 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:1:32, endln:1:33, parent:work@top
+        |vpiTypespec:
+        \_logic_typespec: , line:1:19, endln:1:24
+          |vpiRange:
+          \_range: , line:1:26, endln:1:30
+            |vpiLeftRange:
+            \_constant: , line:1:26, endln:1:28
+              |vpiDecompile:31
+              |vpiSize:64
+              |UINT:31
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:1:29, endln:1:30
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:o
         |vpiFullName:work@top.o
         |vpiNetType:36
-        |vpiRange:
-        \_range: , line:1:26, endln:1:30
-          |vpiLeftRange:
-          \_constant: , line:1:26, endln:1:28
-            |vpiDecompile:31
-            |vpiSize:64
-            |UINT:31
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:1:29, endln:1:30
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:1:1: , endln:7:10
   |vpiName:work@top
@@ -238,6 +240,22 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:1:32, endln:1:33, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:19, endln:1:24
+      |vpiRange:
+      \_range: , line:1:26, endln:1:30, parent:o
+        |vpiLeftRange:
+        \_constant: , line:1:26, endln:1:28
+          |vpiDecompile:31
+          |vpiSize:64
+          |UINT:31
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:1:29, endln:1:30
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:7:10
   |vpiContAssign:

--- a/tests/PackedEnumPort/PackedEnumPort.log
+++ b/tests/PackedEnumPort/PackedEnumPort.log
@@ -346,6 +346,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:24:23, endln:24:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:24:19, endln:24:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:24:1: , endln:37:16
   |vpiPort:
@@ -358,6 +361,9 @@ design: (work@top)
       |vpiFullName:work@top.p
       |vpiActual:
       \_int_var: (work@top.p), line:24:37, endln:24:38, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:24:33, endln:24:36
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:24:1: , endln:37:16
   |vpiModule:
@@ -369,6 +375,8 @@ design: (work@top)
     |vpiDefLineNo:11
     |vpiNet:
     \_logic_net: (work@top.u_lc_ctrl_fsm.lc_clk_byp_ack_i), line:13:15, endln:13:31, parent:work@top.u_lc_ctrl_fsm
+      |vpiTypespec:
+      \_logic_typespec: , line:13:9, endln:13:14
       |vpiName:lc_clk_byp_ack_i
       |vpiFullName:work@top.u_lc_ctrl_fsm.lc_clk_byp_ack_i
       |vpiNetType:36
@@ -398,6 +406,8 @@ design: (work@top)
         |vpiFullName:work@top.u_lc_ctrl_fsm.lc_clk_byp_ack_i
         |vpiActual:
         \_logic_net: (work@top.u_lc_ctrl_fsm.lc_clk_byp_ack_i), line:13:15, endln:13:31, parent:work@top.u_lc_ctrl_fsm
+      |vpiTypedef:
+      \_logic_typespec: , line:13:9, endln:13:14
       |vpiInstance:
       \_module: work@lc_ctrl_fsm (work@top.u_lc_ctrl_fsm) dut.sv:34:4: , endln:36:6, parent:work@top
 ===================

--- a/tests/ParamFile/ParamFile.log
+++ b/tests/ParamFile/ParamFile.log
@@ -353,6 +353,8 @@ design: (work@dut)
               |vpiFullName:work@ram_1p.gen_meminit.out
               |vpiActual:
               \_logic_net: (work@dut.u_ram.out), line:15:22, endln:15:25, parent:work@dut.u_ram
+                |vpiTypespec:
+                \_logic_typespec: , line:15:16, endln:15:21
                 |vpiName:out
                 |vpiFullName:work@dut.u_ram.out
                 |vpiNetType:36
@@ -420,6 +422,8 @@ design: (work@dut)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@dut.o), line:3:26, endln:3:27, parent:work@dut
+    |vpiTypespec:
+    \_logic_typespec: , line:3:20, endln:3:25
     |vpiName:o
     |vpiFullName:work@dut.o
     |vpiNetType:36
@@ -434,6 +438,8 @@ design: (work@dut)
       |vpiFullName:work@dut.o
       |vpiActual:
       \_logic_net: (work@dut.o), line:3:26, endln:3:27, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:3:20, endln:3:25
   |vpiModule:
   \_module: work@ram_1p (work@dut.u_ram) dut.sv:5:4: , endln:9:6, parent:work@dut
     |vpiName:u_ram
@@ -479,6 +485,8 @@ design: (work@dut)
         |vpiFullName:work@dut.u_ram.out
         |vpiActual:
         \_logic_net: (work@dut.u_ram.out), line:15:22, endln:15:25, parent:work@dut.u_ram
+      |vpiTypedef:
+      \_logic_typespec: , line:15:16, endln:15:21
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ParamFile/ParamFileOverr.log
+++ b/tests/ParamFile/ParamFileOverr.log
@@ -351,6 +351,8 @@ design: (work@dut)
               |vpiFullName:work@ram_1p.gen_meminit.out
               |vpiActual:
               \_logic_net: (work@dut.u_ram.out), line:15:22, endln:15:25, parent:work@dut.u_ram
+                |vpiTypespec:
+                \_logic_typespec: , line:15:16, endln:15:21
                 |vpiName:out
                 |vpiFullName:work@dut.u_ram.out
                 |vpiNetType:36
@@ -416,6 +418,8 @@ design: (work@dut)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@dut.o), line:3:26, endln:3:27, parent:work@dut
+    |vpiTypespec:
+    \_logic_typespec: , line:3:20, endln:3:25
     |vpiName:o
     |vpiFullName:work@dut.o
     |vpiNetType:36
@@ -430,6 +434,8 @@ design: (work@dut)
       |vpiFullName:work@dut.o
       |vpiActual:
       \_logic_net: (work@dut.o), line:3:26, endln:3:27, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:3:20, endln:3:25
   |vpiModule:
   \_module: work@ram_1p (work@dut.u_ram) dut.sv:5:4: , endln:9:6, parent:work@dut
     |vpiName:u_ram
@@ -477,6 +483,8 @@ design: (work@dut)
         |vpiFullName:work@dut.u_ram.out
         |vpiActual:
         \_logic_net: (work@dut.u_ram.out), line:15:22, endln:15:25, parent:work@dut.u_ram
+      |vpiTypedef:
+      \_logic_typespec: , line:15:16, endln:15:21
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ParamMultiConcat/ParamMultiConcat.log
+++ b/tests/ParamMultiConcat/ParamMultiConcat.log
@@ -404,22 +404,24 @@ design: (work@top)
     |vpiDefLineNo:1
     |vpiNet:
     \_logic_net: (work@top.u_dut.wmask_i), line:5:22, endln:5:29, parent:work@top.u_dut
+      |vpiTypespec:
+      \_logic_typespec: , line:5:10, endln:5:21
+        |vpiRange:
+        \_range: , line:5:11, endln:5:20
+          |vpiLeftRange:
+          \_constant: , line:5:11, endln:5:16
+            |vpiDecompile:18
+            |vpiSize:64
+            |INT:18
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:5:19, endln:5:20
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:wmask_i
       |vpiFullName:work@top.u_dut.wmask_i
-      |vpiRange:
-      \_range: , line:5:11, endln:5:20
-        |vpiLeftRange:
-        \_constant: , line:5:11, endln:5:16
-          |vpiDecompile:18
-          |vpiSize:64
-          |INT:18
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:5:19, endln:5:20
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:9:1: , endln:18:10
     |vpiPort:
@@ -441,6 +443,22 @@ design: (work@top)
         |vpiFullName:work@top.u_dut.wmask_i
         |vpiActual:
         \_logic_net: (work@top.u_dut.wmask_i), line:5:22, endln:5:29, parent:work@top.u_dut
+      |vpiTypedef:
+      \_logic_typespec: , line:5:10, endln:5:21
+        |vpiRange:
+        \_range: , line:5:11, endln:5:20, parent:wmask_i
+          |vpiLeftRange:
+          \_constant: , line:5:11, endln:5:16
+            |vpiDecompile:18
+            |vpiSize:64
+            |INT:18
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:5:19, endln:5:20
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@dut (work@top.u_dut) dut.sv:13:4: , endln:17:6, parent:work@top
 ===================

--- a/tests/ParamOverload1/ParamOverload1.log
+++ b/tests/ParamOverload1/ParamOverload1.log
@@ -368,6 +368,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:6:23, endln:6:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:6:19, endln:6:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:6:1: , endln:10:10
   |vpiModule:
@@ -472,6 +475,9 @@ design: (work@top)
         |vpiFullName:work@top.u_dut1.x
         |vpiActual:
         \_int_var: (work@top.u_dut1.x), line:1:23, endln:1:24, parent:work@top.u_dut1
+      |vpiTypedef:
+      \_int_typespec: , line:1:19, endln:1:22
+        |vpiSigned:1
       |vpiInstance:
       \_module: work@dut (work@top.u_dut1) dut.sv:7:4: , endln:7:43, parent:work@top
     |vpiContAssign:
@@ -646,6 +652,9 @@ design: (work@top)
         |vpiFullName:work@top.u_dut2.x
         |vpiActual:
         \_int_var: (work@top.u_dut2.x), line:1:23, endln:1:24, parent:work@top.u_dut2
+      |vpiTypedef:
+      \_int_typespec: , line:1:19, endln:1:22
+        |vpiSigned:1
       |vpiInstance:
       \_module: work@dut (work@top.u_dut2) dut.sv:8:4: , endln:8:22, parent:work@top
     |vpiContAssign:
@@ -769,6 +778,9 @@ design: (work@top)
         |vpiFullName:work@top.u_dut3.x
         |vpiActual:
         \_int_var: (work@top.u_dut3.x), line:1:23, endln:1:24, parent:work@top.u_dut3
+      |vpiTypedef:
+      \_int_typespec: , line:1:19, endln:1:22
+        |vpiSigned:1
       |vpiInstance:
       \_module: work@dut (work@top.u_dut3) dut.sv:9:4: , endln:9:34, parent:work@top
     |vpiContAssign:

--- a/tests/ParamTypespec/ParamTypespec.log
+++ b/tests/ParamTypespec/ParamTypespec.log
@@ -556,6 +556,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:9:23, endln:9:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:9:19, endln:9:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:9:1: , endln:16:10
   |vpiContAssign:

--- a/tests/ParamTypespec2/ParamTypespec2.log
+++ b/tests/ParamTypespec2/ParamTypespec2.log
@@ -565,6 +565,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:21:23, endln:21:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:21:19, endln:21:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:21:1: , endln:26:10
   |vpiModule:
@@ -745,6 +748,9 @@ design: (work@top)
         |vpiFullName:work@top.u_nmi_gen.x
         |vpiActual:
         \_int_var: (work@top.u_nmi_gen.x), line:16:15, endln:16:16, parent:work@top.u_nmi_gen
+      |vpiTypedef:
+      \_int_typespec: , line:16:11, endln:16:14
+        |vpiSigned:1
       |vpiInstance:
       \_module: work@nmi_gen (work@top.u_nmi_gen) dut.sv:22:4: , endln:25:6, parent:work@top
     |vpiContAssign:

--- a/tests/PartSelectElab/PartSelectElab.log
+++ b/tests/PartSelectElab/PartSelectElab.log
@@ -148,6 +148,8 @@ design: (work@test)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@test.state), line:1:24, endln:1:29, parent:work@test
+    |vpiTypespec:
+    \_logic_typespec: , line:1:20, endln:1:23
     |vpiName:state
     |vpiFullName:work@test.state
     |vpiNetType:48
@@ -155,23 +157,25 @@ design: (work@test)
   \_logic_net: (work@test.clk), line:1:37, endln:1:40, parent:work@test
   |vpiNet:
   \_logic_net: (work@test.data), line:2:12, endln:2:16, parent:work@test
+    |vpiTypespec:
+    \_logic_typespec: , line:2:1, endln:2:4
+      |vpiRange:
+      \_range: , line:2:6, endln:2:10
+        |vpiLeftRange:
+        \_constant: , line:2:6, endln:2:8
+          |vpiDecompile:15
+          |vpiSize:64
+          |UINT:15
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:2:9, endln:2:10
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:data
     |vpiFullName:work@test.data
     |vpiNetType:48
-    |vpiRange:
-    \_range: , line:2:6, endln:2:10
-      |vpiLeftRange:
-      \_constant: , line:2:6, endln:2:8
-        |vpiDecompile:15
-        |vpiSize:64
-        |UINT:15
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:2:9, endln:2:10
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (state), line:1:24, endln:1:29, parent:work@test
@@ -183,6 +187,8 @@ design: (work@test)
       |vpiFullName:work@test.state
       |vpiActual:
       \_logic_net: (work@test.state), line:1:24, endln:1:29, parent:work@test
+    |vpiTypedef:
+    \_logic_typespec: , line:1:20, endln:1:23
     |vpiInstance:
     \_module: work@test (work@test) dut.sv:1:1: , endln:8:10
   |vpiPort:

--- a/tests/PartSelectNoParent/PartSelectNoParent.log
+++ b/tests/PartSelectNoParent/PartSelectNoParent.log
@@ -772,6 +772,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:11:23, endln:11:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:11:19, endln:11:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:11:1: , endln:19:10
   |vpiProcess:

--- a/tests/PartSelectParent/PartSelectParent.log
+++ b/tests/PartSelectParent/PartSelectParent.log
@@ -253,6 +253,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:1:23, endln:1:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:1:19, endln:1:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:8:10
   |vpiProcess:

--- a/tests/PkgImportFunc/PkgImportFunc.log
+++ b/tests/PkgImportFunc/PkgImportFunc.log
@@ -283,6 +283,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:12:23, endln:12:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:12:19, endln:12:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:12:1: , endln:14:10
   |vpiContAssign:

--- a/tests/PortByName/PortByName.log
+++ b/tests/PortByName/PortByName.log
@@ -190,22 +190,24 @@ design: (work@top)
               |vpiConstType:7
         |vpiNet:
         \_logic_net: (work@top.id_stage_i.third), line:15:39, endln:15:44, parent:work@top.id_stage_i.third
+          |vpiTypespec:
+          \_logic_typespec: , line:15:12, endln:15:17
+            |vpiRange:
+            \_range: , line:15:19, endln:15:23
+              |vpiLeftRange:
+              \_constant: , line:15:19, endln:15:21
+                |vpiDecompile:33
+                |vpiSize:64
+                |UINT:33
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:15:22, endln:15:23
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiFullName:work@top.id_stage_i.third
           |vpiNetType:36
-          |vpiRange:
-          \_range: , line:15:19, endln:15:23
-            |vpiLeftRange:
-            \_constant: , line:15:19, endln:15:21
-              |vpiDecompile:33
-              |vpiSize:64
-              |UINT:33
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:15:22, endln:15:23
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
 |uhdmallModules:
 \_module: work@top (work@top) dut.sv:1:1: , endln:11:10, parent:work@top
   |vpiFullName:work@top
@@ -403,23 +405,25 @@ design: (work@top)
     |vpiDefLineNo:12
     |vpiNet:
     \_logic_net: (work@top.id_stage_i.first), line:13:39, endln:13:44, parent:work@top.id_stage_i
+      |vpiTypespec:
+      \_logic_typespec: , line:13:12, endln:13:17
+        |vpiRange:
+        \_range: , line:13:19, endln:13:22
+          |vpiLeftRange:
+          \_constant: , line:13:19, endln:13:20
+            |vpiDecompile:1
+            |vpiSize:64
+            |UINT:1
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:13:21, endln:13:22
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:first
       |vpiFullName:work@top.id_stage_i.first
       |vpiNetType:36
-      |vpiRange:
-      \_range: , line:13:19, endln:13:22
-        |vpiLeftRange:
-        \_constant: , line:13:19, endln:13:20
-          |vpiDecompile:1
-          |vpiSize:64
-          |UINT:1
-          |vpiConstType:9
-        |vpiRightRange:
-        \_constant: , line:13:21, endln:13:22
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiArrayNet:
     \_array_net: (work@top.id_stage_i.second), line:14:39, endln:14:45, parent:work@top.id_stage_i
       |vpiSize:2
@@ -449,22 +453,24 @@ design: (work@top)
             |vpiConstType:7
       |vpiNet:
       \_logic_net: (work@top.id_stage_i.second), line:14:39, endln:14:45, parent:work@top.id_stage_i.second
+        |vpiTypespec:
+        \_logic_typespec: , line:14:12, endln:14:17
+          |vpiRange:
+          \_range: , line:14:19, endln:14:23
+            |vpiLeftRange:
+            \_constant: , line:14:19, endln:14:21
+              |vpiDecompile:33
+              |vpiSize:64
+              |UINT:33
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:14:22, endln:14:23
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiFullName:work@top.id_stage_i.second
         |vpiNetType:36
-        |vpiRange:
-        \_range: , line:14:19, endln:14:23
-          |vpiLeftRange:
-          \_constant: , line:14:19, endln:14:21
-            |vpiDecompile:33
-            |vpiSize:64
-            |UINT:33
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:14:22, endln:14:23
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
     |vpiArrayNet:
     \_array_net: (work@top.id_stage_i.third), line:15:39, endln:15:44, parent:work@top.id_stage_i
     |vpiInstance:
@@ -485,6 +491,22 @@ design: (work@top)
         |vpiFullName:work@top.id_stage_i.first
         |vpiActual:
         \_logic_net: (work@top.id_stage_i.first), line:13:39, endln:13:44, parent:work@top.id_stage_i
+      |vpiTypedef:
+      \_logic_typespec: , line:13:12, endln:13:17
+        |vpiRange:
+        \_range: , line:13:19, endln:13:22, parent:first
+          |vpiLeftRange:
+          \_constant: , line:13:19, endln:13:20
+            |vpiDecompile:1
+            |vpiSize:64
+            |UINT:1
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:13:21, endln:13:22
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@ibex_id_stage (work@top.id_stage_i) dut.sv:5:3: , endln:9:5, parent:work@top
     |vpiPort:
@@ -503,6 +525,22 @@ design: (work@top)
         |vpiFullName:work@top.id_stage_i.second
         |vpiActual:
         \_array_net: (work@top.id_stage_i.second), line:14:39, endln:14:45, parent:work@top.id_stage_i
+      |vpiTypedef:
+      \_logic_typespec: , line:14:12, endln:14:17
+        |vpiRange:
+        \_range: , line:14:19, endln:14:23, parent:second
+          |vpiLeftRange:
+          \_constant: , line:14:19, endln:14:21
+            |vpiDecompile:33
+            |vpiSize:64
+            |UINT:33
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:14:22, endln:14:23
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@ibex_id_stage (work@top.id_stage_i) dut.sv:5:3: , endln:9:5, parent:work@top
     |vpiPort:
@@ -521,6 +559,22 @@ design: (work@top)
         |vpiFullName:work@top.id_stage_i.third
         |vpiActual:
         \_array_net: (work@top.id_stage_i.third), line:15:39, endln:15:44, parent:work@top.id_stage_i
+      |vpiTypedef:
+      \_logic_typespec: , line:15:12, endln:15:17
+        |vpiRange:
+        \_range: , line:15:19, endln:15:23, parent:third
+          |vpiLeftRange:
+          \_constant: , line:15:19, endln:15:21
+            |vpiDecompile:33
+            |vpiSize:64
+            |UINT:33
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:15:22, endln:15:23
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@ibex_id_stage (work@top.id_stage_i) dut.sv:5:3: , endln:9:5, parent:work@top
     |vpiContAssign:

--- a/tests/PortInitVal/PortInitVal.log
+++ b/tests/PortInitVal/PortInitVal.log
@@ -174,6 +174,8 @@ design: (work@dut)
             |vpiFullName:work@dut.a
             |vpiActual:
             \_logic_net: (work@dut.a), line:2:14, endln:2:15, parent:work@dut
+              |vpiTypespec:
+              \_logic_typespec: , line:2:9, endln:2:13
               |vpiName:a
               |vpiFullName:work@dut.a
               |vpiNetType:1
@@ -193,6 +195,8 @@ design: (work@dut)
               |vpiFullName:work@dut.b
               |vpiActual:
               \_logic_net: (work@dut.b), line:1:13, endln:1:14, parent:work@dut
+                |vpiTypespec:
+                \_logic_typespec: , line:3:16, endln:3:19
                 |vpiName:b
                 |vpiFullName:work@dut.b
                 |vpiNetType:48

--- a/tests/PortMultiDim/PortMultiDim.log
+++ b/tests/PortMultiDim/PortMultiDim.log
@@ -164,10 +164,39 @@ design: (work@ibex_multdiv_fast)
           |vpiConstType:7
     |vpiNet:
     \_logic_net: (work@ibex_multdiv_fast.imd_val_q_i), line:2:24, endln:2:35, parent:work@ibex_multdiv_fast.imd_val_q_i
+      |vpiTypespec:
+      \_logic_typespec: , line:2:11, endln:2:16
+        |vpiRange:
+        \_range: , line:2:18, endln:2:22
+          |vpiLeftRange:
+          \_constant: , line:2:18, endln:2:20
+            |vpiDecompile:33
+            |vpiSize:64
+            |UINT:33
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:2:21, endln:2:22
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiFullName:work@ibex_multdiv_fast.imd_val_q_i
       |vpiNetType:36
+  |vpiTopModule:1
+  |vpiPort:
+  \_port: (imd_val_q_i), line:2:24, endln:2:35, parent:work@ibex_multdiv_fast
+    |vpiName:imd_val_q_i
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@ibex_multdiv_fast.imd_val_q_i), line:2:24, endln:2:35, parent:imd_val_q_i
+      |vpiName:imd_val_q_i
+      |vpiFullName:work@ibex_multdiv_fast.imd_val_q_i
+      |vpiActual:
+      \_array_net: (work@ibex_multdiv_fast.imd_val_q_i), line:2:24, endln:2:35, parent:work@ibex_multdiv_fast
+    |vpiTypedef:
+    \_logic_typespec: , line:2:11, endln:2:16
       |vpiRange:
-      \_range: , line:2:18, endln:2:22
+      \_range: , line:2:18, endln:2:22, parent:imd_val_q_i
         |vpiLeftRange:
         \_constant: , line:2:18, endln:2:20
           |vpiDecompile:33
@@ -180,17 +209,6 @@ design: (work@ibex_multdiv_fast)
           |vpiSize:64
           |UINT:0
           |vpiConstType:9
-  |vpiTopModule:1
-  |vpiPort:
-  \_port: (imd_val_q_i), line:2:24, endln:2:35, parent:work@ibex_multdiv_fast
-    |vpiName:imd_val_q_i
-    |vpiDirection:1
-    |vpiLowConn:
-    \_ref_obj: (work@ibex_multdiv_fast.imd_val_q_i), line:2:24, endln:2:35, parent:imd_val_q_i
-      |vpiName:imd_val_q_i
-      |vpiFullName:work@ibex_multdiv_fast.imd_val_q_i
-      |vpiActual:
-      \_array_net: (work@ibex_multdiv_fast.imd_val_q_i), line:2:24, endln:2:35, parent:work@ibex_multdiv_fast
     |vpiInstance:
     \_module: work@ibex_multdiv_fast (work@ibex_multdiv_fast) dut.sv:1:1: , endln:8:10
   |vpiContAssign:

--- a/tests/PortRanges/PortRanges.log
+++ b/tests/PortRanges/PortRanges.log
@@ -936,78 +936,86 @@ design: (work@DFlipflop8Bit)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@DFlipflop8Bit.A1), line:1:22, endln:1:24, parent:work@DFlipflop8Bit
+    |vpiTypespec:
+    \_logic_typespec: , line:4:7, endln:4:11
+      |vpiRange:
+      \_range: , line:4:13, endln:4:16
+        |vpiLeftRange:
+        \_constant: , line:4:13, endln:4:14
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:4:15, endln:4:16
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:A1
     |vpiFullName:work@DFlipflop8Bit.A1
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:4:13, endln:4:16
-      |vpiLeftRange:
-      \_constant: , line:4:13, endln:4:14
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:4:15, endln:4:16
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@DFlipflop8Bit.Q1), line:1:26, endln:1:28, parent:work@DFlipflop8Bit
+    |vpiTypespec:
+    \_logic_typespec: , line:3:8, endln:3:11
+      |vpiRange:
+      \_range: , line:3:13, endln:3:16
+        |vpiLeftRange:
+        \_constant: , line:3:13, endln:3:14
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:3:15, endln:3:16
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:Q1
     |vpiFullName:work@DFlipflop8Bit.Q1
     |vpiNetType:48
-    |vpiRange:
-    \_range: , line:3:13, endln:3:16
-      |vpiLeftRange:
-      \_constant: , line:3:13, endln:3:14
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:3:15, endln:3:16
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@DFlipflop8Bit.A2), line:1:30, endln:1:32, parent:work@DFlipflop8Bit
+    |vpiTypespec:
+    \_logic_typespec: , line:7:8, endln:7:13
+      |vpiRange:
+      \_range: , line:7:9, endln:7:12
+        |vpiLeftRange:
+        \_constant: , line:7:9, endln:7:10
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:7:11, endln:7:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:A2
     |vpiFullName:work@DFlipflop8Bit.A2
-    |vpiRange:
-    \_range: , line:7:9, endln:7:12
-      |vpiLeftRange:
-      \_constant: , line:7:9, endln:7:10
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:7:11, endln:7:12
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@DFlipflop8Bit.Q2), line:1:34, endln:1:36, parent:work@DFlipflop8Bit
+    |vpiTypespec:
+    \_logic_typespec: , line:6:9, endln:6:14
+      |vpiRange:
+      \_range: , line:6:10, endln:6:13
+        |vpiLeftRange:
+        \_constant: , line:6:10, endln:6:11
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:6:12, endln:6:13
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:Q2
     |vpiFullName:work@DFlipflop8Bit.Q2
-    |vpiRange:
-    \_range: , line:6:10, endln:6:13
-      |vpiLeftRange:
-      \_constant: , line:6:10, endln:6:11
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:6:12, endln:6:13
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (A1), line:1:22, endln:1:24, parent:work@DFlipflop8Bit
@@ -1019,6 +1027,22 @@ design: (work@DFlipflop8Bit)
       |vpiFullName:work@DFlipflop8Bit.A1
       |vpiActual:
       \_logic_net: (work@DFlipflop8Bit.A1), line:1:22, endln:1:24, parent:work@DFlipflop8Bit
+    |vpiTypedef:
+    \_logic_typespec: , line:4:7, endln:4:11
+      |vpiRange:
+      \_range: , line:4:13, endln:4:16, parent:A1
+        |vpiLeftRange:
+        \_constant: , line:4:13, endln:4:14
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:4:15, endln:4:16
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@DFlipflop8Bit (work@DFlipflop8Bit) dut.sv:1:1: , endln:9:10
   |vpiPort:
@@ -1059,6 +1083,22 @@ design: (work@DFlipflop8Bit)
       |vpiFullName:work@DFlipflop8Bit.A2
       |vpiActual:
       \_logic_net: (work@DFlipflop8Bit.A2), line:1:30, endln:1:32, parent:work@DFlipflop8Bit
+    |vpiTypedef:
+    \_logic_typespec: , line:7:8, endln:7:13
+      |vpiRange:
+      \_range: , line:7:9, endln:7:12, parent:A2
+        |vpiLeftRange:
+        \_constant: , line:7:9, endln:7:10
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:7:11, endln:7:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@DFlipflop8Bit (work@DFlipflop8Bit) dut.sv:1:1: , endln:9:10
   |vpiPort:
@@ -1071,6 +1111,22 @@ design: (work@DFlipflop8Bit)
       |vpiFullName:work@DFlipflop8Bit.Q2
       |vpiActual:
       \_logic_net: (work@DFlipflop8Bit.Q2), line:1:34, endln:1:36, parent:work@DFlipflop8Bit
+    |vpiTypedef:
+    \_logic_typespec: , line:6:9, endln:6:14
+      |vpiRange:
+      \_range: , line:6:10, endln:6:13, parent:Q2
+        |vpiLeftRange:
+        \_constant: , line:6:10, endln:6:11
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:6:12, endln:6:13
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@DFlipflop8Bit (work@DFlipflop8Bit) dut.sv:1:1: , endln:9:10
 |uhdmtopModules:
@@ -1080,78 +1136,86 @@ design: (work@DFlipflop8Bit)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@DFlipflop8Bit2.A3), line:12:35, endln:12:37, parent:work@DFlipflop8Bit2
+    |vpiTypespec:
+    \_logic_typespec: , line:12:29, endln:12:34
+      |vpiRange:
+      \_range: , line:12:30, endln:12:33
+        |vpiLeftRange:
+        \_constant: , line:12:30, endln:12:31
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:12:32, endln:12:33
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:A3
     |vpiFullName:work@DFlipflop8Bit2.A3
-    |vpiRange:
-    \_range: , line:12:30, endln:12:33
-      |vpiLeftRange:
-      \_constant: , line:12:30, endln:12:31
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:12:32, endln:12:33
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@DFlipflop8Bit2.A4), line:13:40, endln:13:42, parent:work@DFlipflop8Bit2
+    |vpiTypespec:
+    \_logic_typespec: , line:13:29, endln:13:33
+      |vpiRange:
+      \_range: , line:13:35, endln:13:38
+        |vpiLeftRange:
+        \_constant: , line:13:35, endln:13:36
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:13:37, endln:13:38
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:A4
     |vpiFullName:work@DFlipflop8Bit2.A4
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:13:35, endln:13:38
-      |vpiLeftRange:
-      \_constant: , line:13:35, endln:13:36
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:13:37, endln:13:38
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@DFlipflop8Bit2.Q3), line:14:36, endln:14:38, parent:work@DFlipflop8Bit2
+    |vpiTypespec:
+    \_logic_typespec: , line:14:30, endln:14:35
+      |vpiRange:
+      \_range: , line:14:31, endln:14:34
+        |vpiLeftRange:
+        \_constant: , line:14:31, endln:14:32
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:14:33, endln:14:34
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:Q3
     |vpiFullName:work@DFlipflop8Bit2.Q3
-    |vpiRange:
-    \_range: , line:14:31, endln:14:34
-      |vpiLeftRange:
-      \_constant: , line:14:31, endln:14:32
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:14:33, endln:14:34
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@DFlipflop8Bit2.Q4), line:15:40, endln:15:42, parent:work@DFlipflop8Bit2
+    |vpiTypespec:
+    \_logic_typespec: , line:15:30, endln:15:33
+      |vpiRange:
+      \_range: , line:15:35, endln:15:38
+        |vpiLeftRange:
+        \_constant: , line:15:35, endln:15:36
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:15:37, endln:15:38
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:Q4
     |vpiFullName:work@DFlipflop8Bit2.Q4
     |vpiNetType:48
-    |vpiRange:
-    \_range: , line:15:35, endln:15:38
-      |vpiLeftRange:
-      \_constant: , line:15:35, endln:15:36
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:15:37, endln:15:38
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (A3), line:12:35, endln:12:37, parent:work@DFlipflop8Bit2
@@ -1163,6 +1227,22 @@ design: (work@DFlipflop8Bit)
       |vpiFullName:work@DFlipflop8Bit2.A3
       |vpiActual:
       \_logic_net: (work@DFlipflop8Bit2.A3), line:12:35, endln:12:37, parent:work@DFlipflop8Bit2
+    |vpiTypedef:
+    \_logic_typespec: , line:12:29, endln:12:34
+      |vpiRange:
+      \_range: , line:12:30, endln:12:33, parent:A3
+        |vpiLeftRange:
+        \_constant: , line:12:30, endln:12:31
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:12:32, endln:12:33
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@DFlipflop8Bit2 (work@DFlipflop8Bit2) dut.sv:12:1: , endln:17:10
   |vpiPort:
@@ -1175,6 +1255,22 @@ design: (work@DFlipflop8Bit)
       |vpiFullName:work@DFlipflop8Bit2.A4
       |vpiActual:
       \_logic_net: (work@DFlipflop8Bit2.A4), line:13:40, endln:13:42, parent:work@DFlipflop8Bit2
+    |vpiTypedef:
+    \_logic_typespec: , line:13:29, endln:13:33
+      |vpiRange:
+      \_range: , line:13:35, endln:13:38, parent:A4
+        |vpiLeftRange:
+        \_constant: , line:13:35, endln:13:36
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:13:37, endln:13:38
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@DFlipflop8Bit2 (work@DFlipflop8Bit2) dut.sv:12:1: , endln:17:10
   |vpiPort:
@@ -1187,6 +1283,22 @@ design: (work@DFlipflop8Bit)
       |vpiFullName:work@DFlipflop8Bit2.Q3
       |vpiActual:
       \_logic_net: (work@DFlipflop8Bit2.Q3), line:14:36, endln:14:38, parent:work@DFlipflop8Bit2
+    |vpiTypedef:
+    \_logic_typespec: , line:14:30, endln:14:35
+      |vpiRange:
+      \_range: , line:14:31, endln:14:34, parent:Q3
+        |vpiLeftRange:
+        \_constant: , line:14:31, endln:14:32
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:14:33, endln:14:34
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@DFlipflop8Bit2 (work@DFlipflop8Bit2) dut.sv:12:1: , endln:17:10
   |vpiPort:
@@ -1199,6 +1311,22 @@ design: (work@DFlipflop8Bit)
       |vpiFullName:work@DFlipflop8Bit2.Q4
       |vpiActual:
       \_logic_net: (work@DFlipflop8Bit2.Q4), line:15:40, endln:15:42, parent:work@DFlipflop8Bit2
+    |vpiTypedef:
+    \_logic_typespec: , line:15:30, endln:15:33
+      |vpiRange:
+      \_range: , line:15:35, endln:15:38, parent:Q4
+        |vpiLeftRange:
+        \_constant: , line:15:35, endln:15:36
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:15:37, endln:15:38
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@DFlipflop8Bit2 (work@DFlipflop8Bit2) dut.sv:12:1: , endln:17:10
 ===================

--- a/tests/PortWildcard/PortWildcard.log
+++ b/tests/PortWildcard/PortWildcard.log
@@ -895,6 +895,8 @@ design: (work@dut)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@dut.rst_l), line:16:31, endln:16:36, parent:work@dut
+    |vpiTypespec:
+    \_logic_typespec: , line:16:7, endln:16:12
     |vpiName:rst_l
     |vpiFullName:work@dut.rst_l
     |vpiNetType:36
@@ -930,6 +932,8 @@ design: (work@dut)
       |vpiFullName:work@dut.rst_l
       |vpiActual:
       \_logic_net: (work@dut.rst_l), line:16:31, endln:16:36, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:16:7, endln:16:12
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:15:1: , endln:21:10
   |vpiModule:
@@ -961,52 +965,60 @@ design: (work@dut)
     |vpiDefLineNo:3
     |vpiNet:
     \_logic_net: (work@dut.freezerfpc_ff.din), line:5:30, endln:5:33, parent:work@dut.freezerfpc_ff
+      |vpiTypespec:
+      \_logic_typespec: , line:5:12, endln:5:17
+        |vpiRange:
+        \_range: , line:5:19, endln:5:28
+          |vpiLeftRange:
+          \_constant: , line:5:19, endln:5:24
+            |vpiDecompile:1
+            |vpiSize:64
+            |INT:1
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:5:27, endln:5:28
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:din
       |vpiFullName:work@dut.freezerfpc_ff.din
       |vpiNetType:36
-      |vpiRange:
-      \_range: , line:5:19, endln:5:28
-        |vpiLeftRange:
-        \_constant: , line:5:19, endln:5:24
-          |vpiDecompile:1
-          |vpiSize:64
-          |INT:1
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:5:27, endln:5:28
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@dut.freezerfpc_ff.clk), line:6:28, endln:6:31, parent:work@dut.freezerfpc_ff
+      |vpiTypespec:
+      \_logic_typespec: , line:6:12, endln:6:17
       |vpiName:clk
       |vpiFullName:work@dut.freezerfpc_ff.clk
       |vpiNetType:36
     |vpiNet:
     \_logic_net: (work@dut.freezerfpc_ff.rst_l), line:7:36, endln:7:41, parent:work@dut.freezerfpc_ff
+      |vpiTypespec:
+      \_logic_typespec: , line:7:12, endln:7:17
       |vpiName:rst_l
       |vpiFullName:work@dut.freezerfpc_ff.rst_l
       |vpiNetType:36
     |vpiNet:
     \_logic_net: (work@dut.freezerfpc_ff.dout), line:9:31, endln:9:35, parent:work@dut.freezerfpc_ff
+      |vpiTypespec:
+      \_logic_typespec: , line:9:13, endln:9:18
+        |vpiRange:
+        \_range: , line:9:20, endln:9:29
+          |vpiLeftRange:
+          \_constant: , line:9:20, endln:9:25
+            |vpiDecompile:1
+            |vpiSize:64
+            |INT:1
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:9:28, endln:9:29
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:dout
       |vpiFullName:work@dut.freezerfpc_ff.dout
       |vpiNetType:36
-      |vpiRange:
-      \_range: , line:9:20, endln:9:29
-        |vpiLeftRange:
-        \_constant: , line:9:20, endln:9:25
-          |vpiDecompile:1
-          |vpiSize:64
-          |INT:1
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:9:28, endln:9:29
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:15:1: , endln:21:10
     |vpiPort:
@@ -1034,6 +1046,22 @@ design: (work@dut)
         |vpiFullName:work@dut.freezerfpc_ff.din
         |vpiActual:
         \_logic_net: (work@dut.freezerfpc_ff.din), line:5:30, endln:5:33, parent:work@dut.freezerfpc_ff
+      |vpiTypedef:
+      \_logic_typespec: , line:5:12, endln:5:17
+        |vpiRange:
+        \_range: , line:5:19, endln:5:28, parent:din
+          |vpiLeftRange:
+          \_constant: , line:5:19, endln:5:24
+            |vpiDecompile:1
+            |vpiSize:64
+            |INT:1
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:5:27, endln:5:28
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@rvdff (work@dut.freezerfpc_ff) dut.sv:17:3: , endln:19:77, parent:work@dut
     |vpiPort:
@@ -1052,6 +1080,8 @@ design: (work@dut)
         |vpiFullName:work@dut.freezerfpc_ff.clk
         |vpiActual:
         \_logic_net: (work@dut.freezerfpc_ff.clk), line:6:28, endln:6:31, parent:work@dut.freezerfpc_ff
+      |vpiTypedef:
+      \_logic_typespec: , line:6:12, endln:6:17
       |vpiInstance:
       \_module: work@rvdff (work@dut.freezerfpc_ff) dut.sv:17:3: , endln:19:77, parent:work@dut
     |vpiPort:
@@ -1070,6 +1100,8 @@ design: (work@dut)
         |vpiFullName:work@dut.freezerfpc_ff.rst_l
         |vpiActual:
         \_logic_net: (work@dut.freezerfpc_ff.rst_l), line:7:36, endln:7:41, parent:work@dut.freezerfpc_ff
+      |vpiTypedef:
+      \_logic_typespec: , line:7:12, endln:7:17
       |vpiInstance:
       \_module: work@rvdff (work@dut.freezerfpc_ff) dut.sv:17:3: , endln:19:77, parent:work@dut
     |vpiPort:
@@ -1097,6 +1129,22 @@ design: (work@dut)
         |vpiFullName:work@dut.freezerfpc_ff.dout
         |vpiActual:
         \_logic_net: (work@dut.freezerfpc_ff.dout), line:9:31, endln:9:35, parent:work@dut.freezerfpc_ff
+      |vpiTypedef:
+      \_logic_typespec: , line:9:13, endln:9:18
+        |vpiRange:
+        \_range: , line:9:20, endln:9:29, parent:dout
+          |vpiLeftRange:
+          \_constant: , line:9:20, endln:9:25
+            |vpiDecompile:1
+            |vpiSize:64
+            |INT:1
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:9:28, endln:9:29
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@rvdff (work@dut.freezerfpc_ff) dut.sv:17:3: , endln:19:77, parent:work@dut
 ===================

--- a/tests/PreprocUhdmCov/PreprocUhdmCov.log
+++ b/tests/PreprocUhdmCov/PreprocUhdmCov.log
@@ -1022,6 +1022,8 @@ design: (work@top)
       |vpiFullName:work@top.b
       |vpiActual:
       \_logic_net: (work@top.b), line:4:25, endln:4:26, parent:work@top
+        |vpiTypespec:
+        \_logic_typespec: , line:4:19, endln:4:24
         |vpiName:b
         |vpiFullName:work@top.b
         |vpiNetType:36
@@ -1031,6 +1033,8 @@ design: (work@top)
       |vpiFullName:work@top.a
       |vpiActual:
       \_logic_net: (work@top.a), line:4:41, endln:4:42, parent:work@top
+        |vpiTypespec:
+        \_logic_typespec: , line:4:35, endln:4:40
         |vpiName:a
         |vpiFullName:work@top.a
         |vpiNetType:36
@@ -1128,6 +1132,8 @@ design: (work@top)
       |vpiFullName:work@top.b
       |vpiActual:
       \_logic_net: (work@top.b), line:4:25, endln:4:26, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:4:19, endln:4:24
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:4:1: , endln:50:17
   |vpiPort:
@@ -1140,6 +1146,8 @@ design: (work@top)
       |vpiFullName:work@top.a
       |vpiActual:
       \_logic_net: (work@top.a), line:4:41, endln:4:42, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:4:35, endln:4:40
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:4:1: , endln:50:17
   |vpiContAssign:

--- a/tests/RangeInf/RangeInf.log
+++ b/tests/RangeInf/RangeInf.log
@@ -907,44 +907,34 @@ design: (work@FullAdder)
           |vpiFullName:work@FullAdder.A
           |vpiActual:
           \_logic_net: (work@FullAdder.A), line:1:18, endln:1:19, parent:work@FullAdder
+            |vpiTypespec:
+            \_logic_typespec: , line:2:10, endln:2:15
+              |vpiRange:
+              \_range: , line:2:11, endln:2:14
+                |vpiLeftRange:
+                \_constant: , line:2:11, endln:2:12
+                  |vpiDecompile:3
+                  |vpiSize:64
+                  |UINT:3
+                  |vpiConstType:9
+                |vpiRightRange:
+                \_constant: , line:2:13, endln:2:14
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiName:A
             |vpiFullName:work@FullAdder.A
-            |vpiRange:
-            \_range: , line:2:11, endln:2:14
-              |vpiLeftRange:
-              \_constant: , line:2:11, endln:2:12
-                |vpiDecompile:3
-                |vpiSize:64
-                |UINT:3
-                |vpiConstType:9
-              |vpiRightRange:
-              \_constant: , line:2:13, endln:2:14
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
         |vpiOperand:
         \_ref_obj: (work@FullAdder.B), line:7:18, endln:7:19
           |vpiName:B
           |vpiFullName:work@FullAdder.B
           |vpiActual:
           \_logic_net: (work@FullAdder.B), line:1:20, endln:1:21, parent:work@FullAdder
+            |vpiTypespec:
+            \_logic_typespec: , line:2:10, endln:2:15
             |vpiName:B
             |vpiFullName:work@FullAdder.B
-            |vpiRange:
-            \_range: , line:2:11, endln:2:14
-              |vpiLeftRange:
-              \_constant: , line:2:11, endln:2:12
-                |vpiDecompile:3
-                |vpiSize:64
-                |UINT:3
-                |vpiConstType:9
-              |vpiRightRange:
-              \_constant: , line:2:13, endln:2:14
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
       |vpiOperand:
       \_ref_obj: (work@FullAdder.Cin), line:7:20, endln:7:23
         |vpiName:Cin
@@ -959,23 +949,25 @@ design: (work@FullAdder)
       |vpiFullName:work@FullAdder.temp
       |vpiActual:
       \_logic_net: (work@FullAdder.temp), line:6:14, endln:6:18, parent:work@FullAdder
+        |vpiTypespec:
+        \_logic_typespec: , line:6:4, endln:6:8
+          |vpiRange:
+          \_range: , line:6:10, endln:6:13
+            |vpiLeftRange:
+            \_constant: , line:6:10, endln:6:11
+              |vpiDecompile:4
+              |vpiSize:64
+              |UINT:4
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:6:12, endln:6:13
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:temp
         |vpiFullName:work@FullAdder.temp
         |vpiNetType:1
-        |vpiRange:
-        \_range: , line:6:10, endln:6:13
-          |vpiLeftRange:
-          \_constant: , line:6:10, endln:6:11
-            |vpiDecompile:4
-            |vpiSize:64
-            |UINT:4
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:6:12, endln:6:13
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
   |vpiContAssign:
   \_cont_assign: , line:8:11, endln:8:24, parent:work@FullAdder
     |vpiRhs:
@@ -1004,23 +996,25 @@ design: (work@FullAdder)
       |vpiFullName:work@FullAdder.Sum
       |vpiActual:
       \_logic_net: (work@FullAdder.Sum), line:1:26, endln:1:29, parent:work@FullAdder
+        |vpiTypespec:
+        \_logic_typespec: , line:4:11, endln:4:15
+          |vpiRange:
+          \_range: , line:4:17, endln:4:20
+            |vpiLeftRange:
+            \_constant: , line:4:17, endln:4:18
+              |vpiDecompile:3
+              |vpiSize:64
+              |UINT:3
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:4:19, endln:4:20
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:Sum
         |vpiFullName:work@FullAdder.Sum
         |vpiNetType:1
-        |vpiRange:
-        \_range: , line:4:17, endln:4:20
-          |vpiLeftRange:
-          \_constant: , line:4:17, endln:4:18
-            |vpiDecompile:3
-            |vpiSize:64
-            |UINT:3
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:4:19, endln:4:20
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
   |vpiContAssign:
   \_cont_assign: , line:9:11, endln:9:23, parent:work@FullAdder
     |vpiRhs:
@@ -1043,6 +1037,8 @@ design: (work@FullAdder)
       |vpiFullName:work@FullAdder.Cout
       |vpiActual:
       \_logic_net: (work@FullAdder.Cout), line:1:30, endln:1:34, parent:work@FullAdder
+        |vpiTypespec:
+        \_logic_typespec: , line:5:11, endln:5:15
         |vpiName:Cout
         |vpiFullName:work@FullAdder.Cout
         |vpiNetType:1
@@ -1074,6 +1070,22 @@ design: (work@FullAdder)
       |vpiFullName:work@FullAdder.A
       |vpiActual:
       \_logic_net: (work@FullAdder.A), line:1:18, endln:1:19, parent:work@FullAdder
+    |vpiTypedef:
+    \_logic_typespec: , line:2:10, endln:2:15
+      |vpiRange:
+      \_range: , line:2:11, endln:2:14, parent:A
+        |vpiLeftRange:
+        \_constant: , line:2:11, endln:2:12
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:2:13, endln:2:14
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@FullAdder (work@FullAdder) dut.sv:1:1: , endln:10:10
   |vpiPort:
@@ -1086,6 +1098,8 @@ design: (work@FullAdder)
       |vpiFullName:work@FullAdder.B
       |vpiActual:
       \_logic_net: (work@FullAdder.B), line:1:20, endln:1:21, parent:work@FullAdder
+    |vpiTypedef:
+    \_logic_typespec: , line:2:10, endln:2:15
     |vpiInstance:
     \_module: work@FullAdder (work@FullAdder) dut.sv:1:1: , endln:10:10
   |vpiPort:
@@ -1110,6 +1124,22 @@ design: (work@FullAdder)
       |vpiFullName:work@FullAdder.Sum
       |vpiActual:
       \_logic_net: (work@FullAdder.Sum), line:1:26, endln:1:29, parent:work@FullAdder
+    |vpiTypedef:
+    \_logic_typespec: , line:4:11, endln:4:15
+      |vpiRange:
+      \_range: , line:4:17, endln:4:20, parent:Sum
+        |vpiLeftRange:
+        \_constant: , line:4:17, endln:4:18
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:4:19, endln:4:20
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@FullAdder (work@FullAdder) dut.sv:1:1: , endln:10:10
   |vpiPort:
@@ -1122,6 +1152,8 @@ design: (work@FullAdder)
       |vpiFullName:work@FullAdder.Cout
       |vpiActual:
       \_logic_net: (work@FullAdder.Cout), line:1:30, endln:1:34, parent:work@FullAdder
+    |vpiTypedef:
+    \_logic_typespec: , line:5:11, endln:5:15
     |vpiInstance:
     \_module: work@FullAdder (work@FullAdder) dut.sv:1:1: , endln:10:10
   |vpiContAssign:

--- a/tests/SignedBin/SignedBin.log
+++ b/tests/SignedBin/SignedBin.log
@@ -125,6 +125,8 @@ design: (work@dut)
     |vpiDefLineNo:1
     |vpiNet:
     \_logic_net: (work@dut.s.test), line:2:13, endln:2:17, parent:work@dut.s
+      |vpiTypespec:
+      \_logic_typespec: , line:2:7, endln:2:12
       |vpiName:test
       |vpiFullName:work@dut.s.test
       |vpiNetType:36
@@ -149,6 +151,8 @@ design: (work@dut)
         |vpiFullName:work@dut.s.test
         |vpiActual:
         \_logic_net: (work@dut.s.test), line:2:13, endln:2:17, parent:work@dut.s
+      |vpiTypedef:
+      \_logic_typespec: , line:2:7, endln:2:12
       |vpiInstance:
       \_module: work@prim_subreg (work@dut.s) dut.sv:9:1: , endln:9:36, parent:work@dut
 ===================

--- a/tests/SignedPort/SignedPort.log
+++ b/tests/SignedPort/SignedPort.log
@@ -768,24 +768,26 @@ design: (work@dut)
         |vpiFullName:work@dut.a
         |vpiActual:
         \_logic_net: (work@dut.a), line:2:38, endln:2:39, parent:work@dut
+          |vpiTypespec:
+          \_logic_typespec: , line:2:19, endln:2:24
+            |vpiRange:
+            \_range: , line:2:33, endln:2:36
+              |vpiLeftRange:
+              \_constant: , line:2:33, endln:2:34
+                |vpiDecompile:2
+                |vpiSize:64
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:2:35, endln:2:36
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:a
           |vpiFullName:work@dut.a
           |vpiNetType:36
           |vpiSigned:1
-          |vpiRange:
-          \_range: , line:2:33, endln:2:36
-            |vpiLeftRange:
-            \_constant: , line:2:33, endln:2:34
-              |vpiDecompile:2
-              |vpiSize:64
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:2:35, endln:2:36
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
       |vpiName:$unsigned
     |vpiLhs:
     \_ref_obj: (work@dut.b), line:4:11, endln:4:12
@@ -793,23 +795,25 @@ design: (work@dut)
       |vpiFullName:work@dut.b
       |vpiActual:
       \_logic_net: (work@dut.b), line:2:69, endln:2:70, parent:work@dut
+        |vpiTypespec:
+        \_logic_typespec: , line:2:48, endln:2:53
+          |vpiRange:
+          \_range: , line:2:64, endln:2:67
+            |vpiLeftRange:
+            \_constant: , line:2:64, endln:2:65
+              |vpiDecompile:2
+              |vpiSize:64
+              |UINT:2
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:2:66, endln:2:67
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:b
         |vpiFullName:work@dut.b
         |vpiNetType:36
-        |vpiRange:
-        \_range: , line:2:64, endln:2:67
-          |vpiLeftRange:
-          \_constant: , line:2:64, endln:2:65
-            |vpiDecompile:2
-            |vpiSize:64
-            |UINT:2
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:2:66, endln:2:67
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@dut (work@dut) dut.sv:2:1: , endln:5:10
   |vpiName:work@dut
@@ -817,6 +821,20 @@ design: (work@dut)
   \_logic_var: (work@dut.c), line:3:22, endln:3:23, parent:work@dut
     |vpiTypespec:
     \_logic_typespec: , line:3:3, endln:3:8
+      |vpiRange:
+      \_range: , line:3:17, endln:3:20
+        |vpiLeftRange:
+        \_constant: , line:3:17, endln:3:18
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:3:19, endln:3:20
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:c
     |vpiFullName:work@dut.c
     |vpiSigned:1
@@ -852,6 +870,22 @@ design: (work@dut)
       |vpiFullName:work@dut.a
       |vpiActual:
       \_logic_net: (work@dut.a), line:2:38, endln:2:39, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:2:19, endln:2:24
+      |vpiRange:
+      \_range: , line:2:33, endln:2:36, parent:a
+        |vpiLeftRange:
+        \_constant: , line:2:33, endln:2:34
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:2:35, endln:2:36
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:2:1: , endln:5:10
   |vpiPort:
@@ -864,6 +898,22 @@ design: (work@dut)
       |vpiFullName:work@dut.b
       |vpiActual:
       \_logic_net: (work@dut.b), line:2:69, endln:2:70, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:2:48, endln:2:53
+      |vpiRange:
+      \_range: , line:2:64, endln:2:67, parent:b
+        |vpiLeftRange:
+        \_constant: , line:2:64, endln:2:65
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:2:66, endln:2:67
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:2:1: , endln:5:10
   |vpiContAssign:

--- a/tests/StandardNetVar/StandardNetVar.log
+++ b/tests/StandardNetVar/StandardNetVar.log
@@ -105,8 +105,7 @@ n<> u<96> t<Top_level_rule> l<1:1> el<9:1>
 
 [INF:CP0303] dut.sv:1: Compile module "work@net_vars".
 
-[NTE:CP0309] dut.sv:1:111: Implicit port type (wire) for "o1",
-there are 1 more instances of this message.
+[NTE:CP0309] dut.sv:1:133: Implicit port type (wire) for "o2".
 
 [INF:EL0526] Design Elaboration...
 
@@ -144,6 +143,7 @@ design: (work@net_vars)
   \_logic_net: (work@net_vars.i1), line:1:34, endln:1:36, parent:work@net_vars
     |vpiName:i1
     |vpiFullName:work@net_vars.i1
+    |vpiNetType:36
   |vpiNet:
   \_logic_net: (work@net_vars.i2), line:1:54, endln:1:56, parent:work@net_vars
     |vpiName:i2
@@ -157,6 +157,7 @@ design: (work@net_vars)
   \_logic_net: (work@net_vars.o1), line:1:111, endln:1:113, parent:work@net_vars
     |vpiName:o1
     |vpiFullName:work@net_vars.o1
+    |vpiNetType:36
   |vpiNet:
   \_logic_net: (work@net_vars.o2), line:1:133, endln:1:135, parent:work@net_vars
     |vpiName:o2
@@ -225,11 +226,15 @@ design: (work@net_vars)
   |vpiName:work@net_vars
   |vpiVariables:
   \_logic_var: (work@net_vars.i1), line:1:34, endln:1:36, parent:work@net_vars
+    |vpiTypespec:
+    \_logic_typespec: , line:1:28, endln:1:33
     |vpiName:i1
     |vpiFullName:work@net_vars.i1
     |vpiVisibility:1
   |vpiVariables:
   \_logic_var: (work@net_vars.o1), line:1:111, endln:1:113, parent:work@net_vars
+    |vpiTypespec:
+    \_logic_typespec: , line:1:105, endln:1:110
     |vpiName:o1
     |vpiFullName:work@net_vars.o1
     |vpiVisibility:1
@@ -253,6 +258,8 @@ design: (work@net_vars)
     |vpiFullName:work@net_vars.i2
   |vpiNet:
   \_logic_net: (work@net_vars.i3), line:1:80, endln:1:82, parent:work@net_vars
+    |vpiTypespec:
+    \_logic_typespec: , line:1:74, endln:1:79
     |vpiName:i3
     |vpiFullName:work@net_vars.i3
     |vpiNetType:36
@@ -262,11 +269,15 @@ design: (work@net_vars)
     |vpiFullName:work@net_vars.o2
   |vpiNet:
   \_logic_net: (work@net_vars.a), line:3:6, endln:3:7, parent:work@net_vars
+    |vpiTypespec:
+    \_logic_typespec: , line:3:1, endln:3:5
     |vpiName:a
     |vpiFullName:work@net_vars.a
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@net_vars.b), line:4:12, endln:4:13, parent:work@net_vars
+    |vpiTypespec:
+    \_logic_typespec: , line:4:6, endln:4:11
     |vpiName:b
     |vpiFullName:work@net_vars.b
     |vpiNetType:1
@@ -281,6 +292,8 @@ design: (work@net_vars)
       |vpiFullName:work@net_vars.i1
       |vpiActual:
       \_logic_var: (work@net_vars.i1), line:1:34, endln:1:36, parent:work@net_vars
+    |vpiTypedef:
+    \_logic_typespec: , line:1:28, endln:1:33
     |vpiInstance:
     \_module: work@net_vars (work@net_vars) dut.sv:1:1: , endln:8:10
   |vpiPort:
@@ -305,6 +318,8 @@ design: (work@net_vars)
       |vpiFullName:work@net_vars.i3
       |vpiActual:
       \_logic_net: (work@net_vars.i3), line:1:80, endln:1:82, parent:work@net_vars
+    |vpiTypedef:
+    \_logic_typespec: , line:1:74, endln:1:79
     |vpiInstance:
     \_module: work@net_vars (work@net_vars) dut.sv:1:1: , endln:8:10
   |vpiPort:
@@ -317,6 +332,8 @@ design: (work@net_vars)
       |vpiFullName:work@net_vars.o1
       |vpiActual:
       \_logic_var: (work@net_vars.o1), line:1:111, endln:1:113, parent:work@net_vars
+    |vpiTypedef:
+    \_logic_typespec: , line:1:105, endln:1:110
     |vpiInstance:
     \_module: work@net_vars (work@net_vars) dut.sv:1:1: , endln:8:10
   |vpiPort:

--- a/tests/StringPort/StringPort.log
+++ b/tests/StringPort/StringPort.log
@@ -731,6 +731,8 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_string_var: (work@top.o), line:1:26, endln:1:27, parent:work@top
+    |vpiTypedef:
+    \_string_typespec: , line:1:19, endln:1:25
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:6:10
   |vpiProcess:

--- a/tests/StructArrayNet/StructArrayNet.log
+++ b/tests/StructArrayNet/StructArrayNet.log
@@ -328,6 +328,9 @@ design: (work@dut)
       |vpiFullName:work@dut.sel
       |vpiActual:
       \_int_var: (work@dut.sel), line:9:22, endln:9:25, parent:work@dut
+    |vpiTypedef:
+    \_int_typespec: , line:9:18, endln:9:21
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@dut (work@dut) dut.sv:9:1: , endln:13:10
   |vpiModule:

--- a/tests/TaskProto/TaskProto.log
+++ b/tests/TaskProto/TaskProto.log
@@ -177,6 +177,9 @@ design: (work@top)
       |vpiFullName:work@top.a
       |vpiActual:
       \_int_var: (work@top.a), line:1:23, endln:1:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:1:19, endln:1:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:7:10
   |vpiProcess:

--- a/tests/Ternary/Ternary.log
+++ b/tests/Ternary/Ternary.log
@@ -1940,6 +1940,8 @@ design: (work@test)
             |vpiName:RAMRST
             |vpiActual:
             \_logic_net: (work@test.RAMRST), line:12:10, endln:12:16, parent:work@test
+              |vpiTypespec:
+              \_logic_typespec: , line:12:5, endln:12:9
               |vpiName:RAMRST
               |vpiFullName:work@test.RAMRST
               |vpiNetType:1
@@ -1989,23 +1991,25 @@ design: (work@test)
                 |vpiFullName:work@test.UserState
                 |vpiActual:
                 \_logic_net: (work@test.UserState), line:17:16, endln:17:25, parent:work@test
+                  |vpiTypespec:
+                  \_logic_typespec: , line:17:5, endln:17:8
+                    |vpiRange:
+                    \_range: , line:17:10, endln:17:14
+                      |vpiLeftRange:
+                      \_constant: , line:17:10, endln:17:12
+                        |vpiDecompile:10
+                        |vpiSize:64
+                        |UINT:10
+                        |vpiConstType:9
+                      |vpiRightRange:
+                      \_constant: , line:17:13, endln:17:14
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:UserState
                   |vpiFullName:work@test.UserState
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:17:10, endln:17:14
-                    |vpiLeftRange:
-                    \_constant: , line:17:10, endln:17:12
-                      |vpiDecompile:10
-                      |vpiSize:64
-                      |UINT:10
-                      |vpiConstType:9
-                    |vpiRightRange:
-                    \_constant: , line:17:13, endln:17:14
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
             |vpiStmt:
             \_assignment: , line:40:13, endln:40:23, parent:work@test
               |vpiOpType:82
@@ -2021,23 +2025,25 @@ design: (work@test)
                 |vpiFullName:work@test.Delay
                 |vpiActual:
                 \_logic_net: (work@test.Delay), line:16:16, endln:16:21, parent:work@test
+                  |vpiTypespec:
+                  \_logic_typespec: , line:16:5, endln:16:8
+                    |vpiRange:
+                    \_range: , line:16:10, endln:16:14
+                      |vpiLeftRange:
+                      \_constant: , line:16:10, endln:16:12
+                        |vpiDecompile:23
+                        |vpiSize:64
+                        |UINT:23
+                        |vpiConstType:9
+                      |vpiRightRange:
+                      \_constant: , line:16:13, endln:16:14
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:Delay
                   |vpiFullName:work@test.Delay
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:16:10, endln:16:14
-                    |vpiLeftRange:
-                    \_constant: , line:16:10, endln:16:12
-                      |vpiDecompile:23
-                      |vpiSize:64
-                      |UINT:23
-                      |vpiConstType:9
-                    |vpiRightRange:
-                    \_constant: , line:16:13, endln:16:14
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
             |vpiStmt:
             \_assignment: , line:41:13, endln:41:32, parent:work@test
               |vpiOpType:82
@@ -2053,23 +2059,25 @@ design: (work@test)
                 |vpiFullName:work@test.UserValidCount
                 |vpiActual:
                 \_logic_net: (work@test.UserValidCount), line:18:16, endln:18:30, parent:work@test
+                  |vpiTypespec:
+                  \_logic_typespec: , line:18:5, endln:18:8
+                    |vpiRange:
+                    \_range: , line:18:10, endln:18:14
+                      |vpiLeftRange:
+                      \_constant: , line:18:10, endln:18:12
+                        |vpiDecompile:15
+                        |vpiSize:64
+                        |UINT:15
+                        |vpiConstType:9
+                      |vpiRightRange:
+                      \_constant: , line:18:13, endln:18:14
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:UserValidCount
                   |vpiFullName:work@test.UserValidCount
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:18:10, endln:18:14
-                    |vpiLeftRange:
-                    \_constant: , line:18:10, endln:18:12
-                      |vpiDecompile:15
-                      |vpiSize:64
-                      |UINT:15
-                      |vpiConstType:9
-                    |vpiRightRange:
-                    \_constant: , line:18:13, endln:18:14
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
             |vpiStmt:
             \_assignment: , line:42:13, endln:42:33, parent:work@test
               |vpiOpType:82
@@ -2085,23 +2093,25 @@ design: (work@test)
                 |vpiFullName:work@test.ConnectionState
                 |vpiActual:
                 \_logic_net: (work@test.ConnectionState), line:19:15, endln:19:30, parent:work@test
+                  |vpiTypespec:
+                  \_logic_typespec: , line:19:5, endln:19:8
+                    |vpiRange:
+                    \_range: , line:19:10, endln:19:13
+                      |vpiLeftRange:
+                      \_constant: , line:19:10, endln:19:11
+                        |vpiDecompile:5
+                        |vpiSize:64
+                        |UINT:5
+                        |vpiConstType:9
+                      |vpiRightRange:
+                      \_constant: , line:19:12, endln:19:13
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:ConnectionState
                   |vpiFullName:work@test.ConnectionState
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:19:10, endln:19:13
-                    |vpiLeftRange:
-                    \_constant: , line:19:10, endln:19:11
-                      |vpiDecompile:5
-                      |vpiSize:64
-                      |UINT:5
-                      |vpiConstType:9
-                    |vpiRightRange:
-                    \_constant: , line:19:12, endln:19:13
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
             |vpiStmt:
             \_assignment: , line:43:13, endln:43:33, parent:work@test
               |vpiOpType:82
@@ -2117,23 +2127,25 @@ design: (work@test)
                 |vpiFullName:work@test.InterruptStatus
                 |vpiActual:
                 \_logic_net: (work@test.InterruptStatus), line:20:16, endln:20:31, parent:work@test
+                  |vpiTypespec:
+                  \_logic_typespec: , line:20:5, endln:20:8
+                    |vpiRange:
+                    \_range: , line:20:10, endln:20:14
+                      |vpiLeftRange:
+                      \_constant: , line:20:10, endln:20:12
+                        |vpiDecompile:15
+                        |vpiSize:64
+                        |UINT:15
+                        |vpiConstType:9
+                      |vpiRightRange:
+                      \_constant: , line:20:13, endln:20:14
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:InterruptStatus
                   |vpiFullName:work@test.InterruptStatus
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:20:10, endln:20:14
-                    |vpiLeftRange:
-                    \_constant: , line:20:10, endln:20:12
-                      |vpiDecompile:15
-                      |vpiSize:64
-                      |UINT:15
-                      |vpiConstType:9
-                    |vpiRightRange:
-                    \_constant: , line:20:13, endln:20:14
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
             |vpiStmt:
             \_assignment: , line:44:13, endln:44:29, parent:work@test
               |vpiOpType:82
@@ -2149,23 +2161,25 @@ design: (work@test)
                 |vpiFullName:work@test.FrameLength
                 |vpiActual:
                 \_logic_net: (work@test.FrameLength), line:21:16, endln:21:27, parent:work@test
+                  |vpiTypespec:
+                  \_logic_typespec: , line:21:5, endln:21:8
+                    |vpiRange:
+                    \_range: , line:21:10, endln:21:14
+                      |vpiLeftRange:
+                      \_constant: , line:21:10, endln:21:12
+                        |vpiDecompile:15
+                        |vpiSize:64
+                        |UINT:15
+                        |vpiConstType:9
+                      |vpiRightRange:
+                      \_constant: , line:21:13, endln:21:14
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:FrameLength
                   |vpiFullName:work@test.FrameLength
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:21:10, endln:21:14
-                    |vpiLeftRange:
-                    \_constant: , line:21:10, endln:21:12
-                      |vpiDecompile:15
-                      |vpiSize:64
-                      |UINT:15
-                      |vpiConstType:9
-                    |vpiRightRange:
-                    \_constant: , line:21:13, endln:21:14
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
             |vpiStmt:
             \_assignment: , line:45:13, endln:45:30, parent:work@test
               |vpiOpType:82
@@ -2181,23 +2195,25 @@ design: (work@test)
                 |vpiFullName:work@test.LatencyDelay
                 |vpiActual:
                 \_logic_net: (work@test.LatencyDelay), line:22:15, endln:22:27, parent:work@test
+                  |vpiTypespec:
+                  \_logic_typespec: , line:22:5, endln:22:8
+                    |vpiRange:
+                    \_range: , line:22:10, endln:22:13
+                      |vpiLeftRange:
+                      \_constant: , line:22:10, endln:22:11
+                        |vpiDecompile:3
+                        |vpiSize:64
+                        |UINT:3
+                        |vpiConstType:9
+                      |vpiRightRange:
+                      \_constant: , line:22:12, endln:22:13
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:LatencyDelay
                   |vpiFullName:work@test.LatencyDelay
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:22:10, endln:22:13
-                    |vpiLeftRange:
-                    \_constant: , line:22:10, endln:22:11
-                      |vpiDecompile:3
-                      |vpiSize:64
-                      |UINT:3
-                      |vpiConstType:9
-                    |vpiRightRange:
-                    \_constant: , line:22:12, endln:22:13
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
           |vpiElseStmt:
           \_begin: (work@test), line:46:18, endln:82:12
             |vpiFullName:work@test
@@ -2299,6 +2315,8 @@ design: (work@test)
                           |vpiFullName:work@test.UserReadDataValid
                           |vpiActual:
                           \_logic_net: (work@test.UserReadDataValid), line:14:10, endln:14:27, parent:work@test
+                            |vpiTypespec:
+                            \_logic_typespec: , line:14:5, endln:14:9
                             |vpiName:UserReadDataValid
                             |vpiFullName:work@test.UserReadDataValid
                             |vpiNetType:1
@@ -2890,23 +2908,25 @@ design: (work@test)
   \_logic_net: (work@test.RAMRST), line:12:10, endln:12:16, parent:work@test
   |vpiNet:
   \_logic_net: (work@test.UserReadData), line:13:17, endln:13:29, parent:work@test
+    |vpiTypespec:
+    \_logic_typespec: , line:13:5, endln:13:9
+      |vpiRange:
+      \_range: , line:13:11, endln:13:15
+        |vpiLeftRange:
+        \_constant: , line:13:11, endln:13:13
+          |vpiDecompile:15
+          |vpiSize:64
+          |UINT:15
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:13:14, endln:13:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:UserReadData
     |vpiFullName:work@test.UserReadData
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:13:11, endln:13:15
-      |vpiLeftRange:
-      \_constant: , line:13:11, endln:13:13
-        |vpiDecompile:15
-        |vpiSize:64
-        |UINT:15
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:13:14, endln:13:15
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@test.UserReadDataValid), line:14:10, endln:14:27, parent:work@test
   |vpiNet:

--- a/tests/TopFunc/TopFunc.log
+++ b/tests/TopFunc/TopFunc.log
@@ -159,6 +159,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:5:23, endln:5:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:5:19, endln:5:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:5:1: , endln:7:10
   |vpiContAssign:

--- a/tests/TypedefPack/TypedefPack.log
+++ b/tests/TypedefPack/TypedefPack.log
@@ -268,22 +268,24 @@ design: (work@prim_lc_sender)
         |vpiFullName:work@prim_lc_sender.lc_en_i
         |vpiActual:
         \_logic_net: (work@prim_lc_sender.lc_en_i), line:11:16, endln:11:23, parent:work@prim_lc_sender
+          |vpiTypespec:
+          \_logic_typespec: , line:11:10, endln:11:15
+            |vpiRange:
+            \_range: , line:11:11, endln:11:14
+              |vpiLeftRange:
+              \_constant: , line:11:11, endln:11:12
+                |vpiDecompile:3
+                |vpiSize:64
+                |UINT:3
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:11:13, endln:11:14
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:lc_en_i
           |vpiFullName:work@prim_lc_sender.lc_en_i
-          |vpiRange:
-          \_range: , line:11:11, endln:11:14
-            |vpiLeftRange:
-            \_constant: , line:11:11, endln:11:12
-              |vpiDecompile:3
-              |vpiSize:64
-              |UINT:3
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:11:13, endln:11:14
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
     |vpiLhs:
     \_ref_obj: (work@prim_lc_sender.lc_en_o), line:14:10, endln:14:17
       |vpiName:lc_en_o
@@ -315,6 +317,22 @@ design: (work@prim_lc_sender)
       |vpiFullName:work@prim_lc_sender.lc_en_i
       |vpiActual:
       \_logic_net: (work@prim_lc_sender.lc_en_i), line:11:16, endln:11:23, parent:work@prim_lc_sender
+    |vpiTypedef:
+    \_logic_typespec: , line:11:10, endln:11:15
+      |vpiRange:
+      \_range: , line:11:11, endln:11:14, parent:lc_en_i
+        |vpiLeftRange:
+        \_constant: , line:11:11, endln:11:12
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:11:13, endln:11:14
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@prim_lc_sender (work@prim_lc_sender) dut.sv:10:1: , endln:15:27
   |vpiPort:

--- a/tests/TypespecExpr/TypespecExpr.log
+++ b/tests/TypespecExpr/TypespecExpr.log
@@ -276,23 +276,25 @@ design: (work@Mod2)
       |vpiFullName:work@Mod1.x
       |vpiActual:
       \_logic_net: (work@Mod2.mod1.x), line:1:71, endln:1:72, parent:work@Mod2.mod1
+        |vpiTypespec:
+        \_logic_typespec: , line:1:58, endln:1:63
+          |vpiRange:
+          \_range: , line:1:65, endln:1:69
+            |vpiLeftRange:
+            \_constant: , line:1:65, endln:1:67
+              |vpiDecompile:31
+              |vpiSize:64
+              |UINT:31
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:1:68, endln:1:69
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:x
         |vpiFullName:work@Mod2.mod1.x
         |vpiNetType:36
-        |vpiRange:
-        \_range: , line:1:65, endln:1:69
-          |vpiLeftRange:
-          \_constant: , line:1:65, endln:1:67
-            |vpiDecompile:31
-            |vpiSize:64
-            |UINT:31
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:1:68, endln:1:69
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmallModules:
 \_module: work@Mod2 (work@Mod2) dut.sv:5:1: , endln:10:10, parent:work@Mod2
   |vpiFullName:work@Mod2
@@ -567,6 +569,22 @@ design: (work@Mod2)
         |vpiFullName:work@Mod2.mod1.x
         |vpiActual:
         \_logic_net: (work@Mod2.mod1.x), line:1:71, endln:1:72, parent:work@Mod2.mod1
+      |vpiTypedef:
+      \_logic_typespec: , line:1:58, endln:1:63
+        |vpiRange:
+        \_range: , line:1:65, endln:1:69, parent:x
+          |vpiLeftRange:
+          \_constant: , line:1:65, endln:1:67
+            |vpiDecompile:31
+            |vpiSize:64
+            |UINT:31
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:1:68, endln:1:69
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@Mod1 (work@Mod2.mod1) dut.sv:9:4: , endln:9:39, parent:work@Mod2
     |vpiContAssign:

--- a/tests/Udp/Udp.log
+++ b/tests/Udp/Udp.log
@@ -1539,6 +1539,8 @@ design: (work@udp_body_tb)
           |vpiFullName:work@udp_body_tb.b
           |vpiActual:
           \_logic_net: (work@udp_body_tb.b), line:86:5, endln:86:6, parent:work@udp_body_tb
+            |vpiTypespec:
+            \_logic_typespec: , line:86:1, endln:86:4
             |vpiName:b
             |vpiFullName:work@udp_body_tb.b
             |vpiNetType:48
@@ -1548,6 +1550,8 @@ design: (work@udp_body_tb)
           |vpiFullName:work@udp_body_tb.c
           |vpiActual:
           \_logic_net: (work@udp_body_tb.c), line:86:7, endln:86:8, parent:work@udp_body_tb
+            |vpiTypespec:
+            \_logic_typespec: , line:86:1, endln:86:4
             |vpiName:c
             |vpiFullName:work@udp_body_tb.c
             |vpiNetType:48
@@ -1557,6 +1561,8 @@ design: (work@udp_body_tb)
           |vpiFullName:work@udp_body_tb.a
           |vpiActual:
           \_logic_net: (work@udp_body_tb.a), line:87:6, endln:87:7, parent:work@udp_body_tb
+            |vpiTypespec:
+            \_logic_typespec: , line:87:1, endln:87:5
             |vpiName:a
             |vpiFullName:work@udp_body_tb.a
             |vpiNetType:1

--- a/tests/UnitElab/UnitElab.log
+++ b/tests/UnitElab/UnitElab.log
@@ -14420,58 +14420,50 @@ design: (work@bottom1)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.a), line:26:13, endln:26:14, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:27:7, endln:27:12
+      |vpiRange:
+      \_range: , line:27:8, endln:27:11
+        |vpiLeftRange:
+        \_constant: , line:27:8, endln:27:9
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:27:10, endln:27:11
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:a
     |vpiFullName:work@top.a
-    |vpiRange:
-    \_range: , line:27:8, endln:27:11
-      |vpiLeftRange:
-      \_constant: , line:27:8, endln:27:9
-        |vpiDecompile:3
-        |vpiSize:64
-        |UINT:3
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:27:10, endln:27:11
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@top.b), line:26:16, endln:26:17, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:27:7, endln:27:12
     |vpiName:b
     |vpiFullName:work@top.b
-    |vpiRange:
-    \_range: , line:27:8, endln:27:11
-      |vpiLeftRange:
-      \_constant: , line:27:8, endln:27:9
-        |vpiDecompile:3
-        |vpiSize:64
-        |UINT:3
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:27:10, endln:27:11
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@top.c), line:26:19, endln:26:20, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:28:8, endln:28:13
+      |vpiRange:
+      \_range: , line:28:9, endln:28:12
+        |vpiLeftRange:
+        \_constant: , line:28:9, endln:28:10
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:28:11, endln:28:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:c
     |vpiFullName:work@top.c
-    |vpiRange:
-    \_range: , line:28:9, endln:28:12
-      |vpiLeftRange:
-      \_constant: , line:28:9, endln:28:10
-        |vpiDecompile:3
-        |vpiSize:64
-        |UINT:3
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:28:11, endln:28:12
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (a), line:26:13, endln:26:14, parent:work@top
@@ -14483,6 +14475,22 @@ design: (work@bottom1)
       |vpiFullName:work@top.a
       |vpiActual:
       \_logic_net: (work@top.a), line:26:13, endln:26:14, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:27:7, endln:27:12
+      |vpiRange:
+      \_range: , line:27:8, endln:27:11, parent:a
+        |vpiLeftRange:
+        \_constant: , line:27:8, endln:27:9
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:27:10, endln:27:11
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (b), line:26:16, endln:26:17, parent:work@top
     |vpiName:b
@@ -14493,6 +14501,8 @@ design: (work@bottom1)
       |vpiFullName:work@top.b
       |vpiActual:
       \_logic_net: (work@top.b), line:26:16, endln:26:17, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:27:7, endln:27:12
   |vpiPort:
   \_port: (c), line:26:19, endln:26:20, parent:work@top
     |vpiName:c
@@ -14503,6 +14513,22 @@ design: (work@bottom1)
       |vpiFullName:work@top.c
       |vpiActual:
       \_logic_net: (work@top.c), line:26:19, endln:26:20, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:28:8, endln:28:13
+      |vpiRange:
+      \_range: , line:28:9, endln:28:12, parent:c
+        |vpiLeftRange:
+        \_constant: , line:28:9, endln:28:10
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:28:11, endln:28:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiModule:
   \_module: work@my_module (work@top.inst[0][0][0]) top.v:29:3: , endln:29:44, parent:work@top
     |vpiName:inst[0][0][0]

--- a/tests/UnitEnum/UnitEnum.log
+++ b/tests/UnitEnum/UnitEnum.log
@@ -875,6 +875,9 @@ design: (work@top)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.env), line:21:13, endln:21:16, parent:work@top
+    |vpiTypespec:
+    \_unsupported_typespec: (Environment), line:21:1, endln:21:12
+      |vpiName:Environment
     |vpiName:env
     |vpiFullName:work@top.env
   |vpiTopModule:1

--- a/tests/UnitPartSelect/UnitPartSelect.log
+++ b/tests/UnitPartSelect/UnitPartSelect.log
@@ -1233,23 +1233,25 @@ design: (work@toto)
       |vpiFullName:work@dut.o
       |vpiActual:
       \_logic_net: (work@dut.o), line:25:15, endln:25:16, parent:work@dut
+        |vpiTypespec:
+        \_logic_typespec: , line:25:5, endln:25:8
+          |vpiRange:
+          \_range: , line:25:10, endln:25:13
+            |vpiLeftRange:
+            \_constant: , line:25:10, endln:25:11
+              |vpiDecompile:2
+              |vpiSize:64
+              |UINT:2
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:25:12, endln:25:13
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:o
         |vpiFullName:work@dut.o
         |vpiNetType:48
-        |vpiRange:
-        \_range: , line:25:10, endln:25:13
-          |vpiLeftRange:
-          \_constant: , line:25:10, endln:25:11
-            |vpiDecompile:2
-            |vpiSize:64
-            |UINT:2
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:25:12, endln:25:13
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmallModules:
 \_module: work@dut_no_decl (work@dut_no_decl) top.sv:38:1: , endln:41:10, parent:work@toto
   |vpiFullName:work@dut_no_decl
@@ -1623,42 +1625,32 @@ design: (work@toto)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@toto.state), line:5:13, endln:5:18, parent:work@toto
+    |vpiTypespec:
+    \_logic_typespec: , line:5:3, endln:5:6
+      |vpiRange:
+      \_range: , line:5:8, endln:5:11
+        |vpiLeftRange:
+        \_constant: , line:5:8, endln:5:9
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:5:10, endln:5:11
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:state
     |vpiFullName:work@toto.state
     |vpiNetType:48
-    |vpiRange:
-    \_range: , line:5:8, endln:5:11
-      |vpiLeftRange:
-      \_constant: , line:5:8, endln:5:9
-        |vpiDecompile:3
-        |vpiSize:64
-        |UINT:3
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:5:10, endln:5:11
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@toto.next), line:5:20, endln:5:24, parent:work@toto
+    |vpiTypespec:
+    \_logic_typespec: , line:5:3, endln:5:6
     |vpiName:next
     |vpiFullName:work@toto.next
     |vpiNetType:48
-    |vpiRange:
-    \_range: , line:5:8, endln:5:11
-      |vpiLeftRange:
-      \_constant: , line:5:8, endln:5:9
-        |vpiDecompile:3
-        |vpiSize:64
-        |UINT:3
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:5:10, endln:5:11
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (clk)
   |vpiNet:
@@ -1754,23 +1746,25 @@ design: (work@toto)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@dut.a), line:24:16, endln:24:17, parent:work@dut
+    |vpiTypespec:
+    \_logic_typespec: , line:24:5, endln:24:9
+      |vpiRange:
+      \_range: , line:24:11, endln:24:14
+        |vpiLeftRange:
+        \_constant: , line:24:11, endln:24:12
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:24:13, endln:24:14
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:a
     |vpiFullName:work@dut.a
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:24:11, endln:24:14
-      |vpiLeftRange:
-      \_constant: , line:24:11, endln:24:12
-        |vpiDecompile:3
-        |vpiSize:64
-        |UINT:3
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:24:13, endln:24:14
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@dut.o), line:25:15, endln:25:16, parent:work@dut
   |vpiTopModule:1
@@ -1784,6 +1778,22 @@ design: (work@toto)
       |vpiFullName:work@dut.a
       |vpiActual:
       \_logic_net: (work@dut.a), line:24:16, endln:24:17, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:22:11, endln:22:16
+      |vpiRange:
+      \_range: , line:22:12, endln:22:15, parent:a
+        |vpiLeftRange:
+        \_constant: , line:22:12, endln:22:13
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:22:14, endln:22:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) top.sv:21:1: , endln:27:10
   |vpiPort:
@@ -1796,6 +1806,22 @@ design: (work@toto)
       |vpiFullName:work@dut.o
       |vpiActual:
       \_logic_net: (work@dut.o), line:25:15, endln:25:16, parent:work@dut
+    |vpiTypedef:
+    \_logic_typespec: , line:23:12, endln:23:17
+      |vpiRange:
+      \_range: , line:23:13, endln:23:16, parent:o
+        |vpiLeftRange:
+        \_constant: , line:23:13, endln:23:14
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:23:15, endln:23:16
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut (work@dut) top.sv:21:1: , endln:27:10
   |vpiContAssign:
@@ -1826,78 +1852,86 @@ design: (work@toto)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@dut_part_select.a), line:30:36, endln:30:37, parent:work@dut_part_select
+    |vpiTypespec:
+    \_logic_typespec: , line:30:30, endln:30:35
+      |vpiRange:
+      \_range: , line:30:31, endln:30:34
+        |vpiLeftRange:
+        \_constant: , line:30:31, endln:30:32
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:30:33, endln:30:34
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:a
     |vpiFullName:work@dut_part_select.a
-    |vpiRange:
-    \_range: , line:30:31, endln:30:34
-      |vpiLeftRange:
-      \_constant: , line:30:31, endln:30:32
-        |vpiDecompile:2
-        |vpiSize:64
-        |UINT:2
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:30:33, endln:30:34
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@dut_part_select.b), line:30:52, endln:30:53, parent:work@dut_part_select
+    |vpiTypespec:
+    \_logic_typespec: , line:30:46, endln:30:51
+      |vpiRange:
+      \_range: , line:30:47, endln:30:50
+        |vpiLeftRange:
+        \_constant: , line:30:47, endln:30:48
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:30:49, endln:30:50
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:b
     |vpiFullName:work@dut_part_select.b
-    |vpiRange:
-    \_range: , line:30:47, endln:30:50
-      |vpiLeftRange:
-      \_constant: , line:30:47, endln:30:48
-        |vpiDecompile:2
-        |vpiSize:64
-        |UINT:2
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:30:49, endln:30:50
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@dut_part_select.a), line:31:14, endln:31:15, parent:work@dut_part_select
+    |vpiTypespec:
+    \_logic_typespec: , line:31:3, endln:31:7
+      |vpiRange:
+      \_range: , line:31:9, endln:31:12
+        |vpiLeftRange:
+        \_constant: , line:31:9, endln:31:10
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:31:11, endln:31:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:a
     |vpiFullName:work@dut_part_select.a
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:31:9, endln:31:12
-      |vpiLeftRange:
-      \_constant: , line:31:9, endln:31:10
-        |vpiDecompile:2
-        |vpiSize:64
-        |UINT:2
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:31:11, endln:31:12
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@dut_part_select.b), line:32:13, endln:32:14, parent:work@dut_part_select
+    |vpiTypespec:
+    \_logic_typespec: , line:32:3, endln:32:6
+      |vpiRange:
+      \_range: , line:32:8, endln:32:11
+        |vpiLeftRange:
+        \_constant: , line:32:8, endln:32:9
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:32:10, endln:32:11
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:b
     |vpiFullName:work@dut_part_select.b
     |vpiNetType:48
-    |vpiRange:
-    \_range: , line:32:8, endln:32:11
-      |vpiLeftRange:
-      \_constant: , line:32:8, endln:32:9
-        |vpiDecompile:2
-        |vpiSize:64
-        |UINT:2
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:32:10, endln:32:11
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (a), line:30:36, endln:30:37, parent:work@dut_part_select
@@ -1909,6 +1943,22 @@ design: (work@toto)
       |vpiFullName:work@dut_part_select.a
       |vpiActual:
       \_logic_net: (work@dut_part_select.a), line:30:36, endln:30:37, parent:work@dut_part_select
+    |vpiTypedef:
+    \_logic_typespec: , line:30:30, endln:30:35
+      |vpiRange:
+      \_range: , line:30:31, endln:30:34, parent:a
+        |vpiLeftRange:
+        \_constant: , line:30:31, endln:30:32
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:30:33, endln:30:34
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut_part_select (work@dut_part_select) top.sv:30:1: , endln:35:10
   |vpiPort:
@@ -1921,6 +1971,22 @@ design: (work@toto)
       |vpiFullName:work@dut_part_select.b
       |vpiActual:
       \_logic_net: (work@dut_part_select.b), line:30:52, endln:30:53, parent:work@dut_part_select
+    |vpiTypedef:
+    \_logic_typespec: , line:30:46, endln:30:51
+      |vpiRange:
+      \_range: , line:30:47, endln:30:50, parent:b
+        |vpiLeftRange:
+        \_constant: , line:30:47, endln:30:48
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:30:49, endln:30:50
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut_part_select (work@dut_part_select) top.sv:30:1: , endln:35:10
   |vpiContAssign:
@@ -1984,40 +2050,44 @@ design: (work@toto)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@dut_no_decl.a), line:38:32, endln:38:33, parent:work@dut_no_decl
+    |vpiTypespec:
+    \_logic_typespec: , line:38:26, endln:38:31
+      |vpiRange:
+      \_range: , line:38:27, endln:38:30
+        |vpiLeftRange:
+        \_constant: , line:38:27, endln:38:28
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:38:29, endln:38:30
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:a
     |vpiFullName:work@dut_no_decl.a
-    |vpiRange:
-    \_range: , line:38:27, endln:38:30
-      |vpiLeftRange:
-      \_constant: , line:38:27, endln:38:28
-        |vpiDecompile:2
-        |vpiSize:64
-        |UINT:2
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:38:29, endln:38:30
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@dut_no_decl.b), line:38:48, endln:38:49, parent:work@dut_no_decl
+    |vpiTypespec:
+    \_logic_typespec: , line:38:42, endln:38:47
+      |vpiRange:
+      \_range: , line:38:43, endln:38:46
+        |vpiLeftRange:
+        \_constant: , line:38:43, endln:38:44
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:38:45, endln:38:46
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:b
     |vpiFullName:work@dut_no_decl.b
-    |vpiRange:
-    \_range: , line:38:43, endln:38:46
-      |vpiLeftRange:
-      \_constant: , line:38:43, endln:38:44
-        |vpiDecompile:2
-        |vpiSize:64
-        |UINT:2
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:38:45, endln:38:46
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (a), line:38:32, endln:38:33, parent:work@dut_no_decl
@@ -2029,6 +2099,22 @@ design: (work@toto)
       |vpiFullName:work@dut_no_decl.a
       |vpiActual:
       \_logic_net: (work@dut_no_decl.a), line:38:32, endln:38:33, parent:work@dut_no_decl
+    |vpiTypedef:
+    \_logic_typespec: , line:38:26, endln:38:31
+      |vpiRange:
+      \_range: , line:38:27, endln:38:30, parent:a
+        |vpiLeftRange:
+        \_constant: , line:38:27, endln:38:28
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:38:29, endln:38:30
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut_no_decl (work@dut_no_decl) top.sv:38:1: , endln:41:10
   |vpiPort:
@@ -2041,6 +2127,22 @@ design: (work@toto)
       |vpiFullName:work@dut_no_decl.b
       |vpiActual:
       \_logic_net: (work@dut_no_decl.b), line:38:48, endln:38:49, parent:work@dut_no_decl
+    |vpiTypedef:
+    \_logic_typespec: , line:38:42, endln:38:47
+      |vpiRange:
+      \_range: , line:38:43, endln:38:46, parent:b
+        |vpiLeftRange:
+        \_constant: , line:38:43, endln:38:44
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:38:45, endln:38:46
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@dut_no_decl (work@dut_no_decl) top.sv:38:1: , endln:41:10
   |vpiContAssign:

--- a/tests/UnitTest/UnitTest.log
+++ b/tests/UnitTest/UnitTest.log
@@ -790,46 +790,50 @@ design: (work@tb_operators)
           |vpiFullName:work@tb_operators.shifter
           |vpiActual:
           \_logic_net: (work@tb_operators.shifter), line:5:13, endln:5:20, parent:work@tb_operators
+            |vpiTypespec:
+            \_logic_typespec: , line:5:1, endln:5:5
+              |vpiRange:
+              \_range: , line:5:7, endln:5:11
+                |vpiLeftRange:
+                \_constant: , line:5:7, endln:5:9
+                  |vpiDecompile:31
+                  |vpiSize:64
+                  |UINT:31
+                  |vpiConstType:9
+                |vpiRightRange:
+                \_constant: , line:5:10, endln:5:11
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiName:shifter
             |vpiFullName:work@tb_operators.shifter
             |vpiNetType:1
-            |vpiRange:
-            \_range: , line:5:7, endln:5:11
-              |vpiLeftRange:
-              \_constant: , line:5:7, endln:5:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-                |vpiConstType:9
-              |vpiRightRange:
-              \_constant: , line:5:10, endln:5:11
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
         |vpiArgument:
         \_ref_obj: (work@tb_operators.result), line:10:22, endln:10:28, parent:$monitor
           |vpiName:result
           |vpiFullName:work@tb_operators.result
           |vpiActual:
           \_logic_net: (work@tb_operators.result), line:6:13, endln:6:19, parent:work@tb_operators
+            |vpiTypespec:
+            \_logic_typespec: , line:6:1, endln:6:5
+              |vpiRange:
+              \_range: , line:6:7, endln:6:11
+                |vpiLeftRange:
+                \_constant: , line:6:7, endln:6:9
+                  |vpiDecompile:31
+                  |vpiSize:64
+                  |UINT:31
+                  |vpiConstType:9
+                |vpiRightRange:
+                \_constant: , line:6:10, endln:6:11
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiName:result
             |vpiFullName:work@tb_operators.result
             |vpiNetType:1
-            |vpiRange:
-            \_range: , line:6:7, endln:6:11
-              |vpiLeftRange:
-              \_constant: , line:6:7, endln:6:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |UINT:31
-                |vpiConstType:9
-              |vpiRightRange:
-              \_constant: , line:6:10, endln:6:11
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
         |vpiName:$monitor
       |vpiStmt:
       \_assignment: , line:11:5, endln:11:20, parent:work@tb_operators
@@ -1308,11 +1312,15 @@ design: (work@tb_operators)
   \_logic_net: (work@top.o), line:40:29, endln:40:30, parent:work@top
   |vpiNet:
   \_logic_net: (work@top.i), line:41:6, endln:41:7, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:41:1, endln:41:5
     |vpiName:i
     |vpiFullName:work@top.i
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@top.o), line:42:5, endln:42:6, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:42:1, endln:42:4
     |vpiName:o
     |vpiFullName:work@top.o
     |vpiNetType:48
@@ -1354,15 +1362,22 @@ design: (work@tb_operators)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@memory_ctrl1.toto1), line:59:5, endln:59:10, parent:work@memory_ctrl1
+    |vpiTypespec:
+    \_unsupported_typespec: (DD1), line:59:1, endln:59:4
+      |vpiName:DD1
     |vpiName:toto1
     |vpiFullName:work@memory_ctrl1.toto1
   |vpiNet:
   \_logic_net: (work@memory_ctrl1.i1), line:63:6, endln:63:8, parent:work@memory_ctrl1
+    |vpiTypespec:
+    \_logic_typespec: , line:63:1, endln:63:5
     |vpiName:i1
     |vpiFullName:work@memory_ctrl1.i1
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@memory_ctrl1.o1), line:65:5, endln:65:7, parent:work@memory_ctrl1
+    |vpiTypespec:
+    \_logic_typespec: , line:65:1, endln:65:4
     |vpiName:o1
     |vpiFullName:work@memory_ctrl1.o1
     |vpiNetType:48
@@ -1387,6 +1402,8 @@ design: (work@tb_operators)
             |vpiName:clk
             |vpiExpr:
             \_logic_net: (clk), line:47:30, endln:47:33
+              |vpiTypespec:
+              \_logic_typespec: , line:47:25, endln:47:29
               |vpiName:clk
               |vpiNetType:1
           |vpiInterface:
@@ -1418,6 +1435,8 @@ design: (work@tb_operators)
           |vpiName:clk
           |vpiExpr:
           \_logic_net: (clk), line:47:30, endln:47:33
+            |vpiTypespec:
+            \_logic_typespec: , line:47:25, endln:47:29
             |vpiName:clk
             |vpiNetType:1
         |vpiInterface:

--- a/tests/UnsizedPacked/UnsizedPacked.log
+++ b/tests/UnsizedPacked/UnsizedPacked.log
@@ -98,22 +98,24 @@ design: (work@test)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@test.illegal), line:5:8, endln:5:15, parent:work@test
+    |vpiTypespec:
+    \_logic_typespec: , line:5:1, endln:5:4
+      |vpiRange:
+      \_range: 
+        |vpiLeftRange:
+        \_constant: , line:5:5, endln:5:6
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:5:5, endln:5:6
+          |vpiDecompile:unsized
+          |STRING:unsized
+          |vpiConstType:6
     |vpiName:illegal
     |vpiFullName:work@test.illegal
     |vpiNetType:48
-    |vpiRange:
-    \_range: 
-      |vpiLeftRange:
-      \_constant: , line:5:5, endln:5:6
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:5:5, endln:5:6
-        |vpiDecompile:unsized
-        |STRING:unsized
-        |vpiConstType:6
   |vpiArrayNet:
   \_array_net: (work@test.legal), line:3:5, endln:3:10, parent:work@test
     |vpiSize:1
@@ -134,6 +136,8 @@ design: (work@test)
         |vpiConstType:6
     |vpiNet:
     \_logic_net: (work@test.legal), line:3:5, endln:3:10, parent:work@test.legal
+      |vpiTypespec:
+      \_logic_typespec: , line:3:1, endln:3:4
       |vpiFullName:work@test.legal
       |vpiNetType:48
   |vpiTopModule:1

--- a/tests/VarDecl/VarDecl.log
+++ b/tests/VarDecl/VarDecl.log
@@ -243,6 +243,8 @@ design: (work@top)
     \_module: work@top (work@top) dut.sv:1:1: , endln:7:16
   |vpiNet:
   \_logic_net: (work@top.o), line:1:25, endln:1:26, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:1:19, endln:1:24
     |vpiName:o
     |vpiFullName:work@top.o
     |vpiNetType:36
@@ -257,6 +259,8 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:1:25, endln:1:26, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:19, endln:1:24
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:7:16
 ===================

--- a/tests/VarDecl2/VarDecl2.log
+++ b/tests/VarDecl2/VarDecl2.log
@@ -317,6 +317,9 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_int_var: (work@top.o), line:1:23, endln:1:24, parent:work@top
+    |vpiTypedef:
+    \_int_typespec: , line:1:19, endln:1:22
+      |vpiSigned:1
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:11:16
 ===================

--- a/tests/VarInFunc/VarInFunc.log
+++ b/tests/VarInFunc/VarInFunc.log
@@ -856,22 +856,24 @@ design: (work@top)
       |vpiFullName:work@top.b
       |vpiActual:
       \_logic_net: (work@top.b), line:1:34, endln:1:35, parent:work@top
+        |vpiTypespec:
+        \_logic_typespec: , line:1:28, endln:1:33
+          |vpiRange:
+          \_range: , line:1:29, endln:1:32
+            |vpiLeftRange:
+            \_constant: , line:1:29, endln:1:30
+              |vpiDecompile:2
+              |vpiSize:64
+              |UINT:2
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:1:31, endln:1:32
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:b
         |vpiFullName:work@top.b
-        |vpiRange:
-        \_range: , line:1:29, endln:1:32
-          |vpiLeftRange:
-          \_constant: , line:1:29, endln:1:30
-            |vpiDecompile:2
-            |vpiSize:64
-            |UINT:2
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:1:31, endln:1:32
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:1:1: , endln:9:10
   |vpiName:work@top
@@ -947,6 +949,22 @@ design: (work@top)
       |vpiFullName:work@top.b
       |vpiActual:
       \_logic_net: (work@top.b), line:1:34, endln:1:35, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:28, endln:1:33
+      |vpiRange:
+      \_range: , line:1:29, endln:1:32, parent:b
+        |vpiLeftRange:
+        \_constant: , line:1:29, endln:1:30
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:1:31, endln:1:32
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:9:10
   |vpiContAssign:

--- a/tests/VarSelectGenStmt/VarSelectGenStmt.log
+++ b/tests/VarSelectGenStmt/VarSelectGenStmt.log
@@ -264,51 +264,53 @@ design: (work@aes_sub_bytes)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@aes_sub_bytes.data_i), line:10:32, endln:10:38, parent:work@aes_sub_bytes
+    |vpiTypespec:
+    \_logic_typespec: , line:10:10, endln:10:15
+      |vpiRange:
+      \_range: , line:10:17, endln:10:20
+        |vpiLeftRange:
+        \_constant: , line:10:17, endln:10:18
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:10:19, endln:10:20
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
+      |vpiRange:
+      \_range: , line:10:22, endln:10:25
+        |vpiLeftRange:
+        \_constant: , line:10:22, endln:10:23
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:10:24, endln:10:25
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
+      |vpiRange:
+      \_range: , line:10:27, endln:10:30
+        |vpiLeftRange:
+        \_constant: , line:10:27, endln:10:28
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:10:29, endln:10:30
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:data_i
     |vpiFullName:work@aes_sub_bytes.data_i
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:10:17, endln:10:20
-      |vpiLeftRange:
-      \_constant: , line:10:17, endln:10:18
-        |vpiDecompile:3
-        |vpiSize:64
-        |UINT:3
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:10:19, endln:10:20
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
-    |vpiRange:
-    \_range: , line:10:22, endln:10:25
-      |vpiLeftRange:
-      \_constant: , line:10:22, endln:10:23
-        |vpiDecompile:3
-        |vpiSize:64
-        |UINT:3
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:10:24, endln:10:25
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
-    |vpiRange:
-    \_range: , line:10:27, endln:10:30
-      |vpiLeftRange:
-      \_constant: , line:10:27, endln:10:28
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:10:29, endln:10:30
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (data_i), line:10:32, endln:10:38, parent:work@aes_sub_bytes
@@ -320,6 +322,50 @@ design: (work@aes_sub_bytes)
       |vpiFullName:work@aes_sub_bytes.data_i
       |vpiActual:
       \_logic_net: (work@aes_sub_bytes.data_i), line:10:32, endln:10:38, parent:work@aes_sub_bytes
+    |vpiTypedef:
+    \_logic_typespec: , line:10:10, endln:10:15
+      |vpiRange:
+      \_range: , line:10:17, endln:10:20, parent:data_i
+        |vpiLeftRange:
+        \_constant: , line:10:17, endln:10:18
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:10:19, endln:10:20
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
+      |vpiRange:
+      \_range: , line:10:22, endln:10:25, parent:data_i
+        |vpiLeftRange:
+        \_constant: , line:10:22, endln:10:23
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:10:24, endln:10:25
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
+      |vpiRange:
+      \_range: , line:10:27, endln:10:30, parent:data_i
+        |vpiLeftRange:
+        \_constant: , line:10:27, endln:10:28
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:10:29, endln:10:30
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@aes_sub_bytes (work@aes_sub_bytes) dut.sv:8:1: , endln:23:10
   |vpiGenScopeArray:
@@ -389,6 +435,50 @@ design: (work@aes_sub_bytes)
                 |vpiFullName:work@aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[0].aes_sbox_ij.data_i
                 |vpiActual:
                 \_logic_net: (work@aes_sub_bytes.data_i), line:10:32, endln:10:38, parent:work@aes_sub_bytes
+              |vpiTypedef:
+              \_logic_typespec: , line:3:10, endln:3:15
+                |vpiRange:
+                \_range: , line:3:17, endln:3:20, parent:data_i
+                  |vpiLeftRange:
+                  \_constant: , line:3:17, endln:3:18
+                    |vpiDecompile:3
+                    |vpiSize:64
+                    |UINT:3
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:3:19, endln:3:20
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
+                |vpiRange:
+                \_range: , line:3:22, endln:3:25, parent:data_i
+                  |vpiLeftRange:
+                  \_constant: , line:3:22, endln:3:23
+                    |vpiDecompile:3
+                    |vpiSize:64
+                    |UINT:3
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:3:24, endln:3:25
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
+                |vpiRange:
+                \_range: , line:3:27, endln:3:30, parent:data_i
+                  |vpiLeftRange:
+                  \_constant: , line:3:27, endln:3:28
+                    |vpiDecompile:7
+                    |vpiSize:64
+                    |UINT:7
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:3:29, endln:3:30
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiInstance:
               \_module: work@aes_sbox (work@aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[0].aes_sbox_ij) dut.sv:16:7: , endln:19:9, parent:work@aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[0]
       |vpiGenScopeArray:
@@ -443,6 +533,50 @@ design: (work@aes_sub_bytes)
                 |vpiFullName:work@aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[1].aes_sbox_ij.data_i
                 |vpiActual:
                 \_logic_net: (work@aes_sub_bytes.data_i), line:10:32, endln:10:38, parent:work@aes_sub_bytes
+              |vpiTypedef:
+              \_logic_typespec: , line:3:10, endln:3:15
+                |vpiRange:
+                \_range: , line:3:17, endln:3:20, parent:data_i
+                  |vpiLeftRange:
+                  \_constant: , line:3:17, endln:3:18
+                    |vpiDecompile:3
+                    |vpiSize:64
+                    |UINT:3
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:3:19, endln:3:20
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
+                |vpiRange:
+                \_range: , line:3:22, endln:3:25, parent:data_i
+                  |vpiLeftRange:
+                  \_constant: , line:3:22, endln:3:23
+                    |vpiDecompile:3
+                    |vpiSize:64
+                    |UINT:3
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:3:24, endln:3:25
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
+                |vpiRange:
+                \_range: , line:3:27, endln:3:30, parent:data_i
+                  |vpiLeftRange:
+                  \_constant: , line:3:27, endln:3:28
+                    |vpiDecompile:7
+                    |vpiSize:64
+                    |UINT:7
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:3:29, endln:3:30
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiInstance:
               \_module: work@aes_sbox (work@aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[1].aes_sbox_ij) dut.sv:16:7: , endln:19:9, parent:work@aes_sub_bytes.gen_sbox_j[0].gen_sbox_i[1]
   |vpiGenScopeArray:
@@ -512,6 +646,50 @@ design: (work@aes_sub_bytes)
                 |vpiFullName:work@aes_sub_bytes.gen_sbox_j[1].gen_sbox_i[0].aes_sbox_ij.data_i
                 |vpiActual:
                 \_logic_net: (work@aes_sub_bytes.data_i), line:10:32, endln:10:38, parent:work@aes_sub_bytes
+              |vpiTypedef:
+              \_logic_typespec: , line:3:10, endln:3:15
+                |vpiRange:
+                \_range: , line:3:17, endln:3:20, parent:data_i
+                  |vpiLeftRange:
+                  \_constant: , line:3:17, endln:3:18
+                    |vpiDecompile:3
+                    |vpiSize:64
+                    |UINT:3
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:3:19, endln:3:20
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
+                |vpiRange:
+                \_range: , line:3:22, endln:3:25, parent:data_i
+                  |vpiLeftRange:
+                  \_constant: , line:3:22, endln:3:23
+                    |vpiDecompile:3
+                    |vpiSize:64
+                    |UINT:3
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:3:24, endln:3:25
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
+                |vpiRange:
+                \_range: , line:3:27, endln:3:30, parent:data_i
+                  |vpiLeftRange:
+                  \_constant: , line:3:27, endln:3:28
+                    |vpiDecompile:7
+                    |vpiSize:64
+                    |UINT:7
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:3:29, endln:3:30
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiInstance:
               \_module: work@aes_sbox (work@aes_sub_bytes.gen_sbox_j[1].gen_sbox_i[0].aes_sbox_ij) dut.sv:16:7: , endln:19:9, parent:work@aes_sub_bytes.gen_sbox_j[1].gen_sbox_i[0]
       |vpiGenScopeArray:
@@ -566,6 +744,50 @@ design: (work@aes_sub_bytes)
                 |vpiFullName:work@aes_sub_bytes.gen_sbox_j[1].gen_sbox_i[1].aes_sbox_ij.data_i
                 |vpiActual:
                 \_logic_net: (work@aes_sub_bytes.data_i), line:10:32, endln:10:38, parent:work@aes_sub_bytes
+              |vpiTypedef:
+              \_logic_typespec: , line:3:10, endln:3:15
+                |vpiRange:
+                \_range: , line:3:17, endln:3:20, parent:data_i
+                  |vpiLeftRange:
+                  \_constant: , line:3:17, endln:3:18
+                    |vpiDecompile:3
+                    |vpiSize:64
+                    |UINT:3
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:3:19, endln:3:20
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
+                |vpiRange:
+                \_range: , line:3:22, endln:3:25, parent:data_i
+                  |vpiLeftRange:
+                  \_constant: , line:3:22, endln:3:23
+                    |vpiDecompile:3
+                    |vpiSize:64
+                    |UINT:3
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:3:24, endln:3:25
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
+                |vpiRange:
+                \_range: , line:3:27, endln:3:30, parent:data_i
+                  |vpiLeftRange:
+                  \_constant: , line:3:27, endln:3:28
+                    |vpiDecompile:7
+                    |vpiSize:64
+                    |UINT:7
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:3:29, endln:3:30
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiInstance:
               \_module: work@aes_sbox (work@aes_sub_bytes.gen_sbox_j[1].gen_sbox_i[1].aes_sbox_ij) dut.sv:16:7: , endln:19:9, parent:work@aes_sub_bytes.gen_sbox_j[1].gen_sbox_i[1]
 ===================

--- a/tests/Wand/Wand.log
+++ b/tests/Wand/Wand.log
@@ -66,6 +66,8 @@ design: (work@test_wand_wor)
       |vpiFullName:work@test_wand_wor.c
       |vpiActual:
       \_logic_net: (work@test_wand_wor.c), line:5:8, endln:5:9, parent:work@test_wand_wor
+        |vpiTypespec:
+        \_logic_typespec: , line:5:4, endln:5:7
         |vpiName:c
         |vpiFullName:work@test_wand_wor.c
         |vpiNetType:48
@@ -75,6 +77,8 @@ design: (work@test_wand_wor)
       |vpiFullName:work@test_wand_wor.a
       |vpiActual:
       \_logic_net: (work@test_wand_wor.a), line:3:9, endln:3:10, parent:work@test_wand_wor
+        |vpiTypespec:
+        \_logic_typespec: , line:3:4, endln:3:8
         |vpiName:a
         |vpiFullName:work@test_wand_wor.a
         |vpiNetType:2
@@ -86,6 +90,8 @@ design: (work@test_wand_wor)
       |vpiFullName:work@test_wand_wor.d
       |vpiActual:
       \_logic_net: (work@test_wand_wor.d), line:5:11, endln:5:12, parent:work@test_wand_wor
+        |vpiTypespec:
+        \_logic_typespec: , line:5:4, endln:5:7
         |vpiName:d
         |vpiFullName:work@test_wand_wor.d
         |vpiNetType:48
@@ -95,6 +101,8 @@ design: (work@test_wand_wor)
       |vpiFullName:work@test_wand_wor.b
       |vpiActual:
       \_logic_net: (work@test_wand_wor.b), line:4:9, endln:4:10, parent:work@test_wand_wor
+        |vpiTypespec:
+        \_logic_typespec: , line:4:4, endln:4:7
         |vpiName:b
         |vpiFullName:work@test_wand_wor.b
         |vpiNetType:3

--- a/tests/WildConn/WildConn.log
+++ b/tests/WildConn/WildConn.log
@@ -754,11 +754,15 @@ design: (work@top)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.a), line:8:3, endln:8:4, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:7:18, endln:7:23
     |vpiName:a
     |vpiFullName:work@top.a
     |vpiNetType:36
   |vpiNet:
   \_logic_net: (work@top.b), line:9:3, endln:9:4, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:7:18, endln:7:23
     |vpiName:b
     |vpiFullName:work@top.b
     |vpiNetType:36
@@ -773,6 +777,8 @@ design: (work@top)
       |vpiFullName:work@top.a
       |vpiActual:
       \_logic_net: (work@top.a), line:8:3, endln:8:4, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:7:18, endln:7:23
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:7:1: , endln:17:10
   |vpiPort:
@@ -785,6 +791,8 @@ design: (work@top)
       |vpiFullName:work@top.b
       |vpiActual:
       \_logic_net: (work@top.b), line:9:3, endln:9:4, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:7:18, endln:7:23
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:7:1: , endln:17:10
   |vpiModule:
@@ -796,11 +804,15 @@ design: (work@top)
     |vpiDefLineNo:1
     |vpiNet:
     \_logic_net: (work@top.u1.a), line:2:3, endln:2:4, parent:work@top.u1
+      |vpiTypespec:
+      \_logic_typespec: , line:1:19, endln:1:24
       |vpiName:a
       |vpiFullName:work@top.u1.a
       |vpiNetType:36
     |vpiNet:
     \_logic_net: (work@top.u1.b), line:3:3, endln:3:4, parent:work@top.u1
+      |vpiTypespec:
+      \_logic_typespec: , line:1:19, endln:1:24
       |vpiName:b
       |vpiFullName:work@top.u1.b
       |vpiNetType:36
@@ -822,6 +834,8 @@ design: (work@top)
         |vpiFullName:work@top.u1.a
         |vpiActual:
         \_logic_net: (work@top.u1.a), line:2:3, endln:2:4, parent:work@top.u1
+      |vpiTypedef:
+      \_logic_typespec: , line:1:19, endln:1:24
       |vpiInstance:
       \_module: work@MOD (work@top.u1) dut.sv:12:3: , endln:15:5, parent:work@top
     |vpiPort:
@@ -840,6 +854,8 @@ design: (work@top)
         |vpiFullName:work@top.u1.b
         |vpiActual:
         \_logic_net: (work@top.u1.b), line:3:3, endln:3:4, parent:work@top.u1
+      |vpiTypedef:
+      \_logic_typespec: , line:1:19, endln:1:24
       |vpiInstance:
       \_module: work@MOD (work@top.u1) dut.sv:12:3: , endln:15:5, parent:work@top
 ===================

--- a/tests/WireLogicSize/WireLogicSize.log
+++ b/tests/WireLogicSize/WireLogicSize.log
@@ -181,62 +181,60 @@ design: (work@TestFunction)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@TestFunction.O1), line:2:17, endln:2:19, parent:work@TestFunction
+    |vpiTypespec:
+    \_logic_typespec: , line:2:11, endln:2:16
     |vpiName:O1
     |vpiFullName:work@TestFunction.O1
     |vpiNetType:36
   |vpiNet:
   \_logic_net: (work@TestFunction.O2), line:2:21, endln:2:23, parent:work@TestFunction
+    |vpiTypespec:
+    \_logic_typespec: , line:2:11, endln:2:16
     |vpiName:O2
     |vpiFullName:work@TestFunction.O2
     |vpiNetType:36
   |vpiNet:
   \_logic_net: (work@TestFunction.O3), line:2:25, endln:2:27, parent:work@TestFunction
+    |vpiTypespec:
+    \_logic_typespec: , line:2:11, endln:2:16
     |vpiName:O3
     |vpiFullName:work@TestFunction.O3
     |vpiNetType:36
   |vpiNet:
   \_logic_net: (work@TestFunction.O4), line:2:29, endln:2:31, parent:work@TestFunction
+    |vpiTypespec:
+    \_logic_typespec: , line:2:11, endln:2:16
     |vpiName:O4
     |vpiFullName:work@TestFunction.O4
     |vpiNetType:36
   |vpiNet:
   \_logic_net: (work@TestFunction.sw), line:3:27, endln:3:29, parent:work@TestFunction
+    |vpiTypespec:
+    \_logic_typespec: , line:3:16, endln:3:21
+      |vpiRange:
+      \_range: , line:3:22, endln:3:25
+        |vpiLeftRange:
+        \_constant: , line:3:22, endln:3:23
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:3:24, endln:3:25
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:sw
     |vpiFullName:work@TestFunction.sw
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:3:22, endln:3:25
-      |vpiLeftRange:
-      \_constant: , line:3:22, endln:3:23
-        |vpiDecompile:2
-        |vpiSize:64
-        |UINT:2
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:3:24, endln:3:25
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@TestFunction.sw2), line:3:32, endln:3:35, parent:work@TestFunction
+    |vpiTypespec:
+    \_logic_typespec: , line:3:16, endln:3:21
     |vpiName:sw2
     |vpiFullName:work@TestFunction.sw2
     |vpiNetType:36
-    |vpiRange:
-    \_range: , line:3:22, endln:3:25
-      |vpiLeftRange:
-      \_constant: , line:3:22, endln:3:23
-        |vpiDecompile:2
-        |vpiSize:64
-        |UINT:2
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:3:24, endln:3:25
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (O1), line:2:17, endln:2:19, parent:work@TestFunction
@@ -248,6 +246,8 @@ design: (work@TestFunction)
       |vpiFullName:work@TestFunction.O1
       |vpiActual:
       \_logic_net: (work@TestFunction.O1), line:2:17, endln:2:19, parent:work@TestFunction
+    |vpiTypedef:
+    \_logic_typespec: , line:2:11, endln:2:16
     |vpiInstance:
     \_module: work@TestFunction (work@TestFunction) dut.sv:1:1: , endln:23:10
   |vpiPort:
@@ -260,6 +260,8 @@ design: (work@TestFunction)
       |vpiFullName:work@TestFunction.O2
       |vpiActual:
       \_logic_net: (work@TestFunction.O2), line:2:21, endln:2:23, parent:work@TestFunction
+    |vpiTypedef:
+    \_logic_typespec: , line:2:11, endln:2:16
     |vpiInstance:
     \_module: work@TestFunction (work@TestFunction) dut.sv:1:1: , endln:23:10
   |vpiPort:
@@ -272,6 +274,8 @@ design: (work@TestFunction)
       |vpiFullName:work@TestFunction.O3
       |vpiActual:
       \_logic_net: (work@TestFunction.O3), line:2:25, endln:2:27, parent:work@TestFunction
+    |vpiTypedef:
+    \_logic_typespec: , line:2:11, endln:2:16
     |vpiInstance:
     \_module: work@TestFunction (work@TestFunction) dut.sv:1:1: , endln:23:10
   |vpiPort:
@@ -284,6 +288,8 @@ design: (work@TestFunction)
       |vpiFullName:work@TestFunction.O4
       |vpiActual:
       \_logic_net: (work@TestFunction.O4), line:2:29, endln:2:31, parent:work@TestFunction
+    |vpiTypedef:
+    \_logic_typespec: , line:2:11, endln:2:16
     |vpiInstance:
     \_module: work@TestFunction (work@TestFunction) dut.sv:1:1: , endln:23:10
   |vpiPort:
@@ -296,6 +302,22 @@ design: (work@TestFunction)
       |vpiFullName:work@TestFunction.sw
       |vpiActual:
       \_logic_net: (work@TestFunction.sw), line:3:27, endln:3:29, parent:work@TestFunction
+    |vpiTypedef:
+    \_logic_typespec: , line:3:16, endln:3:21
+      |vpiRange:
+      \_range: , line:3:22, endln:3:25, parent:sw
+        |vpiLeftRange:
+        \_constant: , line:3:22, endln:3:23
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:3:24, endln:3:25
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@TestFunction (work@TestFunction) dut.sv:1:1: , endln:23:10
   |vpiPort:
@@ -308,6 +330,8 @@ design: (work@TestFunction)
       |vpiFullName:work@TestFunction.sw2
       |vpiActual:
       \_logic_net: (work@TestFunction.sw2), line:3:32, endln:3:35, parent:work@TestFunction
+    |vpiTypedef:
+    \_logic_typespec: , line:3:16, endln:3:21
     |vpiInstance:
     \_module: work@TestFunction (work@TestFunction) dut.sv:1:1: , endln:23:10
 ===================

--- a/tests/WireUnpacked/WireUnpacked.log
+++ b/tests/WireUnpacked/WireUnpacked.log
@@ -183,22 +183,24 @@ design: (work@dut)
         |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@dut.read_buf), line:2:12, endln:2:20, parent:work@dut.read_buf
+      |vpiTypespec:
+      \_logic_typespec: , line:2:1, endln:2:5
+        |vpiRange:
+        \_range: , line:2:7, endln:2:10
+          |vpiLeftRange:
+          \_constant: , line:2:7, endln:2:8
+            |vpiDecompile:5
+            |vpiSize:64
+            |UINT:5
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:2:9, endln:2:10
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiFullName:work@dut.read_buf
       |vpiNetType:1
-      |vpiRange:
-      \_range: , line:2:7, endln:2:10
-        |vpiLeftRange:
-        \_constant: , line:2:7, endln:2:8
-          |vpiDecompile:5
-          |vpiSize:64
-          |UINT:5
-          |vpiConstType:9
-        |vpiRightRange:
-        \_constant: , line:2:9, endln:2:10
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
   |vpiTopModule:1
   |vpiContAssign:
   \_cont_assign: , line:3:8, endln:3:32, parent:work@dut

--- a/tests/XValue/XValue.log
+++ b/tests/XValue/XValue.log
@@ -196,23 +196,25 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:1:47, endln:1:48, parent:work@top
+        |vpiTypespec:
+        \_logic_typespec: , line:1:36, endln:1:41
+          |vpiRange:
+          \_range: , line:1:42, endln:1:45
+            |vpiLeftRange:
+            \_constant: , line:1:42, endln:1:43
+              |vpiDecompile:3
+              |vpiSize:64
+              |UINT:3
+              |vpiConstType:9
+            |vpiRightRange:
+            \_constant: , line:1:44, endln:1:45
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiName:o
         |vpiFullName:work@top.o
         |vpiNetType:36
-        |vpiRange:
-        \_range: , line:1:42, endln:1:45
-          |vpiLeftRange:
-          \_constant: , line:1:42, endln:1:43
-            |vpiDecompile:3
-            |vpiSize:64
-            |UINT:3
-            |vpiConstType:9
-          |vpiRightRange:
-          \_constant: , line:1:44, endln:1:45
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@top (work@top) dut.sv:1:1: , endln:8:10
   |vpiName:work@top
@@ -222,6 +224,8 @@ design: (work@top)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@top.clk), line:1:24, endln:1:27, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:1:18, endln:1:23
     |vpiName:clk
     |vpiFullName:work@top.clk
     |vpiNetType:36
@@ -238,6 +242,8 @@ design: (work@top)
       |vpiFullName:work@top.clk
       |vpiActual:
       \_logic_net: (work@top.clk), line:1:24, endln:1:27, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:18, endln:1:23
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:8:10
   |vpiPort:
@@ -250,6 +256,22 @@ design: (work@top)
       |vpiFullName:work@top.o
       |vpiActual:
       \_logic_net: (work@top.o), line:1:47, endln:1:48, parent:work@top
+    |vpiTypedef:
+    \_logic_typespec: , line:1:36, endln:1:41
+      |vpiRange:
+      \_range: , line:1:42, endln:1:45, parent:o
+        |vpiLeftRange:
+        \_constant: , line:1:42, endln:1:43
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:1:44, endln:1:45
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:8:10
   |vpiContAssign:

--- a/third_party/tests/SimpleParserTest/SimpleParserTest.log
+++ b/third_party/tests/SimpleParserTest/SimpleParserTest.log
@@ -1084,45 +1084,49 @@ design: (work@dff_async_reset)
             |vpiFullName:work@LFSR_TASK.seed1
             |vpiActual:
             \_logic_net: (work@LFSR_TASK.seed1), line:2:33, endln:2:38, parent:work@LFSR_TASK
+              |vpiTypespec:
+              \_logic_typespec: , line:4:7, endln:4:12
+                |vpiRange:
+                \_range: , line:4:8, endln:4:11
+                  |vpiLeftRange:
+                  \_constant: , line:4:8, endln:4:9
+                    |vpiDecompile:7
+                    |vpiSize:64
+                    |UINT:7
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:4:10, endln:4:11
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiName:seed1
               |vpiFullName:work@LFSR_TASK.seed1
-              |vpiRange:
-              \_range: , line:4:8, endln:4:11
-                |vpiLeftRange:
-                \_constant: , line:4:8, endln:4:9
-                  |vpiDecompile:7
-                  |vpiSize:64
-                  |UINT:7
-                  |vpiConstType:9
-                |vpiRightRange:
-                \_constant: , line:4:10, endln:4:11
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-                  |vpiConstType:9
           |vpiLhs:
           \_ref_obj: (work@LFSR_TASK.random1), line:29:2, endln:29:9
             |vpiName:random1
             |vpiFullName:work@LFSR_TASK.random1
             |vpiActual:
             \_logic_net: (work@LFSR_TASK.random1), line:6:11, endln:6:18, parent:work@LFSR_TASK
+              |vpiTypespec:
+              \_logic_typespec: , line:6:1, endln:6:4
+                |vpiRange:
+                \_range: , line:6:6, endln:6:9
+                  |vpiLeftRange:
+                  \_constant: , line:6:6, endln:6:7
+                    |vpiDecompile:7
+                    |vpiSize:64
+                    |UINT:7
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:6:8, endln:6:9
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiName:random1
               |vpiFullName:work@LFSR_TASK.random1
               |vpiNetType:48
-              |vpiRange:
-              \_range: , line:6:6, endln:6:9
-                |vpiLeftRange:
-                \_constant: , line:6:6, endln:6:7
-                  |vpiDecompile:7
-                  |vpiSize:64
-                  |UINT:7
-                  |vpiConstType:9
-                |vpiRightRange:
-                \_constant: , line:6:8, endln:6:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-                  |vpiConstType:9
         |vpiElseStmt:
         \_func_call: (LFSR_TASK), line:31:2, endln:31:38
           |vpiArgument:
@@ -1195,23 +1199,11 @@ design: (work@dff_async_reset)
             |vpiFullName:work@LFSR_TASK.random2
             |vpiActual:
             \_logic_net: (work@LFSR_TASK.random2), line:6:20, endln:6:27, parent:work@LFSR_TASK
+              |vpiTypespec:
+              \_logic_typespec: , line:6:1, endln:6:4
               |vpiName:random2
               |vpiFullName:work@LFSR_TASK.random2
               |vpiNetType:48
-              |vpiRange:
-              \_range: , line:6:6, endln:6:9
-                |vpiLeftRange:
-                \_constant: , line:6:6, endln:6:7
-                  |vpiDecompile:7
-                  |vpiSize:64
-                  |UINT:7
-                  |vpiConstType:9
-                |vpiRightRange:
-                \_constant: , line:6:8, endln:6:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-                  |vpiConstType:9
         |vpiElseStmt:
         \_func_call: (LFSR_TASK), line:36:2, endln:36:38
           |vpiArgument:
@@ -1457,22 +1449,24 @@ design: (work@dff_async_reset)
         |vpiFullName:work@arbiter.tpriority
         |vpiActual:
         \_logic_net: (work@top.U.tpriority), line:2:56, endln:2:65, parent:work@top.U
+          |vpiTypespec:
+          \_logic_typespec: , line:16:8, endln:16:37
+            |vpiRange:
+            \_range: , line:16:9, endln:16:36
+              |vpiLeftRange:
+              \_constant: , line:16:9, endln:16:30
+                |vpiDecompile:23
+                |vpiSize:64
+                |INT:23
+                |vpiConstType:7
+              |vpiRightRange:
+              \_constant: , line:16:35, endln:16:36
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:tpriority
           |vpiFullName:work@top.U.tpriority
-          |vpiRange:
-          \_range: , line:16:9, endln:16:36
-            |vpiLeftRange:
-            \_constant: , line:16:9, endln:16:30
-              |vpiDecompile:23
-              |vpiSize:64
-              |INT:23
-              |vpiConstType:7
-            |vpiRightRange:
-            \_constant: , line:16:35, endln:16:36
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
       |vpiStmt:
       \_begin: (work@arbiter), line:22:2, endln:29:5
         |vpiFullName:work@arbiter
@@ -1653,23 +1647,25 @@ design: (work@dff_async_reset)
                 |vpiFullName:work@arbiter.tmp_prio
                 |vpiActual:
                 \_logic_net: (work@top.U.tmp_prio), line:20:27, endln:20:35, parent:work@top.U
+                  |vpiTypespec:
+                  \_logic_typespec: , line:20:2, endln:20:5
+                    |vpiRange:
+                    \_range: , line:20:7, endln:20:25
+                      |vpiLeftRange:
+                      \_constant: , line:20:7, endln:20:19
+                        |vpiDecompile:2
+                        |vpiSize:64
+                        |INT:2
+                        |vpiConstType:7
+                      |vpiRightRange:
+                      \_constant: , line:20:24, endln:20:25
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:tmp_prio
                   |vpiFullName:work@top.U.tmp_prio
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:20:7, endln:20:25
-                    |vpiLeftRange:
-                    \_constant: , line:20:7, endln:20:19
-                      |vpiDecompile:2
-                      |vpiSize:64
-                      |INT:2
-                      |vpiConstType:7
-                    |vpiRightRange:
-                    \_constant: , line:20:24, endln:20:25
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
               |vpiLhs:
               \_bit_select: (work@arbiter.prio), line:27:2, endln:27:9, parent:work@arbiter.prio
                 |vpiParent:
@@ -1731,23 +1727,25 @@ design: (work@dff_async_reset)
               |vpiFullName:work@arbiter.grant
               |vpiActual:
               \_logic_net: (work@top.U.grant), line:30:23, endln:30:28, parent:work@top.U
+                |vpiTypespec:
+                \_logic_typespec: , line:30:2, endln:30:5
+                  |vpiRange:
+                  \_range: , line:30:7, endln:30:21
+                    |vpiLeftRange:
+                    \_constant: , line:30:7, endln:30:15
+                      |vpiDecompile:7
+                      |vpiSize:64
+                      |INT:7
+                      |vpiConstType:7
+                    |vpiRightRange:
+                    \_constant: , line:30:20, endln:30:21
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:grant
                 |vpiFullName:work@top.U.grant
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:30:7, endln:30:21
-                  |vpiLeftRange:
-                  \_constant: , line:30:7, endln:30:15
-                    |vpiDecompile:7
-                    |vpiSize:64
-                    |INT:7
-                    |vpiConstType:7
-                  |vpiRightRange:
-                  \_constant: , line:30:20, endln:30:21
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
           |vpiElseStmt:
           \_assignment: , line:52:7, endln:52:22
             |vpiOpType:82
@@ -1757,23 +1755,25 @@ design: (work@dff_async_reset)
               |vpiFullName:work@arbiter.grantD
               |vpiActual:
               \_logic_net: (work@top.U.grantD), line:31:23, endln:31:29, parent:work@top.U
+                |vpiTypespec:
+                \_logic_typespec: , line:31:2, endln:31:5
+                  |vpiRange:
+                  \_range: , line:31:7, endln:31:21
+                    |vpiLeftRange:
+                    \_constant: , line:31:7, endln:31:15
+                      |vpiDecompile:7
+                      |vpiSize:64
+                      |INT:7
+                      |vpiConstType:7
+                    |vpiRightRange:
+                    \_constant: , line:31:20, endln:31:21
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:grantD
                 |vpiFullName:work@top.U.grantD
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:31:7, endln:31:21
-                  |vpiLeftRange:
-                  \_constant: , line:31:7, endln:31:15
-                    |vpiDecompile:7
-                    |vpiSize:64
-                    |INT:7
-                    |vpiConstType:7
-                  |vpiRightRange:
-                  \_constant: , line:31:20, endln:31:21
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
             |vpiLhs:
             \_ref_obj: (work@arbiter.grant), line:52:7, endln:52:12
               |vpiName:grant
@@ -1823,23 +1823,25 @@ design: (work@dff_async_reset)
               |vpiFullName:work@arbiter.next
               |vpiActual:
               \_logic_net: (work@top.U.next), line:32:27, endln:32:31, parent:work@top.U
+                |vpiTypespec:
+                \_logic_typespec: , line:32:2, endln:32:5
+                  |vpiRange:
+                  \_range: , line:32:7, endln:32:25
+                    |vpiLeftRange:
+                    \_constant: , line:32:7, endln:32:19
+                      |vpiDecompile:2
+                      |vpiSize:64
+                      |INT:2
+                      |vpiConstType:7
+                    |vpiRightRange:
+                    \_constant: , line:32:24, endln:32:25
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:next
                 |vpiFullName:work@top.U.next
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:32:7, endln:32:25
-                  |vpiLeftRange:
-                  \_constant: , line:32:7, endln:32:19
-                    |vpiDecompile:2
-                    |vpiSize:64
-                    |INT:2
-                    |vpiConstType:7
-                  |vpiRightRange:
-                  \_constant: , line:32:24, endln:32:25
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
           |vpiElseStmt:
           \_assignment: , line:58:7, endln:58:23
             |vpiOpType:82
@@ -1849,23 +1851,25 @@ design: (work@dff_async_reset)
               |vpiFullName:work@arbiter.nextNext
               |vpiActual:
               \_logic_net: (work@top.U.nextNext), line:33:27, endln:33:35, parent:work@top.U
+                |vpiTypespec:
+                \_logic_typespec: , line:33:2, endln:33:5
+                  |vpiRange:
+                  \_range: , line:33:7, endln:33:25
+                    |vpiLeftRange:
+                    \_constant: , line:33:7, endln:33:19
+                      |vpiDecompile:2
+                      |vpiSize:64
+                      |INT:2
+                      |vpiConstType:7
+                    |vpiRightRange:
+                    \_constant: , line:33:24, endln:33:25
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:nextNext
                 |vpiFullName:work@top.U.nextNext
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:33:7, endln:33:25
-                  |vpiLeftRange:
-                  \_constant: , line:33:7, endln:33:19
-                    |vpiDecompile:2
-                    |vpiSize:64
-                    |INT:2
-                    |vpiConstType:7
-                  |vpiRightRange:
-                  \_constant: , line:33:24, endln:33:25
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
             |vpiLhs:
             \_ref_obj: (work@arbiter.next), line:58:7, endln:58:11
               |vpiName:next
@@ -1906,22 +1910,24 @@ design: (work@dff_async_reset)
                         |vpiName:request
                         |vpiActual:
                         \_logic_net: (work@top.U.request), line:2:47, endln:2:54, parent:work@top.U
+                          |vpiTypespec:
+                          \_logic_typespec: , line:15:8, endln:15:24
+                            |vpiRange:
+                            \_range: , line:15:9, endln:15:23
+                              |vpiLeftRange:
+                              \_constant: , line:15:9, endln:15:17
+                                |vpiDecompile:7
+                                |vpiSize:64
+                                |INT:7
+                                |vpiConstType:7
+                              |vpiRightRange:
+                              \_constant: , line:15:22, endln:15:23
+                                |vpiDecompile:0
+                                |vpiSize:64
+                                |UINT:0
+                                |vpiConstType:9
                           |vpiName:request
                           |vpiFullName:work@top.U.request
-                          |vpiRange:
-                          \_range: , line:15:9, endln:15:23
-                            |vpiLeftRange:
-                            \_constant: , line:15:9, endln:15:17
-                              |vpiDecompile:7
-                              |vpiSize:64
-                              |INT:7
-                              |vpiConstType:7
-                            |vpiRightRange:
-                            \_constant: , line:15:22, endln:15:23
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                              |vpiConstType:9
                       |vpiOperand:
                       \_bit_select: (prio), line:61:21, endln:61:28, parent:prio
                         |vpiParent:
@@ -2157,23 +2163,25 @@ design: (work@dff_async_reset)
             |vpiName:prioRequest
             |vpiActual:
             \_logic_net: (work@top.U.prioRequest), line:44:24, endln:44:35, parent:work@top.U
+              |vpiTypespec:
+              \_logic_typespec: , line:44:2, endln:44:6
+                |vpiRange:
+                \_range: , line:44:8, endln:44:22
+                  |vpiLeftRange:
+                  \_constant: , line:44:8, endln:44:16
+                    |vpiDecompile:7
+                    |vpiSize:64
+                    |INT:7
+                    |vpiConstType:7
+                  |vpiRightRange:
+                  \_constant: , line:44:21, endln:44:22
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiName:prioRequest
               |vpiFullName:work@top.U.prioRequest
               |vpiNetType:1
-              |vpiRange:
-              \_range: , line:44:8, endln:44:22
-                |vpiLeftRange:
-                \_constant: , line:44:8, endln:44:16
-                  |vpiDecompile:7
-                  |vpiSize:64
-                  |INT:7
-                  |vpiConstType:7
-                |vpiRightRange:
-                \_constant: , line:44:21, endln:44:22
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-                  |vpiConstType:9
           |vpiOperand:
           \_ref_obj: (request), line:68:25, endln:68:32
             |vpiName:request
@@ -2451,23 +2459,25 @@ design: (work@dff_async_reset)
             |vpiFullName:work@arbiter.min
             |vpiActual:
             \_logic_net: (work@top.U.min), line:40:27, endln:40:30, parent:work@top.U
+              |vpiTypespec:
+              \_logic_typespec: , line:40:2, endln:40:5
+                |vpiRange:
+                \_range: , line:40:7, endln:40:25
+                  |vpiLeftRange:
+                  \_constant: , line:40:7, endln:40:19
+                    |vpiDecompile:2
+                    |vpiSize:64
+                    |INT:2
+                    |vpiConstType:7
+                  |vpiRightRange:
+                  \_constant: , line:40:24, endln:40:25
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiName:min
               |vpiFullName:work@top.U.min
               |vpiNetType:48
-              |vpiRange:
-              \_range: , line:40:7, endln:40:25
-                |vpiLeftRange:
-                \_constant: , line:40:7, endln:40:19
-                  |vpiDecompile:2
-                  |vpiSize:64
-                  |INT:2
-                  |vpiConstType:7
-                |vpiRightRange:
-                \_constant: , line:40:24, endln:40:25
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-                  |vpiConstType:9
         |vpiStmt:
         \_for_stmt: (work@arbiter), line:81:2, endln:81:5, parent:work@arbiter
           |vpiFullName:work@arbiter
@@ -2617,23 +2627,25 @@ design: (work@dff_async_reset)
                           |vpiName:minPrio
                           |vpiActual:
                           \_logic_net: (work@top.U.minPrio), line:42:23, endln:42:30, parent:work@top.U
+                            |vpiTypespec:
+                            \_logic_typespec: , line:42:2, endln:42:5
+                              |vpiRange:
+                              \_range: , line:42:7, endln:42:21
+                                |vpiLeftRange:
+                                \_constant: , line:42:7, endln:42:15
+                                  |vpiDecompile:7
+                                  |vpiSize:64
+                                  |INT:7
+                                  |vpiConstType:7
+                                |vpiRightRange:
+                                \_constant: , line:42:20, endln:42:21
+                                  |vpiDecompile:0
+                                  |vpiSize:64
+                                  |UINT:0
+                                  |vpiConstType:9
                             |vpiName:minPrio
                             |vpiFullName:work@top.U.minPrio
                             |vpiNetType:48
-                            |vpiRange:
-                            \_range: , line:42:7, endln:42:21
-                              |vpiLeftRange:
-                              \_constant: , line:42:7, endln:42:15
-                                |vpiDecompile:7
-                                |vpiSize:64
-                                |INT:7
-                                |vpiConstType:7
-                              |vpiRightRange:
-                              \_constant: , line:42:20, endln:42:21
-                                |vpiDecompile:0
-                                |vpiSize:64
-                                |UINT:0
-                                |vpiConstType:9
                       |vpiOperand:
                       \_bit_select: (prio), line:85:28, endln:85:35, parent:prio
                         |vpiParent:
@@ -3033,23 +3045,25 @@ design: (work@dff_async_reset)
                         |vpiName:finalRequest
                         |vpiActual:
                         \_logic_net: (work@top.U.finalRequest), line:46:23, endln:46:35, parent:work@top.U
+                          |vpiTypespec:
+                          \_logic_typespec: , line:46:2, endln:46:5
+                            |vpiRange:
+                            \_range: , line:46:7, endln:46:21
+                              |vpiLeftRange:
+                              \_constant: , line:46:7, endln:46:15
+                                |vpiDecompile:7
+                                |vpiSize:64
+                                |INT:7
+                                |vpiConstType:7
+                              |vpiRightRange:
+                              \_constant: , line:46:20, endln:46:21
+                                |vpiDecompile:0
+                                |vpiSize:64
+                                |UINT:0
+                                |vpiConstType:9
                           |vpiName:finalRequest
                           |vpiFullName:work@top.U.finalRequest
                           |vpiNetType:48
-                          |vpiRange:
-                          \_range: , line:46:7, endln:46:21
-                            |vpiLeftRange:
-                            \_constant: , line:46:7, endln:46:15
-                              |vpiDecompile:7
-                              |vpiSize:64
-                              |INT:7
-                              |vpiConstType:7
-                            |vpiRightRange:
-                            \_constant: , line:46:20, endln:46:21
-                              |vpiDecompile:0
-                              |vpiSize:64
-                              |UINT:0
-                              |vpiConstType:9
                       |vpiOperand:
                       \_bit_select: (scan), line:100:26, endln:100:33, parent:scan
                         |vpiParent:
@@ -3364,23 +3378,25 @@ design: (work@dff_async_reset)
                           |vpiName:found
                           |vpiActual:
                           \_logic_net: (work@top.U.found), line:36:23, endln:36:28, parent:work@top.U
+                            |vpiTypespec:
+                            \_logic_typespec: , line:36:2, endln:36:5
+                              |vpiRange:
+                              \_range: , line:36:7, endln:36:21
+                                |vpiLeftRange:
+                                \_constant: , line:36:7, endln:36:15
+                                  |vpiDecompile:6
+                                  |vpiSize:64
+                                  |INT:6
+                                  |vpiConstType:7
+                                |vpiRightRange:
+                                \_constant: , line:36:20, endln:36:21
+                                  |vpiDecompile:0
+                                  |vpiSize:64
+                                  |UINT:0
+                                  |vpiConstType:9
                             |vpiName:found
                             |vpiFullName:work@top.U.found
                             |vpiNetType:48
-                            |vpiRange:
-                            \_range: , line:36:7, endln:36:21
-                              |vpiLeftRange:
-                              \_constant: , line:36:7, endln:36:15
-                                |vpiDecompile:6
-                                |vpiSize:64
-                                |INT:6
-                                |vpiConstType:7
-                              |vpiRightRange:
-                              \_constant: , line:36:20, endln:36:21
-                                |vpiDecompile:0
-                                |vpiSize:64
-                                |UINT:0
-                                |vpiConstType:9
                       |vpiOperand:
                       \_bit_select: (scan), line:108:35, endln:108:42, parent:scan
                         |vpiParent:
@@ -3875,43 +3891,47 @@ design: (work@dff_async_reset)
           |vpiName:in1
           |vpiActual:
           \_logic_net: (work@case1.in1), line:2:15, endln:2:18, parent:work@case1
+            |vpiTypespec:
+            \_logic_typespec: , line:3:7, endln:3:12
+              |vpiRange:
+              \_range: , line:3:8, endln:3:11
+                |vpiLeftRange:
+                \_constant: , line:3:8, endln:3:9
+                  |vpiDecompile:7
+                  |vpiSize:64
+                  |UINT:7
+                  |vpiConstType:9
+                |vpiRightRange:
+                \_constant: , line:3:10, endln:3:11
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiName:in1
             |vpiFullName:work@case1.in1
-            |vpiRange:
-            \_range: , line:3:8, endln:3:11
-              |vpiLeftRange:
-              \_constant: , line:3:8, endln:3:9
-                |vpiDecompile:7
-                |vpiSize:64
-                |UINT:7
-                |vpiConstType:9
-              |vpiRightRange:
-              \_constant: , line:3:10, endln:3:11
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
         |vpiOperand:
         \_ref_obj: (in2), line:6:16, endln:6:19
           |vpiName:in2
           |vpiActual:
           \_logic_net: (work@case1.in2), line:2:20, endln:2:23, parent:work@case1
+            |vpiTypespec:
+            \_logic_typespec: , line:4:7, endln:4:12
+              |vpiRange:
+              \_range: , line:4:8, endln:4:11
+                |vpiLeftRange:
+                \_constant: , line:4:8, endln:4:9
+                  |vpiDecompile:2
+                  |vpiSize:64
+                  |UINT:2
+                  |vpiConstType:9
+                |vpiRightRange:
+                \_constant: , line:4:10, endln:4:11
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiName:in2
             |vpiFullName:work@case1.in2
-            |vpiRange:
-            \_range: , line:4:8, endln:4:11
-              |vpiLeftRange:
-              \_constant: , line:4:8, endln:4:9
-                |vpiDecompile:2
-                |vpiSize:64
-                |UINT:2
-                |vpiConstType:9
-              |vpiRightRange:
-              \_constant: , line:4:10, endln:4:11
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
       |vpiStmt:
       \_case_stmt: , line:7:2, endln:16:9
         |vpiCaseType:1
@@ -4235,22 +4255,24 @@ design: (work@dff_async_reset)
         |vpiFullName:work@case2.sel
         |vpiActual:
         \_logic_net: (work@case2.sel), line:21:20, endln:21:23, parent:work@case2
+          |vpiTypespec:
+          \_logic_typespec: , line:23:7, endln:23:12
+            |vpiRange:
+            \_range: , line:23:8, endln:23:11
+              |vpiLeftRange:
+              \_constant: , line:23:8, endln:23:9
+                |vpiDecompile:2
+                |vpiSize:64
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:23:10, endln:23:11
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sel
           |vpiFullName:work@case2.sel
-          |vpiRange:
-          \_range: , line:23:8, endln:23:11
-            |vpiLeftRange:
-            \_constant: , line:23:8, endln:23:9
-              |vpiDecompile:2
-              |vpiSize:64
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:23:10, endln:23:11
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
       |vpiStmt:
       \_case_stmt: , line:28:2, endln:37:9
         |vpiCaseType:1
@@ -4284,23 +4306,25 @@ design: (work@dff_async_reset)
               |vpiFullName:work@case2.select
               |vpiActual:
               \_logic_net: (work@case2.select), line:25:11, endln:25:17, parent:work@case2
+                |vpiTypespec:
+                \_logic_typespec: , line:25:1, endln:25:4
+                  |vpiRange:
+                  \_range: , line:25:6, endln:25:9
+                    |vpiLeftRange:
+                    \_constant: , line:25:6, endln:25:7
+                      |vpiDecompile:7
+                      |vpiSize:64
+                      |UINT:7
+                      |vpiConstType:9
+                    |vpiRightRange:
+                    \_constant: , line:25:8, endln:25:9
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:select
                 |vpiFullName:work@case2.select
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:25:6, endln:25:9
-                  |vpiLeftRange:
-                  \_constant: , line:25:6, endln:25:7
-                    |vpiDecompile:7
-                    |vpiSize:64
-                    |UINT:7
-                    |vpiConstType:9
-                  |vpiRightRange:
-                  \_constant: , line:25:8, endln:25:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
         |vpiCaseItem:
         \_case_item: , line:30:2, endln:30:32
           |vpiExpr:
@@ -4481,22 +4505,24 @@ design: (work@dff_async_reset)
         |vpiFullName:work@case2.in1
         |vpiActual:
         \_logic_net: (work@case2.in1), line:21:15, endln:21:18, parent:work@case2
+          |vpiTypespec:
+          \_logic_typespec: , line:22:7, endln:22:12
+            |vpiRange:
+            \_range: , line:22:8, endln:22:11
+              |vpiLeftRange:
+              \_constant: , line:22:8, endln:22:9
+                |vpiDecompile:1
+                |vpiSize:64
+                |UINT:1
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:22:10, endln:22:11
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:in1
           |vpiFullName:work@case2.in1
-          |vpiRange:
-          \_range: , line:22:8, endln:22:11
-            |vpiLeftRange:
-            \_constant: , line:22:8, endln:22:9
-              |vpiDecompile:1
-              |vpiSize:64
-              |UINT:1
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:22:10, endln:22:11
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
       |vpiOperand:
       \_bit_select: (work@case2.select), line:38:27, endln:38:36, parent:work@case2.select
         |vpiParent:
@@ -4955,6 +4981,8 @@ design: (work@dff_async_reset)
               |vpiFullName:work@dff_async_reset.q
               |vpiActual:
               \_logic_net: (work@dff_async_reset.q), line:21:5, endln:21:6, parent:work@dff_async_reset
+                |vpiTypespec:
+                \_logic_typespec: , line:21:1, endln:21:4
                 |vpiName:q
                 |vpiFullName:work@dff_async_reset.q
                 |vpiNetType:48
@@ -5039,22 +5067,24 @@ design: (work@dff_async_reset)
           |vpiName:encoder_in
           |vpiActual:
           \_logic_net: (work@encoder_using_case.encoder_in), line:9:1, endln:9:11, parent:work@encoder_using_case
+            |vpiTypespec:
+            \_logic_typespec: , line:14:7, endln:14:13
+              |vpiRange:
+              \_range: , line:14:8, endln:14:12
+                |vpiLeftRange:
+                \_constant: , line:14:8, endln:14:10
+                  |vpiDecompile:15
+                  |vpiSize:64
+                  |UINT:15
+                  |vpiConstType:9
+                |vpiRightRange:
+                \_constant: , line:14:11, endln:14:12
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiName:encoder_in
             |vpiFullName:work@encoder_using_case.encoder_in
-            |vpiRange:
-            \_range: , line:14:8, endln:14:12
-              |vpiLeftRange:
-              \_constant: , line:14:8, endln:14:10
-                |vpiDecompile:15
-                |vpiSize:64
-                |UINT:15
-                |vpiConstType:9
-              |vpiRightRange:
-              \_constant: , line:14:11, endln:14:12
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
       |vpiStmt:
       \_begin: (work@encoder_using_case), line:20:1, endln:41:4
         |vpiFullName:work@encoder_using_case
@@ -5074,23 +5104,25 @@ design: (work@dff_async_reset)
             |vpiFullName:work@encoder_using_case.binary_out
             |vpiActual:
             \_logic_net: (work@encoder_using_case.binary_out), line:17:11, endln:17:21, parent:work@encoder_using_case
+              |vpiTypespec:
+              \_logic_typespec: , line:17:1, endln:17:4
+                |vpiRange:
+                \_range: , line:17:6, endln:17:9
+                  |vpiLeftRange:
+                  \_constant: , line:17:6, endln:17:7
+                    |vpiDecompile:3
+                    |vpiSize:64
+                    |UINT:3
+                    |vpiConstType:9
+                  |vpiRightRange:
+                  \_constant: , line:17:8, endln:17:9
+                    |vpiDecompile:0
+                    |vpiSize:64
+                    |UINT:0
+                    |vpiConstType:9
               |vpiName:binary_out
               |vpiFullName:work@encoder_using_case.binary_out
               |vpiNetType:48
-              |vpiRange:
-              \_range: , line:17:6, endln:17:9
-                |vpiLeftRange:
-                \_constant: , line:17:6, endln:17:7
-                  |vpiDecompile:3
-                  |vpiSize:64
-                  |UINT:3
-                  |vpiConstType:9
-                |vpiRightRange:
-                \_constant: , line:17:8, endln:17:9
-                  |vpiDecompile:0
-                  |vpiSize:64
-                  |UINT:0
-                  |vpiConstType:9
         |vpiStmt:
         \_if_stmt: , line:22:3, endln:40:6, parent:work@encoder_using_case
           |vpiCondition:
@@ -5687,43 +5719,47 @@ design: (work@dff_async_reset)
           |vpiName:Op
           |vpiActual:
           \_logic_net: (work@pri_encooder.Op), line:49:22, endln:49:24, parent:work@pri_encooder
+            |vpiTypespec:
+            \_logic_typespec: , line:50:7, endln:50:12
+              |vpiRange:
+              \_range: , line:50:8, endln:50:11
+                |vpiLeftRange:
+                \_constant: , line:50:8, endln:50:9
+                  |vpiDecompile:1
+                  |vpiSize:64
+                  |UINT:1
+                  |vpiConstType:9
+                |vpiRightRange:
+                \_constant: , line:50:10, endln:50:11
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiName:Op
             |vpiFullName:work@pri_encooder.Op
-            |vpiRange:
-            \_range: , line:50:8, endln:50:11
-              |vpiLeftRange:
-              \_constant: , line:50:8, endln:50:9
-                |vpiDecompile:1
-                |vpiSize:64
-                |UINT:1
-                |vpiConstType:9
-              |vpiRightRange:
-              \_constant: , line:50:10, endln:50:11
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
         |vpiOperand:
         \_ref_obj: (Funct), line:54:15, endln:54:20
           |vpiName:Funct
           |vpiActual:
           \_logic_net: (work@pri_encooder.Funct), line:49:26, endln:49:31, parent:work@pri_encooder
+            |vpiTypespec:
+            \_logic_typespec: , line:51:7, endln:51:12
+              |vpiRange:
+              \_range: , line:51:8, endln:51:11
+                |vpiLeftRange:
+                \_constant: , line:51:8, endln:51:9
+                  |vpiDecompile:4
+                  |vpiSize:64
+                  |UINT:4
+                  |vpiConstType:9
+                |vpiRightRange:
+                \_constant: , line:51:10, endln:51:11
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiName:Funct
             |vpiFullName:work@pri_encooder.Funct
-            |vpiRange:
-            \_range: , line:51:8, endln:51:11
-              |vpiLeftRange:
-              \_constant: , line:51:8, endln:51:9
-                |vpiDecompile:4
-                |vpiSize:64
-                |UINT:4
-                |vpiConstType:9
-              |vpiRightRange:
-              \_constant: , line:51:10, endln:51:11
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
       |vpiStmt:
       \_case_stmt: , line:55:2, endln:72:9
         |vpiCaseType:2
@@ -5778,22 +5814,24 @@ design: (work@dff_async_reset)
                 |vpiFullName:work@pri_encooder.Sel
                 |vpiActual:
                 \_logic_net: (work@pri_encooder.Sel), line:49:33, endln:49:36, parent:work@pri_encooder
+                  |vpiTypespec:
+                  \_logic_typespec: , line:52:8, endln:52:13
+                    |vpiRange:
+                    \_range: , line:52:9, endln:52:12
+                      |vpiLeftRange:
+                      \_constant: , line:52:9, endln:52:10
+                        |vpiDecompile:1
+                        |vpiSize:64
+                        |UINT:1
+                        |vpiConstType:9
+                      |vpiRightRange:
+                      \_constant: , line:52:11, endln:52:12
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:Sel
                   |vpiFullName:work@pri_encooder.Sel
-                  |vpiRange:
-                  \_range: , line:52:9, endln:52:12
-                    |vpiLeftRange:
-                    \_constant: , line:52:9, endln:52:10
-                      |vpiDecompile:1
-                      |vpiSize:64
-                      |UINT:1
-                      |vpiConstType:9
-                    |vpiRightRange:
-                    \_constant: , line:52:11, endln:52:12
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
             |vpiStmt:
             \_assignment: , line:58:2, endln:58:10, parent:work@pri_encooder
               |vpiOpType:82
@@ -6214,23 +6252,25 @@ design: (work@dff_async_reset)
                 |vpiFullName:work@syn_fifo.WRITE_POINTER.wr_pointer
                 |vpiActual:
                 \_logic_net: (work@syn_fifo.wr_pointer), line:38:22, endln:38:32, parent:work@syn_fifo
+                  |vpiTypespec:
+                  \_logic_typespec: , line:38:1, endln:38:4
+                    |vpiRange:
+                    \_range: , line:38:6, endln:38:20
+                      |vpiLeftRange:
+                      \_constant: , line:38:6, endln:38:16
+                        |vpiDecompile:7
+                        |vpiSize:64
+                        |INT:7
+                        |vpiConstType:7
+                      |vpiRightRange:
+                      \_constant: , line:38:19, endln:38:20
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:wr_pointer
                   |vpiFullName:work@syn_fifo.wr_pointer
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:38:6, endln:38:20
-                    |vpiLeftRange:
-                    \_constant: , line:38:6, endln:38:16
-                      |vpiDecompile:7
-                      |vpiSize:64
-                      |INT:7
-                      |vpiConstType:7
-                    |vpiRightRange:
-                    \_constant: , line:38:19, endln:38:20
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
           |vpiElseStmt:
           \_if_stmt: , line:53:12, endln:55:6
             |vpiCondition:
@@ -6333,23 +6373,25 @@ design: (work@dff_async_reset)
                 |vpiFullName:work@syn_fifo.READ_POINTER.rd_pointer
                 |vpiActual:
                 \_logic_net: (work@syn_fifo.rd_pointer), line:39:22, endln:39:32, parent:work@syn_fifo
+                  |vpiTypespec:
+                  \_logic_typespec: , line:39:1, endln:39:4
+                    |vpiRange:
+                    \_range: , line:39:6, endln:39:20
+                      |vpiLeftRange:
+                      \_constant: , line:39:6, endln:39:16
+                        |vpiDecompile:7
+                        |vpiSize:64
+                        |INT:7
+                        |vpiConstType:7
+                      |vpiRightRange:
+                      \_constant: , line:39:19, endln:39:20
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:rd_pointer
                   |vpiFullName:work@syn_fifo.rd_pointer
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:39:6, endln:39:20
-                    |vpiLeftRange:
-                    \_constant: , line:39:6, endln:39:16
-                      |vpiDecompile:7
-                      |vpiSize:64
-                      |INT:7
-                      |vpiConstType:7
-                    |vpiRightRange:
-                    \_constant: , line:39:19, endln:39:20
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
           |vpiElseStmt:
           \_if_stmt: , line:62:12, endln:64:6
             |vpiCondition:
@@ -6452,23 +6494,25 @@ design: (work@dff_async_reset)
                 |vpiFullName:work@syn_fifo.READ_DATA.data_out
                 |vpiActual:
                 \_logic_net: (work@syn_fifo.data_out), line:41:22, endln:41:30, parent:work@syn_fifo
+                  |vpiTypespec:
+                  \_logic_typespec: , line:41:1, endln:41:4
+                    |vpiRange:
+                    \_range: , line:41:6, endln:41:20
+                      |vpiLeftRange:
+                      \_constant: , line:41:6, endln:41:16
+                        |vpiDecompile:7
+                        |vpiSize:64
+                        |INT:7
+                        |vpiConstType:7
+                      |vpiRightRange:
+                      \_constant: , line:41:19, endln:41:20
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:data_out
                   |vpiFullName:work@syn_fifo.data_out
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:41:6, endln:41:20
-                    |vpiLeftRange:
-                    \_constant: , line:41:6, endln:41:16
-                      |vpiDecompile:7
-                      |vpiSize:64
-                      |INT:7
-                      |vpiConstType:7
-                    |vpiRightRange:
-                    \_constant: , line:41:19, endln:41:20
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
           |vpiElseStmt:
           \_if_stmt: , line:71:12, endln:73:6
             |vpiCondition:
@@ -6498,23 +6542,25 @@ design: (work@dff_async_reset)
                   |vpiFullName:work@syn_fifo.READ_DATA.data_ram
                   |vpiActual:
                   \_logic_net: (work@syn_fifo.data_ram), line:42:23, endln:42:31, parent:work@syn_fifo
+                    |vpiTypespec:
+                    \_logic_typespec: , line:42:1, endln:42:5
+                      |vpiRange:
+                      \_range: , line:42:7, endln:42:21
+                        |vpiLeftRange:
+                        \_constant: , line:42:7, endln:42:17
+                          |vpiDecompile:7
+                          |vpiSize:64
+                          |INT:7
+                          |vpiConstType:7
+                        |vpiRightRange:
+                        \_constant: , line:42:20, endln:42:21
+                          |vpiDecompile:0
+                          |vpiSize:64
+                          |UINT:0
+                          |vpiConstType:9
                     |vpiName:data_ram
                     |vpiFullName:work@syn_fifo.data_ram
                     |vpiNetType:1
-                    |vpiRange:
-                    \_range: , line:42:7, endln:42:21
-                      |vpiLeftRange:
-                      \_constant: , line:42:7, endln:42:17
-                        |vpiDecompile:7
-                        |vpiSize:64
-                        |INT:7
-                        |vpiConstType:7
-                      |vpiRightRange:
-                      \_constant: , line:42:20, endln:42:21
-                        |vpiDecompile:0
-                        |vpiSize:64
-                        |UINT:0
-                        |vpiConstType:9
                 |vpiLhs:
                 \_ref_obj: (work@syn_fifo.READ_DATA.data_out), line:72:5, endln:72:13, parent:work@syn_fifo.READ_DATA
                   |vpiName:data_out
@@ -6575,23 +6621,25 @@ design: (work@dff_async_reset)
                 |vpiFullName:work@syn_fifo.STATUS_COUNTER.status_cnt
                 |vpiActual:
                 \_logic_net: (work@syn_fifo.status_cnt), line:40:21, endln:40:31, parent:work@syn_fifo
+                  |vpiTypespec:
+                  \_logic_typespec: , line:40:1, endln:40:4
+                    |vpiRange:
+                    \_range: , line:40:6, endln:40:19
+                      |vpiLeftRange:
+                      \_constant: , line:40:6, endln:40:16
+                        |vpiDecompile:8
+                        |vpiSize:32
+                        |UINT:8
+                        |vpiConstType:9
+                      |vpiRightRange:
+                      \_constant: , line:40:18, endln:40:19
+                        |vpiDecompile:0
+                        |vpiSize:64
+                        |UINT:0
+                        |vpiConstType:9
                   |vpiName:status_cnt
                   |vpiFullName:work@syn_fifo.status_cnt
                   |vpiNetType:48
-                  |vpiRange:
-                  \_range: , line:40:6, endln:40:19
-                    |vpiLeftRange:
-                    \_constant: , line:40:6, endln:40:16
-                      |vpiDecompile:8
-                      |vpiSize:32
-                      |UINT:8
-                      |vpiConstType:9
-                    |vpiRightRange:
-                    \_constant: , line:40:18, endln:40:19
-                      |vpiDecompile:0
-                      |vpiSize:64
-                      |UINT:0
-                      |vpiConstType:9
           |vpiElseStmt:
           \_if_else: , line:81:12, endln:88:6
             |vpiCondition:
@@ -6886,6 +6934,8 @@ design: (work@dff_async_reset)
             |vpiFullName:work@top.clk
             |vpiActual:
             \_logic_net: (work@top.clk), line:5:17, endln:5:20, parent:work@top
+              |vpiTypespec:
+              \_logic_typespec: , line:5:1, endln:5:4
               |vpiName:clk
               |vpiFullName:work@top.clk
               |vpiNetType:48
@@ -6945,6 +6995,8 @@ design: (work@dff_async_reset)
           |vpiFullName:work@top.rst
           |vpiActual:
           \_logic_net: (work@top.rst), line:6:17, endln:6:20, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:6:1, endln:6:4
             |vpiName:rst
             |vpiFullName:work@top.rst
             |vpiNetType:48
@@ -6964,6 +7016,8 @@ design: (work@dff_async_reset)
           |vpiFullName:work@top.req0
           |vpiActual:
           \_logic_net: (work@top.req0), line:10:17, endln:10:21, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:10:1, endln:10:4
             |vpiName:req0
             |vpiFullName:work@top.req0
             |vpiNetType:48
@@ -6983,6 +7037,8 @@ design: (work@dff_async_reset)
           |vpiFullName:work@top.req1
           |vpiActual:
           \_logic_net: (work@top.req1), line:9:17, endln:9:21, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:9:1, endln:9:4
             |vpiName:req1
             |vpiFullName:work@top.req1
             |vpiNetType:48
@@ -7002,6 +7058,8 @@ design: (work@dff_async_reset)
           |vpiFullName:work@top.req2
           |vpiActual:
           \_logic_net: (work@top.req2), line:8:17, endln:8:21, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:8:1, endln:8:4
             |vpiName:req2
             |vpiFullName:work@top.req2
             |vpiNetType:48
@@ -7021,6 +7079,8 @@ design: (work@dff_async_reset)
           |vpiFullName:work@top.req3
           |vpiActual:
           \_logic_net: (work@top.req3), line:7:17, endln:7:21, parent:work@top
+            |vpiTypespec:
+            \_logic_typespec: , line:7:1, endln:7:4
             |vpiName:req3
             |vpiFullName:work@top.req3
             |vpiNetType:48
@@ -7623,23 +7683,25 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.rx_reg
               |vpiActual:
               \_logic_net: (work@uart.rx_reg), line:44:14, endln:44:20, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:44:1, endln:44:4
+                  |vpiRange:
+                  \_range: , line:44:6, endln:44:9
+                    |vpiLeftRange:
+                    \_constant: , line:44:6, endln:44:7
+                      |vpiDecompile:7
+                      |vpiSize:64
+                      |UINT:7
+                      |vpiConstType:9
+                    |vpiRightRange:
+                    \_constant: , line:44:8, endln:44:9
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:rx_reg
                 |vpiFullName:work@uart.rx_reg
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:44:6, endln:44:9
-                  |vpiLeftRange:
-                  \_constant: , line:44:6, endln:44:7
-                    |vpiDecompile:7
-                    |vpiSize:64
-                    |UINT:7
-                    |vpiConstType:9
-                  |vpiRightRange:
-                  \_constant: , line:44:8, endln:44:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
           |vpiStmt:
           \_assignment: , line:59:3, endln:59:21, parent:work@uart
             |vpiOpType:82
@@ -7655,23 +7717,25 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.rx_data
               |vpiActual:
               \_logic_net: (work@uart.rx_data), line:45:14, endln:45:21, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:45:1, endln:45:4
+                  |vpiRange:
+                  \_range: , line:45:6, endln:45:9
+                    |vpiLeftRange:
+                    \_constant: , line:45:6, endln:45:7
+                      |vpiDecompile:7
+                      |vpiSize:64
+                      |UINT:7
+                      |vpiConstType:9
+                    |vpiRightRange:
+                    \_constant: , line:45:8, endln:45:9
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:rx_data
                 |vpiFullName:work@uart.rx_data
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:45:6, endln:45:9
-                  |vpiLeftRange:
-                  \_constant: , line:45:6, endln:45:7
-                    |vpiDecompile:7
-                    |vpiSize:64
-                    |UINT:7
-                    |vpiConstType:9
-                  |vpiRightRange:
-                  \_constant: , line:45:8, endln:45:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
           |vpiStmt:
           \_assignment: , line:60:3, endln:60:21, parent:work@uart
             |vpiOpType:82
@@ -7687,23 +7751,25 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.rx_sample_cnt
               |vpiActual:
               \_logic_net: (work@uart.rx_sample_cnt), line:46:14, endln:46:27, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:46:1, endln:46:4
+                  |vpiRange:
+                  \_range: , line:46:6, endln:46:9
+                    |vpiLeftRange:
+                    \_constant: , line:46:6, endln:46:7
+                      |vpiDecompile:3
+                      |vpiSize:64
+                      |UINT:3
+                      |vpiConstType:9
+                    |vpiRightRange:
+                    \_constant: , line:46:8, endln:46:9
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:rx_sample_cnt
                 |vpiFullName:work@uart.rx_sample_cnt
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:46:6, endln:46:9
-                  |vpiLeftRange:
-                  \_constant: , line:46:6, endln:46:7
-                    |vpiDecompile:3
-                    |vpiSize:64
-                    |UINT:3
-                    |vpiConstType:9
-                  |vpiRightRange:
-                  \_constant: , line:46:8, endln:46:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
           |vpiStmt:
           \_assignment: , line:61:3, endln:61:21, parent:work@uart
             |vpiOpType:82
@@ -7719,23 +7785,25 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.rx_cnt
               |vpiActual:
               \_logic_net: (work@uart.rx_cnt), line:47:14, endln:47:20, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:47:1, endln:47:4
+                  |vpiRange:
+                  \_range: , line:47:6, endln:47:9
+                    |vpiLeftRange:
+                    \_constant: , line:47:6, endln:47:7
+                      |vpiDecompile:3
+                      |vpiSize:64
+                      |UINT:3
+                      |vpiConstType:9
+                    |vpiRightRange:
+                    \_constant: , line:47:8, endln:47:9
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:rx_cnt
                 |vpiFullName:work@uart.rx_cnt
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:47:6, endln:47:9
-                  |vpiLeftRange:
-                  \_constant: , line:47:6, endln:47:7
-                    |vpiDecompile:3
-                    |vpiSize:64
-                    |UINT:3
-                    |vpiConstType:9
-                  |vpiRightRange:
-                  \_constant: , line:47:8, endln:47:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
           |vpiStmt:
           \_assignment: , line:62:3, endln:62:21, parent:work@uart
             |vpiOpType:82
@@ -7751,6 +7819,8 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.rx_frame_err
               |vpiActual:
               \_logic_net: (work@uart.rx_frame_err), line:48:14, endln:48:26, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:48:1, endln:48:4
                 |vpiName:rx_frame_err
                 |vpiFullName:work@uart.rx_frame_err
                 |vpiNetType:48
@@ -7769,6 +7839,8 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.rx_over_run
               |vpiActual:
               \_logic_net: (work@uart.rx_over_run), line:49:14, endln:49:25, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:49:1, endln:49:4
                 |vpiName:rx_over_run
                 |vpiFullName:work@uart.rx_over_run
                 |vpiNetType:48
@@ -7787,6 +7859,8 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.rx_empty
               |vpiActual:
               \_logic_net: (work@uart.rx_empty), line:50:14, endln:50:22, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:50:1, endln:50:4
                 |vpiName:rx_empty
                 |vpiFullName:work@uart.rx_empty
                 |vpiNetType:48
@@ -7805,6 +7879,8 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.rx_d1
               |vpiActual:
               \_logic_net: (work@uart.rx_d1), line:51:14, endln:51:19, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:51:1, endln:51:4
                 |vpiName:rx_d1
                 |vpiFullName:work@uart.rx_d1
                 |vpiNetType:48
@@ -7823,6 +7899,8 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.rx_d2
               |vpiActual:
               \_logic_net: (work@uart.rx_d2), line:52:14, endln:52:19, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:52:1, endln:52:4
                 |vpiName:rx_d2
                 |vpiFullName:work@uart.rx_d2
                 |vpiNetType:48
@@ -7841,6 +7919,8 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.rx_busy
               |vpiActual:
               \_logic_net: (work@uart.rx_busy), line:53:14, endln:53:21, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:53:1, endln:53:4
                 |vpiName:rx_busy
                 |vpiFullName:work@uart.rx_busy
                 |vpiNetType:48
@@ -8425,23 +8505,25 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.tx_reg
               |vpiActual:
               \_logic_net: (work@uart.tx_reg), line:39:14, endln:39:20, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:39:1, endln:39:4
+                  |vpiRange:
+                  \_range: , line:39:6, endln:39:9
+                    |vpiLeftRange:
+                    \_constant: , line:39:6, endln:39:7
+                      |vpiDecompile:7
+                      |vpiSize:64
+                      |UINT:7
+                      |vpiConstType:9
+                    |vpiRightRange:
+                    \_constant: , line:39:8, endln:39:9
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:tx_reg
                 |vpiFullName:work@uart.tx_reg
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:39:6, endln:39:9
-                  |vpiLeftRange:
-                  \_constant: , line:39:6, endln:39:7
-                    |vpiDecompile:7
-                    |vpiSize:64
-                    |UINT:7
-                    |vpiConstType:9
-                  |vpiRightRange:
-                  \_constant: , line:39:8, endln:39:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
           |vpiStmt:
           \_assignment: , line:123:3, endln:123:21, parent:work@uart
             |vpiOpType:82
@@ -8457,6 +8539,8 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.tx_empty
               |vpiActual:
               \_logic_net: (work@uart.tx_empty), line:40:14, endln:40:22, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:40:1, endln:40:4
                 |vpiName:tx_empty
                 |vpiFullName:work@uart.tx_empty
                 |vpiNetType:48
@@ -8475,6 +8559,8 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.tx_over_run
               |vpiActual:
               \_logic_net: (work@uart.tx_over_run), line:41:14, endln:41:25, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:41:1, endln:41:4
                 |vpiName:tx_over_run
                 |vpiFullName:work@uart.tx_over_run
                 |vpiNetType:48
@@ -8493,6 +8579,8 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.tx_out
               |vpiActual:
               \_logic_net: (work@uart.tx_out), line:43:14, endln:43:20, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:43:1, endln:43:4
                 |vpiName:tx_out
                 |vpiFullName:work@uart.tx_out
                 |vpiNetType:48
@@ -8511,23 +8599,25 @@ design: (work@dff_async_reset)
               |vpiFullName:work@uart.tx_cnt
               |vpiActual:
               \_logic_net: (work@uart.tx_cnt), line:42:14, endln:42:20, parent:work@uart
+                |vpiTypespec:
+                \_logic_typespec: , line:42:1, endln:42:4
+                  |vpiRange:
+                  \_range: , line:42:6, endln:42:9
+                    |vpiLeftRange:
+                    \_constant: , line:42:6, endln:42:7
+                      |vpiDecompile:3
+                      |vpiSize:64
+                      |UINT:3
+                      |vpiConstType:9
+                    |vpiRightRange:
+                    \_constant: , line:42:8, endln:42:9
+                      |vpiDecompile:0
+                      |vpiSize:64
+                      |UINT:0
+                      |vpiConstType:9
                 |vpiName:tx_cnt
                 |vpiFullName:work@uart.tx_cnt
                 |vpiNetType:48
-                |vpiRange:
-                \_range: , line:42:6, endln:42:9
-                  |vpiLeftRange:
-                  \_constant: , line:42:6, endln:42:7
-                    |vpiDecompile:3
-                    |vpiSize:64
-                    |UINT:3
-                    |vpiConstType:9
-                  |vpiRightRange:
-                  \_constant: , line:42:8, endln:42:9
-                    |vpiDecompile:0
-                    |vpiSize:64
-                    |UINT:0
-                    |vpiConstType:9
         |vpiElseStmt:
         \_begin: (work@uart), line:127:10, endln:153:4
           |vpiFullName:work@uart
@@ -8585,22 +8675,24 @@ design: (work@dff_async_reset)
                       |vpiFullName:work@uart.tx_data
                       |vpiActual:
                       \_logic_net: (work@uart.tx_data), line:12:1, endln:12:8, parent:work@uart
+                        |vpiTypespec:
+                        \_logic_typespec: , line:27:8, endln:27:13
+                          |vpiRange:
+                          \_range: , line:27:9, endln:27:12
+                            |vpiLeftRange:
+                            \_constant: , line:27:9, endln:27:10
+                              |vpiDecompile:7
+                              |vpiSize:64
+                              |UINT:7
+                              |vpiConstType:9
+                            |vpiRightRange:
+                            \_constant: , line:27:11, endln:27:12
+                              |vpiDecompile:0
+                              |vpiSize:64
+                              |UINT:0
+                              |vpiConstType:9
                         |vpiName:tx_data
                         |vpiFullName:work@uart.tx_data
-                        |vpiRange:
-                        \_range: , line:27:9, endln:27:12
-                          |vpiLeftRange:
-                          \_constant: , line:27:9, endln:27:10
-                            |vpiDecompile:7
-                            |vpiSize:64
-                            |UINT:7
-                            |vpiConstType:9
-                          |vpiRightRange:
-                          \_constant: , line:27:11, endln:27:12
-                            |vpiDecompile:0
-                            |vpiSize:64
-                            |UINT:0
-                            |vpiConstType:9
                     |vpiLhs:
                     \_ref_obj: (work@uart.tx_reg), line:132:9, endln:132:15, parent:work@uart
                       |vpiName:tx_reg
@@ -8947,6 +9039,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@encoder_using_case.binary_out
       |vpiActual:
       \_logic_net: (work@encoder_using_case.binary_out), line:17:11, endln:17:21, parent:work@encoder_using_case
+    |vpiTypedef:
+    \_logic_typespec: , line:12:8, endln:12:13
+      |vpiRange:
+      \_range: , line:12:9, endln:12:12, parent:binary_out
+        |vpiLeftRange:
+        \_constant: , line:12:9, endln:12:10
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:12:11, endln:12:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (encoder_in), line:9:1, endln:9:11, parent:work@encoder_using_case
     |vpiName:encoder_in
@@ -8957,6 +9065,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@encoder_using_case.encoder_in
       |vpiActual:
       \_logic_net: (work@encoder_using_case.encoder_in), line:9:1, endln:9:11, parent:work@encoder_using_case
+    |vpiTypedef:
+    \_logic_typespec: , line:14:7, endln:14:13
+      |vpiRange:
+      \_range: , line:14:8, endln:14:12, parent:encoder_in
+        |vpiLeftRange:
+        \_constant: , line:14:8, endln:14:10
+          |vpiDecompile:15
+          |vpiSize:64
+          |UINT:15
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:14:11, endln:14:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (enable), line:10:1, endln:10:7, parent:work@encoder_using_case
     |vpiName:enable
@@ -8989,6 +9113,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@case1.in1
       |vpiActual:
       \_logic_net: (work@case1.in1), line:2:15, endln:2:18, parent:work@case1
+    |vpiTypedef:
+    \_logic_typespec: , line:3:7, endln:3:12
+      |vpiRange:
+      \_range: , line:3:8, endln:3:11, parent:in1
+        |vpiLeftRange:
+        \_constant: , line:3:8, endln:3:9
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:3:10, endln:3:11
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (in2), line:2:20, endln:2:23, parent:work@case1
     |vpiName:in2
@@ -8999,6 +9139,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@case1.in2
       |vpiActual:
       \_logic_net: (work@case1.in2), line:2:20, endln:2:23, parent:work@case1
+    |vpiTypedef:
+    \_logic_typespec: , line:4:7, endln:4:12
+      |vpiRange:
+      \_range: , line:4:8, endln:4:11, parent:in2
+        |vpiLeftRange:
+        \_constant: , line:4:8, endln:4:9
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:4:10, endln:4:11
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (out2), line:2:25, endln:2:29, parent:work@case1
     |vpiName:out2
@@ -9022,22 +9178,24 @@ design: (work@dff_async_reset)
   \_logic_net: (work@case2.sel), line:21:20, endln:21:23, parent:work@case2
   |vpiNet:
   \_logic_net: (work@case2.out2), line:21:25, endln:21:29, parent:work@case2
+    |vpiTypespec:
+    \_logic_typespec: , line:24:8, endln:24:14
+      |vpiRange:
+      \_range: , line:24:9, endln:24:13
+        |vpiLeftRange:
+        \_constant: , line:24:9, endln:24:11
+          |vpiDecompile:15
+          |vpiSize:64
+          |UINT:15
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:24:12, endln:24:13
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:out2
     |vpiFullName:work@case2.out2
-    |vpiRange:
-    \_range: , line:24:9, endln:24:13
-      |vpiLeftRange:
-      \_constant: , line:24:9, endln:24:11
-        |vpiDecompile:15
-        |vpiSize:64
-        |UINT:15
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:24:12, endln:24:13
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiTopModule:1
   |vpiPort:
   \_port: (in1), line:21:15, endln:21:18, parent:work@case2
@@ -9049,6 +9207,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@case2.in1
       |vpiActual:
       \_logic_net: (work@case2.in1), line:21:15, endln:21:18, parent:work@case2
+    |vpiTypedef:
+    \_logic_typespec: , line:22:7, endln:22:12
+      |vpiRange:
+      \_range: , line:22:8, endln:22:11, parent:in1
+        |vpiLeftRange:
+        \_constant: , line:22:8, endln:22:9
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:22:10, endln:22:11
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (sel), line:21:20, endln:21:23, parent:work@case2
     |vpiName:sel
@@ -9059,6 +9233,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@case2.sel
       |vpiActual:
       \_logic_net: (work@case2.sel), line:21:20, endln:21:23, parent:work@case2
+    |vpiTypedef:
+    \_logic_typespec: , line:23:7, endln:23:12
+      |vpiRange:
+      \_range: , line:23:8, endln:23:11, parent:sel
+        |vpiLeftRange:
+        \_constant: , line:23:8, endln:23:9
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:23:10, endln:23:11
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (out2), line:21:25, endln:21:29, parent:work@case2
     |vpiName:out2
@@ -9069,6 +9259,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@case2.out2
       |vpiActual:
       \_logic_net: (work@case2.out2), line:21:25, endln:21:29, parent:work@case2
+    |vpiTypedef:
+    \_logic_typespec: , line:24:8, endln:24:14
+      |vpiRange:
+      \_range: , line:24:9, endln:24:13, parent:out2
+        |vpiLeftRange:
+        \_constant: , line:24:9, endln:24:11
+          |vpiDecompile:15
+          |vpiSize:64
+          |UINT:15
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:24:12, endln:24:13
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
 |uhdmtopModules:
 \_module: work@pri_encooder (work@pri_encooder) m_input_mult.v:49:1: , endln:73:10
   |vpiName:work@pri_encooder
@@ -9093,6 +9299,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@pri_encooder.Op
       |vpiActual:
       \_logic_net: (work@pri_encooder.Op), line:49:22, endln:49:24, parent:work@pri_encooder
+    |vpiTypedef:
+    \_logic_typespec: , line:50:7, endln:50:12
+      |vpiRange:
+      \_range: , line:50:8, endln:50:11, parent:Op
+        |vpiLeftRange:
+        \_constant: , line:50:8, endln:50:9
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:50:10, endln:50:11
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (Funct), line:49:26, endln:49:31, parent:work@pri_encooder
     |vpiName:Funct
@@ -9103,6 +9325,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@pri_encooder.Funct
       |vpiActual:
       \_logic_net: (work@pri_encooder.Funct), line:49:26, endln:49:31, parent:work@pri_encooder
+    |vpiTypedef:
+    \_logic_typespec: , line:51:7, endln:51:12
+      |vpiRange:
+      \_range: , line:51:8, endln:51:11, parent:Funct
+        |vpiLeftRange:
+        \_constant: , line:51:8, endln:51:9
+          |vpiDecompile:4
+          |vpiSize:64
+          |UINT:4
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:51:10, endln:51:11
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (Sel), line:49:33, endln:49:36, parent:work@pri_encooder
     |vpiName:Sel
@@ -9113,6 +9351,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@pri_encooder.Sel
       |vpiActual:
       \_logic_net: (work@pri_encooder.Sel), line:49:33, endln:49:36, parent:work@pri_encooder
+    |vpiTypedef:
+    \_logic_typespec: , line:52:8, endln:52:13
+      |vpiRange:
+      \_range: , line:52:9, endln:52:12, parent:Sel
+        |vpiLeftRange:
+        \_constant: , line:52:9, endln:52:10
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:52:11, endln:52:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (B), line:49:38, endln:49:39, parent:work@pri_encooder
     |vpiName:B
@@ -9200,22 +9454,24 @@ design: (work@dff_async_reset)
   \_logic_net: (work@syn_fifo.rd_cs), line:12:1, endln:12:6, parent:work@syn_fifo
   |vpiNet:
   \_logic_net: (work@syn_fifo.data_in), line:13:1, endln:13:8, parent:work@syn_fifo
+    |vpiTypespec:
+    \_logic_typespec: , line:32:7, endln:32:23
+      |vpiRange:
+      \_range: , line:32:8, endln:32:22
+        |vpiLeftRange:
+        \_constant: , line:32:8, endln:32:18
+          |vpiDecompile:7
+          |vpiSize:64
+          |INT:7
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:32:21, endln:32:22
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:data_in
     |vpiFullName:work@syn_fifo.data_in
-    |vpiRange:
-    \_range: , line:32:8, endln:32:22
-      |vpiLeftRange:
-      \_constant: , line:32:8, endln:32:18
-        |vpiDecompile:7
-        |vpiSize:64
-        |INT:7
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:32:21, endln:32:22
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@syn_fifo.rd_en), line:14:1, endln:14:6, parent:work@syn_fifo
   |vpiNet:
@@ -9275,6 +9531,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@syn_fifo.data_in
       |vpiActual:
       \_logic_net: (work@syn_fifo.data_in), line:13:1, endln:13:8, parent:work@syn_fifo
+    |vpiTypedef:
+    \_logic_typespec: , line:32:7, endln:32:23
+      |vpiRange:
+      \_range: , line:32:8, endln:32:22, parent:data_in
+        |vpiLeftRange:
+        \_constant: , line:32:8, endln:32:18
+          |vpiDecompile:7
+          |vpiSize:64
+          |INT:7
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:32:21, endln:32:22
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (rd_en), line:14:1, endln:14:6, parent:work@syn_fifo
     |vpiName:rd_en
@@ -9305,6 +9577,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@syn_fifo.data_out
       |vpiActual:
       \_logic_net: (work@syn_fifo.data_out), line:41:22, endln:41:30, parent:work@syn_fifo
+    |vpiTypedef:
+    \_logic_typespec: , line:35:8, endln:35:24
+      |vpiRange:
+      \_range: , line:35:9, endln:35:23, parent:data_out
+        |vpiLeftRange:
+        \_constant: , line:35:9, endln:35:19
+          |vpiDecompile:7
+          |vpiSize:64
+          |INT:7
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:35:22, endln:35:23
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (empty), line:17:1, endln:17:6, parent:work@syn_fifo
     |vpiName:empty
@@ -9516,6 +9804,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@uart.tx_data
       |vpiActual:
       \_logic_net: (work@uart.tx_data), line:12:1, endln:12:8, parent:work@uart
+    |vpiTypedef:
+    \_logic_typespec: , line:27:8, endln:27:13
+      |vpiRange:
+      \_range: , line:27:9, endln:27:12, parent:tx_data
+        |vpiLeftRange:
+        \_constant: , line:27:9, endln:27:10
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:27:11, endln:27:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (tx_enable), line:13:1, endln:13:10, parent:work@uart
     |vpiName:tx_enable
@@ -9576,6 +9880,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@uart.rx_data
       |vpiActual:
       \_logic_net: (work@uart.rx_data), line:45:14, endln:45:21, parent:work@uart
+    |vpiTypedef:
+    \_logic_typespec: , line:33:8, endln:33:13
+      |vpiRange:
+      \_range: , line:33:9, endln:33:12, parent:rx_data
+        |vpiLeftRange:
+        \_constant: , line:33:9, endln:33:10
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:33:11, endln:33:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (rx_enable), line:19:1, endln:19:10, parent:work@uart
     |vpiName:rx_enable
@@ -9625,21 +9945,29 @@ design: (work@dff_async_reset)
   \_logic_net: (work@top.req0), line:10:17, endln:10:21, parent:work@top
   |vpiNet:
   \_logic_net: (work@top.gnt3), line:11:17, endln:11:21, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:11:1, endln:11:5
     |vpiName:gnt3
     |vpiFullName:work@top.gnt3
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@top.gnt2), line:12:17, endln:12:21, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:12:1, endln:12:5
     |vpiName:gnt2
     |vpiFullName:work@top.gnt2
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@top.gnt1), line:13:17, endln:13:21, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:13:1, endln:13:5
     |vpiName:gnt1
     |vpiFullName:work@top.gnt1
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@top.gnt0), line:14:17, endln:14:21, parent:work@top
+    |vpiTypespec:
+    \_logic_typespec: , line:14:1, endln:14:5
     |vpiName:gnt0
     |vpiFullName:work@top.gnt0
     |vpiNetType:1
@@ -9760,22 +10088,24 @@ design: (work@dff_async_reset)
           |vpiConstType:9
       |vpiNet:
       \_logic_net: (work@top.U.prio), line:19:27, endln:19:31, parent:work@top.U.prio
+        |vpiTypespec:
+        \_logic_typespec: , line:19:2, endln:19:5
+          |vpiRange:
+          \_range: , line:19:7, endln:19:25
+            |vpiLeftRange:
+            \_constant: , line:19:7, endln:19:19
+              |vpiDecompile:2
+              |vpiSize:64
+              |INT:2
+              |vpiConstType:7
+            |vpiRightRange:
+            \_constant: , line:19:24, endln:19:25
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiFullName:work@top.U.prio
         |vpiNetType:48
-        |vpiRange:
-        \_range: , line:19:7, endln:19:25
-          |vpiLeftRange:
-          \_constant: , line:19:7, endln:19:19
-            |vpiDecompile:2
-            |vpiSize:64
-            |INT:2
-            |vpiConstType:7
-          |vpiRightRange:
-          \_constant: , line:19:24, endln:19:25
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
     |vpiArrayNet:
     \_array_net: (work@top.U.scan), line:34:27, endln:34:31, parent:work@top.U
       |vpiSize:1
@@ -9797,22 +10127,24 @@ design: (work@dff_async_reset)
           |vpiConstType:9
       |vpiNet:
       \_logic_net: (work@top.U.scan), line:34:27, endln:34:31, parent:work@top.U.scan
+        |vpiTypespec:
+        \_logic_typespec: , line:34:2, endln:34:5
+          |vpiRange:
+          \_range: , line:34:7, endln:34:25
+            |vpiLeftRange:
+            \_constant: , line:34:7, endln:34:19
+              |vpiDecompile:2
+              |vpiSize:64
+              |INT:2
+              |vpiConstType:7
+            |vpiRightRange:
+            \_constant: , line:34:24, endln:34:25
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiFullName:work@top.U.scan
         |vpiNetType:48
-        |vpiRange:
-        \_range: , line:34:7, endln:34:25
-          |vpiLeftRange:
-          \_constant: , line:34:7, endln:34:19
-            |vpiDecompile:2
-            |vpiSize:64
-            |INT:2
-            |vpiConstType:7
-          |vpiRightRange:
-          \_constant: , line:34:24, endln:34:25
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
     |vpiArrayNet:
     \_array_net: (work@top.U.selectPrio), line:38:27, endln:38:37, parent:work@top.U
       |vpiSize:1
@@ -9834,22 +10166,24 @@ design: (work@dff_async_reset)
           |vpiConstType:9
       |vpiNet:
       \_logic_net: (work@top.U.selectPrio), line:38:27, endln:38:37, parent:work@top.U.selectPrio
+        |vpiTypespec:
+        \_logic_typespec: , line:38:2, endln:38:5
+          |vpiRange:
+          \_range: , line:38:7, endln:38:25
+            |vpiLeftRange:
+            \_constant: , line:38:7, endln:38:19
+              |vpiDecompile:2
+              |vpiSize:64
+              |INT:2
+              |vpiConstType:7
+            |vpiRightRange:
+            \_constant: , line:38:24, endln:38:25
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
         |vpiFullName:work@top.U.selectPrio
         |vpiNetType:48
-        |vpiRange:
-        \_range: , line:38:7, endln:38:25
-          |vpiLeftRange:
-          \_constant: , line:38:7, endln:38:19
-            |vpiDecompile:2
-            |vpiSize:64
-            |INT:2
-            |vpiConstType:7
-          |vpiRightRange:
-          \_constant: , line:38:24, endln:38:25
-            |vpiDecompile:0
-            |vpiSize:64
-            |UINT:0
-            |vpiConstType:9
     |vpiInstance:
     \_module: work@top (work@top) arbiter_tb.v:3:1: , endln:64:10
     |vpiPort:
@@ -9916,6 +10250,22 @@ design: (work@dff_async_reset)
         |vpiFullName:work@top.U.request
         |vpiActual:
         \_logic_net: (work@top.U.request), line:2:47, endln:2:54, parent:work@top.U
+      |vpiTypedef:
+      \_logic_typespec: , line:15:8, endln:15:24
+        |vpiRange:
+        \_range: , line:15:9, endln:15:23, parent:request
+          |vpiLeftRange:
+          \_constant: , line:15:9, endln:15:17
+            |vpiDecompile:7
+            |vpiSize:64
+            |INT:7
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:15:22, endln:15:23
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
     |vpiPort:
     \_port: (tpriority), line:2:56, endln:2:65, parent:work@top.U
       |vpiName:tpriority
@@ -9932,6 +10282,22 @@ design: (work@dff_async_reset)
         |vpiFullName:work@top.U.tpriority
         |vpiActual:
         \_logic_net: (work@top.U.tpriority), line:2:56, endln:2:65, parent:work@top.U
+      |vpiTypedef:
+      \_logic_typespec: , line:16:8, endln:16:37
+        |vpiRange:
+        \_range: , line:16:9, endln:16:36, parent:tpriority
+          |vpiLeftRange:
+          \_constant: , line:16:9, endln:16:30
+            |vpiDecompile:23
+            |vpiSize:64
+            |INT:23
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:16:35, endln:16:36
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
     |vpiPort:
     \_port: (grant), line:2:67, endln:2:72, parent:work@top.U
       |vpiName:grant
@@ -9948,6 +10314,22 @@ design: (work@dff_async_reset)
         |vpiFullName:work@top.U.grant
         |vpiActual:
         \_logic_net: (work@top.U.grant), line:30:23, endln:30:28, parent:work@top.U
+      |vpiTypedef:
+      \_logic_typespec: , line:17:9, endln:17:25
+        |vpiRange:
+        \_range: , line:17:10, endln:17:24, parent:grant
+          |vpiLeftRange:
+          \_constant: , line:17:10, endln:17:18
+            |vpiDecompile:7
+            |vpiSize:64
+            |INT:7
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:17:23, endln:17:24
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
 |uhdmtopModules:
 \_module: work@full_adder_gates (work@full_adder_gates) full_adder.v:7:1: , endln:18:10
   |vpiName:work@full_adder_gates
@@ -9955,21 +10337,29 @@ design: (work@dff_async_reset)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@full_adder_gates.and1), line:10:6, endln:10:10, parent:work@full_adder_gates
+    |vpiTypespec:
+    \_logic_typespec: , line:10:1, endln:10:5
     |vpiName:and1
     |vpiFullName:work@full_adder_gates.and1
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@full_adder_gates.and2), line:10:11, endln:10:15, parent:work@full_adder_gates
+    |vpiTypespec:
+    \_logic_typespec: , line:10:1, endln:10:5
     |vpiName:and2
     |vpiFullName:work@full_adder_gates.and2
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@full_adder_gates.and3), line:10:16, endln:10:20, parent:work@full_adder_gates
+    |vpiTypespec:
+    \_logic_typespec: , line:10:1, endln:10:5
     |vpiName:and3
     |vpiFullName:work@full_adder_gates.and3
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@full_adder_gates.sum1), line:10:21, endln:10:25, parent:work@full_adder_gates
+    |vpiTypespec:
+    \_logic_typespec: , line:10:1, endln:10:5
     |vpiName:sum1
     |vpiFullName:work@full_adder_gates.sum1
     |vpiNetType:1
@@ -10287,6 +10677,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@LFSR_TASK.seed1
       |vpiActual:
       \_logic_net: (work@LFSR_TASK.seed1), line:2:33, endln:2:38, parent:work@LFSR_TASK
+    |vpiTypedef:
+    \_logic_typespec: , line:4:7, endln:4:12
+      |vpiRange:
+      \_range: , line:4:8, endln:4:11, parent:seed1
+        |vpiLeftRange:
+        \_constant: , line:4:8, endln:4:9
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:4:10, endln:4:11
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (seed2), line:2:40, endln:2:45, parent:work@LFSR_TASK
     |vpiName:seed2
@@ -10307,6 +10713,22 @@ design: (work@dff_async_reset)
       |vpiFullName:work@LFSR_TASK.random1
       |vpiActual:
       \_logic_net: (work@LFSR_TASK.random1), line:6:11, endln:6:18, parent:work@LFSR_TASK
+    |vpiTypedef:
+    \_logic_typespec: , line:5:8, endln:5:13
+      |vpiRange:
+      \_range: , line:5:9, endln:5:12, parent:random1
+        |vpiLeftRange:
+        \_constant: , line:5:9, endln:5:10
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:5:11, endln:5:12
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
   |vpiPort:
   \_port: (random2), line:2:56, endln:2:63, parent:work@LFSR_TASK
     |vpiName:random2
@@ -10317,6 +10739,8 @@ design: (work@dff_async_reset)
       |vpiFullName:work@LFSR_TASK.random2
       |vpiActual:
       \_logic_net: (work@LFSR_TASK.random2), line:6:20, endln:6:27, parent:work@LFSR_TASK
+    |vpiTypedef:
+    \_logic_typespec: , line:5:8, endln:5:13
 |uhdmtopModules:
 \_module: work@mux21_switch (work@mux21_switch) mux21.v:7:1: , endln:22:10
   |vpiName:work@mux21_switch
@@ -10324,16 +10748,22 @@ design: (work@dff_async_reset)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@mux21_switch.e), line:11:18, endln:11:19, parent:work@mux21_switch
+    |vpiTypespec:
+    \_logic_typespec: , line:11:4, endln:11:8
     |vpiName:e
     |vpiFullName:work@mux21_switch.e
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@mux21_switch.power), line:13:12, endln:13:17, parent:work@mux21_switch
+    |vpiTypespec:
+    \_logic_typespec: , line:13:4, endln:13:11
     |vpiName:power
     |vpiFullName:work@mux21_switch.power
     |vpiNetType:10
   |vpiNet:
   \_logic_net: (work@mux21_switch.ground), line:14:12, endln:14:18, parent:work@mux21_switch
+    |vpiTypespec:
+    \_logic_typespec: , line:14:4, endln:14:11
     |vpiName:ground
     |vpiFullName:work@mux21_switch.ground
     |vpiNetType:11

--- a/third_party/tests/Sky130Cell/Sky130Cell.log
+++ b/third_party/tests/Sky130Cell/Sky130Cell.log
@@ -2293,11 +2293,15 @@ design: (work@sky130_fd_sc_hd__dfrtp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfrtp.buf_Q), line:50:10, endln:50:15, parent:work@sky130_fd_sc_hd__dfrtp
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dfrtp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfrtp.RESET), line:51:10, endln:51:15, parent:work@sky130_fd_sc_hd__dfrtp
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__dfrtp.RESET
     |vpiNetType:1
@@ -2640,11 +2644,15 @@ design: (work@sky130_fd_sc_hd__sdfxbp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfxbp.buf_Q), line:55:10, endln:55:15, parent:work@sky130_fd_sc_hd__sdfxbp
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__sdfxbp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfxbp.mux_out), line:56:10, endln:56:17, parent:work@sky130_fd_sc_hd__sdfxbp
+    |vpiTypespec:
+    \_logic_typespec: , line:56:5, endln:56:9
     |vpiName:mux_out
     |vpiFullName:work@sky130_fd_sc_hd__sdfxbp.mux_out
     |vpiNetType:1
@@ -2920,11 +2928,15 @@ design: (work@sky130_fd_sc_hd__o41ai)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o41ai.or0_out), line:53:10, endln:53:17, parent:work@sky130_fd_sc_hd__o41ai
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o41ai.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o41ai.nand0_out_Y), line:54:10, endln:54:21, parent:work@sky130_fd_sc_hd__o41ai
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:nand0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__o41ai.nand0_out_Y
     |vpiNetType:1
@@ -3178,6 +3190,8 @@ design: (work@sky130_fd_sc_hd__clkdlybuf4s15)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__clkdlybuf4s15.buf0_out_X), line:44:10, endln:44:20, parent:work@sky130_fd_sc_hd__clkdlybuf4s15
+    |vpiTypespec:
+    \_logic_typespec: , line:44:5, endln:44:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__clkdlybuf4s15.buf0_out_X
     |vpiNetType:1
@@ -3490,16 +3504,22 @@ design: (work@sky130_fd_sc_hd__sedfxtp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sedfxtp.buf_Q), line:56:10, endln:56:15, parent:work@sky130_fd_sc_hd__sedfxtp
+    |vpiTypespec:
+    \_logic_typespec: , line:56:5, endln:56:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__sedfxtp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sedfxtp.mux_out), line:57:10, endln:57:17, parent:work@sky130_fd_sc_hd__sedfxtp
+    |vpiTypespec:
+    \_logic_typespec: , line:57:5, endln:57:9
     |vpiName:mux_out
     |vpiFullName:work@sky130_fd_sc_hd__sedfxtp.mux_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sedfxtp.de_d), line:58:10, endln:58:14, parent:work@sky130_fd_sc_hd__sedfxtp
+    |vpiTypespec:
+    \_logic_typespec: , line:58:5, endln:58:9
     |vpiName:de_d
     |vpiFullName:work@sky130_fd_sc_hd__sedfxtp.de_d
     |vpiNetType:1
@@ -3696,6 +3716,8 @@ design: (work@sky130_fd_sc_hd__xor2)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__xor2.xor0_out_X), line:47:10, endln:47:20, parent:work@sky130_fd_sc_hd__xor2
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:xor0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__xor2.xor0_out_X
     |vpiNetType:1
@@ -3901,41 +3923,57 @@ design: (work@sky130_fd_sc_hd__macro_sparecell)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__macro_sparecell.nor2left), line:49:10, endln:49:18, parent:work@sky130_fd_sc_hd__macro_sparecell
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:nor2left
     |vpiFullName:work@sky130_fd_sc_hd__macro_sparecell.nor2left
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__macro_sparecell.invleft), line:50:10, endln:50:17, parent:work@sky130_fd_sc_hd__macro_sparecell
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:invleft
     |vpiFullName:work@sky130_fd_sc_hd__macro_sparecell.invleft
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__macro_sparecell.nor2right), line:51:10, endln:51:19, parent:work@sky130_fd_sc_hd__macro_sparecell
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:nor2right
     |vpiFullName:work@sky130_fd_sc_hd__macro_sparecell.nor2right
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__macro_sparecell.invright), line:52:10, endln:52:18, parent:work@sky130_fd_sc_hd__macro_sparecell
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:invright
     |vpiFullName:work@sky130_fd_sc_hd__macro_sparecell.invright
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__macro_sparecell.nd2left), line:53:10, endln:53:17, parent:work@sky130_fd_sc_hd__macro_sparecell
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:nd2left
     |vpiFullName:work@sky130_fd_sc_hd__macro_sparecell.nd2left
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__macro_sparecell.nd2right), line:54:10, endln:54:18, parent:work@sky130_fd_sc_hd__macro_sparecell
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:nd2right
     |vpiFullName:work@sky130_fd_sc_hd__macro_sparecell.nd2right
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__macro_sparecell.tielo), line:55:10, endln:55:15, parent:work@sky130_fd_sc_hd__macro_sparecell
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:tielo
     |vpiFullName:work@sky130_fd_sc_hd__macro_sparecell.tielo
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__macro_sparecell.net7), line:56:10, endln:56:14, parent:work@sky130_fd_sc_hd__macro_sparecell
+    |vpiTypespec:
+    \_logic_typespec: , line:56:5, endln:56:9
     |vpiName:net7
     |vpiFullName:work@sky130_fd_sc_hd__macro_sparecell.net7
     |vpiNetType:1
@@ -4260,6 +4298,8 @@ design: (work@sky130_fd_sc_hd__inv)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__inv.not0_out_Y), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__inv
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:not0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__inv.not0_out_Y
     |vpiNetType:1
@@ -4409,11 +4449,15 @@ design: (work@sky130_fd_sc_hd__lpflow_isobufsrc)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__lpflow_isobufsrc.not0_out), line:47:10, endln:47:18, parent:work@sky130_fd_sc_hd__lpflow_isobufsrc
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:not0_out
     |vpiFullName:work@sky130_fd_sc_hd__lpflow_isobufsrc.not0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__lpflow_isobufsrc.and0_out_X), line:48:10, endln:48:20, parent:work@sky130_fd_sc_hd__lpflow_isobufsrc
+    |vpiTypespec:
+    \_logic_typespec: , line:48:5, endln:48:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__lpflow_isobufsrc.and0_out_X
     |vpiNetType:1
@@ -4595,6 +4639,8 @@ design: (work@sky130_fd_sc_hd__clkinvlp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__clkinvlp.not0_out_Y), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__clkinvlp
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:not0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__clkinvlp.not0_out_Y
     |vpiNetType:1
@@ -4727,6 +4773,8 @@ design: (work@sky130_fd_sc_hd__bufinv)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__bufinv.not0_out_Y), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__bufinv
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:not0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__bufinv.not0_out_Y
     |vpiNetType:1
@@ -4917,16 +4965,22 @@ design: (work@sky130_fd_sc_hd__a32o)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a32o.and0_out), line:54:10, endln:54:18, parent:work@sky130_fd_sc_hd__a32o
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a32o.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a32o.and1_out), line:55:10, endln:55:18, parent:work@sky130_fd_sc_hd__a32o
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:and1_out
     |vpiFullName:work@sky130_fd_sc_hd__a32o.and1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a32o.or0_out_X), line:56:10, endln:56:19, parent:work@sky130_fd_sc_hd__a32o
+    |vpiTypespec:
+    \_logic_typespec: , line:56:5, endln:56:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__a32o.or0_out_X
     |vpiNetType:1
@@ -5261,26 +5315,36 @@ design: (work@sky130_fd_sc_hd__fahcon)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fahcon.xor0_out_SUM), line:49:10, endln:49:22, parent:work@sky130_fd_sc_hd__fahcon
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:xor0_out_SUM
     |vpiFullName:work@sky130_fd_sc_hd__fahcon.xor0_out_SUM
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fahcon.a_b), line:50:10, endln:50:13, parent:work@sky130_fd_sc_hd__fahcon
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:a_b
     |vpiFullName:work@sky130_fd_sc_hd__fahcon.a_b
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fahcon.a_ci), line:51:10, endln:51:14, parent:work@sky130_fd_sc_hd__fahcon
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:a_ci
     |vpiFullName:work@sky130_fd_sc_hd__fahcon.a_ci
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fahcon.b_ci), line:52:10, endln:52:14, parent:work@sky130_fd_sc_hd__fahcon
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:b_ci
     |vpiFullName:work@sky130_fd_sc_hd__fahcon.b_ci
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fahcon.or0_out_coutn), line:53:10, endln:53:23, parent:work@sky130_fd_sc_hd__fahcon
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:or0_out_coutn
     |vpiFullName:work@sky130_fd_sc_hd__fahcon.or0_out_coutn
     |vpiNetType:1
@@ -5650,6 +5714,8 @@ design: (work@sky130_fd_sc_hd__dlymetal6s2s)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlymetal6s2s.buf0_out_X), line:44:10, endln:44:20, parent:work@sky130_fd_sc_hd__dlymetal6s2s
+    |vpiTypespec:
+    \_logic_typespec: , line:44:5, endln:44:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__dlymetal6s2s.buf0_out_X
     |vpiNetType:1
@@ -5840,16 +5906,22 @@ design: (work@sky130_fd_sc_hd__o32a)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o32a.or0_out), line:53:10, endln:53:17, parent:work@sky130_fd_sc_hd__o32a
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o32a.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o32a.or1_out), line:54:10, endln:54:17, parent:work@sky130_fd_sc_hd__o32a
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:or1_out
     |vpiFullName:work@sky130_fd_sc_hd__o32a.or1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o32a.and0_out_X), line:55:10, endln:55:20, parent:work@sky130_fd_sc_hd__o32a
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__o32a.and0_out_X
     |vpiNetType:1
@@ -6362,26 +6434,36 @@ design: (work@sky130_fd_sc_hd__sdfbbn)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfbbn.RESET), line:60:10, endln:60:15, parent:work@sky130_fd_sc_hd__sdfbbn
+    |vpiTypespec:
+    \_logic_typespec: , line:60:5, endln:60:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__sdfbbn.RESET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfbbn.SET), line:61:10, endln:61:13, parent:work@sky130_fd_sc_hd__sdfbbn
+    |vpiTypespec:
+    \_logic_typespec: , line:61:5, endln:61:9
     |vpiName:SET
     |vpiFullName:work@sky130_fd_sc_hd__sdfbbn.SET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfbbn.CLK), line:62:10, endln:62:13, parent:work@sky130_fd_sc_hd__sdfbbn
+    |vpiTypespec:
+    \_logic_typespec: , line:62:5, endln:62:9
     |vpiName:CLK
     |vpiFullName:work@sky130_fd_sc_hd__sdfbbn.CLK
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfbbn.buf_Q), line:63:10, endln:63:15, parent:work@sky130_fd_sc_hd__sdfbbn
+    |vpiTypespec:
+    \_logic_typespec: , line:63:5, endln:63:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__sdfbbn.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfbbn.mux_out), line:64:10, endln:64:17, parent:work@sky130_fd_sc_hd__sdfbbn
+    |vpiTypespec:
+    \_logic_typespec: , line:64:5, endln:64:9
     |vpiName:mux_out
     |vpiFullName:work@sky130_fd_sc_hd__sdfbbn.mux_out
     |vpiNetType:1
@@ -6774,6 +6856,8 @@ design: (work@sky130_fd_sc_hd__dfxbp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfxbp.buf_Q), line:50:10, endln:50:15, parent:work@sky130_fd_sc_hd__dfxbp
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dfxbp.buf_Q
     |vpiNetType:1
@@ -7046,16 +7130,22 @@ design: (work@sky130_fd_sc_hd__dlrtn)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlrtn.RESET), line:50:10, endln:50:15, parent:work@sky130_fd_sc_hd__dlrtn
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__dlrtn.RESET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlrtn.intgate), line:51:10, endln:51:17, parent:work@sky130_fd_sc_hd__dlrtn
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:intgate
     |vpiFullName:work@sky130_fd_sc_hd__dlrtn.intgate
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlrtn.buf_Q), line:52:10, endln:52:15, parent:work@sky130_fd_sc_hd__dlrtn
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dlrtn.buf_Q
     |vpiNetType:1
@@ -7331,6 +7421,8 @@ design: (work@sky130_fd_sc_hd__mux2i)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__mux2i.mux_2to1_n0_out_Y), line:50:10, endln:50:27, parent:work@sky130_fd_sc_hd__mux2i
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:mux_2to1_n0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__mux2i.mux_2to1_n0_out_Y
     |vpiNetType:1
@@ -7526,11 +7618,15 @@ design: (work@sky130_fd_sc_hd__o2111ai)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o2111ai.or0_out), line:53:10, endln:53:17, parent:work@sky130_fd_sc_hd__o2111ai
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o2111ai.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o2111ai.nand0_out_Y), line:54:10, endln:54:21, parent:work@sky130_fd_sc_hd__o2111ai
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:nand0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__o2111ai.nand0_out_Y
     |vpiNetType:1
@@ -7859,21 +7955,29 @@ design: (work@sky130_fd_sc_hd__a222oi)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a222oi.nand0_out), line:55:10, endln:55:19, parent:work@sky130_fd_sc_hd__a222oi
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:nand0_out
     |vpiFullName:work@sky130_fd_sc_hd__a222oi.nand0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a222oi.nand1_out), line:56:10, endln:56:19, parent:work@sky130_fd_sc_hd__a222oi
+    |vpiTypespec:
+    \_logic_typespec: , line:56:5, endln:56:9
     |vpiName:nand1_out
     |vpiFullName:work@sky130_fd_sc_hd__a222oi.nand1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a222oi.nand2_out), line:57:10, endln:57:19, parent:work@sky130_fd_sc_hd__a222oi
+    |vpiTypespec:
+    \_logic_typespec: , line:57:5, endln:57:9
     |vpiName:nand2_out
     |vpiFullName:work@sky130_fd_sc_hd__a222oi.nand2_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a222oi.and0_out_Y), line:58:10, endln:58:20, parent:work@sky130_fd_sc_hd__a222oi
+    |vpiTypespec:
+    \_logic_typespec: , line:58:5, endln:58:9
     |vpiName:and0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__a222oi.and0_out_Y
     |vpiNetType:1
@@ -8201,6 +8305,8 @@ design: (work@sky130_fd_sc_hd__clkdlybuf4s25)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__clkdlybuf4s25.buf0_out_X), line:44:10, endln:44:20, parent:work@sky130_fd_sc_hd__clkdlybuf4s25
+    |vpiTypespec:
+    \_logic_typespec: , line:44:5, endln:44:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__clkdlybuf4s25.buf0_out_X
     |vpiNetType:1
@@ -8374,11 +8480,15 @@ design: (work@sky130_fd_sc_hd__or4bb)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__or4bb.nand0_out), line:49:10, endln:49:19, parent:work@sky130_fd_sc_hd__or4bb
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:nand0_out
     |vpiFullName:work@sky130_fd_sc_hd__or4bb.nand0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__or4bb.or0_out_X), line:50:10, endln:50:19, parent:work@sky130_fd_sc_hd__or4bb
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__or4bb.or0_out_X
     |vpiNetType:1
@@ -8746,11 +8856,15 @@ design: (work@sky130_fd_sc_hd__nor4bb)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nor4bb.nor0_out), line:49:10, endln:49:18, parent:work@sky130_fd_sc_hd__nor4bb
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:nor0_out
     |vpiFullName:work@sky130_fd_sc_hd__nor4bb.nor0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nor4bb.and0_out_Y), line:50:10, endln:50:20, parent:work@sky130_fd_sc_hd__nor4bb
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:and0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nor4bb.and0_out_Y
     |vpiNetType:1
@@ -9004,6 +9118,8 @@ design: (work@sky130_fd_sc_hd__nand3)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nand3.nand0_out_Y), line:47:10, endln:47:21, parent:work@sky130_fd_sc_hd__nand3
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:nand0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nand3.nand0_out_Y
     |vpiNetType:1
@@ -9330,21 +9446,29 @@ design: (work@sky130_fd_sc_hd__dfbbn)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfbbn.RESET), line:55:10, endln:55:15, parent:work@sky130_fd_sc_hd__dfbbn
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__dfbbn.RESET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfbbn.SET), line:56:10, endln:56:13, parent:work@sky130_fd_sc_hd__dfbbn
+    |vpiTypespec:
+    \_logic_typespec: , line:56:5, endln:56:9
     |vpiName:SET
     |vpiFullName:work@sky130_fd_sc_hd__dfbbn.SET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfbbn.CLK), line:57:10, endln:57:13, parent:work@sky130_fd_sc_hd__dfbbn
+    |vpiTypespec:
+    \_logic_typespec: , line:57:5, endln:57:9
     |vpiName:CLK
     |vpiFullName:work@sky130_fd_sc_hd__dfbbn.CLK
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfbbn.buf_Q), line:58:10, endln:58:15, parent:work@sky130_fd_sc_hd__dfbbn
+    |vpiTypespec:
+    \_logic_typespec: , line:58:5, endln:58:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dfbbn.buf_Q
     |vpiNetType:1
@@ -9807,16 +9931,22 @@ design: (work@sky130_fd_sc_hd__sedfxbp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sedfxbp.buf_Q), line:58:10, endln:58:15, parent:work@sky130_fd_sc_hd__sedfxbp
+    |vpiTypespec:
+    \_logic_typespec: , line:58:5, endln:58:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__sedfxbp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sedfxbp.mux_out), line:59:10, endln:59:17, parent:work@sky130_fd_sc_hd__sedfxbp
+    |vpiTypespec:
+    \_logic_typespec: , line:59:5, endln:59:9
     |vpiName:mux_out
     |vpiFullName:work@sky130_fd_sc_hd__sedfxbp.mux_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sedfxbp.de_d), line:60:10, endln:60:14, parent:work@sky130_fd_sc_hd__sedfxbp
+    |vpiTypespec:
+    \_logic_typespec: , line:60:5, endln:60:9
     |vpiName:de_d
     |vpiFullName:work@sky130_fd_sc_hd__sedfxbp.de_d
     |vpiNetType:1
@@ -10249,11 +10379,15 @@ design: (work@sky130_fd_sc_hd__sdfxtp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfxtp.buf_Q), line:53:10, endln:53:15, parent:work@sky130_fd_sc_hd__sdfxtp
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__sdfxtp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfxtp.mux_out), line:54:10, endln:54:17, parent:work@sky130_fd_sc_hd__sdfxtp
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:mux_out
     |vpiFullName:work@sky130_fd_sc_hd__sdfxtp.mux_out
     |vpiNetType:1
@@ -10417,6 +10551,8 @@ design: (work@sky130_fd_sc_hd__probec_p)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__probec_p.buf0_out_X), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__probec_p
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__probec_p.buf0_out_X
     |vpiNetType:1
@@ -10590,11 +10726,15 @@ design: (work@sky130_fd_sc_hd__a211oi)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a211oi.and0_out), line:51:10, endln:51:18, parent:work@sky130_fd_sc_hd__a211oi
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a211oi.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a211oi.nor0_out_Y), line:52:10, endln:52:20, parent:work@sky130_fd_sc_hd__a211oi
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:nor0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__a211oi.nor0_out_Y
     |vpiNetType:1
@@ -10870,16 +11010,22 @@ design: (work@sky130_fd_sc_hd__o22a)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o22a.or0_out), line:51:10, endln:51:17, parent:work@sky130_fd_sc_hd__o22a
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o22a.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o22a.or1_out), line:52:10, endln:52:17, parent:work@sky130_fd_sc_hd__o22a
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:or1_out
     |vpiFullName:work@sky130_fd_sc_hd__o22a.or1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o22a.and0_out_X), line:53:10, endln:53:20, parent:work@sky130_fd_sc_hd__o22a
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__o22a.and0_out_X
     |vpiNetType:1
@@ -11209,6 +11355,8 @@ design: (work@sky130_fd_sc_hd__dfxtp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfxtp.buf_Q), line:48:10, endln:48:15, parent:work@sky130_fd_sc_hd__dfxtp
+    |vpiTypespec:
+    \_logic_typespec: , line:48:5, endln:48:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dfxtp.buf_Q
     |vpiNetType:1
@@ -11366,11 +11514,15 @@ design: (work@sky130_fd_sc_hd__a21oi)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a21oi.and0_out), line:49:10, endln:49:18, parent:work@sky130_fd_sc_hd__a21oi
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a21oi.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a21oi.nor0_out_Y), line:50:10, endln:50:20, parent:work@sky130_fd_sc_hd__a21oi
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:nor0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__a21oi.nor0_out_Y
     |vpiNetType:1
@@ -11622,16 +11774,22 @@ design: (work@sky130_fd_sc_hd__a22oi)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a22oi.nand0_out), line:51:10, endln:51:19, parent:work@sky130_fd_sc_hd__a22oi
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:nand0_out
     |vpiFullName:work@sky130_fd_sc_hd__a22oi.nand0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a22oi.nand1_out), line:52:10, endln:52:19, parent:work@sky130_fd_sc_hd__a22oi
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:nand1_out
     |vpiFullName:work@sky130_fd_sc_hd__a22oi.nand1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a22oi.and0_out_Y), line:53:10, endln:53:20, parent:work@sky130_fd_sc_hd__a22oi
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:and0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__a22oi.and0_out_Y
     |vpiNetType:1
@@ -11886,6 +12044,8 @@ design: (work@sky130_fd_sc_hd__lpflow_clkinvkapwr)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__lpflow_clkinvkapwr.not0_out_Y), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__lpflow_clkinvkapwr
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:not0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__lpflow_clkinvkapwr.not0_out_Y
     |vpiNetType:1
@@ -12062,6 +12222,8 @@ design: (work@sky130_fd_sc_hd__and3)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__and3.and0_out_X), line:47:10, endln:47:20, parent:work@sky130_fd_sc_hd__and3
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__and3.and0_out_X
     |vpiNetType:1
@@ -12283,11 +12445,15 @@ design: (work@sky130_fd_sc_hd__o211ai)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o211ai.or0_out), line:51:10, endln:51:17, parent:work@sky130_fd_sc_hd__o211ai
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o211ai.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o211ai.nand0_out_Y), line:52:10, endln:52:21, parent:work@sky130_fd_sc_hd__o211ai
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:nand0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__o211ai.nand0_out_Y
     |vpiNetType:1
@@ -12517,6 +12683,8 @@ design: (work@sky130_fd_sc_hd__clkdlybuf4s18)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__clkdlybuf4s18.buf0_out_X), line:44:10, endln:44:20, parent:work@sky130_fd_sc_hd__clkdlybuf4s18
+    |vpiTypespec:
+    \_logic_typespec: , line:44:5, endln:44:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__clkdlybuf4s18.buf0_out_X
     |vpiNetType:1
@@ -12666,11 +12834,15 @@ design: (work@sky130_fd_sc_hd__or2b)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__or2b.not0_out), line:45:10, endln:45:18, parent:work@sky130_fd_sc_hd__or2b
+    |vpiTypespec:
+    \_logic_typespec: , line:45:5, endln:45:9
     |vpiName:not0_out
     |vpiFullName:work@sky130_fd_sc_hd__or2b.not0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__or2b.or0_out_X), line:46:10, endln:46:19, parent:work@sky130_fd_sc_hd__or2b
+    |vpiTypespec:
+    \_logic_typespec: , line:46:5, endln:46:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__or2b.or0_out_X
     |vpiNetType:1
@@ -13060,16 +13232,22 @@ design: (work@sky130_fd_sc_hd__sdfrbp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfrbp.buf_Q), line:58:10, endln:58:15, parent:work@sky130_fd_sc_hd__sdfrbp
+    |vpiTypespec:
+    \_logic_typespec: , line:58:5, endln:58:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__sdfrbp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfrbp.RESET), line:59:10, endln:59:15, parent:work@sky130_fd_sc_hd__sdfrbp
+    |vpiTypespec:
+    \_logic_typespec: , line:59:5, endln:59:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__sdfrbp.RESET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfrbp.mux_out), line:60:10, endln:60:17, parent:work@sky130_fd_sc_hd__sdfrbp
+    |vpiTypespec:
+    \_logic_typespec: , line:60:5, endln:60:9
     |vpiName:mux_out
     |vpiFullName:work@sky130_fd_sc_hd__sdfrbp.mux_out
     |vpiNetType:1
@@ -13375,11 +13553,15 @@ design: (work@sky130_fd_sc_hd__dlclkp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlclkp.m0), line:48:10, endln:48:12, parent:work@sky130_fd_sc_hd__dlclkp
+    |vpiTypespec:
+    \_logic_typespec: , line:48:5, endln:48:9
     |vpiName:m0
     |vpiFullName:work@sky130_fd_sc_hd__dlclkp.m0
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlclkp.clkn), line:49:10, endln:49:14, parent:work@sky130_fd_sc_hd__dlclkp
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:clkn
     |vpiFullName:work@sky130_fd_sc_hd__dlclkp.clkn
     |vpiNetType:1
@@ -13543,6 +13725,8 @@ design: (work@sky130_fd_sc_hd__clkinv)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__clkinv.not0_out_Y), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__clkinv
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:not0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__clkinv.not0_out_Y
     |vpiNetType:1
@@ -13866,6 +14050,8 @@ design: (work@sky130_fd_sc_hd__mux4)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__mux4.mux_4to20_out_X), line:56:10, endln:56:25, parent:work@sky130_fd_sc_hd__mux4
+    |vpiTypespec:
+    \_logic_typespec: , line:56:5, endln:56:9
     |vpiName:mux_4to20_out_X
     |vpiFullName:work@sky130_fd_sc_hd__mux4.mux_4to20_out_X
     |vpiNetType:1
@@ -14079,11 +14265,15 @@ design: (work@sky130_fd_sc_hd__a21o)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a21o.and0_out), line:49:10, endln:49:18, parent:work@sky130_fd_sc_hd__a21o
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a21o.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a21o.or0_out_X), line:50:10, endln:50:19, parent:work@sky130_fd_sc_hd__a21o
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__a21o.or0_out_X
     |vpiNetType:1
@@ -14325,6 +14515,8 @@ design: (work@sky130_fd_sc_hd__or4)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__or4.or0_out_X), line:49:10, endln:49:19, parent:work@sky130_fd_sc_hd__or4
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__or4.or0_out_X
     |vpiNetType:1
@@ -14529,6 +14721,8 @@ design: (work@sky130_fd_sc_hd__dlygate4sd2)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlygate4sd2.buf0_out_X), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__dlygate4sd2
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__dlygate4sd2.buf0_out_X
     |vpiNetType:1
@@ -14685,6 +14879,8 @@ design: (work@sky130_fd_sc_hd__or3)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__or3.or0_out_X), line:47:10, endln:47:19, parent:work@sky130_fd_sc_hd__or3
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__or3.or0_out_X
     |vpiNetType:1
@@ -14865,6 +15061,8 @@ design: (work@sky130_fd_sc_hd__probe_p)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__probe_p.buf0_out_X), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__probe_p
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__probe_p.buf0_out_X
     |vpiNetType:1
@@ -15058,31 +15256,43 @@ design: (work@sky130_fd_sc_hd__fahcin)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fahcin.ci), line:49:10, endln:49:12, parent:work@sky130_fd_sc_hd__fahcin
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:ci
     |vpiFullName:work@sky130_fd_sc_hd__fahcin.ci
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fahcin.xor0_out_SUM), line:50:10, endln:50:22, parent:work@sky130_fd_sc_hd__fahcin
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:xor0_out_SUM
     |vpiFullName:work@sky130_fd_sc_hd__fahcin.xor0_out_SUM
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fahcin.a_b), line:51:10, endln:51:13, parent:work@sky130_fd_sc_hd__fahcin
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:a_b
     |vpiFullName:work@sky130_fd_sc_hd__fahcin.a_b
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fahcin.a_ci), line:52:10, endln:52:14, parent:work@sky130_fd_sc_hd__fahcin
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:a_ci
     |vpiFullName:work@sky130_fd_sc_hd__fahcin.a_ci
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fahcin.b_ci), line:53:10, endln:53:14, parent:work@sky130_fd_sc_hd__fahcin
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:b_ci
     |vpiFullName:work@sky130_fd_sc_hd__fahcin.b_ci
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fahcin.or0_out_COUT), line:54:10, endln:54:22, parent:work@sky130_fd_sc_hd__fahcin
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:or0_out_COUT
     |vpiFullName:work@sky130_fd_sc_hd__fahcin.or0_out_COUT
     |vpiNetType:1
@@ -15530,11 +15740,15 @@ design: (work@sky130_fd_sc_hd__a2111oi)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a2111oi.and0_out), line:53:10, endln:53:18, parent:work@sky130_fd_sc_hd__a2111oi
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a2111oi.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a2111oi.nor0_out_Y), line:54:10, endln:54:20, parent:work@sky130_fd_sc_hd__a2111oi
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:nor0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__a2111oi.nor0_out_Y
     |vpiNetType:1
@@ -15817,11 +16031,15 @@ design: (work@sky130_fd_sc_hd__o21ba)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o21ba.nor0_out), line:50:10, endln:50:18, parent:work@sky130_fd_sc_hd__o21ba
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:nor0_out
     |vpiFullName:work@sky130_fd_sc_hd__o21ba.nor0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o21ba.nor1_out_X), line:51:10, endln:51:20, parent:work@sky130_fd_sc_hd__o21ba
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:nor1_out_X
     |vpiFullName:work@sky130_fd_sc_hd__o21ba.nor1_out_X
     |vpiNetType:1
@@ -16056,11 +16274,15 @@ design: (work@sky130_fd_sc_hd__nand3b)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nand3b.not0_out), line:47:10, endln:47:18, parent:work@sky130_fd_sc_hd__nand3b
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:not0_out
     |vpiFullName:work@sky130_fd_sc_hd__nand3b.not0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nand3b.nand0_out_Y), line:48:10, endln:48:21, parent:work@sky130_fd_sc_hd__nand3b
+    |vpiTypespec:
+    \_logic_typespec: , line:48:5, endln:48:9
     |vpiName:nand0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nand3b.nand0_out_Y
     |vpiNetType:1
@@ -16266,6 +16488,8 @@ design: (work@sky130_fd_sc_hd__clkbuf)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__clkbuf.buf0_out_X), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__clkbuf
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__clkbuf.buf0_out_X
     |vpiNetType:1
@@ -16456,16 +16680,22 @@ design: (work@sky130_fd_sc_hd__o221a)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o221a.or0_out), line:53:10, endln:53:17, parent:work@sky130_fd_sc_hd__o221a
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o221a.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o221a.or1_out), line:54:10, endln:54:17, parent:work@sky130_fd_sc_hd__o221a
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:or1_out
     |vpiFullName:work@sky130_fd_sc_hd__o221a.or1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o221a.and0_out_X), line:55:10, endln:55:20, parent:work@sky130_fd_sc_hd__o221a
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__o221a.and0_out_X
     |vpiNetType:1
@@ -16802,16 +17032,22 @@ design: (work@sky130_fd_sc_hd__o32ai)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o32ai.nor0_out), line:53:10, endln:53:18, parent:work@sky130_fd_sc_hd__o32ai
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:nor0_out
     |vpiFullName:work@sky130_fd_sc_hd__o32ai.nor0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o32ai.nor1_out), line:54:10, endln:54:18, parent:work@sky130_fd_sc_hd__o32ai
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:nor1_out
     |vpiFullName:work@sky130_fd_sc_hd__o32ai.nor1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o32ai.or0_out_Y), line:55:10, endln:55:19, parent:work@sky130_fd_sc_hd__o32ai
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:or0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__o32ai.or0_out_Y
     |vpiNetType:1
@@ -17102,6 +17338,8 @@ design: (work@sky130_fd_sc_hd__lpflow_inputiso1n)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__lpflow_inputiso1n.SLEEP), line:47:10, endln:47:15, parent:work@sky130_fd_sc_hd__lpflow_inputiso1n
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:SLEEP
     |vpiFullName:work@sky130_fd_sc_hd__lpflow_inputiso1n.SLEEP
     |vpiNetType:1
@@ -17459,21 +17697,29 @@ design: (work@sky130_fd_sc_hd__sdfrtn)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfrtn.buf_Q), line:56:10, endln:56:15, parent:work@sky130_fd_sc_hd__sdfrtn
+    |vpiTypespec:
+    \_logic_typespec: , line:56:5, endln:56:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__sdfrtn.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfrtn.RESET), line:57:10, endln:57:15, parent:work@sky130_fd_sc_hd__sdfrtn
+    |vpiTypespec:
+    \_logic_typespec: , line:57:5, endln:57:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__sdfrtn.RESET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfrtn.intclk), line:58:10, endln:58:16, parent:work@sky130_fd_sc_hd__sdfrtn
+    |vpiTypespec:
+    \_logic_typespec: , line:58:5, endln:58:9
     |vpiName:intclk
     |vpiFullName:work@sky130_fd_sc_hd__sdfrtn.intclk
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfrtn.mux_out), line:59:10, endln:59:17, parent:work@sky130_fd_sc_hd__sdfrtn
+    |vpiTypespec:
+    \_logic_typespec: , line:59:5, endln:59:9
     |vpiName:mux_out
     |vpiFullName:work@sky130_fd_sc_hd__sdfrtn.mux_out
     |vpiNetType:1
@@ -17742,11 +17988,15 @@ design: (work@sky130_fd_sc_hd__nor4b)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nor4b.not0_out), line:49:10, endln:49:18, parent:work@sky130_fd_sc_hd__nor4b
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:not0_out
     |vpiFullName:work@sky130_fd_sc_hd__nor4b.not0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nor4b.nor0_out_Y), line:50:10, endln:50:20, parent:work@sky130_fd_sc_hd__nor4b
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:nor0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nor4b.nor0_out_Y
     |vpiNetType:1
@@ -18029,11 +18279,15 @@ design: (work@sky130_fd_sc_hd__a2111o)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a2111o.and0_out), line:53:10, endln:53:18, parent:work@sky130_fd_sc_hd__a2111o
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a2111o.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a2111o.or0_out_X), line:54:10, endln:54:19, parent:work@sky130_fd_sc_hd__a2111o
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__a2111o.or0_out_X
     |vpiNetType:1
@@ -18323,6 +18577,8 @@ design: (work@sky130_fd_sc_hd__nand4)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nand4.nand0_out_Y), line:49:10, endln:49:21, parent:work@sky130_fd_sc_hd__nand4
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:nand0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nand4.nand0_out_Y
     |vpiNetType:1
@@ -18610,6 +18866,8 @@ design: (work@sky130_fd_sc_hd__mux2)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__mux2.mux_2to10_out_X), line:50:10, endln:50:25, parent:work@sky130_fd_sc_hd__mux2
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:mux_2to10_out_X
     |vpiFullName:work@sky130_fd_sc_hd__mux2.mux_2to10_out_X
     |vpiNetType:1
@@ -18764,6 +19022,8 @@ design: (work@sky130_fd_sc_hd__nand2)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nand2.nand0_out_Y), line:45:10, endln:45:21, parent:work@sky130_fd_sc_hd__nand2
+    |vpiTypespec:
+    \_logic_typespec: , line:45:5, endln:45:9
     |vpiName:nand0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nand2.nand0_out_Y
     |vpiNetType:1
@@ -19032,11 +19292,15 @@ design: (work@sky130_fd_sc_hd__dlrbp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlrbp.RESET), line:53:10, endln:53:15, parent:work@sky130_fd_sc_hd__dlrbp
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__dlrbp.RESET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlrbp.buf_Q), line:54:10, endln:54:15, parent:work@sky130_fd_sc_hd__dlrbp
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dlrbp.buf_Q
     |vpiNetType:1
@@ -19289,16 +19553,22 @@ design: (work@sky130_fd_sc_hd__o2bb2a)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o2bb2a.nand0_out), line:51:10, endln:51:19, parent:work@sky130_fd_sc_hd__o2bb2a
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:nand0_out
     |vpiFullName:work@sky130_fd_sc_hd__o2bb2a.nand0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o2bb2a.or0_out), line:52:10, endln:52:17, parent:work@sky130_fd_sc_hd__o2bb2a
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o2bb2a.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o2bb2a.and0_out_X), line:53:10, endln:53:20, parent:work@sky130_fd_sc_hd__o2bb2a
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__o2bb2a.and0_out_X
     |vpiNetType:1
@@ -19704,11 +19974,15 @@ design: (work@sky130_fd_sc_hd__edfxtp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__edfxtp.buf_Q), line:52:10, endln:52:15, parent:work@sky130_fd_sc_hd__edfxtp
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__edfxtp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__edfxtp.mux_out), line:53:10, endln:53:17, parent:work@sky130_fd_sc_hd__edfxtp
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:mux_out
     |vpiFullName:work@sky130_fd_sc_hd__edfxtp.mux_out
     |vpiNetType:1
@@ -20087,21 +20361,29 @@ design: (work@sky130_fd_sc_hd__sdfbbp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfbbp.RESET), line:60:10, endln:60:15, parent:work@sky130_fd_sc_hd__sdfbbp
+    |vpiTypespec:
+    \_logic_typespec: , line:60:5, endln:60:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__sdfbbp.RESET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfbbp.SET), line:61:10, endln:61:13, parent:work@sky130_fd_sc_hd__sdfbbp
+    |vpiTypespec:
+    \_logic_typespec: , line:61:5, endln:61:9
     |vpiName:SET
     |vpiFullName:work@sky130_fd_sc_hd__sdfbbp.SET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfbbp.buf_Q), line:62:10, endln:62:15, parent:work@sky130_fd_sc_hd__sdfbbp
+    |vpiTypespec:
+    \_logic_typespec: , line:62:5, endln:62:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__sdfbbp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfbbp.mux_out), line:63:10, endln:63:17, parent:work@sky130_fd_sc_hd__sdfbbp
+    |vpiTypespec:
+    \_logic_typespec: , line:63:5, endln:63:9
     |vpiName:mux_out
     |vpiFullName:work@sky130_fd_sc_hd__sdfbbp.mux_out
     |vpiNetType:1
@@ -20578,16 +20860,22 @@ design: (work@sky130_fd_sc_hd__sdfrtp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfrtp.buf_Q), line:56:10, endln:56:15, parent:work@sky130_fd_sc_hd__sdfrtp
+    |vpiTypespec:
+    \_logic_typespec: , line:56:5, endln:56:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__sdfrtp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfrtp.RESET), line:57:10, endln:57:15, parent:work@sky130_fd_sc_hd__sdfrtp
+    |vpiTypespec:
+    \_logic_typespec: , line:57:5, endln:57:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__sdfrtp.RESET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfrtp.mux_out), line:58:10, endln:58:17, parent:work@sky130_fd_sc_hd__sdfrtp
+    |vpiTypespec:
+    \_logic_typespec: , line:58:5, endln:58:9
     |vpiName:mux_out
     |vpiFullName:work@sky130_fd_sc_hd__sdfrtp.mux_out
     |vpiNetType:1
@@ -21006,16 +21294,22 @@ design: (work@sky130_fd_sc_hd__sdfstp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfstp.buf_Q), line:56:10, endln:56:15, parent:work@sky130_fd_sc_hd__sdfstp
+    |vpiTypespec:
+    \_logic_typespec: , line:56:5, endln:56:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__sdfstp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfstp.SET), line:57:10, endln:57:13, parent:work@sky130_fd_sc_hd__sdfstp
+    |vpiTypespec:
+    \_logic_typespec: , line:57:5, endln:57:9
     |vpiName:SET
     |vpiFullName:work@sky130_fd_sc_hd__sdfstp.SET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfstp.mux_out), line:58:10, endln:58:17, parent:work@sky130_fd_sc_hd__sdfstp
+    |vpiTypespec:
+    \_logic_typespec: , line:58:5, endln:58:9
     |vpiName:mux_out
     |vpiFullName:work@sky130_fd_sc_hd__sdfstp.mux_out
     |vpiNetType:1
@@ -21264,16 +21558,22 @@ design: (work@sky130_fd_sc_hd__a22o)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a22o.and0_out), line:51:10, endln:51:18, parent:work@sky130_fd_sc_hd__a22o
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a22o.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a22o.and1_out), line:52:10, endln:52:18, parent:work@sky130_fd_sc_hd__a22o
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:and1_out
     |vpiFullName:work@sky130_fd_sc_hd__a22o.and1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a22o.or0_out_X), line:53:10, endln:53:19, parent:work@sky130_fd_sc_hd__a22o
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__a22o.or0_out_X
     |vpiNetType:1
@@ -21589,11 +21889,15 @@ design: (work@sky130_fd_sc_hd__o31a)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o31a.or0_out), line:51:10, endln:51:17, parent:work@sky130_fd_sc_hd__o31a
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o31a.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o31a.and0_out_X), line:52:10, endln:52:20, parent:work@sky130_fd_sc_hd__o31a
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__o31a.and0_out_X
     |vpiNetType:1
@@ -21823,6 +22127,8 @@ design: (work@sky130_fd_sc_hd__lpflow_clkbufkapwr)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__lpflow_clkbufkapwr.buf0_out_X), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__lpflow_clkbufkapwr
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__lpflow_clkbufkapwr.buf0_out_X
     |vpiNetType:1
@@ -22079,21 +22385,29 @@ design: (work@sky130_fd_sc_hd__fill)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fill.VPWR), line:36:13, endln:36:17, parent:work@sky130_fd_sc_hd__fill
+    |vpiTypespec:
+    \_logic_typespec: , line:36:5, endln:36:12
     |vpiName:VPWR
     |vpiFullName:work@sky130_fd_sc_hd__fill.VPWR
     |vpiNetType:10
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fill.VGND), line:37:13, endln:37:17, parent:work@sky130_fd_sc_hd__fill
+    |vpiTypespec:
+    \_logic_typespec: , line:37:5, endln:37:12
     |vpiName:VGND
     |vpiFullName:work@sky130_fd_sc_hd__fill.VGND
     |vpiNetType:11
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fill.VPB), line:38:13, endln:38:16, parent:work@sky130_fd_sc_hd__fill
+    |vpiTypespec:
+    \_logic_typespec: , line:38:5, endln:38:12
     |vpiName:VPB
     |vpiFullName:work@sky130_fd_sc_hd__fill.VPB
     |vpiNetType:10
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fill.VNB), line:39:13, endln:39:16, parent:work@sky130_fd_sc_hd__fill
+    |vpiTypespec:
+    \_logic_typespec: , line:39:5, endln:39:12
     |vpiName:VNB
     |vpiFullName:work@sky130_fd_sc_hd__fill.VNB
     |vpiNetType:11
@@ -22160,6 +22474,8 @@ design: (work@sky130_fd_sc_hd__or2)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__or2.or0_out_X), line:45:10, endln:45:19, parent:work@sky130_fd_sc_hd__or2
+    |vpiTypespec:
+    \_logic_typespec: , line:45:5, endln:45:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__or2.or0_out_X
     |vpiNetType:1
@@ -22374,16 +22690,22 @@ design: (work@sky130_fd_sc_hd__a221o)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a221o.and0_out), line:53:10, endln:53:18, parent:work@sky130_fd_sc_hd__a221o
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a221o.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a221o.and1_out), line:54:10, endln:54:18, parent:work@sky130_fd_sc_hd__a221o
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:and1_out
     |vpiFullName:work@sky130_fd_sc_hd__a221o.and1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a221o.or0_out_X), line:55:10, endln:55:19, parent:work@sky130_fd_sc_hd__a221o
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__a221o.or0_out_X
     |vpiNetType:1
@@ -22698,6 +23020,8 @@ design: (work@sky130_fd_sc_hd__and4)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__and4.and0_out_X), line:49:10, endln:49:20, parent:work@sky130_fd_sc_hd__and4
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__and4.and0_out_X
     |vpiNetType:1
@@ -22914,6 +23238,8 @@ design: (work@sky130_fd_sc_hd__lpflow_inputiso0p)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__lpflow_inputiso0p.sleepn), line:47:10, endln:47:16, parent:work@sky130_fd_sc_hd__lpflow_inputiso0p
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:sleepn
     |vpiFullName:work@sky130_fd_sc_hd__lpflow_inputiso0p.sleepn
     |vpiNetType:1
@@ -23070,6 +23396,8 @@ design: (work@sky130_fd_sc_hd__buf)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__buf.buf0_out_X), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__buf
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__buf.buf0_out_X
     |vpiNetType:1
@@ -23231,11 +23559,15 @@ design: (work@sky130_fd_sc_hd__o21a)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o21a.or0_out), line:49:10, endln:49:17, parent:work@sky130_fd_sc_hd__o21a
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o21a.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o21a.and0_out_X), line:50:10, endln:50:20, parent:work@sky130_fd_sc_hd__o21a
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__o21a.and0_out_X
     |vpiNetType:1
@@ -23465,6 +23797,8 @@ design: (work@sky130_fd_sc_hd__xnor3)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__xnor3.xnor0_out_X), line:47:10, endln:47:21, parent:work@sky130_fd_sc_hd__xnor3
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:xnor0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__xnor3.xnor0_out_X
     |vpiNetType:1
@@ -23674,11 +24008,15 @@ design: (work@sky130_fd_sc_hd__and3b)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__and3b.not0_out), line:47:10, endln:47:18, parent:work@sky130_fd_sc_hd__and3b
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:not0_out
     |vpiFullName:work@sky130_fd_sc_hd__and3b.not0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__and3b.and0_out_X), line:48:10, endln:48:20, parent:work@sky130_fd_sc_hd__and3b
+    |vpiTypespec:
+    \_logic_typespec: , line:48:5, endln:48:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__and3b.and0_out_X
     |vpiNetType:1
@@ -23930,16 +24268,22 @@ design: (work@sky130_fd_sc_hd__o22ai)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o22ai.nor0_out), line:51:10, endln:51:18, parent:work@sky130_fd_sc_hd__o22ai
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:nor0_out
     |vpiFullName:work@sky130_fd_sc_hd__o22ai.nor0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o22ai.nor1_out), line:52:10, endln:52:18, parent:work@sky130_fd_sc_hd__o22ai
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:nor1_out
     |vpiFullName:work@sky130_fd_sc_hd__o22ai.nor1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o22ai.or0_out_Y), line:53:10, endln:53:19, parent:work@sky130_fd_sc_hd__o22ai
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:or0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__o22ai.or0_out_Y
     |vpiNetType:1
@@ -24223,11 +24567,15 @@ design: (work@sky130_fd_sc_hd__o21ai)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o21ai.or0_out), line:49:10, endln:49:17, parent:work@sky130_fd_sc_hd__o21ai
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o21ai.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o21ai.nand0_out_Y), line:50:10, endln:50:21, parent:work@sky130_fd_sc_hd__o21ai
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:nand0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__o21ai.nand0_out_Y
     |vpiNetType:1
@@ -24486,11 +24834,15 @@ design: (work@sky130_fd_sc_hd__o41a)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o41a.or0_out), line:53:10, endln:53:17, parent:work@sky130_fd_sc_hd__o41a
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o41a.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o41a.and0_out_X), line:54:10, endln:54:20, parent:work@sky130_fd_sc_hd__o41a
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__o41a.and0_out_X
     |vpiNetType:1
@@ -24877,6 +25229,8 @@ design: (work@sky130_fd_sc_hd__clkdlybuf4s50)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__clkdlybuf4s50.buf0_out_X), line:44:10, endln:44:20, parent:work@sky130_fd_sc_hd__clkdlybuf4s50
+    |vpiTypespec:
+    \_logic_typespec: , line:44:5, endln:44:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__clkdlybuf4s50.buf0_out_X
     |vpiNetType:1
@@ -25050,11 +25404,15 @@ design: (work@sky130_fd_sc_hd__or4b)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__or4b.not0_out), line:49:10, endln:49:18, parent:work@sky130_fd_sc_hd__or4b
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:not0_out
     |vpiFullName:work@sky130_fd_sc_hd__or4b.not0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__or4b.or0_out_X), line:50:10, endln:50:19, parent:work@sky130_fd_sc_hd__or4b
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__or4b.or0_out_X
     |vpiNetType:1
@@ -25284,6 +25642,8 @@ design: (work@sky130_fd_sc_hd__dlymetal6s4s)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlymetal6s4s.buf0_out_X), line:44:10, endln:44:20, parent:work@sky130_fd_sc_hd__dlymetal6s4s
+    |vpiTypespec:
+    \_logic_typespec: , line:44:5, endln:44:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__dlymetal6s4s.buf0_out_X
     |vpiNetType:1
@@ -25472,16 +25832,22 @@ design: (work@sky130_fd_sc_hd__a2bb2o)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a2bb2o.and0_out), line:52:10, endln:52:18, parent:work@sky130_fd_sc_hd__a2bb2o
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a2bb2o.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a2bb2o.nor0_out), line:53:10, endln:53:18, parent:work@sky130_fd_sc_hd__a2bb2o
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:nor0_out
     |vpiFullName:work@sky130_fd_sc_hd__a2bb2o.nor0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a2bb2o.or0_out_X), line:54:10, endln:54:19, parent:work@sky130_fd_sc_hd__a2bb2o
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__a2bb2o.or0_out_X
     |vpiNetType:1
@@ -25899,11 +26265,15 @@ design: (work@sky130_fd_sc_hd__edfxbp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__edfxbp.buf_Q), line:54:10, endln:54:15, parent:work@sky130_fd_sc_hd__edfxbp
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__edfxbp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__edfxbp.mux_out), line:55:10, endln:55:17, parent:work@sky130_fd_sc_hd__edfxbp
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:mux_out
     |vpiFullName:work@sky130_fd_sc_hd__edfxbp.mux_out
     |vpiNetType:1
@@ -26212,11 +26582,15 @@ design: (work@sky130_fd_sc_hd__dfrbp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfrbp.buf_Q), line:52:10, endln:52:15, parent:work@sky130_fd_sc_hd__dfrbp
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dfrbp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfrbp.RESET), line:53:10, endln:53:15, parent:work@sky130_fd_sc_hd__dfrbp
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__dfrbp.RESET
     |vpiNetType:1
@@ -26509,21 +26883,29 @@ design: (work@sky130_fd_sc_hd__sdlclkp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdlclkp.m0), line:50:10, endln:50:12, parent:work@sky130_fd_sc_hd__sdlclkp
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:m0
     |vpiFullName:work@sky130_fd_sc_hd__sdlclkp.m0
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdlclkp.m0n), line:51:10, endln:51:13, parent:work@sky130_fd_sc_hd__sdlclkp
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:m0n
     |vpiFullName:work@sky130_fd_sc_hd__sdlclkp.m0n
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdlclkp.clkn), line:52:10, endln:52:14, parent:work@sky130_fd_sc_hd__sdlclkp
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:clkn
     |vpiFullName:work@sky130_fd_sc_hd__sdlclkp.clkn
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdlclkp.SCE_GATE), line:53:10, endln:53:18, parent:work@sky130_fd_sc_hd__sdlclkp
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:SCE_GATE
     |vpiFullName:work@sky130_fd_sc_hd__sdlclkp.SCE_GATE
     |vpiNetType:1
@@ -26814,11 +27196,15 @@ design: (work@sky130_fd_sc_hd__o311ai)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o311ai.or0_out), line:53:10, endln:53:17, parent:work@sky130_fd_sc_hd__o311ai
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o311ai.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o311ai.nand0_out_Y), line:54:10, endln:54:21, parent:work@sky130_fd_sc_hd__o311ai
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:nand0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__o311ai.nand0_out_Y
     |vpiNetType:1
@@ -27128,26 +27514,36 @@ design: (work@sky130_fd_sc_hd__fah)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fah.xor0_out_SUM), line:49:10, endln:49:22, parent:work@sky130_fd_sc_hd__fah
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:xor0_out_SUM
     |vpiFullName:work@sky130_fd_sc_hd__fah.xor0_out_SUM
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fah.a_b), line:50:10, endln:50:13, parent:work@sky130_fd_sc_hd__fah
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:a_b
     |vpiFullName:work@sky130_fd_sc_hd__fah.a_b
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fah.a_ci), line:51:10, endln:51:14, parent:work@sky130_fd_sc_hd__fah
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:a_ci
     |vpiFullName:work@sky130_fd_sc_hd__fah.a_ci
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fah.b_ci), line:52:10, endln:52:14, parent:work@sky130_fd_sc_hd__fah
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:b_ci
     |vpiFullName:work@sky130_fd_sc_hd__fah.b_ci
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fah.or0_out_COUT), line:53:10, endln:53:22, parent:work@sky130_fd_sc_hd__fah
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:or0_out_COUT
     |vpiFullName:work@sky130_fd_sc_hd__fah.or0_out_COUT
     |vpiNetType:1
@@ -27558,11 +27954,15 @@ design: (work@sky130_fd_sc_hd__nand4bb)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nand4bb.nand0_out), line:49:10, endln:49:19, parent:work@sky130_fd_sc_hd__nand4bb
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:nand0_out
     |vpiFullName:work@sky130_fd_sc_hd__nand4bb.nand0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nand4bb.or0_out_Y), line:50:10, endln:50:19, parent:work@sky130_fd_sc_hd__nand4bb
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:or0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nand4bb.or0_out_Y
     |vpiNetType:1
@@ -27809,11 +28209,15 @@ design: (work@sky130_fd_sc_hd__nand2b)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nand2b.not0_out), line:45:10, endln:45:18, parent:work@sky130_fd_sc_hd__nand2b
+    |vpiTypespec:
+    \_logic_typespec: , line:45:5, endln:45:9
     |vpiName:not0_out
     |vpiFullName:work@sky130_fd_sc_hd__nand2b.not0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nand2b.or0_out_Y), line:46:10, endln:46:19, parent:work@sky130_fd_sc_hd__nand2b
+    |vpiTypespec:
+    \_logic_typespec: , line:46:5, endln:46:9
     |vpiName:or0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nand2b.or0_out_Y
     |vpiNetType:1
@@ -28019,6 +28423,8 @@ design: (work@sky130_fd_sc_hd__nor3)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nor3.nor0_out_Y), line:49:10, endln:49:20, parent:work@sky130_fd_sc_hd__nor3
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:nor0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nor3.nor0_out_Y
     |vpiNetType:1
@@ -28240,11 +28646,15 @@ design: (work@sky130_fd_sc_hd__a211o)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a211o.and0_out), line:51:10, endln:51:18, parent:work@sky130_fd_sc_hd__a211o
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a211o.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a211o.or0_out_X), line:52:10, endln:52:19, parent:work@sky130_fd_sc_hd__a211o
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__a211o.or0_out_X
     |vpiNetType:1
@@ -28550,11 +28960,15 @@ design: (work@sky130_fd_sc_hd__dlxbn)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlxbn.GATE), line:50:10, endln:50:14, parent:work@sky130_fd_sc_hd__dlxbn
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:GATE
     |vpiFullName:work@sky130_fd_sc_hd__dlxbn.GATE
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlxbn.buf_Q), line:51:10, endln:51:15, parent:work@sky130_fd_sc_hd__dlxbn
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dlxbn.buf_Q
     |vpiNetType:1
@@ -28786,21 +29200,29 @@ design: (work@sky130_fd_sc_hd__maj3)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__maj3.or0_out), line:47:10, endln:47:17, parent:work@sky130_fd_sc_hd__maj3
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__maj3.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__maj3.and0_out), line:48:10, endln:48:18, parent:work@sky130_fd_sc_hd__maj3
+    |vpiTypespec:
+    \_logic_typespec: , line:48:5, endln:48:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__maj3.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__maj3.and1_out), line:49:10, endln:49:18, parent:work@sky130_fd_sc_hd__maj3
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:and1_out
     |vpiFullName:work@sky130_fd_sc_hd__maj3.and1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__maj3.or1_out_X), line:50:10, endln:50:19, parent:work@sky130_fd_sc_hd__maj3
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:or1_out_X
     |vpiFullName:work@sky130_fd_sc_hd__maj3.or1_out_X
     |vpiNetType:1
@@ -29105,11 +29527,15 @@ design: (work@sky130_fd_sc_hd__a21bo)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a21bo.nand0_out), line:50:10, endln:50:19, parent:work@sky130_fd_sc_hd__a21bo
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:nand0_out
     |vpiFullName:work@sky130_fd_sc_hd__a21bo.nand0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a21bo.nand1_out_X), line:51:10, endln:51:21, parent:work@sky130_fd_sc_hd__a21bo
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:nand1_out_X
     |vpiFullName:work@sky130_fd_sc_hd__a21bo.nand1_out_X
     |vpiNetType:1
@@ -29432,16 +29858,22 @@ design: (work@sky130_fd_sc_hd__dlrbn)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlrbn.RESET), line:53:10, endln:53:15, parent:work@sky130_fd_sc_hd__dlrbn
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__dlrbn.RESET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlrbn.intgate), line:54:10, endln:54:17, parent:work@sky130_fd_sc_hd__dlrbn
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:intgate
     |vpiFullName:work@sky130_fd_sc_hd__dlrbn.intgate
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlrbn.buf_Q), line:55:10, endln:55:15, parent:work@sky130_fd_sc_hd__dlrbn
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dlrbn.buf_Q
     |vpiNetType:1
@@ -29732,6 +30164,8 @@ design: (work@sky130_fd_sc_hd__lpflow_inputisolatch)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__lpflow_inputisolatch.buf_Q), line:48:10, endln:48:15, parent:work@sky130_fd_sc_hd__lpflow_inputisolatch
+    |vpiTypespec:
+    \_logic_typespec: , line:48:5, endln:48:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__lpflow_inputisolatch.buf_Q
     |vpiNetType:1
@@ -29918,16 +30352,22 @@ design: (work@sky130_fd_sc_hd__o221ai)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o221ai.or0_out), line:53:10, endln:53:17, parent:work@sky130_fd_sc_hd__o221ai
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o221ai.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o221ai.or1_out), line:54:10, endln:54:17, parent:work@sky130_fd_sc_hd__o221ai
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:or1_out
     |vpiFullName:work@sky130_fd_sc_hd__o221ai.or1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o221ai.nand0_out_Y), line:55:10, endln:55:21, parent:work@sky130_fd_sc_hd__o221ai
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:nand0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__o221ai.nand0_out_Y
     |vpiNetType:1
@@ -30259,11 +30699,15 @@ design: (work@sky130_fd_sc_hd__o2111a)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o2111a.or0_out), line:53:10, endln:53:17, parent:work@sky130_fd_sc_hd__o2111a
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o2111a.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o2111a.and0_out_X), line:54:10, endln:54:20, parent:work@sky130_fd_sc_hd__o2111a
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__o2111a.and0_out_X
     |vpiNetType:1
@@ -30558,11 +31002,15 @@ design: (work@sky130_fd_sc_hd__and4b)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__and4b.not0_out), line:49:10, endln:49:18, parent:work@sky130_fd_sc_hd__and4b
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:not0_out
     |vpiFullName:work@sky130_fd_sc_hd__and4b.not0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__and4b.and0_out_X), line:50:10, endln:50:20, parent:work@sky130_fd_sc_hd__and4b
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__and4b.and0_out_X
     |vpiNetType:1
@@ -30804,6 +31252,8 @@ design: (work@sky130_fd_sc_hd__and2)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__and2.and0_out_X), line:45:10, endln:45:20, parent:work@sky130_fd_sc_hd__and2
+    |vpiTypespec:
+    \_logic_typespec: , line:45:5, endln:45:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__and2.and0_out_X
     |vpiNetType:1
@@ -30994,16 +31444,22 @@ design: (work@sky130_fd_sc_hd__o21bai)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o21bai.b), line:50:10, endln:50:11, parent:work@sky130_fd_sc_hd__o21bai
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:b
     |vpiFullName:work@sky130_fd_sc_hd__o21bai.b
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o21bai.or0_out), line:51:10, endln:51:17, parent:work@sky130_fd_sc_hd__o21bai
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o21bai.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o21bai.nand0_out_Y), line:52:10, endln:52:21, parent:work@sky130_fd_sc_hd__o21bai
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:nand0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__o21bai.nand0_out_Y
     |vpiNetType:1
@@ -31305,41 +31761,57 @@ design: (work@sky130_fd_sc_hd__fa)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fa.or0_out), line:49:10, endln:49:17, parent:work@sky130_fd_sc_hd__fa
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__fa.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fa.and0_out), line:50:10, endln:50:18, parent:work@sky130_fd_sc_hd__fa
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__fa.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fa.and1_out), line:51:10, endln:51:18, parent:work@sky130_fd_sc_hd__fa
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:and1_out
     |vpiFullName:work@sky130_fd_sc_hd__fa.and1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fa.and2_out), line:52:10, endln:52:18, parent:work@sky130_fd_sc_hd__fa
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:and2_out
     |vpiFullName:work@sky130_fd_sc_hd__fa.and2_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fa.nor0_out), line:53:10, endln:53:18, parent:work@sky130_fd_sc_hd__fa
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:nor0_out
     |vpiFullName:work@sky130_fd_sc_hd__fa.nor0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fa.nor1_out), line:54:10, endln:54:18, parent:work@sky130_fd_sc_hd__fa
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:nor1_out
     |vpiFullName:work@sky130_fd_sc_hd__fa.nor1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fa.or1_out_COUT), line:55:10, endln:55:22, parent:work@sky130_fd_sc_hd__fa
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:or1_out_COUT
     |vpiFullName:work@sky130_fd_sc_hd__fa.or1_out_COUT
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__fa.or2_out_SUM), line:56:10, endln:56:21, parent:work@sky130_fd_sc_hd__fa
+    |vpiTypespec:
+    \_logic_typespec: , line:56:5, endln:56:9
     |vpiName:or2_out_SUM
     |vpiFullName:work@sky130_fd_sc_hd__fa.or2_out_SUM
     |vpiNetType:1
@@ -31845,11 +32317,15 @@ design: (work@sky130_fd_sc_hd__a31oi)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a31oi.and0_out), line:51:10, endln:51:18, parent:work@sky130_fd_sc_hd__a31oi
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a31oi.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a31oi.nor0_out_Y), line:52:10, endln:52:20, parent:work@sky130_fd_sc_hd__a31oi
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:nor0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__a31oi.nor0_out_Y
     |vpiNetType:1
@@ -32096,11 +32572,15 @@ design: (work@sky130_fd_sc_hd__nor2b)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nor2b.not0_out), line:47:10, endln:47:18, parent:work@sky130_fd_sc_hd__nor2b
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:not0_out
     |vpiFullName:work@sky130_fd_sc_hd__nor2b.not0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nor2b.and0_out_Y), line:48:10, endln:48:20, parent:work@sky130_fd_sc_hd__nor2b
+    |vpiTypespec:
+    \_logic_typespec: , line:48:5, endln:48:9
     |vpiName:and0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nor2b.and0_out_Y
     |vpiNetType:1
@@ -32535,11 +33015,15 @@ design: (work@sky130_fd_sc_hd__dfsbp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfsbp.buf_Q), line:52:10, endln:52:15, parent:work@sky130_fd_sc_hd__dfsbp
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dfsbp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfsbp.SET), line:53:10, endln:53:13, parent:work@sky130_fd_sc_hd__dfsbp
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:SET
     |vpiFullName:work@sky130_fd_sc_hd__dfsbp.SET
     |vpiNetType:1
@@ -32792,16 +33276,22 @@ design: (work@sky130_fd_sc_hd__a2bb2oi)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a2bb2oi.and0_out), line:52:10, endln:52:18, parent:work@sky130_fd_sc_hd__a2bb2oi
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a2bb2oi.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a2bb2oi.nor0_out), line:53:10, endln:53:18, parent:work@sky130_fd_sc_hd__a2bb2oi
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:nor0_out
     |vpiFullName:work@sky130_fd_sc_hd__a2bb2oi.nor0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a2bb2oi.nor1_out_Y), line:54:10, endln:54:20, parent:work@sky130_fd_sc_hd__a2bb2oi
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:nor1_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__a2bb2oi.nor1_out_Y
     |vpiNetType:1
@@ -33169,16 +33659,22 @@ design: (work@sky130_fd_sc_hd__dfrtn)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfrtn.buf_Q), line:51:10, endln:51:15, parent:work@sky130_fd_sc_hd__dfrtn
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dfrtn.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfrtn.RESET), line:52:10, endln:52:15, parent:work@sky130_fd_sc_hd__dfrtn
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__dfrtn.RESET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfrtn.intclk), line:53:10, endln:53:16, parent:work@sky130_fd_sc_hd__dfrtn
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:intclk
     |vpiFullName:work@sky130_fd_sc_hd__dfrtn.intclk
     |vpiNetType:1
@@ -33471,11 +33967,15 @@ design: (work@sky130_fd_sc_hd__dlrtp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlrtp.RESET), line:51:10, endln:51:15, parent:work@sky130_fd_sc_hd__dlrtp
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__dlrtp.RESET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlrtp.buf_Q), line:52:10, endln:52:15, parent:work@sky130_fd_sc_hd__dlrtp
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dlrtp.buf_Q
     |vpiNetType:1
@@ -33684,11 +34184,15 @@ design: (work@sky130_fd_sc_hd__and4bb)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__and4bb.nor0_out), line:49:10, endln:49:18, parent:work@sky130_fd_sc_hd__and4bb
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:nor0_out
     |vpiFullName:work@sky130_fd_sc_hd__and4bb.nor0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__and4bb.and0_out_X), line:50:10, endln:50:20, parent:work@sky130_fd_sc_hd__and4bb
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__and4bb.and0_out_X
     |vpiNetType:1
@@ -33971,11 +34475,15 @@ design: (work@sky130_fd_sc_hd__a41o)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a41o.and0_out), line:53:10, endln:53:18, parent:work@sky130_fd_sc_hd__a41o
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a41o.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a41o.or0_out_X), line:54:10, endln:54:19, parent:work@sky130_fd_sc_hd__a41o
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__a41o.or0_out_X
     |vpiNetType:1
@@ -34258,11 +34766,15 @@ design: (work@sky130_fd_sc_hd__ha)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__ha.and0_out_COUT), line:47:10, endln:47:23, parent:work@sky130_fd_sc_hd__ha
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:and0_out_COUT
     |vpiFullName:work@sky130_fd_sc_hd__ha.and0_out_COUT
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__ha.xor0_out_SUM), line:48:10, endln:48:22, parent:work@sky130_fd_sc_hd__ha
+    |vpiTypespec:
+    \_logic_typespec: , line:48:5, endln:48:9
     |vpiName:xor0_out_SUM
     |vpiFullName:work@sky130_fd_sc_hd__ha.xor0_out_SUM
     |vpiNetType:1
@@ -34634,16 +35146,22 @@ design: (work@sky130_fd_sc_hd__dfbbp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfbbp.RESET), line:55:10, endln:55:15, parent:work@sky130_fd_sc_hd__dfbbp
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:RESET
     |vpiFullName:work@sky130_fd_sc_hd__dfbbp.RESET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfbbp.SET), line:56:10, endln:56:13, parent:work@sky130_fd_sc_hd__dfbbp
+    |vpiTypespec:
+    \_logic_typespec: , line:56:5, endln:56:9
     |vpiName:SET
     |vpiFullName:work@sky130_fd_sc_hd__dfbbp.SET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfbbp.buf_Q), line:57:10, endln:57:15, parent:work@sky130_fd_sc_hd__dfbbp
+    |vpiTypespec:
+    \_logic_typespec: , line:57:5, endln:57:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dfbbp.buf_Q
     |vpiNetType:1
@@ -35075,11 +35593,15 @@ design: (work@sky130_fd_sc_hd__a311o)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a311o.and0_out), line:53:10, endln:53:18, parent:work@sky130_fd_sc_hd__a311o
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a311o.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a311o.or0_out_X), line:54:10, endln:54:19, parent:work@sky130_fd_sc_hd__a311o
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__a311o.or0_out_X
     |vpiNetType:1
@@ -35397,11 +35919,15 @@ design: (work@sky130_fd_sc_hd__dlxtn)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlxtn.GATE), line:48:10, endln:48:14, parent:work@sky130_fd_sc_hd__dlxtn
+    |vpiTypespec:
+    \_logic_typespec: , line:48:5, endln:48:9
     |vpiName:GATE
     |vpiFullName:work@sky130_fd_sc_hd__dlxtn.GATE
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlxtn.buf_Q), line:49:10, endln:49:15, parent:work@sky130_fd_sc_hd__dlxtn
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dlxtn.buf_Q
     |vpiNetType:1
@@ -35608,11 +36134,15 @@ design: (work@sky130_fd_sc_hd__a41oi)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a41oi.and0_out), line:53:10, endln:53:18, parent:work@sky130_fd_sc_hd__a41oi
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a41oi.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a41oi.nor0_out_Y), line:54:10, endln:54:20, parent:work@sky130_fd_sc_hd__a41oi
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:nor0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__a41oi.nor0_out_Y
     |vpiNetType:1
@@ -36074,16 +36604,22 @@ design: (work@sky130_fd_sc_hd__sdfsbp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfsbp.buf_Q), line:58:10, endln:58:15, parent:work@sky130_fd_sc_hd__sdfsbp
+    |vpiTypespec:
+    \_logic_typespec: , line:58:5, endln:58:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__sdfsbp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfsbp.SET), line:59:10, endln:59:13, parent:work@sky130_fd_sc_hd__sdfsbp
+    |vpiTypespec:
+    \_logic_typespec: , line:59:5, endln:59:9
     |vpiName:SET
     |vpiFullName:work@sky130_fd_sc_hd__sdfsbp.SET
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__sdfsbp.mux_out), line:60:10, endln:60:17, parent:work@sky130_fd_sc_hd__sdfsbp
+    |vpiTypespec:
+    \_logic_typespec: , line:60:5, endln:60:9
     |vpiName:mux_out
     |vpiFullName:work@sky130_fd_sc_hd__sdfsbp.mux_out
     |vpiNetType:1
@@ -36555,6 +37091,8 @@ design: (work@sky130_fd_sc_hd__bufbuf)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__bufbuf.buf0_out_X), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__bufbuf
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__bufbuf.buf0_out_X
     |vpiNetType:1
@@ -36711,6 +37249,8 @@ design: (work@sky130_fd_sc_hd__xor3)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__xor3.xor0_out_X), line:49:10, endln:49:20, parent:work@sky130_fd_sc_hd__xor3
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:xor0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__xor3.xor0_out_X
     |vpiNetType:1
@@ -36937,16 +37477,22 @@ design: (work@sky130_fd_sc_hd__o2bb2ai)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o2bb2ai.nand0_out), line:51:10, endln:51:19, parent:work@sky130_fd_sc_hd__o2bb2ai
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:nand0_out
     |vpiFullName:work@sky130_fd_sc_hd__o2bb2ai.nand0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o2bb2ai.or0_out), line:52:10, endln:52:17, parent:work@sky130_fd_sc_hd__o2bb2ai
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o2bb2ai.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o2bb2ai.nand1_out_Y), line:53:10, endln:53:21, parent:work@sky130_fd_sc_hd__o2bb2ai
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:nand1_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__o2bb2ai.nand1_out_Y
     |vpiNetType:1
@@ -37213,6 +37759,8 @@ design: (work@sky130_fd_sc_hd__nor2)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nor2.nor0_out_Y), line:45:10, endln:45:20, parent:work@sky130_fd_sc_hd__nor2
+    |vpiTypespec:
+    \_logic_typespec: , line:45:5, endln:45:9
     |vpiName:nor0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nor2.nor0_out_Y
     |vpiNetType:1
@@ -37440,6 +37988,8 @@ design: (work@sky130_fd_sc_hd__dlxbp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlxbp.buf_Q), line:50:10, endln:50:15, parent:work@sky130_fd_sc_hd__dlxbp
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dlxbp.buf_Q
     |vpiNetType:1
@@ -37733,11 +38283,15 @@ design: (work@sky130_fd_sc_hd__or3b)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__or3b.not0_out), line:47:10, endln:47:18, parent:work@sky130_fd_sc_hd__or3b
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:not0_out
     |vpiFullName:work@sky130_fd_sc_hd__or3b.not0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__or3b.or0_out_X), line:48:10, endln:48:19, parent:work@sky130_fd_sc_hd__or3b
+    |vpiTypespec:
+    \_logic_typespec: , line:48:5, endln:48:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__or3b.or0_out_X
     |vpiNetType:1
@@ -37955,6 +38509,8 @@ design: (work@sky130_fd_sc_hd__xnor2)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__xnor2.xnor0_out_Y), line:47:10, endln:47:21, parent:work@sky130_fd_sc_hd__xnor2
+    |vpiTypespec:
+    \_logic_typespec: , line:47:5, endln:47:9
     |vpiName:xnor0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__xnor2.xnor0_out_Y
     |vpiNetType:1
@@ -38152,11 +38708,15 @@ design: (work@sky130_fd_sc_hd__o211a)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o211a.or0_out), line:51:10, endln:51:17, parent:work@sky130_fd_sc_hd__o211a
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o211a.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o211a.and0_out_X), line:52:10, endln:52:20, parent:work@sky130_fd_sc_hd__o211a
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__o211a.and0_out_X
     |vpiNetType:1
@@ -38415,11 +38975,15 @@ design: (work@sky130_fd_sc_hd__nor3b)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nor3b.nor0_out), line:49:10, endln:49:18, parent:work@sky130_fd_sc_hd__nor3b
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:nor0_out
     |vpiFullName:work@sky130_fd_sc_hd__nor3b.nor0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nor3b.and0_out_Y), line:50:10, endln:50:20, parent:work@sky130_fd_sc_hd__nor3b
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:and0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nor3b.and0_out_Y
     |vpiNetType:1
@@ -38666,11 +39230,15 @@ design: (work@sky130_fd_sc_hd__o31ai)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o31ai.or0_out), line:51:10, endln:51:17, parent:work@sky130_fd_sc_hd__o31ai
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o31ai.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o31ai.nand0_out_Y), line:52:10, endln:52:21, parent:work@sky130_fd_sc_hd__o31ai
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:nand0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__o31ai.nand0_out_Y
     |vpiNetType:1
@@ -38900,6 +39468,8 @@ design: (work@sky130_fd_sc_hd__dlymetal6s6s)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlymetal6s6s.buf0_out_X), line:44:10, endln:44:20, parent:work@sky130_fd_sc_hd__dlymetal6s6s
+    |vpiTypespec:
+    \_logic_typespec: , line:44:5, endln:44:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__dlymetal6s6s.buf0_out_X
     |vpiNetType:1
@@ -39085,11 +39655,15 @@ design: (work@sky130_fd_sc_hd__a311oi)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a311oi.and0_out), line:53:10, endln:53:18, parent:work@sky130_fd_sc_hd__a311oi
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a311oi.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a311oi.nor0_out_Y), line:54:10, endln:54:20, parent:work@sky130_fd_sc_hd__a311oi
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:nor0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__a311oi.nor0_out_Y
     |vpiNetType:1
@@ -39384,11 +39958,15 @@ design: (work@sky130_fd_sc_hd__a31o)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a31o.and0_out), line:51:10, endln:51:18, parent:work@sky130_fd_sc_hd__a31o
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a31o.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a31o.or0_out_X), line:52:10, endln:52:19, parent:work@sky130_fd_sc_hd__a31o
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:or0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__a31o.or0_out_X
     |vpiNetType:1
@@ -39659,11 +40237,15 @@ design: (work@sky130_fd_sc_hd__nand4b)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nand4b.not0_out), line:49:10, endln:49:18, parent:work@sky130_fd_sc_hd__nand4b
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:not0_out
     |vpiFullName:work@sky130_fd_sc_hd__nand4b.not0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nand4b.nand0_out_Y), line:50:10, endln:50:21, parent:work@sky130_fd_sc_hd__nand4b
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:nand0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nand4b.nand0_out_Y
     |vpiNetType:1
@@ -39910,11 +40492,15 @@ design: (work@sky130_fd_sc_hd__lpflow_isobufsrckapwr)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__lpflow_isobufsrckapwr.not0_out), line:48:10, endln:48:18, parent:work@sky130_fd_sc_hd__lpflow_isobufsrckapwr
+    |vpiTypespec:
+    \_logic_typespec: , line:48:5, endln:48:9
     |vpiName:not0_out
     |vpiFullName:work@sky130_fd_sc_hd__lpflow_isobufsrckapwr.not0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__lpflow_isobufsrckapwr.and0_out_X), line:49:10, endln:49:20, parent:work@sky130_fd_sc_hd__lpflow_isobufsrckapwr
+    |vpiTypespec:
+    \_logic_typespec: , line:49:5, endln:49:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__lpflow_isobufsrckapwr.and0_out_X
     |vpiNetType:1
@@ -40130,16 +40716,22 @@ design: (work@sky130_fd_sc_hd__a21boi)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a21boi.b), line:50:10, endln:50:11, parent:work@sky130_fd_sc_hd__a21boi
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:b
     |vpiFullName:work@sky130_fd_sc_hd__a21boi.b
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a21boi.and0_out), line:51:10, endln:51:18, parent:work@sky130_fd_sc_hd__a21boi
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a21boi.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a21boi.nor0_out_Y), line:52:10, endln:52:20, parent:work@sky130_fd_sc_hd__a21boi
+    |vpiTypespec:
+    \_logic_typespec: , line:52:5, endln:52:9
     |vpiName:nor0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__a21boi.nor0_out_Y
     |vpiNetType:1
@@ -40370,6 +40962,8 @@ design: (work@sky130_fd_sc_hd__dlygate4sd1)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlygate4sd1.buf0_out_X), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__dlygate4sd1
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__dlygate4sd1.buf0_out_X
     |vpiNetType:1
@@ -40560,16 +41154,22 @@ design: (work@sky130_fd_sc_hd__a32oi)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a32oi.nand0_out), line:54:10, endln:54:19, parent:work@sky130_fd_sc_hd__a32oi
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:nand0_out
     |vpiFullName:work@sky130_fd_sc_hd__a32oi.nand0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a32oi.nand1_out), line:55:10, endln:55:19, parent:work@sky130_fd_sc_hd__a32oi
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:nand1_out
     |vpiFullName:work@sky130_fd_sc_hd__a32oi.nand1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a32oi.and0_out_Y), line:56:10, endln:56:20, parent:work@sky130_fd_sc_hd__a32oi
+    |vpiTypespec:
+    \_logic_typespec: , line:56:5, endln:56:9
     |vpiName:and0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__a32oi.and0_out_Y
     |vpiNetType:1
@@ -40901,11 +41501,15 @@ design: (work@sky130_fd_sc_hd__o311a)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o311a.or0_out), line:53:10, endln:53:17, parent:work@sky130_fd_sc_hd__o311a
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:or0_out
     |vpiFullName:work@sky130_fd_sc_hd__o311a.or0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__o311a.and0_out_X), line:54:10, endln:54:20, parent:work@sky130_fd_sc_hd__o311a
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__o311a.and0_out_X
     |vpiNetType:1
@@ -41176,11 +41780,15 @@ design: (work@sky130_fd_sc_hd__and2b)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__and2b.not0_out), line:45:10, endln:45:18, parent:work@sky130_fd_sc_hd__and2b
+    |vpiTypespec:
+    \_logic_typespec: , line:45:5, endln:45:9
     |vpiName:not0_out
     |vpiFullName:work@sky130_fd_sc_hd__and2b.not0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__and2b.and0_out_X), line:46:10, endln:46:20, parent:work@sky130_fd_sc_hd__and2b
+    |vpiTypespec:
+    \_logic_typespec: , line:46:5, endln:46:9
     |vpiName:and0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__and2b.and0_out_X
     |vpiNetType:1
@@ -41420,16 +42028,22 @@ design: (work@sky130_fd_sc_hd__a221oi)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a221oi.and0_out), line:53:10, endln:53:18, parent:work@sky130_fd_sc_hd__a221oi
+    |vpiTypespec:
+    \_logic_typespec: , line:53:5, endln:53:9
     |vpiName:and0_out
     |vpiFullName:work@sky130_fd_sc_hd__a221oi.and0_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a221oi.and1_out), line:54:10, endln:54:18, parent:work@sky130_fd_sc_hd__a221oi
+    |vpiTypespec:
+    \_logic_typespec: , line:54:5, endln:54:9
     |vpiName:and1_out
     |vpiFullName:work@sky130_fd_sc_hd__a221oi.and1_out
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__a221oi.nor0_out_Y), line:55:10, endln:55:20, parent:work@sky130_fd_sc_hd__a221oi
+    |vpiTypespec:
+    \_logic_typespec: , line:55:5, endln:55:9
     |vpiName:nor0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__a221oi.nor0_out_Y
     |vpiNetType:1
@@ -41767,6 +42381,8 @@ design: (work@sky130_fd_sc_hd__dlxtp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlxtp.buf_Q), line:48:10, endln:48:15, parent:work@sky130_fd_sc_hd__dlxtp
+    |vpiTypespec:
+    \_logic_typespec: , line:48:5, endln:48:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dlxtp.buf_Q
     |vpiNetType:1
@@ -42003,11 +42619,15 @@ design: (work@sky130_fd_sc_hd__dfstp)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfstp.buf_Q), line:50:10, endln:50:15, parent:work@sky130_fd_sc_hd__dfstp
+    |vpiTypespec:
+    \_logic_typespec: , line:50:5, endln:50:9
     |vpiName:buf_Q
     |vpiFullName:work@sky130_fd_sc_hd__dfstp.buf_Q
     |vpiNetType:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dfstp.SET), line:51:10, endln:51:13, parent:work@sky130_fd_sc_hd__dfstp
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:SET
     |vpiFullName:work@sky130_fd_sc_hd__dfstp.SET
     |vpiNetType:1
@@ -42313,6 +42933,8 @@ design: (work@sky130_fd_sc_hd__nor4)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__nor4.nor0_out_Y), line:51:10, endln:51:20, parent:work@sky130_fd_sc_hd__nor4
+    |vpiTypespec:
+    \_logic_typespec: , line:51:5, endln:51:9
     |vpiName:nor0_out_Y
     |vpiFullName:work@sky130_fd_sc_hd__nor4.nor0_out_Y
     |vpiNetType:1
@@ -42517,6 +43139,8 @@ design: (work@sky130_fd_sc_hd__dlygate4sd3)
   |vpiTop:1
   |vpiNet:
   \_logic_net: (work@sky130_fd_sc_hd__dlygate4sd3.buf0_out_X), line:43:10, endln:43:20, parent:work@sky130_fd_sc_hd__dlygate4sd3
+    |vpiTypespec:
+    \_logic_typespec: , line:43:5, endln:43:9
     |vpiName:buf0_out_X
     |vpiFullName:work@sky130_fd_sc_hd__dlygate4sd3.buf0_out_X
     |vpiNetType:1

--- a/third_party/tests/Tnoc/Tnoc.log
+++ b/third_party/tests/Tnoc/Tnoc.log
@@ -192,14 +192,7 @@
 
 [INF:CP0302] Compile class "work@semaphore".
 
-[NTE:CP0309] cores/tnoc/rtl/common/tnoc_flit_if_fifo.sv:16:33: Implicit port type (wire) for "o_empty",
-there are 2 more instances of this message.
-
 [NTE:CP0309] cores/tnoc/rtl/router/tnoc_output_switch.sv:14:27: Implicit port type (wire) for "o_output_free".
-
-[NTE:CP0309] cores/tnoc/rtl/router/tnoc_port_controller_internal.sv:10:37: Implicit port type (wire) for "o_output_grant".
-
-[NTE:CP0309] cores/tnoc/rtl/router/tnoc_port_controller_local.sv:10:41: Implicit port type (wire) for "o_output_grant".
 
 [INF:EL0526] Design Elaboration...
 
@@ -9227,5 +9220,5 @@ there are 2 more instances of this message.
 [ SYNTAX] : 0
 [  ERROR] : 0
 [WARNING] : 46
-[   NOTE] : 9
+[   NOTE] : 6
 

--- a/third_party/tests/oh/BasicOh.log
+++ b/third_party/tests/oh/BasicOh.log
@@ -12333,6 +12333,8 @@ design: (work@oh_fifo_async)
             |vpiName:wr_nreset
             |vpiActual:
             \_logic_net: (work@oh_fifo_async.wr_nreset), line:64:11, endln:64:20, parent:work@oh_fifo_async
+              |vpiTypespec:
+              \_logic_typespec: , line:64:4, endln:64:8
               |vpiName:wr_nreset
               |vpiFullName:work@oh_fifo_async.wr_nreset
               |vpiNetType:1
@@ -12381,6 +12383,8 @@ design: (work@oh_fifo_async)
             |vpiFullName:work@oh_fifo_async.fifo_write
             |vpiActual:
             \_logic_net: (work@oh_fifo_async.fifo_write), line:62:11, endln:62:21, parent:work@oh_fifo_async
+              |vpiTypespec:
+              \_logic_typespec: , line:62:4, endln:62:8
               |vpiName:fifo_write
               |vpiFullName:work@oh_fifo_async.fifo_write
               |vpiNetType:1
@@ -12458,6 +12462,8 @@ design: (work@oh_fifo_async)
             |vpiName:rd_nreset
             |vpiActual:
             \_logic_net: (work@oh_fifo_async.rd_nreset), line:63:11, endln:63:20, parent:work@oh_fifo_async
+              |vpiTypespec:
+              \_logic_typespec: , line:63:4, endln:63:8
               |vpiName:rd_nreset
               |vpiFullName:work@oh_fifo_async.rd_nreset
               |vpiNetType:1
@@ -30636,22 +30642,24 @@ design: (work@oh_fifo_async)
   \_logic_net: (work@oh_fifo_async.wr_clk), line:25:16, endln:25:22, parent:work@oh_fifo_async
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.wr_din), line:26:20, endln:26:26, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:26:11, endln:26:18
+      |vpiRange:
+      \_range: , line:26:12, endln:26:17
+        |vpiLeftRange:
+        \_constant: , line:26:12, endln:26:13
+          |vpiDecompile:31
+          |vpiSize:64
+          |INT:31
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:26:16, endln:26:17
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:wr_din
     |vpiFullName:work@oh_fifo_async.wr_din
-    |vpiRange:
-    \_range: , line:26:12, endln:26:17
-      |vpiLeftRange:
-      \_constant: , line:26:12, endln:26:13
-        |vpiDecompile:31
-        |vpiSize:64
-        |INT:31
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:26:16, endln:26:17
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.wr_en), line:27:16, endln:27:21, parent:work@oh_fifo_async
   |vpiNet:
@@ -30666,64 +30674,70 @@ design: (work@oh_fifo_async)
     |vpiFullName:work@oh_fifo_async.wr_prog_full
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.wr_count), line:31:21, endln:31:29, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:31:12, endln:31:20
+      |vpiRange:
+      \_range: , line:31:13, endln:31:19
+        |vpiLeftRange:
+        \_constant: , line:31:13, endln:31:15
+          |vpiDecompile:4
+          |vpiSize:64
+          |INT:4
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:31:18, endln:31:19
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:wr_count
     |vpiFullName:work@oh_fifo_async.wr_count
-    |vpiRange:
-    \_range: , line:31:13, endln:31:19
-      |vpiLeftRange:
-      \_constant: , line:31:13, endln:31:15
-        |vpiDecompile:4
-        |vpiSize:64
-        |INT:4
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:31:18, endln:31:19
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.rd_clk), line:33:16, endln:33:22, parent:work@oh_fifo_async
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.rd_dout), line:34:20, endln:34:27, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:34:12, endln:34:19
+      |vpiRange:
+      \_range: , line:34:13, endln:34:18
+        |vpiLeftRange:
+        \_constant: , line:34:13, endln:34:14
+          |vpiDecompile:31
+          |vpiSize:64
+          |INT:31
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:34:17, endln:34:18
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:rd_dout
     |vpiFullName:work@oh_fifo_async.rd_dout
-    |vpiRange:
-    \_range: , line:34:13, endln:34:18
-      |vpiLeftRange:
-      \_constant: , line:34:13, endln:34:14
-        |vpiDecompile:31
-        |vpiSize:64
-        |INT:31
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:34:17, endln:34:18
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.rd_en), line:35:16, endln:35:21, parent:work@oh_fifo_async
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.rd_empty), line:36:17, endln:36:25, parent:work@oh_fifo_async
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.rd_count), line:37:21, endln:37:29, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:37:12, endln:37:20
+      |vpiRange:
+      \_range: , line:37:13, endln:37:19
+        |vpiLeftRange:
+        \_constant: , line:37:13, endln:37:15
+          |vpiDecompile:4
+          |vpiSize:64
+          |INT:4
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:37:18, endln:37:19
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:rd_count
     |vpiFullName:work@oh_fifo_async.rd_count
-    |vpiRange:
-    \_range: , line:37:13, endln:37:19
-      |vpiLeftRange:
-      \_constant: , line:37:13, endln:37:15
-        |vpiDecompile:4
-        |vpiSize:64
-        |INT:4
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:37:18, endln:37:19
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.bist_en), line:39:16, endln:39:23, parent:work@oh_fifo_async
     |vpiName:bist_en
@@ -30734,76 +30748,84 @@ design: (work@oh_fifo_async)
     |vpiFullName:work@oh_fifo_async.bist_we
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.bist_wem), line:41:20, endln:41:28, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:41:11, endln:41:18
+      |vpiRange:
+      \_range: , line:41:12, endln:41:17
+        |vpiLeftRange:
+        \_constant: , line:41:12, endln:41:13
+          |vpiDecompile:31
+          |vpiSize:64
+          |INT:31
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:41:16, endln:41:17
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:bist_wem
     |vpiFullName:work@oh_fifo_async.bist_wem
-    |vpiRange:
-    \_range: , line:41:12, endln:41:17
-      |vpiLeftRange:
-      \_constant: , line:41:12, endln:41:13
-        |vpiDecompile:31
-        |vpiSize:64
-        |INT:31
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:41:16, endln:41:17
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.bist_addr), line:42:21, endln:42:30, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:42:11, endln:42:19
+      |vpiRange:
+      \_range: , line:42:12, endln:42:18
+        |vpiLeftRange:
+        \_constant: , line:42:12, endln:42:14
+          |vpiDecompile:4
+          |vpiSize:64
+          |INT:4
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:42:17, endln:42:18
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:bist_addr
     |vpiFullName:work@oh_fifo_async.bist_addr
-    |vpiRange:
-    \_range: , line:42:12, endln:42:18
-      |vpiLeftRange:
-      \_constant: , line:42:12, endln:42:14
-        |vpiDecompile:4
-        |vpiSize:64
-        |INT:4
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:42:17, endln:42:18
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.bist_din), line:43:20, endln:43:28, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:43:11, endln:43:18
+      |vpiRange:
+      \_range: , line:43:12, endln:43:17
+        |vpiLeftRange:
+        \_constant: , line:43:12, endln:43:13
+          |vpiDecompile:31
+          |vpiSize:64
+          |INT:31
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:43:16, endln:43:17
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:bist_din
     |vpiFullName:work@oh_fifo_async.bist_din
-    |vpiRange:
-    \_range: , line:43:12, endln:43:17
-      |vpiLeftRange:
-      \_constant: , line:43:12, endln:43:13
-        |vpiDecompile:31
-        |vpiSize:64
-        |INT:31
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:43:16, endln:43:17
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.bist_dout), line:44:20, endln:44:29, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:44:11, endln:44:18
+      |vpiRange:
+      \_range: , line:44:12, endln:44:17
+        |vpiLeftRange:
+        \_constant: , line:44:12, endln:44:13
+          |vpiDecompile:31
+          |vpiSize:64
+          |INT:31
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:44:16, endln:44:17
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:bist_dout
     |vpiFullName:work@oh_fifo_async.bist_dout
-    |vpiRange:
-    \_range: , line:44:12, endln:44:17
-      |vpiLeftRange:
-      \_constant: , line:44:12, endln:44:13
-        |vpiDecompile:31
-        |vpiSize:64
-        |INT:31
-        |vpiConstType:7
-      |vpiRightRange:
-      \_constant: , line:44:16, endln:44:17
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.shutdown), line:46:16, endln:46:24, parent:work@oh_fifo_async
     |vpiName:shutdown
@@ -30822,173 +30844,191 @@ design: (work@oh_fifo_async)
     |vpiFullName:work@oh_fifo_async.vddio
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.memconfig), line:50:21, endln:50:30, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:50:11, endln:50:16
+      |vpiRange:
+      \_range: , line:50:12, endln:50:15
+        |vpiLeftRange:
+        \_constant: , line:50:12, endln:50:13
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:50:14, endln:50:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:memconfig
     |vpiFullName:work@oh_fifo_async.memconfig
-    |vpiRange:
-    \_range: , line:50:12, endln:50:15
-      |vpiLeftRange:
-      \_constant: , line:50:12, endln:50:13
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:50:14, endln:50:15
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.memrepair), line:51:21, endln:51:30, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:51:11, endln:51:16
+      |vpiRange:
+      \_range: , line:51:12, endln:51:15
+        |vpiLeftRange:
+        \_constant: , line:51:12, endln:51:13
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:51:14, endln:51:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:memrepair
     |vpiFullName:work@oh_fifo_async.memrepair
-    |vpiRange:
-    \_range: , line:51:12, endln:51:15
-      |vpiLeftRange:
-      \_constant: , line:51:12, endln:51:13
-        |vpiDecompile:7
-        |vpiSize:64
-        |UINT:7
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:51:14, endln:51:15
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.wr_addr), line:55:17, endln:55:24, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:55:4, endln:55:7
+      |vpiRange:
+      \_range: , line:55:9, endln:55:13
+        |vpiLeftRange:
+        \_constant: , line:55:9, endln:55:11
+          |vpiDecompile:5
+          |vpiSize:64
+          |UINT:5
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:55:12, endln:55:13
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:wr_addr
     |vpiFullName:work@oh_fifo_async.wr_addr
     |vpiNetType:48
-    |vpiRange:
-    \_range: , line:55:9, endln:55:13
-      |vpiLeftRange:
-      \_constant: , line:55:9, endln:55:11
-        |vpiDecompile:5
-        |vpiSize:64
-        |UINT:5
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:55:12, endln:55:13
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.rd_addr), line:56:17, endln:56:24, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:56:4, endln:56:7
+      |vpiRange:
+      \_range: , line:56:9, endln:56:13
+        |vpiLeftRange:
+        \_constant: , line:56:9, endln:56:11
+          |vpiDecompile:5
+          |vpiSize:64
+          |UINT:5
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:56:12, endln:56:13
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:rd_addr
     |vpiFullName:work@oh_fifo_async.rd_addr
     |vpiNetType:48
-    |vpiRange:
-    \_range: , line:56:9, endln:56:13
-      |vpiLeftRange:
-      \_constant: , line:56:9, endln:56:11
-        |vpiDecompile:5
-        |vpiSize:64
-        |UINT:5
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:56:12, endln:56:13
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.wr_addr_gray), line:57:18, endln:57:30, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:57:4, endln:57:8
+      |vpiRange:
+      \_range: , line:57:10, endln:57:14
+        |vpiLeftRange:
+        \_constant: , line:57:10, endln:57:12
+          |vpiDecompile:5
+          |vpiSize:64
+          |UINT:5
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:57:13, endln:57:14
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:wr_addr_gray
     |vpiFullName:work@oh_fifo_async.wr_addr_gray
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:57:10, endln:57:14
-      |vpiLeftRange:
-      \_constant: , line:57:10, endln:57:12
-        |vpiDecompile:5
-        |vpiSize:64
-        |UINT:5
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:57:13, endln:57:14
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.wr_addr_gray_sync), line:58:18, endln:58:35, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:58:4, endln:58:8
+      |vpiRange:
+      \_range: , line:58:10, endln:58:14
+        |vpiLeftRange:
+        \_constant: , line:58:10, endln:58:12
+          |vpiDecompile:5
+          |vpiSize:64
+          |UINT:5
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:58:13, endln:58:14
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:wr_addr_gray_sync
     |vpiFullName:work@oh_fifo_async.wr_addr_gray_sync
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:58:10, endln:58:14
-      |vpiLeftRange:
-      \_constant: , line:58:10, endln:58:12
-        |vpiDecompile:5
-        |vpiSize:64
-        |UINT:5
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:58:13, endln:58:14
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.rd_addr_gray), line:59:18, endln:59:30, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:59:4, endln:59:8
+      |vpiRange:
+      \_range: , line:59:10, endln:59:14
+        |vpiLeftRange:
+        \_constant: , line:59:10, endln:59:12
+          |vpiDecompile:5
+          |vpiSize:64
+          |UINT:5
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:59:13, endln:59:14
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:rd_addr_gray
     |vpiFullName:work@oh_fifo_async.rd_addr_gray
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:59:10, endln:59:14
-      |vpiLeftRange:
-      \_constant: , line:59:10, endln:59:12
-        |vpiDecompile:5
-        |vpiSize:64
-        |UINT:5
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:59:13, endln:59:14
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.rd_addr_gray_sync), line:60:18, endln:60:35, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:60:4, endln:60:8
+      |vpiRange:
+      \_range: , line:60:10, endln:60:14
+        |vpiLeftRange:
+        \_constant: , line:60:10, endln:60:12
+          |vpiDecompile:5
+          |vpiSize:64
+          |UINT:5
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:60:13, endln:60:14
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:rd_addr_gray_sync
     |vpiFullName:work@oh_fifo_async.rd_addr_gray_sync
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:60:10, endln:60:14
-      |vpiLeftRange:
-      \_constant: , line:60:10, endln:60:12
-        |vpiDecompile:5
-        |vpiSize:64
-        |UINT:5
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:60:13, endln:60:14
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.rd_addr_sync), line:61:18, endln:61:30, parent:work@oh_fifo_async
+    |vpiTypespec:
+    \_logic_typespec: , line:61:4, endln:61:8
+      |vpiRange:
+      \_range: , line:61:10, endln:61:14
+        |vpiLeftRange:
+        \_constant: , line:61:10, endln:61:12
+          |vpiDecompile:5
+          |vpiSize:64
+          |UINT:5
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:61:13, endln:61:14
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiName:rd_addr_sync
     |vpiFullName:work@oh_fifo_async.rd_addr_sync
     |vpiNetType:1
-    |vpiRange:
-    \_range: , line:61:10, endln:61:14
-      |vpiLeftRange:
-      \_constant: , line:61:10, endln:61:12
-        |vpiDecompile:5
-        |vpiSize:64
-        |UINT:5
-        |vpiConstType:9
-      |vpiRightRange:
-      \_constant: , line:61:13, endln:61:14
-        |vpiDecompile:0
-        |vpiSize:64
-        |UINT:0
-        |vpiConstType:9
   |vpiNet:
   \_logic_net: (work@oh_fifo_async.fifo_write), line:62:11, endln:62:21, parent:work@oh_fifo_async
   |vpiNet:
@@ -31030,6 +31070,22 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.wr_din
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.wr_din), line:26:20, endln:26:26, parent:work@oh_fifo_async
+    |vpiTypedef:
+    \_logic_typespec: , line:26:11, endln:26:18
+      |vpiRange:
+      \_range: , line:26:12, endln:26:17, parent:wr_din
+        |vpiLeftRange:
+        \_constant: , line:26:12, endln:26:13
+          |vpiDecompile:31
+          |vpiSize:64
+          |INT:31
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:26:16, endln:26:17
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@oh_fifo_async (work@oh_fifo_async) stdlib/hdl/oh_fifo_async.v:11:1: , endln:186:10
   |vpiPort:
@@ -31090,6 +31146,22 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.wr_count
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.wr_count), line:31:21, endln:31:29, parent:work@oh_fifo_async
+    |vpiTypedef:
+    \_logic_typespec: , line:31:12, endln:31:20
+      |vpiRange:
+      \_range: , line:31:13, endln:31:19, parent:wr_count
+        |vpiLeftRange:
+        \_constant: , line:31:13, endln:31:15
+          |vpiDecompile:4
+          |vpiSize:64
+          |INT:4
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:31:18, endln:31:19
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@oh_fifo_async (work@oh_fifo_async) stdlib/hdl/oh_fifo_async.v:11:1: , endln:186:10
   |vpiPort:
@@ -31114,6 +31186,22 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.rd_dout
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.rd_dout), line:34:20, endln:34:27, parent:work@oh_fifo_async
+    |vpiTypedef:
+    \_logic_typespec: , line:34:12, endln:34:19
+      |vpiRange:
+      \_range: , line:34:13, endln:34:18, parent:rd_dout
+        |vpiLeftRange:
+        \_constant: , line:34:13, endln:34:14
+          |vpiDecompile:31
+          |vpiSize:64
+          |INT:31
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:34:17, endln:34:18
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@oh_fifo_async (work@oh_fifo_async) stdlib/hdl/oh_fifo_async.v:11:1: , endln:186:10
   |vpiPort:
@@ -31150,6 +31238,22 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.rd_count
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.rd_count), line:37:21, endln:37:29, parent:work@oh_fifo_async
+    |vpiTypedef:
+    \_logic_typespec: , line:37:12, endln:37:20
+      |vpiRange:
+      \_range: , line:37:13, endln:37:19, parent:rd_count
+        |vpiLeftRange:
+        \_constant: , line:37:13, endln:37:15
+          |vpiDecompile:4
+          |vpiSize:64
+          |INT:4
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:37:18, endln:37:19
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@oh_fifo_async (work@oh_fifo_async) stdlib/hdl/oh_fifo_async.v:11:1: , endln:186:10
   |vpiPort:
@@ -31186,6 +31290,22 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.bist_wem
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.bist_wem), line:41:20, endln:41:28, parent:work@oh_fifo_async
+    |vpiTypedef:
+    \_logic_typespec: , line:41:11, endln:41:18
+      |vpiRange:
+      \_range: , line:41:12, endln:41:17, parent:bist_wem
+        |vpiLeftRange:
+        \_constant: , line:41:12, endln:41:13
+          |vpiDecompile:31
+          |vpiSize:64
+          |INT:31
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:41:16, endln:41:17
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@oh_fifo_async (work@oh_fifo_async) stdlib/hdl/oh_fifo_async.v:11:1: , endln:186:10
   |vpiPort:
@@ -31198,6 +31318,22 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.bist_addr
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.bist_addr), line:42:21, endln:42:30, parent:work@oh_fifo_async
+    |vpiTypedef:
+    \_logic_typespec: , line:42:11, endln:42:19
+      |vpiRange:
+      \_range: , line:42:12, endln:42:18, parent:bist_addr
+        |vpiLeftRange:
+        \_constant: , line:42:12, endln:42:14
+          |vpiDecompile:4
+          |vpiSize:64
+          |INT:4
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:42:17, endln:42:18
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@oh_fifo_async (work@oh_fifo_async) stdlib/hdl/oh_fifo_async.v:11:1: , endln:186:10
   |vpiPort:
@@ -31210,6 +31346,22 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.bist_din
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.bist_din), line:43:20, endln:43:28, parent:work@oh_fifo_async
+    |vpiTypedef:
+    \_logic_typespec: , line:43:11, endln:43:18
+      |vpiRange:
+      \_range: , line:43:12, endln:43:17, parent:bist_din
+        |vpiLeftRange:
+        \_constant: , line:43:12, endln:43:13
+          |vpiDecompile:31
+          |vpiSize:64
+          |INT:31
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:43:16, endln:43:17
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@oh_fifo_async (work@oh_fifo_async) stdlib/hdl/oh_fifo_async.v:11:1: , endln:186:10
   |vpiPort:
@@ -31222,6 +31374,22 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.bist_dout
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.bist_dout), line:44:20, endln:44:29, parent:work@oh_fifo_async
+    |vpiTypedef:
+    \_logic_typespec: , line:44:11, endln:44:18
+      |vpiRange:
+      \_range: , line:44:12, endln:44:17, parent:bist_dout
+        |vpiLeftRange:
+        \_constant: , line:44:12, endln:44:13
+          |vpiDecompile:31
+          |vpiSize:64
+          |INT:31
+          |vpiConstType:7
+        |vpiRightRange:
+        \_constant: , line:44:16, endln:44:17
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@oh_fifo_async (work@oh_fifo_async) stdlib/hdl/oh_fifo_async.v:11:1: , endln:186:10
   |vpiPort:
@@ -31282,6 +31450,22 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.memconfig
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.memconfig), line:50:21, endln:50:30, parent:work@oh_fifo_async
+    |vpiTypedef:
+    \_logic_typespec: , line:50:11, endln:50:16
+      |vpiRange:
+      \_range: , line:50:12, endln:50:15, parent:memconfig
+        |vpiLeftRange:
+        \_constant: , line:50:12, endln:50:13
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:50:14, endln:50:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@oh_fifo_async (work@oh_fifo_async) stdlib/hdl/oh_fifo_async.v:11:1: , endln:186:10
   |vpiPort:
@@ -31294,6 +31478,22 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.memrepair
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.memrepair), line:51:21, endln:51:30, parent:work@oh_fifo_async
+    |vpiTypedef:
+    \_logic_typespec: , line:51:11, endln:51:16
+      |vpiRange:
+      \_range: , line:51:12, endln:51:15, parent:memrepair
+        |vpiLeftRange:
+        \_constant: , line:51:12, endln:51:13
+          |vpiDecompile:7
+          |vpiSize:64
+          |UINT:7
+          |vpiConstType:9
+        |vpiRightRange:
+        \_constant: , line:51:14, endln:51:15
+          |vpiDecompile:0
+          |vpiSize:64
+          |UINT:0
+          |vpiConstType:9
     |vpiInstance:
     \_module: work@oh_fifo_async (work@oh_fifo_async) stdlib/hdl/oh_fifo_async.v:11:1: , endln:186:10
   |vpiProcess:
@@ -31822,23 +32022,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.wr_rsync.genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.wr_rsync.genblk1.sync_pipe), line:22:24, endln:22:33, parent:work@oh_fifo_async.wr_rsync.genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:22:5, endln:22:8
+            |vpiRange:
+            \_range: , line:22:10, endln:22:22
+              |vpiLeftRange:
+              \_constant: , line:22:10, endln:22:18
+                |vpiDecompile:1
+                |vpiSize:64
+                |INT:1
+                |vpiConstType:7
+              |vpiRightRange:
+              \_constant: , line:22:21, endln:22:22
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.wr_rsync.genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:22:10, endln:22:22
-            |vpiLeftRange:
-            \_constant: , line:22:10, endln:22:18
-              |vpiDecompile:1
-              |vpiSize:64
-              |INT:1
-              |vpiConstType:7
-            |vpiRightRange:
-            \_constant: , line:22:21, endln:22:22
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:23:5, endln:27:67, parent:work@oh_fifo_async.wr_rsync.genblk1
           |vpiStmt:
@@ -32170,23 +32372,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.rd_rsync.genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.rd_rsync.genblk1.sync_pipe), line:22:24, endln:22:33, parent:work@oh_fifo_async.rd_rsync.genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:22:5, endln:22:8
+            |vpiRange:
+            \_range: , line:22:10, endln:22:22
+              |vpiLeftRange:
+              \_constant: , line:22:10, endln:22:18
+                |vpiDecompile:1
+                |vpiSize:64
+                |INT:1
+                |vpiConstType:7
+              |vpiRightRange:
+              \_constant: , line:22:21, endln:22:22
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.rd_rsync.genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:22:10, endln:22:22
-            |vpiLeftRange:
-            \_constant: , line:22:10, endln:22:18
-              |vpiDecompile:1
-              |vpiSize:64
-              |INT:1
-              |vpiConstType:7
-            |vpiRightRange:
-            \_constant: , line:22:21, endln:22:22
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:23:5, endln:27:67, parent:work@oh_fifo_async.rd_rsync.genblk1
           |vpiStmt:
@@ -32406,78 +32610,86 @@ design: (work@oh_fifo_async)
     |vpiDefLineNo:8
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.wr_bin2gray.in), line:12:20, endln:12:22, parent:work@oh_fifo_async.wr_bin2gray
+      |vpiTypespec:
+      \_logic_typespec: , line:12:11, endln:12:18
+        |vpiRange:
+        \_range: , line:12:12, endln:12:17
+          |vpiLeftRange:
+          \_constant: , line:12:12, endln:12:13
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:12:16, endln:12:17
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:in
       |vpiFullName:work@oh_fifo_async.wr_bin2gray.in
-      |vpiRange:
-      \_range: , line:12:12, endln:12:17
-        |vpiLeftRange:
-        \_constant: , line:12:12, endln:12:13
-          |vpiDecompile:5
-          |vpiSize:64
-          |INT:5
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:12:16, endln:12:17
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.wr_bin2gray.out), line:13:20, endln:13:23, parent:work@oh_fifo_async.wr_bin2gray
+      |vpiTypespec:
+      \_logic_typespec: , line:13:12, endln:13:19
+        |vpiRange:
+        \_range: , line:13:13, endln:13:18
+          |vpiLeftRange:
+          \_constant: , line:13:13, endln:13:14
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:13:17, endln:13:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:out
       |vpiFullName:work@oh_fifo_async.wr_bin2gray.out
-      |vpiRange:
-      \_range: , line:13:13, endln:13:18
-        |vpiLeftRange:
-        \_constant: , line:13:13, endln:13:14
-          |vpiDecompile:5
-          |vpiSize:64
-          |INT:5
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:13:17, endln:13:18
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.wr_bin2gray.gray), line:16:20, endln:16:24, parent:work@oh_fifo_async.wr_bin2gray
+      |vpiTypespec:
+      \_logic_typespec: , line:16:4, endln:16:7
+        |vpiRange:
+        \_range: , line:16:9, endln:16:14
+          |vpiLeftRange:
+          \_constant: , line:16:9, endln:16:10
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:16:13, endln:16:14
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:gray
       |vpiFullName:work@oh_fifo_async.wr_bin2gray.gray
       |vpiNetType:48
-      |vpiRange:
-      \_range: , line:16:9, endln:16:14
-        |vpiLeftRange:
-        \_constant: , line:16:9, endln:16:10
-          |vpiDecompile:5
-          |vpiSize:64
-          |INT:5
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:16:13, endln:16:14
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.wr_bin2gray.bin), line:17:20, endln:17:23, parent:work@oh_fifo_async.wr_bin2gray
+      |vpiTypespec:
+      \_logic_typespec: , line:17:4, endln:17:8
+        |vpiRange:
+        \_range: , line:17:10, endln:17:15
+          |vpiLeftRange:
+          \_constant: , line:17:10, endln:17:11
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:17:14, endln:17:15
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:bin
       |vpiFullName:work@oh_fifo_async.wr_bin2gray.bin
       |vpiNetType:1
-      |vpiRange:
-      \_range: , line:17:10, endln:17:15
-        |vpiLeftRange:
-        \_constant: , line:17:10, endln:17:11
-          |vpiDecompile:5
-          |vpiSize:64
-          |INT:5
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:17:14, endln:17:15
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiInstance:
     \_module: work@oh_fifo_async (work@oh_fifo_async) stdlib/hdl/oh_fifo_async.v:11:1: , endln:186:10
     |vpiPort:
@@ -32510,6 +32722,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.wr_bin2gray.in
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.wr_bin2gray.in), line:12:20, endln:12:22, parent:work@oh_fifo_async.wr_bin2gray
+      |vpiTypedef:
+      \_logic_typespec: , line:12:11, endln:12:18
+        |vpiRange:
+        \_range: , line:12:12, endln:12:17, parent:in
+          |vpiLeftRange:
+          \_constant: , line:12:12, endln:12:13
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:12:16, endln:12:17
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_bin2gray (work@oh_fifo_async.wr_bin2gray) stdlib/hdl/oh_fifo_async.v:114:4: , endln:116:24, parent:work@oh_fifo_async
     |vpiPort:
@@ -32542,6 +32770,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.wr_bin2gray.out
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.wr_bin2gray.out), line:13:20, endln:13:23, parent:work@oh_fifo_async.wr_bin2gray
+      |vpiTypedef:
+      \_logic_typespec: , line:13:12, endln:13:19
+        |vpiRange:
+        \_range: , line:13:13, endln:13:18, parent:out
+          |vpiLeftRange:
+          \_constant: , line:13:13, endln:13:14
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:13:17, endln:13:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_bin2gray (work@oh_fifo_async.wr_bin2gray) stdlib/hdl/oh_fifo_async.v:114:4: , endln:116:24, parent:work@oh_fifo_async
     |vpiProcess:
@@ -33017,23 +33261,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.wr_sync[0].genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.wr_sync[0].genblk1.sync_pipe), line:23:20, endln:23:29, parent:work@oh_fifo_async.wr_sync[0].genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:23:3, endln:23:6
+            |vpiRange:
+            \_range: , line:23:8, endln:23:18
+              |vpiLeftRange:
+              \_constant: , line:23:8, endln:23:16
+                |vpiDecompile:2
+                |vpiSize:32
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:23:17, endln:23:18
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.wr_sync[0].genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:23:8, endln:23:18
-            |vpiLeftRange:
-            \_constant: , line:23:8, endln:23:16
-              |vpiDecompile:2
-              |vpiSize:32
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:23:17, endln:23:18
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:24:3, endln:28:62, parent:work@oh_fifo_async.wr_sync[0].genblk1
           |vpiStmt:
@@ -33462,23 +33708,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.wr_sync[1].genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.wr_sync[1].genblk1.sync_pipe), line:23:20, endln:23:29, parent:work@oh_fifo_async.wr_sync[1].genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:23:3, endln:23:6
+            |vpiRange:
+            \_range: , line:23:8, endln:23:18
+              |vpiLeftRange:
+              \_constant: , line:23:8, endln:23:16
+                |vpiDecompile:2
+                |vpiSize:32
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:23:17, endln:23:18
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.wr_sync[1].genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:23:8, endln:23:18
-            |vpiLeftRange:
-            \_constant: , line:23:8, endln:23:16
-              |vpiDecompile:2
-              |vpiSize:32
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:23:17, endln:23:18
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:24:3, endln:28:62, parent:work@oh_fifo_async.wr_sync[1].genblk1
           |vpiStmt:
@@ -33907,23 +34155,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.wr_sync[2].genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.wr_sync[2].genblk1.sync_pipe), line:23:20, endln:23:29, parent:work@oh_fifo_async.wr_sync[2].genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:23:3, endln:23:6
+            |vpiRange:
+            \_range: , line:23:8, endln:23:18
+              |vpiLeftRange:
+              \_constant: , line:23:8, endln:23:16
+                |vpiDecompile:2
+                |vpiSize:32
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:23:17, endln:23:18
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.wr_sync[2].genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:23:8, endln:23:18
-            |vpiLeftRange:
-            \_constant: , line:23:8, endln:23:16
-              |vpiDecompile:2
-              |vpiSize:32
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:23:17, endln:23:18
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:24:3, endln:28:62, parent:work@oh_fifo_async.wr_sync[2].genblk1
           |vpiStmt:
@@ -34352,23 +34602,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.wr_sync[3].genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.wr_sync[3].genblk1.sync_pipe), line:23:20, endln:23:29, parent:work@oh_fifo_async.wr_sync[3].genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:23:3, endln:23:6
+            |vpiRange:
+            \_range: , line:23:8, endln:23:18
+              |vpiLeftRange:
+              \_constant: , line:23:8, endln:23:16
+                |vpiDecompile:2
+                |vpiSize:32
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:23:17, endln:23:18
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.wr_sync[3].genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:23:8, endln:23:18
-            |vpiLeftRange:
-            \_constant: , line:23:8, endln:23:16
-              |vpiDecompile:2
-              |vpiSize:32
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:23:17, endln:23:18
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:24:3, endln:28:62, parent:work@oh_fifo_async.wr_sync[3].genblk1
           |vpiStmt:
@@ -34797,23 +35049,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.wr_sync[4].genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.wr_sync[4].genblk1.sync_pipe), line:23:20, endln:23:29, parent:work@oh_fifo_async.wr_sync[4].genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:23:3, endln:23:6
+            |vpiRange:
+            \_range: , line:23:8, endln:23:18
+              |vpiLeftRange:
+              \_constant: , line:23:8, endln:23:16
+                |vpiDecompile:2
+                |vpiSize:32
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:23:17, endln:23:18
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.wr_sync[4].genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:23:8, endln:23:18
-            |vpiLeftRange:
-            \_constant: , line:23:8, endln:23:16
-              |vpiDecompile:2
-              |vpiSize:32
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:23:17, endln:23:18
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:24:3, endln:28:62, parent:work@oh_fifo_async.wr_sync[4].genblk1
           |vpiStmt:
@@ -35242,23 +35496,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.wr_sync[5].genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.wr_sync[5].genblk1.sync_pipe), line:23:20, endln:23:29, parent:work@oh_fifo_async.wr_sync[5].genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:23:3, endln:23:6
+            |vpiRange:
+            \_range: , line:23:8, endln:23:18
+              |vpiLeftRange:
+              \_constant: , line:23:8, endln:23:16
+                |vpiDecompile:2
+                |vpiSize:32
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:23:17, endln:23:18
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.wr_sync[5].genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:23:8, endln:23:18
-            |vpiLeftRange:
-            \_constant: , line:23:8, endln:23:16
-              |vpiDecompile:2
-              |vpiSize:32
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:23:17, endln:23:18
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:24:3, endln:28:62, parent:work@oh_fifo_async.wr_sync[5].genblk1
           |vpiStmt:
@@ -35511,78 +35767,86 @@ design: (work@oh_fifo_async)
     |vpiDefLineNo:8
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.rd_bin2gray.in), line:12:20, endln:12:22, parent:work@oh_fifo_async.rd_bin2gray
+      |vpiTypespec:
+      \_logic_typespec: , line:12:11, endln:12:18
+        |vpiRange:
+        \_range: , line:12:12, endln:12:17
+          |vpiLeftRange:
+          \_constant: , line:12:12, endln:12:13
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:12:16, endln:12:17
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:in
       |vpiFullName:work@oh_fifo_async.rd_bin2gray.in
-      |vpiRange:
-      \_range: , line:12:12, endln:12:17
-        |vpiLeftRange:
-        \_constant: , line:12:12, endln:12:13
-          |vpiDecompile:5
-          |vpiSize:64
-          |INT:5
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:12:16, endln:12:17
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.rd_bin2gray.out), line:13:20, endln:13:23, parent:work@oh_fifo_async.rd_bin2gray
+      |vpiTypespec:
+      \_logic_typespec: , line:13:12, endln:13:19
+        |vpiRange:
+        \_range: , line:13:13, endln:13:18
+          |vpiLeftRange:
+          \_constant: , line:13:13, endln:13:14
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:13:17, endln:13:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:out
       |vpiFullName:work@oh_fifo_async.rd_bin2gray.out
-      |vpiRange:
-      \_range: , line:13:13, endln:13:18
-        |vpiLeftRange:
-        \_constant: , line:13:13, endln:13:14
-          |vpiDecompile:5
-          |vpiSize:64
-          |INT:5
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:13:17, endln:13:18
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.rd_bin2gray.gray), line:16:20, endln:16:24, parent:work@oh_fifo_async.rd_bin2gray
+      |vpiTypespec:
+      \_logic_typespec: , line:16:4, endln:16:7
+        |vpiRange:
+        \_range: , line:16:9, endln:16:14
+          |vpiLeftRange:
+          \_constant: , line:16:9, endln:16:10
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:16:13, endln:16:14
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:gray
       |vpiFullName:work@oh_fifo_async.rd_bin2gray.gray
       |vpiNetType:48
-      |vpiRange:
-      \_range: , line:16:9, endln:16:14
-        |vpiLeftRange:
-        \_constant: , line:16:9, endln:16:10
-          |vpiDecompile:5
-          |vpiSize:64
-          |INT:5
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:16:13, endln:16:14
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.rd_bin2gray.bin), line:17:20, endln:17:23, parent:work@oh_fifo_async.rd_bin2gray
+      |vpiTypespec:
+      \_logic_typespec: , line:17:4, endln:17:8
+        |vpiRange:
+        \_range: , line:17:10, endln:17:15
+          |vpiLeftRange:
+          \_constant: , line:17:10, endln:17:11
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:17:14, endln:17:15
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:bin
       |vpiFullName:work@oh_fifo_async.rd_bin2gray.bin
       |vpiNetType:1
-      |vpiRange:
-      \_range: , line:17:10, endln:17:15
-        |vpiLeftRange:
-        \_constant: , line:17:10, endln:17:11
-          |vpiDecompile:5
-          |vpiSize:64
-          |INT:5
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:17:14, endln:17:15
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiInstance:
     \_module: work@oh_fifo_async (work@oh_fifo_async) stdlib/hdl/oh_fifo_async.v:11:1: , endln:186:10
     |vpiPort:
@@ -35615,6 +35879,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.rd_bin2gray.in
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.rd_bin2gray.in), line:12:20, endln:12:22, parent:work@oh_fifo_async.rd_bin2gray
+      |vpiTypedef:
+      \_logic_typespec: , line:12:11, endln:12:18
+        |vpiRange:
+        \_range: , line:12:12, endln:12:17, parent:in
+          |vpiLeftRange:
+          \_constant: , line:12:12, endln:12:13
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:12:16, endln:12:17
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_bin2gray (work@oh_fifo_async.rd_bin2gray) stdlib/hdl/oh_fifo_async.v:130:4: , endln:132:27, parent:work@oh_fifo_async
     |vpiPort:
@@ -35647,6 +35927,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.rd_bin2gray.out
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.rd_bin2gray.out), line:13:20, endln:13:23, parent:work@oh_fifo_async.rd_bin2gray
+      |vpiTypedef:
+      \_logic_typespec: , line:13:12, endln:13:19
+        |vpiRange:
+        \_range: , line:13:13, endln:13:18, parent:out
+          |vpiLeftRange:
+          \_constant: , line:13:13, endln:13:14
+            |vpiDecompile:5
+            |vpiSize:64
+            |INT:5
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:13:17, endln:13:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_bin2gray (work@oh_fifo_async.rd_bin2gray) stdlib/hdl/oh_fifo_async.v:130:4: , endln:132:27, parent:work@oh_fifo_async
     |vpiProcess:
@@ -36122,23 +36418,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.rd_sync[0].genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.rd_sync[0].genblk1.sync_pipe), line:23:20, endln:23:29, parent:work@oh_fifo_async.rd_sync[0].genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:23:3, endln:23:6
+            |vpiRange:
+            \_range: , line:23:8, endln:23:18
+              |vpiLeftRange:
+              \_constant: , line:23:8, endln:23:16
+                |vpiDecompile:2
+                |vpiSize:32
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:23:17, endln:23:18
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.rd_sync[0].genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:23:8, endln:23:18
-            |vpiLeftRange:
-            \_constant: , line:23:8, endln:23:16
-              |vpiDecompile:2
-              |vpiSize:32
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:23:17, endln:23:18
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:24:3, endln:28:62, parent:work@oh_fifo_async.rd_sync[0].genblk1
           |vpiStmt:
@@ -36567,23 +36865,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.rd_sync[1].genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.rd_sync[1].genblk1.sync_pipe), line:23:20, endln:23:29, parent:work@oh_fifo_async.rd_sync[1].genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:23:3, endln:23:6
+            |vpiRange:
+            \_range: , line:23:8, endln:23:18
+              |vpiLeftRange:
+              \_constant: , line:23:8, endln:23:16
+                |vpiDecompile:2
+                |vpiSize:32
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:23:17, endln:23:18
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.rd_sync[1].genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:23:8, endln:23:18
-            |vpiLeftRange:
-            \_constant: , line:23:8, endln:23:16
-              |vpiDecompile:2
-              |vpiSize:32
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:23:17, endln:23:18
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:24:3, endln:28:62, parent:work@oh_fifo_async.rd_sync[1].genblk1
           |vpiStmt:
@@ -37012,23 +37312,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.rd_sync[2].genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.rd_sync[2].genblk1.sync_pipe), line:23:20, endln:23:29, parent:work@oh_fifo_async.rd_sync[2].genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:23:3, endln:23:6
+            |vpiRange:
+            \_range: , line:23:8, endln:23:18
+              |vpiLeftRange:
+              \_constant: , line:23:8, endln:23:16
+                |vpiDecompile:2
+                |vpiSize:32
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:23:17, endln:23:18
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.rd_sync[2].genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:23:8, endln:23:18
-            |vpiLeftRange:
-            \_constant: , line:23:8, endln:23:16
-              |vpiDecompile:2
-              |vpiSize:32
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:23:17, endln:23:18
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:24:3, endln:28:62, parent:work@oh_fifo_async.rd_sync[2].genblk1
           |vpiStmt:
@@ -37457,23 +37759,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.rd_sync[3].genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.rd_sync[3].genblk1.sync_pipe), line:23:20, endln:23:29, parent:work@oh_fifo_async.rd_sync[3].genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:23:3, endln:23:6
+            |vpiRange:
+            \_range: , line:23:8, endln:23:18
+              |vpiLeftRange:
+              \_constant: , line:23:8, endln:23:16
+                |vpiDecompile:2
+                |vpiSize:32
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:23:17, endln:23:18
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.rd_sync[3].genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:23:8, endln:23:18
-            |vpiLeftRange:
-            \_constant: , line:23:8, endln:23:16
-              |vpiDecompile:2
-              |vpiSize:32
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:23:17, endln:23:18
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:24:3, endln:28:62, parent:work@oh_fifo_async.rd_sync[3].genblk1
           |vpiStmt:
@@ -37902,23 +38206,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.rd_sync[4].genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.rd_sync[4].genblk1.sync_pipe), line:23:20, endln:23:29, parent:work@oh_fifo_async.rd_sync[4].genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:23:3, endln:23:6
+            |vpiRange:
+            \_range: , line:23:8, endln:23:18
+              |vpiLeftRange:
+              \_constant: , line:23:8, endln:23:16
+                |vpiDecompile:2
+                |vpiSize:32
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:23:17, endln:23:18
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.rd_sync[4].genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:23:8, endln:23:18
-            |vpiLeftRange:
-            \_constant: , line:23:8, endln:23:16
-              |vpiDecompile:2
-              |vpiSize:32
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:23:17, endln:23:18
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:24:3, endln:28:62, parent:work@oh_fifo_async.rd_sync[4].genblk1
           |vpiStmt:
@@ -38347,23 +38653,25 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.rd_sync[5].genblk1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.rd_sync[5].genblk1.sync_pipe), line:23:20, endln:23:29, parent:work@oh_fifo_async.rd_sync[5].genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:23:3, endln:23:6
+            |vpiRange:
+            \_range: , line:23:8, endln:23:18
+              |vpiLeftRange:
+              \_constant: , line:23:8, endln:23:16
+                |vpiDecompile:2
+                |vpiSize:32
+                |UINT:2
+                |vpiConstType:9
+              |vpiRightRange:
+              \_constant: , line:23:17, endln:23:18
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:sync_pipe
           |vpiFullName:work@oh_fifo_async.rd_sync[5].genblk1.sync_pipe
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:23:8, endln:23:18
-            |vpiLeftRange:
-            \_constant: , line:23:8, endln:23:16
-              |vpiDecompile:2
-              |vpiSize:32
-              |UINT:2
-              |vpiConstType:9
-            |vpiRightRange:
-            \_constant: , line:23:17, endln:23:18
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiProcess:
         \_always: , line:24:3, endln:28:62, parent:work@oh_fifo_async.rd_sync[5].genblk1
           |vpiStmt:
@@ -38730,58 +39038,64 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.wr_en
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.oh_memory_dp.wr_wem), line:20:20, endln:20:26, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypespec:
+      \_logic_typespec: , line:20:11, endln:20:18
+        |vpiRange:
+        \_range: , line:20:12, endln:20:17
+          |vpiLeftRange:
+          \_constant: , line:20:12, endln:20:13
+            |vpiDecompile:31
+            |vpiSize:64
+            |INT:31
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:20:16, endln:20:17
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:wr_wem
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.wr_wem
-      |vpiRange:
-      \_range: , line:20:12, endln:20:17
-        |vpiLeftRange:
-        \_constant: , line:20:12, endln:20:13
-          |vpiDecompile:31
-          |vpiSize:64
-          |INT:31
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:20:16, endln:20:17
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.oh_memory_dp.wr_addr), line:21:21, endln:21:28, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypespec:
+      \_logic_typespec: , line:21:11, endln:21:19
+        |vpiRange:
+        \_range: , line:21:12, endln:21:18
+          |vpiLeftRange:
+          \_constant: , line:21:12, endln:21:14
+            |vpiDecompile:4
+            |vpiSize:64
+            |INT:4
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:21:17, endln:21:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:wr_addr
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.wr_addr
-      |vpiRange:
-      \_range: , line:21:12, endln:21:18
-        |vpiLeftRange:
-        \_constant: , line:21:12, endln:21:14
-          |vpiDecompile:4
-          |vpiSize:64
-          |INT:4
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:21:17, endln:21:18
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.oh_memory_dp.wr_din), line:22:20, endln:22:26, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypespec:
+      \_logic_typespec: , line:22:11, endln:22:18
+        |vpiRange:
+        \_range: , line:22:12, endln:22:17
+          |vpiLeftRange:
+          \_constant: , line:22:12, endln:22:13
+            |vpiDecompile:31
+            |vpiSize:64
+            |INT:31
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:22:16, endln:22:17
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:wr_din
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.wr_din
-      |vpiRange:
-      \_range: , line:22:12, endln:22:17
-        |vpiLeftRange:
-        \_constant: , line:22:12, endln:22:13
-          |vpiDecompile:31
-          |vpiSize:64
-          |INT:31
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:22:16, endln:22:17
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.oh_memory_dp.rd_clk), line:23:16, endln:23:22, parent:work@oh_fifo_async.oh_memory_dp
       |vpiName:rd_clk
@@ -38792,40 +39106,44 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.rd_en
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.oh_memory_dp.rd_addr), line:25:21, endln:25:28, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypespec:
+      \_logic_typespec: , line:25:11, endln:25:19
+        |vpiRange:
+        \_range: , line:25:12, endln:25:18
+          |vpiLeftRange:
+          \_constant: , line:25:12, endln:25:14
+            |vpiDecompile:4
+            |vpiSize:64
+            |INT:4
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:25:17, endln:25:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:rd_addr
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.rd_addr
-      |vpiRange:
-      \_range: , line:25:12, endln:25:18
-        |vpiLeftRange:
-        \_constant: , line:25:12, endln:25:14
-          |vpiDecompile:4
-          |vpiSize:64
-          |INT:4
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:25:17, endln:25:18
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.oh_memory_dp.rd_dout), line:26:20, endln:26:27, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypespec:
+      \_logic_typespec: , line:26:12, endln:26:19
+        |vpiRange:
+        \_range: , line:26:13, endln:26:18
+          |vpiLeftRange:
+          \_constant: , line:26:13, endln:26:14
+            |vpiDecompile:31
+            |vpiSize:64
+            |INT:31
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:26:17, endln:26:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:rd_dout
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.rd_dout
-      |vpiRange:
-      \_range: , line:26:13, endln:26:18
-        |vpiLeftRange:
-        \_constant: , line:26:13, endln:26:14
-          |vpiDecompile:31
-          |vpiSize:64
-          |INT:31
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:26:17, endln:26:18
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.oh_memory_dp.bist_en), line:28:16, endln:28:23, parent:work@oh_fifo_async.oh_memory_dp
       |vpiName:bist_en
@@ -38836,58 +39154,64 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.bist_we
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.oh_memory_dp.bist_wem), line:30:20, endln:30:28, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypespec:
+      \_logic_typespec: , line:30:11, endln:30:18
+        |vpiRange:
+        \_range: , line:30:12, endln:30:17
+          |vpiLeftRange:
+          \_constant: , line:30:12, endln:30:13
+            |vpiDecompile:31
+            |vpiSize:64
+            |INT:31
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:30:16, endln:30:17
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:bist_wem
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.bist_wem
-      |vpiRange:
-      \_range: , line:30:12, endln:30:17
-        |vpiLeftRange:
-        \_constant: , line:30:12, endln:30:13
-          |vpiDecompile:31
-          |vpiSize:64
-          |INT:31
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:30:16, endln:30:17
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.oh_memory_dp.bist_addr), line:31:21, endln:31:30, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypespec:
+      \_logic_typespec: , line:31:11, endln:31:19
+        |vpiRange:
+        \_range: , line:31:12, endln:31:18
+          |vpiLeftRange:
+          \_constant: , line:31:12, endln:31:14
+            |vpiDecompile:4
+            |vpiSize:64
+            |INT:4
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:31:17, endln:31:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:bist_addr
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.bist_addr
-      |vpiRange:
-      \_range: , line:31:12, endln:31:18
-        |vpiLeftRange:
-        \_constant: , line:31:12, endln:31:14
-          |vpiDecompile:4
-          |vpiSize:64
-          |INT:4
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:31:17, endln:31:18
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.oh_memory_dp.bist_din), line:32:20, endln:32:28, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypespec:
+      \_logic_typespec: , line:32:11, endln:32:18
+        |vpiRange:
+        \_range: , line:32:12, endln:32:17
+          |vpiLeftRange:
+          \_constant: , line:32:12, endln:32:13
+            |vpiDecompile:31
+            |vpiSize:64
+            |INT:31
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:32:16, endln:32:17
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:bist_din
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.bist_din
-      |vpiRange:
-      \_range: , line:32:12, endln:32:17
-        |vpiLeftRange:
-        \_constant: , line:32:12, endln:32:13
-          |vpiDecompile:31
-          |vpiSize:64
-          |INT:31
-          |vpiConstType:7
-        |vpiRightRange:
-        \_constant: , line:32:16, endln:32:17
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.oh_memory_dp.shutdown), line:34:16, endln:34:24, parent:work@oh_fifo_async.oh_memory_dp
       |vpiName:shutdown
@@ -38906,40 +39230,44 @@ design: (work@oh_fifo_async)
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.vddio
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.oh_memory_dp.memconfig), line:38:21, endln:38:30, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypespec:
+      \_logic_typespec: , line:38:11, endln:38:16
+        |vpiRange:
+        \_range: , line:38:12, endln:38:15
+          |vpiLeftRange:
+          \_constant: , line:38:12, endln:38:13
+            |vpiDecompile:7
+            |vpiSize:64
+            |UINT:7
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:38:14, endln:38:15
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:memconfig
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.memconfig
-      |vpiRange:
-      \_range: , line:38:12, endln:38:15
-        |vpiLeftRange:
-        \_constant: , line:38:12, endln:38:13
-          |vpiDecompile:7
-          |vpiSize:64
-          |UINT:7
-          |vpiConstType:9
-        |vpiRightRange:
-        \_constant: , line:38:14, endln:38:15
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiNet:
     \_logic_net: (work@oh_fifo_async.oh_memory_dp.memrepair), line:39:21, endln:39:30, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypespec:
+      \_logic_typespec: , line:39:11, endln:39:16
+        |vpiRange:
+        \_range: , line:39:12, endln:39:15
+          |vpiLeftRange:
+          \_constant: , line:39:12, endln:39:13
+            |vpiDecompile:7
+            |vpiSize:64
+            |UINT:7
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:39:14, endln:39:15
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiName:memrepair
       |vpiFullName:work@oh_fifo_async.oh_memory_dp.memrepair
-      |vpiRange:
-      \_range: , line:39:12, endln:39:15
-        |vpiLeftRange:
-        \_constant: , line:39:12, endln:39:13
-          |vpiDecompile:7
-          |vpiSize:64
-          |UINT:7
-          |vpiConstType:9
-        |vpiRightRange:
-        \_constant: , line:39:14, endln:39:15
-          |vpiDecompile:0
-          |vpiSize:64
-          |UINT:0
-          |vpiConstType:9
     |vpiInstance:
     \_module: work@oh_fifo_async (work@oh_fifo_async) stdlib/hdl/oh_fifo_async.v:11:1: , endln:186:10
     |vpiPort:
@@ -38997,6 +39325,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.oh_memory_dp.wr_wem
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.oh_memory_dp.wr_wem), line:20:20, endln:20:26, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypedef:
+      \_logic_typespec: , line:20:11, endln:20:18
+        |vpiRange:
+        \_range: , line:20:12, endln:20:17, parent:wr_wem
+          |vpiLeftRange:
+          \_constant: , line:20:12, endln:20:13
+            |vpiDecompile:31
+            |vpiSize:64
+            |INT:31
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:20:16, endln:20:17
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_memory_dp (work@oh_fifo_async.oh_memory_dp) stdlib/hdl/oh_fifo_async.v:157:4: , endln:184:33, parent:work@oh_fifo_async
     |vpiPort:
@@ -39038,6 +39382,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.oh_memory_dp.wr_addr
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.oh_memory_dp.wr_addr), line:21:21, endln:21:28, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypedef:
+      \_logic_typespec: , line:21:11, endln:21:19
+        |vpiRange:
+        \_range: , line:21:12, endln:21:18, parent:wr_addr
+          |vpiLeftRange:
+          \_constant: , line:21:12, endln:21:14
+            |vpiDecompile:4
+            |vpiSize:64
+            |INT:4
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:21:17, endln:21:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_memory_dp (work@oh_fifo_async.oh_memory_dp) stdlib/hdl/oh_fifo_async.v:157:4: , endln:184:33, parent:work@oh_fifo_async
     |vpiPort:
@@ -39081,6 +39441,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.oh_memory_dp.wr_din
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.oh_memory_dp.wr_din), line:22:20, endln:22:26, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypedef:
+      \_logic_typespec: , line:22:11, endln:22:18
+        |vpiRange:
+        \_range: , line:22:12, endln:22:17, parent:wr_din
+          |vpiLeftRange:
+          \_constant: , line:22:12, endln:22:13
+            |vpiDecompile:31
+            |vpiSize:64
+            |INT:31
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:22:16, endln:22:17
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_memory_dp (work@oh_fifo_async.oh_memory_dp) stdlib/hdl/oh_fifo_async.v:157:4: , endln:184:33, parent:work@oh_fifo_async
     |vpiPort:
@@ -39158,6 +39534,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.oh_memory_dp.rd_addr
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.oh_memory_dp.rd_addr), line:25:21, endln:25:28, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypedef:
+      \_logic_typespec: , line:25:11, endln:25:19
+        |vpiRange:
+        \_range: , line:25:12, endln:25:18, parent:rd_addr
+          |vpiLeftRange:
+          \_constant: , line:25:12, endln:25:14
+            |vpiDecompile:4
+            |vpiSize:64
+            |INT:4
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:25:17, endln:25:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_memory_dp (work@oh_fifo_async.oh_memory_dp) stdlib/hdl/oh_fifo_async.v:157:4: , endln:184:33, parent:work@oh_fifo_async
     |vpiPort:
@@ -39201,6 +39593,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.oh_memory_dp.rd_dout
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.oh_memory_dp.rd_dout), line:26:20, endln:26:27, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypedef:
+      \_logic_typespec: , line:26:12, endln:26:19
+        |vpiRange:
+        \_range: , line:26:13, endln:26:18, parent:rd_dout
+          |vpiLeftRange:
+          \_constant: , line:26:13, endln:26:14
+            |vpiDecompile:31
+            |vpiSize:64
+            |INT:31
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:26:17, endln:26:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_memory_dp (work@oh_fifo_async.oh_memory_dp) stdlib/hdl/oh_fifo_async.v:157:4: , endln:184:33, parent:work@oh_fifo_async
     |vpiPort:
@@ -39280,6 +39688,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.oh_memory_dp.bist_wem
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.oh_memory_dp.bist_wem), line:30:20, endln:30:28, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypedef:
+      \_logic_typespec: , line:30:11, endln:30:18
+        |vpiRange:
+        \_range: , line:30:12, endln:30:17, parent:bist_wem
+          |vpiLeftRange:
+          \_constant: , line:30:12, endln:30:13
+            |vpiDecompile:31
+            |vpiSize:64
+            |INT:31
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:30:16, endln:30:17
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_memory_dp (work@oh_fifo_async.oh_memory_dp) stdlib/hdl/oh_fifo_async.v:157:4: , endln:184:33, parent:work@oh_fifo_async
     |vpiPort:
@@ -39321,6 +39745,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.oh_memory_dp.bist_addr
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.oh_memory_dp.bist_addr), line:31:21, endln:31:30, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypedef:
+      \_logic_typespec: , line:31:11, endln:31:19
+        |vpiRange:
+        \_range: , line:31:12, endln:31:18, parent:bist_addr
+          |vpiLeftRange:
+          \_constant: , line:31:12, endln:31:14
+            |vpiDecompile:4
+            |vpiSize:64
+            |INT:4
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:31:17, endln:31:18
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_memory_dp (work@oh_fifo_async.oh_memory_dp) stdlib/hdl/oh_fifo_async.v:157:4: , endln:184:33, parent:work@oh_fifo_async
     |vpiPort:
@@ -39364,6 +39804,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.oh_memory_dp.bist_din
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.oh_memory_dp.bist_din), line:32:20, endln:32:28, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypedef:
+      \_logic_typespec: , line:32:11, endln:32:18
+        |vpiRange:
+        \_range: , line:32:12, endln:32:17, parent:bist_din
+          |vpiLeftRange:
+          \_constant: , line:32:12, endln:32:13
+            |vpiDecompile:31
+            |vpiSize:64
+            |INT:31
+            |vpiConstType:7
+          |vpiRightRange:
+          \_constant: , line:32:16, endln:32:17
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_memory_dp (work@oh_fifo_async.oh_memory_dp) stdlib/hdl/oh_fifo_async.v:157:4: , endln:184:33, parent:work@oh_fifo_async
     |vpiPort:
@@ -39468,6 +39924,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.oh_memory_dp.memconfig
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.oh_memory_dp.memconfig), line:38:21, endln:38:30, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypedef:
+      \_logic_typespec: , line:38:11, endln:38:16
+        |vpiRange:
+        \_range: , line:38:12, endln:38:15, parent:memconfig
+          |vpiLeftRange:
+          \_constant: , line:38:12, endln:38:13
+            |vpiDecompile:7
+            |vpiSize:64
+            |UINT:7
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:38:14, endln:38:15
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_memory_dp (work@oh_fifo_async.oh_memory_dp) stdlib/hdl/oh_fifo_async.v:157:4: , endln:184:33, parent:work@oh_fifo_async
     |vpiPort:
@@ -39500,6 +39972,22 @@ design: (work@oh_fifo_async)
         |vpiFullName:work@oh_fifo_async.oh_memory_dp.memrepair
         |vpiActual:
         \_logic_net: (work@oh_fifo_async.oh_memory_dp.memrepair), line:39:21, endln:39:30, parent:work@oh_fifo_async.oh_memory_dp
+      |vpiTypedef:
+      \_logic_typespec: , line:39:11, endln:39:16
+        |vpiRange:
+        \_range: , line:39:12, endln:39:15, parent:memrepair
+          |vpiLeftRange:
+          \_constant: , line:39:12, endln:39:13
+            |vpiDecompile:7
+            |vpiSize:64
+            |UINT:7
+            |vpiConstType:9
+          |vpiRightRange:
+          \_constant: , line:39:14, endln:39:15
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
       |vpiInstance:
       \_module: work@oh_memory_dp (work@oh_fifo_async.oh_memory_dp) stdlib/hdl/oh_fifo_async.v:157:4: , endln:184:33, parent:work@oh_fifo_async
     |vpiGenScopeArray:
@@ -39518,42 +40006,46 @@ design: (work@oh_fifo_async)
           |vpiVisibility:1
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.oh_memory_dp.genblk1.rdata), line:49:22, endln:49:27, parent:work@oh_fifo_async.oh_memory_dp.genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:49:3, endln:49:7
+            |vpiRange:
+            \_range: , line:49:9, endln:49:14
+              |vpiLeftRange:
+              \_constant: , line:49:9, endln:49:10
+                |vpiDecompile:31
+                |vpiSize:64
+                |INT:31
+                |vpiConstType:7
+              |vpiRightRange:
+              \_constant: , line:49:13, endln:49:14
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:rdata
           |vpiFullName:work@oh_fifo_async.oh_memory_dp.genblk1.rdata
           |vpiNetType:1
-          |vpiRange:
-          \_range: , line:49:9, endln:49:14
-            |vpiLeftRange:
-            \_constant: , line:49:9, endln:49:10
-              |vpiDecompile:31
-              |vpiSize:64
-              |INT:31
-              |vpiConstType:7
-            |vpiRightRange:
-            \_constant: , line:49:13, endln:49:14
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiNet:
         \_logic_net: (work@oh_fifo_async.oh_memory_dp.genblk1.rd_reg), line:62:21, endln:62:27, parent:work@oh_fifo_async.oh_memory_dp.genblk1
+          |vpiTypespec:
+          \_logic_typespec: , line:62:3, endln:62:6
+            |vpiRange:
+            \_range: , line:62:8, endln:62:13
+              |vpiLeftRange:
+              \_constant: , line:62:8, endln:62:9
+                |vpiDecompile:31
+                |vpiSize:64
+                |INT:31
+                |vpiConstType:7
+              |vpiRightRange:
+              \_constant: , line:62:12, endln:62:13
+                |vpiDecompile:0
+                |vpiSize:64
+                |UINT:0
+                |vpiConstType:9
           |vpiName:rd_reg
           |vpiFullName:work@oh_fifo_async.oh_memory_dp.genblk1.rd_reg
           |vpiNetType:48
-          |vpiRange:
-          \_range: , line:62:8, endln:62:13
-            |vpiLeftRange:
-            \_constant: , line:62:8, endln:62:9
-              |vpiDecompile:31
-              |vpiSize:64
-              |INT:31
-              |vpiConstType:7
-            |vpiRightRange:
-            \_constant: , line:62:12, endln:62:13
-              |vpiDecompile:0
-              |vpiSize:64
-              |UINT:0
-              |vpiConstType:9
         |vpiArrayNet:
         \_array_net: (work@oh_fifo_async.oh_memory_dp.genblk1.ram), line:48:22, endln:48:25, parent:work@oh_fifo_async.oh_memory_dp.genblk1
           |vpiSize:1
@@ -39575,22 +40067,24 @@ design: (work@oh_fifo_async)
               |vpiConstType:7
           |vpiNet:
           \_logic_net: (work@oh_fifo_async.oh_memory_dp.genblk1.ram), line:48:22, endln:48:25, parent:work@oh_fifo_async.oh_memory_dp.genblk1.ram
+            |vpiTypespec:
+            \_logic_typespec: , line:48:3, endln:48:6
+              |vpiRange:
+              \_range: , line:48:8, endln:48:13
+                |vpiLeftRange:
+                \_constant: , line:48:8, endln:48:9
+                  |vpiDecompile:31
+                  |vpiSize:64
+                  |INT:31
+                  |vpiConstType:7
+                |vpiRightRange:
+                \_constant: , line:48:12, endln:48:13
+                  |vpiDecompile:0
+                  |vpiSize:64
+                  |UINT:0
+                  |vpiConstType:9
             |vpiFullName:work@oh_fifo_async.oh_memory_dp.genblk1.ram
             |vpiNetType:48
-            |vpiRange:
-            \_range: , line:48:8, endln:48:13
-              |vpiLeftRange:
-              \_constant: , line:48:8, endln:48:9
-                |vpiDecompile:31
-                |vpiSize:64
-                |INT:31
-                |vpiConstType:7
-              |vpiRightRange:
-              \_constant: , line:48:12, endln:48:13
-                |vpiDecompile:0
-                |vpiSize:64
-                |UINT:0
-                |vpiConstType:9
         |vpiProcess:
         \_always: , line:53:3, endln:56:52, parent:work@oh_fifo_async.oh_memory_dp.genblk1
           |vpiStmt:


### PR DESCRIPTION
With this change, there is a typespec for every signal, simple type or complex type.
This brings consistency. 
Also the packed dimensions are on the typespec, and not on the signal anymore for simple typespecs.
Before this change, the ranges were both on the typespec and the signal which seems wrong now.
@rkapuscik @kbieganski, you might have to change a couple of things in your respective backends. I know you where picking the range of signals off the signals in some cases.