### PR TITLE
Introduce StrCat() and StrAppend()

### DIFF
--- a/include/Surelog/Utils/StringUtils.h
+++ b/include/Surelog/Utils/StringUtils.h
@@ -29,8 +29,33 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <sstream>
 
 namespace SURELOG {
+
+// StrCat() and StrAppend() are fairly efficient (at least as good as +/+=)
+// but more optimal implementations are possible (see absl::StrCat()
+// absl::StrAppend(). So these are in the name and spirit of the absl version
+// while being the simplest possible for now until optimization is needed.
+
+// StrCat(): concatenate the string representations of each argument into
+// a string which is returned.
+template <typename... Ts>
+std::string StrCat(Ts&&... args) {
+  std::ostringstream out;
+  (out << ... << std::forward<Ts>(args));
+  return out.str();
+}
+
+// Similar to StrCat(), append arguments, converted to strings to "dest"
+// string.
+template <typename... Ts>
+void StrAppend(std::string *dest, Ts&&... args) {
+  std::ostringstream out;
+  out << *dest;
+  (out << ... << std::forward<Ts>(args));
+  *dest = out.str();
+}
 
 class StringUtils final {
  public:

--- a/src/Design/VObject.cpp
+++ b/src/Design/VObject.cpp
@@ -23,6 +23,7 @@
 
 #include <Surelog/Design/VObject.h>
 #include <Surelog/SourceCompile/SymbolTable.h>
+#include <Surelog/Utils/StringUtils.h>
 
 namespace SURELOG {
 
@@ -31,48 +32,24 @@ std::string VObject::print(SymbolTable* symbols, unsigned int uniqueId,
   std::string text;
   const std::string& symbol = symbols->getSymbol(m_name);
   if (symbol == SymbolTable::getBadSymbol()) {
-    text += "n<>";
+    StrAppend(&text, "n<>");
   } else {
-    text = "n<" + symbols->getSymbol(m_name) + ">";
+    StrAppend(&text, "n<", symbol, ">");
   }
+  StrAppend(&text, " u<", uniqueId, "> ");
+  StrAppend(&text, "t<", getTypeName(m_type).substr(2), ">");
+  if (m_parent) StrAppend(&text, " p<", m_parent, ">");
+  if (m_definition) StrAppend(&text, " d<", m_definition, ">");
+  if (definitionFile) StrAppend(&text, " df<", definitionFile, ">");
+  if (m_child) StrAppend(&text, " c<", m_child, ">");
+  if (m_sibling) StrAppend(&text, " s<", m_sibling, ">");
 
-  text += " ";
-  text += "u<" + std::to_string(uniqueId) + ">";
-  text += " ";
-  std::string type = getTypeName(m_type);
-  type.erase(0, 2);
-  text += "t<" + type + ">";
-  if (m_parent) {
-    text += " ";
-    text += "p<" + std::to_string(m_parent) + ">";
-  }
-  if (m_definition) {
-    text += " ";
-    text += "d<" + std::to_string(m_definition) + ">";
-  }
-  if (definitionFile) {
-    text += " ";
-    text += "df<" + std::to_string(definitionFile) + ">";
-  }
-  if (m_child) {
-    text += " ";
-    text += "c<" + std::to_string(m_child) + ">";
-  }
-  if (m_sibling) {
-    text += " ";
-    text += "s<" + std::to_string(m_sibling) + ">";
-  }
-  text += " ";
-  if (printedFile != m_fileId) {
-    text += "f<" + std::to_string(m_fileId) + ">";
-    text += " ";
-  }
-  text += "l<" + std::to_string(m_line) + ":" + std::to_string(m_column) + ">";
-  if (m_endLine) {
-    text += " ";
-    text += "el<" + std::to_string(m_endLine) + ":" +
-            std::to_string(m_endColumn) + ">";
-  }
+  StrAppend(&text, " ");
+  if (printedFile != m_fileId) StrAppend(&text, "f<", m_fileId, "> ");
+
+  StrAppend(&text, "l<", m_line, ":", m_column, ">");
+  if (m_endLine) StrAppend(&text, " el<", m_endLine, ":", m_endColumn, ">");
+
   return text;
 }
 }  // namespace SURELOG

--- a/src/Utils/StringUtils_test.cpp
+++ b/src/Utils/StringUtils_test.cpp
@@ -254,5 +254,21 @@ TEST(StringUtilsTest, EvaluateEnvironmentVariables) {
             StringUtils::evaluateEnvVars("hello ${REGISTERED_EVAL_FOO} bar"));
 }
 
+TEST(StringUtilsTest, StrCat) {
+  EXPECT_EQ("hello world", StrCat("hello ", "world"));  // const char*
+  EXPECT_EQ("Answer 42", StrCat("Answer ", 42));        // Integer
+
+  // String view.
+  const std::string str_concat = "string";
+  const std::string_view str_view_concat = "string_view";
+  EXPECT_EQ("string string_view", StrCat(str_concat, " ", str_view_concat));
+}
+
+TEST(StringUtilsTest, StrAppend) {
+  std::string target("Base string ");
+  StrAppend(&target, "hello ", "world ", 42);
+  EXPECT_EQ("Base string hello world 42", target);
+}
+
 }  // namespace
 }  // namespace SURELOG


### PR DESCRIPTION
These functions allow to concatenate arbitrary set of arguments
to a string. These functions can now be used in contexts where
strings are concatenated, but some arguments (such as integers)
require to call std::to_string - these are now much easier to
be formulated.

Main use: whenever there are strings concatenated, prefering
this will allow even faster string concatenation in the future
(the implementation is quite simple right now, but it is feasible
to replace this with something that pre-calculates the buffer to
be allocated).
Also, this is compatible with std::string_view, which otherwise
are a pain to += concatenate.

Added StrCat(), StrAppend() and unittest.
As a first user and example, convert the string-concatenation
in VObject::print()

Signed-off-by: Henner Zeller <h.zeller@acm.org>