### PR TITLE
Don't copy all exisiting entries on every copy constructed SymbolTable.

### DIFF
--- a/src/SourceCompile/SymbolTable.cpp
+++ b/src/SourceCompile/SymbolTable.cpp
@@ -27,9 +27,7 @@
 
 namespace SURELOG {
 
-SymbolTable::SymbolTable() : m_idCounter(getBadId()) {
-  registerSymbol(getBadSymbol());
-}
+SymbolTable::SymbolTable() { registerSymbol(getBadSymbol()); }
 
 SymbolTable::~SymbolTable() {}
 
@@ -44,35 +42,63 @@ const std::string& SymbolTable::getEmptyMacroMarker() {
 }
 
 SymbolId SymbolTable::registerSymbol(std::string_view symbol) {
+  if (m_parent) {
+    if (SymbolId id = m_parent->getId(symbol);
+        (id != getBadId() || symbol == getBadSymbol()) && id < m_idOffset) {
+      return id;
+    }
+  }
   assert(symbol.data());
   auto found = m_symbol2IdMap.find(symbol);
   if (found != m_symbol2IdMap.end()) {
-    return found->second;
+    return found->second + m_idOffset;
   }
-  m_id2SymbolMap.emplace_back(new std::string(symbol));
-  const std::string_view normalized_symbol = *m_id2SymbolMap.back();
+  m_id2SymbolMap.emplace_back(symbol);
+  const std::string_view normalized_symbol = m_id2SymbolMap.back();
   const auto inserted = m_symbol2IdMap.insert({normalized_symbol, m_idCounter});
   assert(inserted.second);  // This new insert must succeed.
   m_idCounter++;
-  return inserted.first->second;
+  return inserted.first->second + m_idOffset;
 }
 
 SymbolId SymbolTable::getId(std::string_view symbol) const {
+  if (m_parent) {
+    if (SymbolId id = m_parent->getId(symbol);
+        id != getBadId() && id < m_idOffset) {
+      return id;
+    }
+  }
+
   auto found = m_symbol2IdMap.find(symbol);
-  return (found == m_symbol2IdMap.end()) ? getBadId() : found->second;
+  return (found == m_symbol2IdMap.end()) ? getBadId()
+                                         : found->second + m_idOffset;
 }
 
 const std::string& SymbolTable::getSymbol(SymbolId id) const {
+  if (id < m_idOffset) {
+    assert(m_parent);  // If we have a non-0 idOffset, we must have parent
+    return m_parent->getSymbol(id);
+  }
+  id -= m_idOffset;
   if (id >= m_id2SymbolMap.size()) return getBadSymbol();
-  return *m_id2SymbolMap[id];
+  return m_id2SymbolMap[id];
+}
+
+void SymbolTable::AppendSymbols(int64_t up_to,
+                                std::vector<std::string_view>* dest) const {
+  if (m_parent) m_parent->AppendSymbols(m_idOffset, dest);
+  up_to -= m_idOffset;
+  assert(up_to >= 0);
+  for (const auto& s : m_id2SymbolMap) {
+    if (up_to-- <= 0) return;
+    dest->push_back(s);
+  }
 }
 
 std::vector<std::string_view> SymbolTable::getSymbols() const {
   std::vector<std::string_view> result;
-  result.reserve(m_id2SymbolMap.size());
-  for (const auto& s : m_id2SymbolMap) {
-    result.push_back(*s);
-  }
+  result.reserve(m_idOffset + m_id2SymbolMap.size());
+  AppendSymbols(m_idOffset + m_id2SymbolMap.size(), &result);
   return result;
 }
 

--- a/src/SourceCompile/SymbolTable_test.cpp
+++ b/src/SourceCompile/SymbolTable_test.cpp
@@ -93,5 +93,93 @@ TEST(SymbolTableTest, SymbolStringsAreStableAfterTableCopy) {
     EXPECT_EQ(before_data, after_data);
   }
 }
+
+TEST(SymbolTableTest, SequenceOfStackedSymbolTablesPreserved) {
+  // Testing the semantics of stacked symbol tables with copy constructors.
+  SymbolTable parent;
+  const SymbolId foo_id = parent.registerSymbol("foo");
+  const SymbolId bar_id = parent.registerSymbol("bar");
+  EXPECT_GT(bar_id, foo_id);
+  EXPECT_EQ(bar_id, 2);
+
+  SymbolTable child(parent);
+  const SymbolId baz_id = child.registerSymbol("baz");
+  EXPECT_GT(baz_id, bar_id);
+  const SymbolId quux_id = child.registerSymbol("quux");
+  EXPECT_GT(quux_id, baz_id);
+  EXPECT_EQ(quux_id, 4);
+
+  SymbolTable grandchild(child);
+  const SymbolId foobar_id = grandchild.registerSymbol("foobar");
+  EXPECT_GT(foobar_id, quux_id);
+  const SymbolId flip_id = grandchild.registerSymbol("flip");
+  EXPECT_GT(flip_id, foobar_id);
+  EXPECT_EQ(flip_id, 6);
+
+  // Attempting to re-register symbols will return the existing id.
+  EXPECT_EQ(foo_id, grandchild.registerSymbol("foo"));
+  EXPECT_EQ(baz_id, grandchild.registerSymbol("baz"));
+  EXPECT_EQ(foobar_id, grandchild.registerSymbol("foobar"));
+
+  struct {
+    SymbolTable *testsym;
+    std::vector<std::string_view> expected_symbols;
+  } kTests[] = {
+      {&parent, {"@@BAD_SYMBOL@@", "foo", "bar"}},
+      {&child, {"@@BAD_SYMBOL@@", "foo", "bar", "baz", "quux"}},
+      {&grandchild,
+       {"@@BAD_SYMBOL@@", "foo", "bar", "baz", "quux", "foobar", "flip"}},
+  };
+
+  for (const auto &testcase : kTests) {
+    SymbolTable &testsym = *testcase.testsym;
+    std::vector<std::string_view> all_symbols = testsym.getSymbols();
+    EXPECT_EQ(all_symbols, testcase.expected_symbols);
+
+    for (size_t i = 0; i < all_symbols.size(); ++i) {
+      const std::string_view symbol = all_symbols[i];
+      EXPECT_EQ(symbol, testsym.getSymbol(i)) << i;
+      EXPECT_EQ(testsym.getId(symbol), i);
+      EXPECT_EQ(testsym.registerSymbol(symbol), i);  // re-register attempt.
+    }
+
+    // Request value out of range will return bad symbol.
+    EXPECT_EQ(SymbolTable::getBadSymbol(),
+              testsym.getSymbol(all_symbols.size()));
+  }
+
+  // A new symbol introduced in the parent should not be visible
+  // in any child that had been snapshotted before that time.
+  const SymbolId hello_id = parent.registerSymbol("hello");  // new in parent
+  EXPECT_EQ(child.getId("hello"), SymbolTable::getBadId());  // not in child
+  EXPECT_EQ(grandchild.getId("hello"), SymbolTable::getBadId());
+
+  // We can register our own version of the same name in the child and get
+  // a local id.
+  const SymbolId hello_child_id = child.registerSymbol("hello");
+  EXPECT_NE(hello_id, hello_child_id);
+  EXPECT_EQ(child.getId("hello"), hello_child_id);
+  EXPECT_EQ(child.getSymbol(hello_child_id), "hello");
+
+  const SymbolId hello_grandchild_id = grandchild.registerSymbol("hello");
+  EXPECT_NE(hello_id, hello_grandchild_id);
+  EXPECT_NE(hello_child_id, hello_grandchild_id);
+  EXPECT_EQ(grandchild.getId("hello"), hello_grandchild_id);
+  EXPECT_EQ(grandchild.getSymbol(hello_grandchild_id), "hello");
+
+  // Likewise, looking at 'all symbols', parent symbols only should be
+  // included up to the point the snapshot happened.
+  std::vector<std::string_view> expected_parent{"@@BAD_SYMBOL@@", "foo", "bar",
+                                                "hello"};
+  EXPECT_EQ(parent.getSymbols(), expected_parent);
+
+  std::vector<std::string_view> expected_child{
+      "@@BAD_SYMBOL@@", "foo", "bar", "baz", "quux", "hello"};
+  EXPECT_EQ(child.getSymbols(), expected_child);
+
+  std::vector<std::string_view> expected_grandchild{
+      "@@BAD_SYMBOL@@", "foo", "bar", "baz", "quux", "foobar", "flip", "hello"};
+  EXPECT_EQ(grandchild.getSymbols(), expected_grandchild);
+}
 }  // namespace
 }  // namespace SURELOG


### PR DESCRIPTION
The SymbolTable's copy constructor is used in the code as snapshotting
the current state, but that is resulting in a huge churn in memory as
a lot has to be copied on each such occasions.

This change makes it cheap as snapshotting starts with empty local
containers and then delegates lookups to parents as needed.
This requires an indirection to the parent if there is one, but this
saves a large amount of memory churn and runtime.

This change saved many gigabytes of memory use and a lot of runtime
while processing a larger project. So very worth-while.

Longer term, all the places that use the SymbolTable's copy constructor
to create a snapshot should be investigated if they can be
solved differently.

Siblings of the same parent are thread safe and can operate concurrently.
This is _not_ thread safe if the parent is modified while the client
does a look-up.

There are simple ways around it, but currently, threaded compiling is
[not done](https://github.com/chipsalliance/Surelog/blob/dc9970a0827a84ce5d7dca60f2264d32503a37f3/src/DesignCompile/CompileDesign.cpp#L282-L288),
so this is not an issue right now. And by the time we can do
multi-threaded compiling again, I hope to have resolved the
SymbolTable copy-need already. So for sake of simplicity, no effort
is put into thread-safety right now.

TESTED
Added comprehensive unit test to make sure that all properties of
the previous symbol table still work and behave exactly the same.
The regreession test passes with no diffs. But faster and using
less memory :)

Signed-off-by: Henner Zeller <h.zeller@acm.org>