### PR TITLE
Prepare for different UHDM AllObjects() type.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(FLATBUFFERS_BUILD_TESTS OFF CACHE BOOL "Skip flatbuffers' tests")
 add_subdirectory(third_party/flatbuffers EXCLUDE_FROM_ALL)
+
+set(ANTLR_BUILD_CPP_TESTS OFF CACHE BOOL "Skip ANTLR tests")
 add_subdirectory(third_party/antlr4_fast/runtime/Cpp EXCLUDE_FROM_ALL)
 
 set(UHDM_BUILD_TESTS OFF CACHE BOOL "Skip UHDM tests")

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -525,9 +525,8 @@ float UhdmChecker::reportCoverage(const fs::path& reportFile) {
 
 void UhdmChecker::annotate(CompileDesign* m_compileDesign) {
   Serializer& s = m_compileDesign->getSerializer();
-  const std::unordered_map<const BaseClass*, unsigned long>& objects =
-      s.AllObjects();
-  for (auto& obj : objects) {
+  const auto& objects = s.AllObjects();
+  for (const auto& obj : objects) {
     const BaseClass* bc = obj.first;
     if (!bc) continue;
     bool unsupported = false;


### PR DESCRIPTION
 * AllObjects() will return a different map type
   after next submodule sync. This will work
   with both.
   https://github.com/chipsalliance/UHDM/pull/690

 * CMake: prepare for test switch off for ANTLR
   CPP tests available in the upcoming version
   https://github.com/antlr/antlr4/pull/3624

Signed-off-by: Henner Zeller <h.zeller@acm.org>