### PR TITLE
Revert "chipsalliance/Surelog#2541: Add include file info model"

### DIFF
--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -62,21 +62,20 @@ class FileContent : public DesignComponent {
   typedef std::unordered_map<std::string, NodeId> NameIdMap;
 
   NodeId sl_get(NodeId parent,
-                VObjectType type) const;  // Get first child item of type
+                VObjectType type);  // Get first child item of type
 
   NodeId sl_parent(NodeId parent,
-                   VObjectType type) const;  // Get first parent item of type
+                   VObjectType type);  // Get first parent item of type
 
-  NodeId sl_parent(
-      NodeId parent, const std::vector<VObjectType>& types,
-      VObjectType& actualType) const;  // Get first parent item of type
+  NodeId sl_parent(NodeId parent, const std::vector<VObjectType>& types,
+                   VObjectType& actualType);  // Get first parent item of type
 
   std::vector<NodeId> sl_get_all(
-      NodeId parent, VObjectType type) const;  // get all child items of type
+      NodeId parent, VObjectType type);  // get all child items of type
 
   std::vector<NodeId> sl_get_all(
       NodeId parent,
-      std::vector<VObjectType>& types) const;  // get all child items of types
+      std::vector<VObjectType>& types);  // get all child items of types
 
   NodeId sl_collect(
       NodeId parent,
@@ -104,16 +103,14 @@ class FileContent : public DesignComponent {
   VObjectType getType() const override { return VObjectType::slNoType; }
   bool isInstance() const override { return false; }
   const std::string& getName() const override;
-  NodeId getRootNode() const;
-  std::string printObjects() const;  // The whole file content
-  std::string printSubTree(
-      NodeId parentIndex) const;                 // Print subtree from parent
+  NodeId getRootNode();
+  std::string printObjects() const;              // The whole file content
+  std::string printSubTree(NodeId parentIndex);  // Print subtree from parent
   std::string printObject(NodeId noedId) const;  // Only print that object
-  std::vector<std::string> collectSubTree(
-      NodeId uniqueId) const;  // Helper function
+  std::vector<std::string> collectSubTree(NodeId uniqueId);  // Helper function
   std::filesystem::path getFileName(NodeId id) const;
   std::filesystem::path getChunkFileName() const;
-  SymbolTable* getSymbolTable() const { return m_symbolTable; }
+  SymbolTable* getSymbolTable() { return m_symbolTable; }
   void setSymbolTable(SymbolTable* table) { m_symbolTable = table; }
   SymbolId getFileId(NodeId id) const;
   SymbolId* getMutableFileId(NodeId id);
@@ -123,8 +120,7 @@ class FileContent : public DesignComponent {
   const DesignElement* getDesignElement(std::string_view name) const;
   std::vector<VObject>& getVObjects() { return m_objects; }
   const NameIdMap& getObjectLookup() const { return m_objectLookup; }
-  void insertObjectLookup(const std::string& name, NodeId id,
-                          ErrorContainer* errors);
+  void insertObjectLookup(const std::string& name, NodeId id, ErrorContainer* errors);
   std::unordered_set<std::string>& getReferencedObjects() {
     return m_referencedObjects;
   }
@@ -132,7 +128,7 @@ class FileContent : public DesignComponent {
   VObject Object(NodeId index) const;
   VObject* MutableObject(NodeId index);
 
-  NodeId UniqueId(NodeId index) const;
+  NodeId UniqueId(NodeId index);
 
   SymbolId Name(NodeId index) const;
 
@@ -190,7 +186,7 @@ class FileContent : public DesignComponent {
   DesignComponent* getComponentDefinition(
       const std::string& componentName) const;
 
-  Package* getPackage(const std::string& name) const;
+  Package* getPackage(const std::string& name);
 
   const Program* getProgram(const std::string& name) const;
 
@@ -205,7 +201,7 @@ class FileContent : public DesignComponent {
                 std::string* diff_out) const;
 
   SymbolId getSymbolId() const { return m_fileId; }
-  bool isLibraryCellFile() const { return m_isLibraryCellFile; }
+  bool isLibraryCellFile() { return m_isLibraryCellFile; }
   void setLibraryCellFile() { m_isLibraryCellFile = true; }
 
  protected:

--- a/include/Surelog/SourceCompile/IncludeFileInfo.h
+++ b/include/Surelog/SourceCompile/IncludeFileInfo.h
@@ -31,59 +31,63 @@ namespace SURELOG {
 
 class IncludeFileInfo {
  public:
-  enum class Context : unsigned int { NONE = 0, INCLUDE = 1, MACRO = 2 };
-  enum class Action : unsigned int { NONE = 0, PUSH = 1, POP = 2 };
-
-  IncludeFileInfo(Context context, unsigned int sectionStartLine,
-                  SymbolId sectionFile, unsigned int originalStartLine,
+  typedef enum { NONE = 0, PUSH = 1, POP = 2 } Action;
+  IncludeFileInfo()
+      : m_sectionStartLine(0),
+        m_sectionFile(0),
+        m_originalStartLine(0),
+        m_originalStartColumn(0),
+        m_originalEndLine(0),
+        m_originalEndColumn(0),
+        m_type(NONE),
+        m_indexOpening(-1),
+        m_indexClosing(-1) {}
+  IncludeFileInfo(unsigned int sectionStartLine, SymbolId sectionFile,
+                  unsigned int originalStartLine,
                   unsigned int originalStartColumn,
                   unsigned int originalEndLine, unsigned int originalEndColumn,
-                  Action action)
-      : m_context(context),
-        m_sectionStartLine(sectionStartLine),
+                  Action type)
+      : m_sectionStartLine(sectionStartLine),
         m_sectionFile(sectionFile),
         m_originalStartLine(originalStartLine),
         m_originalStartColumn(originalStartColumn),
         m_originalEndLine(originalEndLine),
         m_originalEndColumn(originalEndColumn),
-        m_action(action),
+        m_type(type),
         m_indexOpening(-1),
         m_indexClosing(-1) {}
   IncludeFileInfo(const IncludeFileInfo& i)
-      : m_context(i.m_context),
-        m_sectionStartLine(i.m_sectionStartLine),
+      : m_sectionStartLine(i.m_sectionStartLine),
         m_sectionFile(i.m_sectionFile),
         m_originalStartLine(i.m_originalStartLine),
         m_originalStartColumn(i.m_originalStartColumn),
         m_originalEndLine(i.m_originalEndLine),
         m_originalEndColumn(i.m_originalEndColumn),
-        m_action(i.m_action),
+        m_type(i.m_type),
         m_indexOpening(i.m_indexOpening),
         m_indexClosing(i.m_indexClosing) {}
-  IncludeFileInfo(Context context, unsigned int sectionStartLine,
-                  SymbolId sectionFile, unsigned int originalStartLine,
+  IncludeFileInfo(unsigned int sectionStartLine, SymbolId sectionFile,
+                  unsigned int originalStartLine,
                   unsigned int originalStartColumn,
                   unsigned int originalEndLine, unsigned int originalEndColumn,
                   Action type, int indexOpening, int indexClosing)
-      : m_context(context),
-        m_sectionStartLine(sectionStartLine),
+      : m_sectionStartLine(sectionStartLine),
         m_sectionFile(sectionFile),
         m_originalStartLine(originalStartLine),
         m_originalStartColumn(originalStartColumn),
         m_originalEndLine(originalEndLine),
         m_originalEndColumn(originalEndColumn),
-        m_action(type),
+        m_type(type),
         m_indexOpening(indexOpening),
         m_indexClosing(indexClosing) {}
 
-  const Context m_context;
   unsigned int m_sectionStartLine = 0;
   SymbolId m_sectionFile = 0;
   unsigned int m_originalStartLine = 0;
   unsigned int m_originalStartColumn = 0;
-  const unsigned int m_originalEndLine = 0;
-  const unsigned int m_originalEndColumn = 0;
-  Action m_action = Action::NONE;  // 1 or 2, push or pop
+  unsigned int m_originalEndLine = 0;
+  unsigned int m_originalEndColumn = 0;
+  Action m_type = NONE;  // 1 or 2, push or pop
   int m_indexOpening = 0;
   int m_indexClosing = 0;
 };

--- a/include/Surelog/SourceCompile/MacroInfo.h
+++ b/include/Surelog/SourceCompile/MacroInfo.h
@@ -35,18 +35,15 @@ namespace SURELOG {
 
 class MacroInfo {
  public:
-  MacroInfo(std::string_view name, int type, SymbolId file,
-            unsigned int startLine, unsigned short int startColumn,
-            unsigned int endLine, unsigned short int endColumn,
+  MacroInfo(std::string_view name, int type, SymbolId file, unsigned int line,
+            unsigned short int column,
             const std::vector<std::string>& arguments,
             const std::vector<std::string>& tokens)
       : m_name(name),
         m_type(type),
         m_file(file),
-        m_startLine(startLine),
-        m_startColumn(startColumn),
-        m_endLine(endLine),
-        m_endColumn(endColumn),
+        m_line(line),
+        m_column(column),
         m_arguments(arguments),
         m_tokens(tokens) {}
   enum Type {
@@ -57,10 +54,8 @@ class MacroInfo {
   const std::string m_name;
   const int m_type;
   const SymbolId m_file;
-  const unsigned int m_startLine;
-  const unsigned short int m_startColumn;
-  const unsigned int m_endLine;
-  const unsigned short int m_endColumn;
+  const unsigned int m_line;
+  const unsigned short int m_column;
   const std::vector<std::string> m_arguments;
   const std::vector<std::string> m_tokens;
 };

--- a/include/Surelog/SourceCompile/PreprocessFile.h
+++ b/include/Surelog/SourceCompile/PreprocessFile.h
@@ -91,14 +91,12 @@ class PreprocessFile {
   std::string getPreProcessedFileContent();
 
   /* Macro manipulations */
-  void recordMacro(const std::string& name, unsigned int startLine,
-                   unsigned short int startColumn, unsigned int endLine,
-                   unsigned short int endColumn,
+  void recordMacro(const std::string& name, unsigned int line,
+                   unsigned short int column,
                    const std::string& formal_arguments,
                    const std::vector<std::string>& body);
-  void recordMacro(const std::string& name, unsigned int startLine,
-                   unsigned short int startColumn, unsigned int endLine,
-                   unsigned short int endColumn,
+  void recordMacro(const std::string& name, unsigned int line,
+                   unsigned short int column,
                    const std::vector<std::string>& formal_arguments,
                    const std::vector<std::string>& body);
   std::string getMacro(const std::string& name,
@@ -149,7 +147,7 @@ class PreprocessFile {
     if (index >= 0 && index < ((int)m_includeFileInfo.size()))
       return m_includeFileInfo[index];
     else
-      return s_badIncludeFileInfo;
+      return m_badIncludeFileInfo;
   }
   unsigned int getEmbeddedMacroCallLine() const {
     return m_embeddedMacroCallLine;
@@ -171,7 +169,7 @@ class PreprocessFile {
   std::vector<PreprocessFile*> m_includes;
   CompileSourceFile* m_compileSourceFile;
   size_t m_lineCount = 0;
-  static IncludeFileInfo s_badIncludeFileInfo;
+  IncludeFileInfo m_badIncludeFileInfo;
 
  public:
   /* Instructions passed from calling scope */
@@ -193,22 +191,19 @@ class PreprocessFile {
           m_filterFileLine(DontFilter),
           m_check_macro_loop(DontCheckLoop),
           m_as_is_undefined_macro(ComplainUndefinedMacro),
-          m_evaluate(Evaluate),
-          m_persist(DontPersist) {}
+          m_evaluate(Evaluate), m_persist(DontPersist) {}
     SpecialInstructions(SpecialInstructions& rhs)
         : m_mute(rhs.m_mute),
           m_mark_empty_macro(rhs.m_mark_empty_macro),
           m_filterFileLine(rhs.m_filterFileLine),
           m_check_macro_loop(rhs.m_check_macro_loop),
           m_as_is_undefined_macro(rhs.m_as_is_undefined_macro),
-          m_evaluate(rhs.m_evaluate),
-          m_persist(rhs.m_persist) {}
+          m_evaluate(rhs.m_evaluate), m_persist(rhs.m_persist) {}
     SpecialInstructions(TraceInstr mute, EmptyMacroInstr mark_empty_macro,
                         FileLineInfoInstr filterFileLine,
                         CheckLoopInstr check_macro_loop,
                         AsIsUndefinedMacroInstr as_is_undefined_macro,
-                        EvaluateInstr evaluate = Evaluate,
-                        PersistMacroInstr persist = DontPersist)
+                        EvaluateInstr evaluate = Evaluate, PersistMacroInstr persist = DontPersist)
         : m_mute(mute),
           m_mark_empty_macro(mark_empty_macro),
           m_filterFileLine(filterFileLine),
@@ -303,7 +298,7 @@ class PreprocessFile {
   LoopCheck m_loopChecker;
 
   void setFileContent(FileContent* content) { m_fileContent = content; }
-  FileContent* getFileContent() const { return m_fileContent; }
+  FileContent* getFileContent() { return m_fileContent; }
 
   void setVerilogVersion(VerilogVersion version) { m_verilogVersion = version; }
   VerilogVersion getVerilogVersion() { return m_verilogVersion; }

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -111,9 +111,8 @@ bool PPCache::restore_(const fs::path& cacheFileName, bool errorsOnly) {
     for (unsigned int j = 0; j < macro->tokens()->size(); j++) {
       tokens.push_back(macro->tokens()->Get(j)->str());
     }
-    m_pp->recordMacro(macro->name()->str(), macro->start_line(),
-                      macro->start_column(), macro->end_line(),
-                      macro->end_column(), args, tokens);
+    m_pp->recordMacro(macro->name()->str(), macro->line(), macro->column(),
+                      args, tokens);
   }
 
   SymbolTable canonicalSymbols;
@@ -163,15 +162,15 @@ bool PPCache::restore_(const fs::path& cacheFileName, bool errorsOnly) {
       // std::cout << "read sectionFile: " << sectionFileName << " s:" <<
       // incinfo->m_sectionStartLine() << " o:" << incinfo->m_originalLine() <<
       // " t:" << incinfo->m_type() << "\n";
-      m_pp->getIncludeFileInfo().emplace_back(
-          static_cast<IncludeFileInfo::Context>(incinfo->context()),
+      IncludeFileInfo inf(
           incinfo->section_start_line(),
           m_pp->getCompileSourceFile()->getSymbolTable()->registerSymbol(
               sectionFileName.string()),
           incinfo->original_start_line(), incinfo->original_start_column(),
           incinfo->original_end_line(), incinfo->original_end_column(),
-          static_cast<IncludeFileInfo::Action>(incinfo->action()),
-          incinfo->index_opening(), incinfo->index_closing());
+          (IncludeFileInfo::Action)incinfo->type(), incinfo->index_opening(),
+          incinfo->index_closing());
+      m_pp->getIncludeFileInfo().push_back(inf);
     }
   }
   // Includes
@@ -356,8 +355,7 @@ bool PPCache::save() {
     */
     auto tokens = builder.CreateVectorOfStrings(info->m_tokens);
     macro_vec.push_back(MACROCACHE::CreateMacro(
-        builder, name, type, info->m_startLine, info->m_startColumn,
-        info->m_endLine, info->m_endColumn, args, tokens));
+        builder, name, type, info->m_line, info->m_column, args, tokens));
   }
   auto macroList = builder.CreateVector(macro_vec);
 
@@ -444,12 +442,11 @@ bool PPCache::save() {
         m_pp->getCompileSourceFile()->getSymbolTable()->getSymbol(
             info.m_sectionFile);
     auto incInfo = MACROCACHE::CreateIncludeFileInfo(
-        builder, static_cast<uint32_t>(info.m_context), info.m_sectionStartLine,
+        builder, info.m_sectionStartLine,
         builder.CreateString(sectionFileName.string()),
         info.m_originalStartLine, info.m_originalStartColumn,
-        info.m_originalEndLine, info.m_originalEndColumn,
-        static_cast<uint32_t>(info.m_action), info.m_indexOpening,
-        info.m_indexClosing);
+        info.m_originalEndLine, info.m_originalEndColumn, info.m_type,
+        info.m_indexOpening, info.m_indexClosing);
     // std::cout << "save sectionFile: " << sectionFileName << " s:" <<
     // info.m_sectionStartLine << " o:" << info.m_originalLine << " t:" <<
     // info.m_type << "\n";

--- a/src/Cache/preproc.fbs
+++ b/src/Cache/preproc.fbs
@@ -29,23 +29,20 @@ enum MacroType :byte { NO_ARGS = 0, WITH_ARGS = 1 }
 table Macro {
   name:string;
   type:MacroType;
-  start_line:uint;
-  start_column:ushort;
-  end_line:uint;
-  end_column:ushort;
+  line:uint;
+  column:ushort;
   arguments:[string];
   tokens:[string];
 }
 
 table IncludeFileInfo {
-  context:uint;
   section_start_line:uint;
   section_file:string;
   original_start_line:uint;
   original_start_column:uint;
   original_end_line:uint;
   original_end_column:uint;
-  action:uint;  // 1 or 2, push or pop
+  type:uint;  // 1 or 2, push or pop
   index_opening:int;
   index_closing:int;
 }

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -54,7 +54,7 @@ std::filesystem::path FileContent::getFileName() const {
   return m_symbolTable->getSymbol(m_fileId);
 }
 
-NodeId FileContent::getRootNode() const {
+NodeId FileContent::getRootNode() {
   if (m_objects.empty()) {
     return 0;
   }
@@ -97,7 +97,7 @@ std::string FileContent::printObject(NodeId nodeId) const {
 
 unsigned int FileContent::getSize() const { return m_objects.size(); }
 
-std::string FileContent::printSubTree(NodeId uniqueId) const {
+std::string FileContent::printSubTree(NodeId uniqueId) {
   std::string text;
   for (const auto& s : collectSubTree(uniqueId)) {
     text += s + "\n";
@@ -143,8 +143,8 @@ DesignComponent* FileContent::getComponentDefinition(
   return nullptr;
 }
 
-Package* FileContent::getPackage(const std::string& name) const {
-  PackageNamePackageDefinitionMultiMap::const_iterator itr =
+Package* FileContent::getPackage(const std::string& name) {
+  PackageNamePackageDefinitionMultiMap::iterator itr =
       m_packageDefinitions.find(name);
   if (itr == m_packageDefinitions.end()) {
     return nullptr;
@@ -174,7 +174,7 @@ const ClassDefinition* FileContent::getClassDefinition(
   }
 }
 
-std::vector<std::string> FileContent::collectSubTree(NodeId index) const {
+std::vector<std::string> FileContent::collectSubTree(NodeId index) {
   std::vector<std::string> text;
 
   text.push_back(m_objects[index].print(m_symbolTable, index,
@@ -227,7 +227,7 @@ VObject* FileContent::MutableObject(NodeId index) {
   return &m_objects[index];
 }
 
-NodeId FileContent::UniqueId(NodeId index) const {
+NodeId FileContent::UniqueId(NodeId index) {
   if (index >= m_objects.size()) {
     Location loc(this->m_fileId);
     Error err(ErrorDefinition::COMP_INTERNAL_ERROR_OUT_OF_BOUND, loc);
@@ -348,7 +348,7 @@ unsigned short FileContent::EndColumn(NodeId index) const {
   return m_objects[index].m_endColumn;
 }
 
-NodeId FileContent::sl_get(NodeId parent, VObjectType type) const {
+NodeId FileContent::sl_get(NodeId parent, VObjectType type) {
   if (m_objects.empty()) return 0;
   if (parent > m_objects.size() - 1) return 0;
   VObject current = Object(parent);
@@ -366,7 +366,7 @@ NodeId FileContent::sl_get(NodeId parent, VObjectType type) const {
 
 NodeId FileContent::sl_parent(NodeId parent,
                               const std::vector<VObjectType>& types,
-                              VObjectType& actualType) const {
+                              VObjectType& actualType) {
   if (m_objects.empty()) return 0;
   if (parent > m_objects.size() - 1) return 0;
   VObject current = Object(parent);
@@ -388,7 +388,7 @@ NodeId FileContent::sl_parent(NodeId parent,
   return InvalidNodeId;
 }
 
-NodeId FileContent::sl_parent(NodeId parent, VObjectType type) const {
+NodeId FileContent::sl_parent(NodeId parent, VObjectType type) {
   if (m_objects.empty()) return 0;
   if (parent > m_objects.size() - 1) return 0;
   VObject current = Object(parent);
@@ -404,8 +404,7 @@ NodeId FileContent::sl_parent(NodeId parent, VObjectType type) const {
   return InvalidNodeId;
 }
 
-std::vector<NodeId> FileContent::sl_get_all(NodeId parent,
-                                            VObjectType type) const {
+std::vector<NodeId> FileContent::sl_get_all(NodeId parent, VObjectType type) {
   std::vector<NodeId> objects;
   if (m_objects.empty()) return objects;
   if (parent > m_objects.size() - 1) return objects;
@@ -422,8 +421,8 @@ std::vector<NodeId> FileContent::sl_get_all(NodeId parent,
   return objects;
 }
 
-std::vector<NodeId> FileContent::sl_get_all(
-    NodeId parent, std::vector<VObjectType>& types) const {
+std::vector<NodeId> FileContent::sl_get_all(NodeId parent,
+                                            std::vector<VObjectType>& types) {
   std::vector<NodeId> objects;
   if (m_objects.empty()) return objects;
   if (parent > m_objects.size() - 1) return objects;

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -2813,32 +2813,6 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
     }
     d->VpiName(designName);
     designs.push_back(designHandle);
-
-    // ---------------------------
-    // Include File Info
-
-    VectorOfinclude_file_info* fileInfos = s.MakeInclude_file_infoVec();
-    d->Include_file_infos(fileInfos);
-    for (const CompileSourceFile* sourceFile :
-         m_compileDesign->getCompiler()->getCompileSourceFiles()) {
-      const PreprocessFile* const pf = sourceFile->getPreprocessor();
-      for (const IncludeFileInfo& ifi : pf->getIncludeFileInfo()) {
-        if ((ifi.m_context == IncludeFileInfo::Context::INCLUDE) &&
-            (ifi.m_action == IncludeFileInfo::Action::PUSH)) {
-          const FileContent* const fC = pf->getFileContent();
-          include_file_info* const pifi = s.MakeInclude_file_info();
-          pifi->VpiFile(fC->getSymbolTable()->getSymbol(pf->getRawFileId()));
-          pifi->VpiIncludedFile(pf->getSymbol(ifi.m_sectionFile));
-          pifi->VpiResolvedIncludedFile(pf->getSymbol(ifi.m_sectionFile));
-          pifi->VpiLineNo(ifi.m_originalStartLine);
-          pifi->VpiColumnNo(ifi.m_originalStartColumn);
-          pifi->VpiEndLineNo(ifi.m_originalEndLine);
-          pifi->VpiEndColumnNo(ifi.m_originalEndColumn);
-          fileInfos->push_back(pifi);
-        }
-      }
-    }
-
     // -------------------------------
     // Non-Elaborated Model
 

--- a/src/Library/SVLibShapeListener.cpp
+++ b/src/Library/SVLibShapeListener.cpp
@@ -52,9 +52,9 @@ SVLibShapeListener::SVLibShapeListener(ParseLibraryDef *parser,
                                   m_parser->getSymbolTable(),
                                   m_parser->getErrorContainer(), nullptr, 0);
   m_pf->setFileContent(m_fileContent);
-  m_includeFileInfo.emplace(IncludeFileInfo::Context::NONE, 1,
-                            m_pf->getFileId(0), 0, 0, 0, 0,
-                            IncludeFileInfo::Action::PUSH);
+  IncludeFileInfo info(1, m_pf->getFileId(0), 0, 0, 0, 0,
+                       IncludeFileInfo::PUSH);
+  m_includeFileInfo.push(info);
 }
 
 SVLibShapeListener::~SVLibShapeListener() {}

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -59,32 +59,29 @@ void AnalyzeFile::checkSLlineDirective_(const std::string& line,
   std::string keyword;
   ss >> keyword;
   if (keyword == "SLline") {
-    IncludeFileInfo info(IncludeFileInfo::Context::NONE, 0, 0, 0, 0, 0, 0,
-                         IncludeFileInfo::Action::NONE);
+    IncludeFileInfo info(0, 0, 0, 0, 0, 0, IncludeFileInfo::NONE);
     ss >> info.m_sectionStartLine;
     std::string file;
     ss >> file;
     file = StringUtils::unquoted(file);
     info.m_sectionFile = m_clp->mutableSymbolTable()->registerSymbol(file);
-    unsigned int action = 0;
-    ss >> action;
+    unsigned int type = 0;
+    ss >> type;
 
-    if (static_cast<IncludeFileInfo::Action>(action) ==
-        IncludeFileInfo::Action::PUSH) {
+    if (type == IncludeFileInfo::PUSH) {
       // Push
       info.m_originalStartLine = lineNb;
-      info.m_action = IncludeFileInfo::Action::PUSH;
+      info.m_type = IncludeFileInfo::PUSH;
       m_includeFileInfo.push(info);
-    } else if (static_cast<IncludeFileInfo::Action>(action) ==
-               IncludeFileInfo::Action::POP) {
+    } else if (type == IncludeFileInfo::POP) {
       // Pop
       if (!m_includeFileInfo.empty()) m_includeFileInfo.pop();
       if (!m_includeFileInfo.empty()) {
-        IncludeFileInfo& top = m_includeFileInfo.top();
-        top.m_sectionFile = info.m_sectionFile;
-        top.m_originalStartLine = lineNb;
-        top.m_sectionStartLine = info.m_sectionStartLine - 1;
-        top.m_action = IncludeFileInfo::Action::POP;
+        m_includeFileInfo.top().m_sectionFile = info.m_sectionFile;
+        m_includeFileInfo.top().m_originalStartLine = lineNb;
+        m_includeFileInfo.top().m_sectionStartLine =
+            info.m_sectionStartLine - 1;
+        m_includeFileInfo.top().m_type = IncludeFileInfo::POP;
       }
     }
   }
@@ -420,9 +417,8 @@ void AnalyzeFile::analyze() {
   unsigned int fromLine = 1;
   unsigned int toIndex = 0;
   m_includeFileInfo.emplace(
-      IncludeFileInfo::Context::INCLUDE, 1,
-      m_clp->mutableSymbolTable()->registerSymbol(m_fileName.string()), 1, 0, 1,
-      0, IncludeFileInfo::Action::PUSH);
+      1, m_clp->mutableSymbolTable()->registerSymbol(m_fileName.string()), 1, 0,
+      1, 0, IncludeFileInfo::PUSH);
   unsigned int linesWriten = 0;
   for (unsigned int i = 0; i < fileChunks.size(); i++) {
     DesignElement::ElemType chunkType = fileChunks[i].m_chunkType;

--- a/src/SourceCompile/ParseFile.cpp
+++ b/src/SourceCompile/ParseFile.cpp
@@ -181,7 +181,7 @@ void ParseFile::buildLineInfoCache_() {
       unsigned int index = infos.size() - 1;
       while (1) {
         if ((lineItr >= infos[index].m_originalStartLine) &&
-            (infos[index].m_action == IncludeFileInfo::Action::POP)) {
+            (infos[index].m_type == IncludeFileInfo::POP)) {
           SymbolId fileId = infos[index].m_sectionFile;
           fileInfoCache[lineItr] = fileId;
           unsigned int l = infos[index].m_sectionStartLine +
@@ -189,7 +189,7 @@ void ParseFile::buildLineInfoCache_() {
           lineInfoCache[lineItr] = l;
           break;
         }
-        if (infos[index].m_action == IncludeFileInfo::Action::POP) {
+        if (infos[index].m_type == IncludeFileInfo::POP) {
           if (!inRange) {
             inRange = true;
             indexOpeningRange = infos[index].m_indexOpening;
@@ -200,7 +200,7 @@ void ParseFile::buildLineInfoCache_() {
           }
         }
         if ((lineItr >= infos[index].m_originalStartLine) &&
-            (infos[index].m_action == IncludeFileInfo::Action::PUSH) &&
+            (infos[index].m_type == IncludeFileInfo::PUSH) &&
             (infos[index].m_indexClosing > -1) &&
             (lineItr <
              infos[infos[index].m_indexClosing].m_originalStartLine)) {

--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
@@ -118,7 +118,7 @@ void SV3_1aPpTreeListenerHelper::logError(ErrorDefinition::ErrorType error,
       ParseUtils::getLineColumn(m_pp->getTokenStream(), ctx);
   if (m_pp->getMacroInfo()) {
     Location loc(m_pp->getMacroInfo()->m_file,
-                 m_pp->getMacroInfo()->m_startLine + lineCol.first - 1,
+                 m_pp->getMacroInfo()->m_line + lineCol.first - 1,
                  lineCol.second, getSymbolTable()->registerSymbol(object));
     Location extraLoc(m_pp->getIncluderFileId(m_pp->getIncluderLine()),
                       m_pp->getIncluderLine(), 0, 0);
@@ -181,12 +181,11 @@ void SV3_1aPpTreeListenerHelper::checkMultiplyDefinedMacro(
     std::pair<int, int> lineCol =
         ParseUtils::getLineColumn(m_pp->getTokenStream(), ctx);
     if ((macroInf->m_file == m_pp->getFileId(lineCol.first)) &&
-        (m_pp->getLineNb(lineCol.first) == macroInf->m_startLine))
+        (m_pp->getLineNb(lineCol.first) == macroInf->m_line))
       return;
     Location loc(m_pp->getFileId(lineCol.first), m_pp->getLineNb(lineCol.first),
                  0, getSymbolTable()->getId(macroName));
-    Location extraLoc(macroInf->m_file, macroInf->m_startLine,
-                      macroInf->m_startColumn, 0);
+    Location extraLoc(macroInf->m_file, macroInf->m_line, 0, 0);
     logError(ErrorDefinition::PP_MULTIPLY_DEFINED_MACRO, loc, extraLoc);
     visited.erase(visited.begin(), visited.end());
     // So we can store the latest declaration

--- a/src/Utils/ParseUtils.cpp
+++ b/src/Utils/ParseUtils.cpp
@@ -30,7 +30,7 @@ ParseUtils::LineColumn ParseUtils::getLineColumn(
     antlr4::tree::TerminalNode* node) {
   const antlr4::Token* token = node->getSymbol();
   const size_t lineNb = token->getLine();
-  const size_t columnNb = token->getCharPositionInLine() + 1;
+  const size_t columnNb = token->getCharPositionInLine();
   return std::make_pair(lineNb, columnNb);
 }
 
@@ -39,8 +39,7 @@ ParseUtils::LineColumn ParseUtils::getEndLineColumn(
   const antlr4::Token* token = node->getSymbol();
   const size_t lineNb = token->getLine();
   const size_t columnNb = token->getCharPositionInLine() +
-                          token->getStopIndex() - token->getStartIndex() + 1 +
-                          1;
+                          token->getStopIndex() - token->getStartIndex();
   return std::make_pair(lineNb, columnNb);
 }
 
@@ -59,10 +58,10 @@ ParseUtils::LineColumn ParseUtils::getEndLineColumn(
   const antlr4::misc::Interval sourceInterval = context->getSourceInterval();
   if (sourceInterval.b == -1) return std::make_pair(0, 0);
   antlr4::Token* firstToken = stream->get(sourceInterval.b);
-  const size_t lineNb = firstToken->getLine();
-  const size_t columnNb = firstToken->getCharPositionInLine() +
-                          firstToken->getStopIndex() -
-                          firstToken->getStartIndex() + 1 + 1;
+  size_t lineNb = firstToken->getLine();
+  size_t columnNb = firstToken->getCharPositionInLine() +
+                    firstToken->getStopIndex() - firstToken->getStartIndex() +
+                    1 + 1;
   return std::make_pair(lineNb, columnNb);
 }
 


### PR DESCRIPTION
Reverts chipsalliance/Surelog#2866

I had to merge to analyse the diffs.
There are many cases where the new line numbers don't make any sense. Did you review carefully the changes in the line numbers?
For instance all the testcases with "diff" because of errors are because of bogus line numbers.

This needs more work to understand the issues introduced.
Example of such an incorrect change:

diff --git a/tests/PreprocUhdmCov/PreprocUhdmCov.log b/tests/PreprocUhdmCov/PreprocUhdmCov.log
index 8f73c900d..ffff487a5 100644
--- a/tests/PreprocUhdmCov/PreprocUhdmCov.log
+++ b/tests/PreprocUhdmCov/PreprocUhdmCov.log


-[INF:CP0303] dut.sv:4: Compile module "work@top".
+[INF:CP0303] prim_assert.sv:45: Compile module "work@top".
 
