### PR TITLE
Get script interpreter paths from /usr/bin/env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Use bash as the default shell
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 ifdef $(LC_ALL)
 	undefine LC_ALL

--- a/src/API/embed_python_api.tcl
+++ b/src/API/embed_python_api.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/tclsh
+#!/usr/bin/env tclsh
 
 # Copyright 2019 Alain Dargelas
 #

--- a/src/API/generate_python_listener_api.tcl
+++ b/src/API/generate_python_listener_api.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/tclsh
+#!/usr/bin/env tclsh
 
 # Copyright 2019 Alain Dargelas
 #

--- a/src/API/yosys.tcl
+++ b/src/API/yosys.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/tclsh
+#!/usr/bin/env tclsh
 
 # Copyright 2019 Alain Dargelas
 #

--- a/src/SourceCompile/generate_parser_listener.tcl
+++ b/src/SourceCompile/generate_parser_listener.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/tclsh
+#!/usr/bin/env tclsh
 
 # Copyright 2019 Alain Dargelas
 #

--- a/src/diff_utils/diff.tcl
+++ b/src/diff_utils/diff.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/tclsh
+#!/usr/bin/env tclsh
 
 proc parse { file gl } {
     global $gl

--- a/src/diff_utils/sort.tcl
+++ b/src/diff_utils/sort.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/tclsh
+#!/usr/bin/env tclsh
 
 proc parse { file } {
     puts "Parsing $file"

--- a/src/diff_utils/verilator.tcl
+++ b/src/diff_utils/verilator.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/tclsh
+#!/usr/bin/env tclsh
 
 proc parse { file } {
     puts "Parsing $file"

--- a/tests/cmake_gen.tcl
+++ b/tests/cmake_gen.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/tclsh
+#!/usr/bin/env tclsh
 
 # Copyright 2020 Alain Dargelas
 #

--- a/tests/create_batch_script.tcl
+++ b/tests/create_batch_script.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/tclsh
+#!/usr/bin/env tclsh
 
 # Copyright 2019 Alain Dargelas
 #

--- a/tests/regression.tcl
+++ b/tests/regression.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/tclsh
+#!/usr/bin/env tclsh
 
 # Copyright 2017-2021 Alain Dargelas
 #


### PR DESCRIPTION
The locations of bash or tclsh can be different on
different systems, so it is better to use /usr/bin/env
to determine the path for the environment in question.

Signed-off-by: Henner Zeller <h.zeller@acm.org>