### PR TITLE
Remove unused member variables.

### DIFF
--- a/include/Surelog/Design/ClockingBlock.h
+++ b/include/Surelog/Design/ClockingBlock.h
@@ -40,11 +40,12 @@ class FileContent;
 class ClockingBlock final {
  public:
   enum Type { Global, Default, Regular };
-  ClockingBlock(const FileContent* fileContent, NodeId blockId,
-                NodeId clockingBlockId, Type type, UHDM::clocking_block* actual)
-      : m_fileContent(fileContent),
-        m_blockId(blockId),
-        m_clockingBlockId(clockingBlockId),
+  // TODO: some of these parameters are not used. Correct or oversight ?
+  ClockingBlock([[maybe_unused]] const FileContent* fileContent,
+                NodeId blockId,
+                [[maybe_unused]] NodeId clockingBlockId,
+                Type type, UHDM::clocking_block* actual)
+      : m_blockId(blockId),
         m_actual(actual),
         m_type(type) {}
 
@@ -55,9 +56,7 @@ class ClockingBlock final {
   Type getType() const { return m_type; }
 
  private:
-  const FileContent* m_fileContent;  // NOLINT: unused field (TODO: remove?)
   NodeId m_blockId;
-  NodeId m_clockingBlockId;  // NOLINT: unused field (TODO: remove?)
   std::vector<Signal> m_signals;
   UHDM::clocking_block* m_actual;
   Type m_type;

--- a/include/Surelog/DesignCompile/CompileFileContent.h
+++ b/include/Surelog/DesignCompile/CompileFileContent.h
@@ -56,13 +56,12 @@ struct FunctorCompileFileContent {
 
 class CompileFileContent final {
  public:
-  CompileFileContent(CompileDesign* compiler, FileContent* file, Design* design,
-                     SymbolTable* symbols, ErrorContainer* errors)
+  CompileFileContent(CompileDesign* compiler, FileContent* file,
+                     [[maybe_unused]] Design* design,
+                     [[maybe_unused]] SymbolTable* symbols,
+                     [[maybe_unused]] ErrorContainer* errors)
       : m_compileDesign(compiler),
-        m_fileContent(file),
-        m_design(design),
-        m_symbols(symbols),
-        m_errors(errors) {
+        m_fileContent(file) {
     m_helper.seterrorReporting(errors, symbols);
   }
 
@@ -74,9 +73,6 @@ class CompileFileContent final {
   bool collectObjects_();
   CompileDesign* const m_compileDesign;
   FileContent* const m_fileContent;
-  Design* const m_design;
-  SymbolTable* const m_symbols;
-  ErrorContainer* const m_errors;
 
   CompileHelper m_helper;
 };

--- a/include/Surelog/Expression/Value.h
+++ b/include/Surelog/Expression/Value.h
@@ -423,8 +423,6 @@ class LValue final : public Value {
   unsigned short m_negative = 0;
   unsigned short m_lrange = 0;
   unsigned short m_rrange = 0;
-  LValue* m_prev = nullptr;
-  LValue* m_next = nullptr;
 };
 
 class StValue final : public Value {

--- a/include/Surelog/Library/SVLibShapeListener.h
+++ b/include/Surelog/Library/SVLibShapeListener.h
@@ -174,7 +174,6 @@ class SVLibShapeListener : public SV3_1aParserBaseListener,
  private:
   ParseLibraryDef* m_parser;
   antlr4::CommonTokenStream* m_tokens;
-  Config* m_currentConfig;
   const std::filesystem::path m_relativePath;
 };
 

--- a/src/Expression/Value.cpp
+++ b/src/Expression/Value.cpp
@@ -968,9 +968,7 @@ LValue::LValue(const LValue& val)  // NOLINT(bugprone-copy-constructor-init)
       m_valid(val.isValid()),
       m_negative(val.isNegative()),
       m_lrange(val.getLRange()),
-      m_rrange(val.getRRange()),
-      m_prev(nullptr),
-      m_next(nullptr) {
+      m_rrange(val.getRRange()) {
   m_valueArray[0].m_size = 0;
   m_valueArray[0].m_type = m_type;
   m_valueArray[0].m_value.u_int = 0;
@@ -988,9 +986,7 @@ LValue::LValue(uint64_t val)
     : m_type(Type::Unsigned),
       m_nbWords(1),
       m_valueArray(new SValue[1]),
-      m_valid(1),
-      m_prev(nullptr),
-      m_next(nullptr) {
+      m_valid(1) {
   m_valueArray[0].m_type = m_type;
   m_valueArray[0].m_value.u_int = val;
   m_valueArray[0].m_size = 64;
@@ -1007,9 +1003,7 @@ LValue::LValue(int64_t val)
     : m_type(Type::Integer),
       m_nbWords(1),
       m_valueArray(new SValue[1]),
-      m_valid(1),
-      m_prev(nullptr),
-      m_next(nullptr) {
+      m_valid(1) {
   m_valueArray[0].m_type = m_type;
   m_valueArray[0].m_value.s_int = val;
   m_valueArray[0].m_size = 64;
@@ -1026,9 +1020,7 @@ LValue::LValue(double val)
     : m_type(Type::Double),
       m_nbWords(1),
       m_valueArray(new SValue[1]),
-      m_valid(1),
-      m_prev(nullptr),
-      m_next(nullptr) {
+      m_valid(1) {
   m_valueArray[0].m_type = m_type;
   m_valueArray[0].m_value.d_int = val;
   m_valueArray[0].m_size = 64;
@@ -1042,12 +1034,7 @@ LValue::LValue(double val)
 }
 
 LValue::LValue(int64_t val, Type type, short size)
-    : m_type(type),
-      m_nbWords(1),
-      m_valueArray(new SValue[1]),
-      m_valid(1),
-      m_prev(nullptr),
-      m_next(nullptr) {
+    : m_type(type), m_nbWords(1), m_valueArray(new SValue[1]), m_valid(1) {
   m_valueArray[0].m_type = m_type;
   m_valueArray[0].m_value.s_int = val;
   m_valueArray[0].m_size = size;

--- a/src/Library/SVLibShapeListener.cpp
+++ b/src/Library/SVLibShapeListener.cpp
@@ -47,7 +47,6 @@ SVLibShapeListener::SVLibShapeListener(ParseLibraryDef *parser,
           tokens, 0),
       m_parser(parser),
       m_tokens(tokens),
-      m_currentConfig(nullptr),
       m_relativePath(relativePath) {
   m_fileContent = new FileContent(m_parser->getFileId(), nullptr,
                                   m_parser->getSymbolTable(),


### PR DESCRIPTION
clang++ points these out in warnings. This is a preparation to
also use clang in the CI.

Signed-off-by: Henner Zeller <h.zeller@acm.org>