### PR TITLE
chipsalliance/Surelog#2855: Rename import model to import_typespec

### DIFF
--- a/include/Surelog/Design/DesignComponent.h
+++ b/include/Surelog/Design/DesignComponent.h
@@ -149,8 +149,8 @@ class DesignComponent : public ValuedComponentI, public PortNetHolder {
   void addParamAssign(ParamAssign* assign) { m_paramAssigns.push_back(assign); }
   const ParamAssignVec& getParamAssignVec() const { return m_paramAssigns; }
 
-  void addImportedSymbol(UHDM::import* i) { m_imported_symbols.push_back(i); }
-  const std::vector<UHDM::import*>& getImportedSymbols() const {
+  void addImportedSymbol(UHDM::import_typespec* i) { m_imported_symbols.push_back(i); }
+  const std::vector<UHDM::import_typespec*>& getImportedSymbols() const {
     return m_imported_symbols;
   }
 
@@ -201,7 +201,7 @@ class DesignComponent : public ValuedComponentI, public PortNetHolder {
   TypeDefMap m_typedefs;
   std::vector<Package*> m_packages;
   VariableMap m_variables;
-  std::vector<UHDM::import*> m_imported_symbols;
+  std::vector<UHDM::import_typespec*> m_imported_symbols;
   std::vector<UHDM::ref_obj*> m_needLateBinding;
   std::vector<UHDM::any*> m_needLateTypedefBinding;
   ParameterMap m_parameterMap;

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -1895,7 +1895,7 @@ void CompileHelper::compileImportDeclaration(DesignComponent* component,
      */
   Serializer& s = compileDesign->getSerializer();
   while (package_import_item_id != 0) {
-    import* import_stmt = s.MakeImport();
+    import_typespec* import_stmt = s.MakeImport_typespec();
     import_stmt->VpiFile(fC->getFileName());
     import_stmt->VpiLineNo(fC->Line(package_import_item_id));
     import_stmt->VpiColumnNo(fC->Column(package_import_item_id));

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -2051,7 +2051,7 @@ void UhdmWriter::lateBinding(UHDM::Serializer& s, DesignComponent* mod,
       bool isTypespec = false;
       std::vector<std::string> importedPackages;
       for (auto n : *m->Typespecs()) {
-        if (n->UhdmType() == uhdmimport) {
+        if (n->UhdmType() == uhdmimport_typespec) {
           importedPackages.push_back(n->VpiName());
         }
       }

--- a/src/roundtrip.cpp
+++ b/src/roundtrip.cpp
@@ -192,7 +192,7 @@ static const typespec_names_t kTypespecNames = {
   { UHDM::uhdmclass_typespec, "" },
   { UHDM::uhdmenum_typespec, "" },
   { UHDM::uhdmevent_typespec, "" },
-  { UHDM::uhdmimport, "" },
+  { UHDM::uhdmimport_typespec, "import" },
   { UHDM::uhdmint_typespec, "int" },
   { UHDM::uhdminteger_typespec, "integer" },
   { UHDM::uhdminterface_typespec, "" },
@@ -3151,7 +3151,7 @@ class RoundTripTracer final : public UHDM::UhdmListener {
     // tests\SimpleClass
   }
 
-  void enterImport(const UHDM::import *const object) final {
+  void enterImport_typespec(const UHDM::import_typespec *const object) final {
     if (visited.find(object) != visited.end()) return;
 
     constexpr std::string_view keyword1 = "import";


### PR DESCRIPTION
chipsalliance/Surelog#2855: Rename import model to import_typespec

* Rename import model to import_typespec (the latter is a keyword in C++20)
* Fixed a few warning messages from Windows build
* For generated model classes, for boolean variables use 'false' as default and not 0.
* Also, fixed a dependency issue in CMakeLists.txt (edits in UHDM/include directory wouldn't trigger a build)