### PR TITLE
Document cache functions; make more const; fix bug

### DIFF
--- a/include/Surelog/Cache/Cache.h
+++ b/include/Surelog/Cache/Cache.h
@@ -76,14 +76,18 @@ class Cache {
       flatbuffers::FlatBufferBuilder& builder, std::string_view schemaVersion,
       const std::filesystem::path& origFileName);
 
-  // Store errors and symbol tables in cache. Using a symbol table
-  // specifically for the cache, which is build and updating "cacheSymbols"
-  std::pair<flatbuffers::Offset<VectorOffsetError>,
-            flatbuffers::Offset<VectorOffsetString>>
+  // Store errors in cache. Canonicalize strings and store in "cacheSymbols".
+  flatbuffers::Offset<VectorOffsetError>
   cacheErrors(flatbuffers::FlatBufferBuilder& builder,
               SymbolTable* cacheSymbols,
               const ErrorContainer* errorContainer,
               const SymbolTable& localSymbols, SymbolId subjectId);
+
+  // Given the symbol table (that we've accumulated while emitting cached
+  // items), convert it to a flatbuffer cache vector.
+  flatbuffers::Offset<Cache::VectorOffsetString> createSymbolCache(
+    flatbuffers::FlatBufferBuilder& builder,
+    const SymbolTable &cacheSymbols);
 
   // Restores errors and the cache symbol table (to be used in other restore
   // operations).
@@ -98,8 +102,9 @@ class Cache {
   // Convert vobjects from "fcontent" into cachable VObjects.
   // Uses "localSymbols" and "cacheSymbols" to map symbols found in "fcontent"
   // to IDs used on the cache on disk.
+  // Updates "cacheSymbols" if new IDs are needed.
   std::vector<CACHE::VObject> cacheVObjects(const FileContent* fcontent,
-                                            const SymbolTable& cacheSymbols,
+                                            SymbolTable* cacheSymbols,
                                             const SymbolTable& localSymbols,
                                             SymbolId fileId);
 

--- a/include/Surelog/Cache/Cache.h
+++ b/include/Surelog/Cache/Cache.h
@@ -30,6 +30,7 @@
 #include <flatbuffers/flatbuffers.h>
 
 #include <filesystem>
+#include <memory>
 
 namespace SURELOG {
 
@@ -40,6 +41,11 @@ class SymbolTable;
 // A cache class used as a base for various other cashes persisting
 // things in flatbuffers.
 // All methods are protected as they are ment for derived classes to use.
+//
+// The cache is storing a symbol table on disk, which we call "cacheSymbols";
+// these typically only contain all the symbols that are exported.
+// The "localSymbols" in the process will differ from "cacheSymbols" as it
+// typically contains more.
 class Cache {
  public:
   static constexpr uint64_t Capacity = 0x000000000FFFFFFF;
@@ -56,7 +62,8 @@ class Cache {
 
   const std::string& getExecutableTimeStamp();
 
-  uint8_t* openFlatBuffers(const std::filesystem::path& cacheFileName);
+  // Open file and read contents into a buffer.
+  std::unique_ptr<uint8_t[]> openFlatBuffers(const std::filesystem::path& cacheFileName);
 
   bool saveFlatbuffers(flatbuffers::FlatBufferBuilder& builder,
                        const std::filesystem::path& cacheFileName);
@@ -69,25 +76,40 @@ class Cache {
       flatbuffers::FlatBufferBuilder& builder, std::string_view schemaVersion,
       const std::filesystem::path& origFileName);
 
+  // Store errors and symbol tables in cache. Using a symbol table
+  // specifically for the cache, which is build and updating "cacheSymbols"
   std::pair<flatbuffers::Offset<VectorOffsetError>,
             flatbuffers::Offset<VectorOffsetString>>
   cacheErrors(flatbuffers::FlatBufferBuilder& builder,
-              SymbolTable& canonicalSymbols, ErrorContainer* errorContainer,
-              SymbolTable* symbols, SymbolId subjectId);
+              SymbolTable* cacheSymbols,
+              const ErrorContainer* errorContainer,
+              const SymbolTable& localSymbols, SymbolId subjectId);
 
+  // Restores errors and the cache symbol table (to be used in other restore
+  // operations).
+  // References in the error container to local symbols will be entered into
+  // the local symbol table.
   void restoreErrors(const VectorOffsetError* errorsBuf,
                      const VectorOffsetString* symbolBuf,
-                     SymbolTable& canonicalSymbols,
-                     ErrorContainer* errorContainer, SymbolTable* symbols);
+                     SymbolTable* cacheSymbols,
+                     ErrorContainer* errorContainer,
+                     SymbolTable* localSymbols);
 
-  std::vector<CACHE::VObject> cacheVObjects(FileContent* fcontent,
-                                            SymbolTable& canonicalSymbols,
-                                            SymbolTable& fileTable,
+  // Convert vobjects from "fcontent" into cachable VObjects.
+  // Uses "localSymbols" and "cacheSymbols" to map symbols found in "fcontent"
+  // to IDs used on the cache on disk.
+  std::vector<CACHE::VObject> cacheVObjects(const FileContent* fcontent,
+                                            const SymbolTable& cacheSymbols,
+                                            const SymbolTable& localSymbols,
                                             SymbolId fileId);
 
+  // Restore objects coming from the flatbuffer cache and with the corresponding
+  // "cacheSymbols" into "fileContent", with IDs relevant in the local
+  // symbol table "localSymbols" (which is updated).
   void restoreVObjects(
       const flatbuffers::Vector<const SURELOG::CACHE::VObject*>* objects,
-      SymbolTable& canonicalSymbols, SymbolTable& fileTable, SymbolId fileId,
+      const SymbolTable& cacheSymbols,
+      SymbolTable* localSymbols, SymbolId fileId,
       FileContent* fileContent);
 
  private:

--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -121,7 +121,8 @@ class FileContent : public DesignComponent {
   std::vector<DesignElement*>& getDesignElements() { return m_elements; }
   void addDesignElement(const std::string& name, DesignElement* elem);
   const DesignElement* getDesignElement(std::string_view name) const;
-  std::vector<VObject>& getVObjects() { return m_objects; }
+  const std::vector<VObject>& getVObjects() const { return m_objects; }
+  std::vector<VObject>& mutableVObjects() { return m_objects; }
   const NameIdMap& getObjectLookup() const { return m_objectLookup; }
   void insertObjectLookup(const std::string& name, NodeId id,
                           ErrorContainer* errors);

--- a/include/Surelog/SourceCompile/CommonListenerHelper.h
+++ b/include/Surelog/SourceCompile/CommonListenerHelper.h
@@ -58,27 +58,20 @@ class CommonListenerHelper {
 
   int ObjectIndexFromContext(const antlr4::tree::ParseTree* ctx) const;
 
-  VObject& Object(NodeId index);
+  const VObject& Object(NodeId index);
 
-  NodeId UniqueId(NodeId index);
+  NodeId UniqueId(NodeId index) const;
 
-  SymbolId& Name(NodeId index);
+  SymbolId Name(NodeId index) const;
+  NodeId Child(NodeId index) const;
+  NodeId Sibling(NodeId index) const;
+  NodeId Parent(NodeId index) const;
+  NodeId Definition(NodeId index) const;
+  VObjectType Type(NodeId index) const;
+  unsigned short Column(NodeId index) const;
+  unsigned int Line(NodeId index) const;
 
-  NodeId& Child(NodeId index);
-
-  NodeId& Sibling(NodeId index);
-
-  NodeId& Definition(NodeId index);
-
-  NodeId& Parent(NodeId index);
-
-  VObjectType& Type(NodeId index);
-
-  unsigned short& Column(NodeId index);
-
-  unsigned int& Line(NodeId index);
-
-  int addVObject(antlr4::ParserRuleContext* ctx, const std::string& name,
+  int addVObject(antlr4::ParserRuleContext* ctx, std::string_view name,
                  VObjectType objtype);
 
   int addVObject(antlr4::ParserRuleContext* ctx, VObjectType objtype);
@@ -93,6 +86,10 @@ class CommonListenerHelper {
   getFileLine(antlr4::ParserRuleContext* ctx, SymbolId& fileId) = 0;
 
  private:
+  NodeId& MutableChild(NodeId index);
+  NodeId& MutableSibling(NodeId index);
+  NodeId& MutableParent(NodeId index);
+
   int addVObject(antlr4::ParserRuleContext* ctx, SymbolId sym,
                  VObjectType objtype);
 

--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -50,7 +50,8 @@ time_t Cache::get_mtime(const fs::path& path) {
   return statbuf.st_mtime;
 }
 
-std::unique_ptr<uint8_t[]> Cache::openFlatBuffers(const fs::path& cacheFileName) {
+std::unique_ptr<uint8_t[]> Cache::openFlatBuffers(
+    const fs::path& cacheFileName) {
   const std::string filename = cacheFileName.string();
   FILE* file = fopen(filename.c_str(), "rb");
   if (file == nullptr) return nullptr;
@@ -129,13 +130,10 @@ bool Cache::saveFlatbuffers(flatbuffers::FlatBufferBuilder& builder,
   return success;
 }
 
-std::pair<flatbuffers::Offset<Cache::VectorOffsetError>,
-          flatbuffers::Offset<Cache::VectorOffsetString>>
-Cache::cacheErrors(flatbuffers::FlatBufferBuilder& builder,
-                   SymbolTable* cacheSymbols,
-                   const ErrorContainer* errorContainer,
-                   const SymbolTable& localSymbols,
-                   SymbolId subjectId) {
+flatbuffers::Offset<Cache::VectorOffsetError> Cache::cacheErrors(
+    flatbuffers::FlatBufferBuilder& builder, SymbolTable* cacheSymbols,
+    const ErrorContainer* errorContainer, const SymbolTable& localSymbols,
+    SymbolId subjectId) {
   const std::vector<Error>& errors = errorContainer->getErrors();
   std::vector<flatbuffers::Offset<SURELOG::CACHE::Error>> error_vec;
   for (const Error& error : errors) {
@@ -151,10 +149,10 @@ Cache::cacheErrors(flatbuffers::FlatBufferBuilder& builder,
       if (matchSubject) {
         std::vector<flatbuffers::Offset<SURELOG::CACHE::Location>> location_vec;
         for (const Location& loc : locs) {
-          SymbolId canonicalFileId =
-              cacheSymbols->registerSymbol(localSymbols.getSymbol(loc.m_fileId));
-          SymbolId canonicalObjectId =
-              cacheSymbols->registerSymbol(localSymbols.getSymbol(loc.m_object));
+          SymbolId canonicalFileId = cacheSymbols->registerSymbol(
+              localSymbols.getSymbol(loc.m_fileId));
+          SymbolId canonicalObjectId = cacheSymbols->registerSymbol(
+              localSymbols.getSymbol(loc.m_object));
           auto locflb =
               CACHE::CreateLocation(builder, canonicalFileId, loc.m_line,
                                     loc.m_column, canonicalObjectId);
@@ -167,14 +165,12 @@ Cache::cacheErrors(flatbuffers::FlatBufferBuilder& builder,
     }
   }
 
-  /* Cache all the symbols */
-  for (const auto& s : localSymbols.getSymbols()) {
-    cacheSymbols->registerSymbol(s);
-  }
+  return builder.CreateVector(error_vec);
+}
 
-  auto symbolVec = builder.CreateVectorOfStrings(cacheSymbols->getSymbols());
-  auto errvec = builder.CreateVector(error_vec);
-  return std::make_pair(errvec, symbolVec);
+flatbuffers::Offset<Cache::VectorOffsetString> Cache::createSymbolCache(
+    flatbuffers::FlatBufferBuilder& builder, const SymbolTable& cacheSymbols) {
+  return builder.CreateVectorOfStrings(cacheSymbols.getSymbols());
 }
 
 void Cache::restoreErrors(const VectorOffsetError* errorsBuf,
@@ -193,8 +189,8 @@ void Cache::restoreErrors(const VectorOffsetError* errorsBuf,
       auto locFlb = errorFlb->locations()->Get(j);
       SymbolId translFileId = localSymbols->registerSymbol(
           cacheSymbols->getSymbol(locFlb->file_id()));
-      SymbolId translObjectId =
-          localSymbols->registerSymbol(cacheSymbols->getSymbol(locFlb->object()));
+      SymbolId translObjectId = localSymbols->registerSymbol(
+          cacheSymbols->getSymbol(locFlb->object()));
       Location loc(translFileId, locFlb->line(), locFlb->column(),
                    translObjectId);
       locs.push_back(loc);
@@ -204,10 +200,9 @@ void Cache::restoreErrors(const VectorOffsetError* errorsBuf,
   }
 }
 
-std::vector<CACHE::VObject> Cache::cacheVObjects(const FileContent* fcontent,
-                                                 const SymbolTable& cacheSymbols,
-                                                 const SymbolTable& localSymbols,
-                                                 SymbolId fileId) {
+std::vector<CACHE::VObject> Cache::cacheVObjects(
+    const FileContent* fcontent, SymbolTable* cacheSymbols,
+    const SymbolTable& localSymbols, SymbolId fileId) {
   /* Cache the design objects */
   // std::vector<flatbuffers::Offset<PARSECACHE::VObject>> object_vec;
   std::vector<CACHE::VObject> object_vec;
@@ -216,10 +211,16 @@ std::vector<CACHE::VObject> Cache::cacheVObjects(const FileContent* fcontent,
     std::cout << "INTERNAL ERROR: Cache is saturated, Use -nocache option\n";
     return object_vec;
   }
+  // Convert a local symbol ID to a cache symbol ID to be stored.
+  std::function<uint64_t(SymbolId)> toCacheSym = [cacheSymbols,
+                                                  localSymbols](SymbolId id) {
+    return cacheSymbols->registerSymbol(localSymbols.getSymbol(id));
+  };
+
   for (const VObject& object : fcontent->getVObjects()) {
     // Lets compress this struct into 20 and 16 bits fields:
     //  object_vec.push_back(PARSECACHE::CreateVObject(builder,
-    //                                              canonicalSymbols.getId(m_parse->getCompileSourceFile()->getSymbolTable()->getSymbol(object.m_name)),
+    //                                              toCacheSym(object.m_name),
     //                                              object.m_uniqueId,
     //                                              object.m_type,
     //                                              object.m_column,
@@ -233,9 +234,9 @@ std::vector<CACHE::VObject> Cache::cacheVObjects(const FileContent* fcontent,
     uint64_t field2 = 0;
     uint64_t field3 = 0;
     uint64_t field4 = 0;
-    SymbolId name = cacheSymbols.getId(localSymbols.getSymbol(object.m_name));
+
     // clang-format off
-    field1 |= 0x0000000000FFFFFF & (name);
+    field1 |= 0x0000000000FFFFFF & toCacheSym(object.m_name);
     field1 |= 0x0000000FFF000000 & (((uint64_t)object.m_type)      << (24));
     field1 |= 0x0000FFF000000000 & (((uint64_t)object.m_column)    << (24 + 12));
     field1 |= 0xFFFF000000000000 & (((uint64_t)object.m_parent     << (24 + 12 + 12)));
@@ -244,7 +245,7 @@ std::vector<CACHE::VObject> Cache::cacheVObjects(const FileContent* fcontent,
     field2 |= 0xFFFFFF0000000000 & (((uint64_t)object.m_child)     << (12 + 28));
     field3 |= 0x000000000000000F & (((uint64_t)object.m_child)     >> (24));
     field3 |= 0x00000000FFFFFFF0 & (object.m_sibling               << (4));
-    field3 |= 0x00FFFFFF00000000 & (((uint64_t)object.m_fileId)    << (4 + 28));
+    field3 |= 0x00FFFFFF00000000 & (toCacheSym(object.m_fileId)    << (4 + 28));
     field3 |= 0xFF00000000000000 & (((uint64_t)object.m_line)      << (4 + 28 + 24));
     field4 |= 0x000000000000FFFF & (((uint64_t)object.m_line)      >> (8));
     field4 |= 0x000000FFFFFF0000 & (((uint64_t)object.m_endLine)   << (16));

--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -50,22 +50,20 @@ time_t Cache::get_mtime(const fs::path& path) {
   return statbuf.st_mtime;
 }
 
-uint8_t* Cache::openFlatBuffers(const fs::path& cacheFileName) {
+std::unique_ptr<uint8_t[]> Cache::openFlatBuffers(const fs::path& cacheFileName) {
   const std::string filename = cacheFileName.string();
   FILE* file = fopen(filename.c_str(), "rb");
   if (file == nullptr) return nullptr;
   fseek(file, 0L, SEEK_END);
   unsigned int length = ftell(file);
   fseek(file, 0L, SEEK_SET);
-  char* data = new char[length];
-  size_t l = fread(data, sizeof(char), length, file);
+  std::unique_ptr<uint8_t[]> data(new uint8_t[length]);
+  size_t l = fread(data.get(), sizeof(uint8_t), length, file);
   fclose(file);
   if (length != l) {
-    delete[] data;
     return nullptr;
   }
-  uint8_t* buffer_pointer = (uint8_t*)data;
-  return buffer_pointer;
+  return data;
 }
 
 bool Cache::checkIfCacheIsValid(const SURELOG::CACHE::Header* header,
@@ -82,15 +80,14 @@ bool Cache::checkIfCacheIsValid(const SURELOG::CACHE::Header* header,
   }
 
   /* Timestamp Tool that created Cache vs tool date */
-  std::string execDate = getExecutableTimeStamp();
-  if (execDate != header->sl_date_compiled()->c_str()) {
+  if (getExecutableTimeStamp() != header->sl_date_compiled()->c_str()) {
     return false;
   }
 
   /* Timestamp Cache vs Orig File */
   if (!cacheFileName.empty()) {
     time_t ct = get_mtime(cacheFileName);
-    std::string fileName = header->file()->c_str();
+    std::string fileName = header->file_deprecated()->c_str();
     time_t ft = get_mtime(fileName.c_str());
     if (ft == -1) {
       return false;
@@ -112,10 +109,8 @@ flatbuffers::Offset<SURELOG::CACHE::Header> Cache::createHeader(
   auto sl_version = builder.CreateString(CommandLineParser::getVersionNumber());
   auto sl_build_date = builder.CreateString(getExecutableTimeStamp());
   auto sl_flb_version = builder.CreateString(schemaVersion);
-  std::time_t t_result = std::time(nullptr);
-  auto file_creation_date = builder.CreateString(std::to_string(t_result));
   auto header = CACHE::CreateHeader(builder, sl_version, sl_flb_version,
-                                    sl_build_date, file_creation_date, fName);
+                                    sl_build_date, fName);
   return header;
 }
 
@@ -137,8 +132,9 @@ bool Cache::saveFlatbuffers(flatbuffers::FlatBufferBuilder& builder,
 std::pair<flatbuffers::Offset<Cache::VectorOffsetError>,
           flatbuffers::Offset<Cache::VectorOffsetString>>
 Cache::cacheErrors(flatbuffers::FlatBufferBuilder& builder,
-                   SymbolTable& canonicalSymbols,
-                   ErrorContainer* errorContainer, SymbolTable* symbols,
+                   SymbolTable* cacheSymbols,
+                   const ErrorContainer* errorContainer,
+                   const SymbolTable& localSymbols,
                    SymbolId subjectId) {
   const std::vector<Error>& errors = errorContainer->getErrors();
   std::vector<flatbuffers::Offset<SURELOG::CACHE::Error>> error_vec;
@@ -156,9 +152,9 @@ Cache::cacheErrors(flatbuffers::FlatBufferBuilder& builder,
         std::vector<flatbuffers::Offset<SURELOG::CACHE::Location>> location_vec;
         for (const Location& loc : locs) {
           SymbolId canonicalFileId =
-              canonicalSymbols.registerSymbol(symbols->getSymbol(loc.m_fileId));
+              cacheSymbols->registerSymbol(localSymbols.getSymbol(loc.m_fileId));
           SymbolId canonicalObjectId =
-              canonicalSymbols.registerSymbol(symbols->getSymbol(loc.m_object));
+              cacheSymbols->registerSymbol(localSymbols.getSymbol(loc.m_object));
           auto locflb =
               CACHE::CreateLocation(builder, canonicalFileId, loc.m_line,
                                     loc.m_column, canonicalObjectId);
@@ -172,33 +168,33 @@ Cache::cacheErrors(flatbuffers::FlatBufferBuilder& builder,
   }
 
   /* Cache all the symbols */
-  for (const auto& s : symbols->getSymbols()) {
-    canonicalSymbols.registerSymbol(s);
+  for (const auto& s : localSymbols.getSymbols()) {
+    cacheSymbols->registerSymbol(s);
   }
 
-  auto symbolVec = builder.CreateVectorOfStrings(canonicalSymbols.getSymbols());
+  auto symbolVec = builder.CreateVectorOfStrings(cacheSymbols->getSymbols());
   auto errvec = builder.CreateVector(error_vec);
   return std::make_pair(errvec, symbolVec);
 }
 
 void Cache::restoreErrors(const VectorOffsetError* errorsBuf,
                           const VectorOffsetString* symbolsBuf,
-                          SymbolTable& canonicalSymbols,
+                          SymbolTable* cacheSymbols,
                           ErrorContainer* errorContainer,
-                          SymbolTable* symbols) {
+                          SymbolTable* localSymbols) {
   for (unsigned int i = 0; i < symbolsBuf->size(); i++) {
     const std::string symbol = symbolsBuf->Get(i)->c_str();
-    canonicalSymbols.registerSymbol(symbol);
+    cacheSymbols->registerSymbol(symbol);
   }
   for (unsigned int i = 0; i < errorsBuf->size(); i++) {
     auto errorFlb = errorsBuf->Get(i);
     std::vector<Location> locs;
     for (unsigned int j = 0; j < errorFlb->locations()->size(); j++) {
       auto locFlb = errorFlb->locations()->Get(j);
-      SymbolId translFileId = symbols->registerSymbol(
-          canonicalSymbols.getSymbol(locFlb->file_id()));
+      SymbolId translFileId = localSymbols->registerSymbol(
+          cacheSymbols->getSymbol(locFlb->file_id()));
       SymbolId translObjectId =
-          symbols->registerSymbol(canonicalSymbols.getSymbol(locFlb->object()));
+          localSymbols->registerSymbol(cacheSymbols->getSymbol(locFlb->object()));
       Location loc(translFileId, locFlb->line(), locFlb->column(),
                    translObjectId);
       locs.push_back(loc);
@@ -208,9 +204,9 @@ void Cache::restoreErrors(const VectorOffsetError* errorsBuf,
   }
 }
 
-std::vector<CACHE::VObject> Cache::cacheVObjects(FileContent* fcontent,
-                                                 SymbolTable& canonicalSymbols,
-                                                 SymbolTable& fileTable,
+std::vector<CACHE::VObject> Cache::cacheVObjects(const FileContent* fcontent,
+                                                 const SymbolTable& cacheSymbols,
+                                                 const SymbolTable& localSymbols,
                                                  SymbolId fileId) {
   /* Cache the design objects */
   // std::vector<flatbuffers::Offset<PARSECACHE::VObject>> object_vec;
@@ -237,7 +233,7 @@ std::vector<CACHE::VObject> Cache::cacheVObjects(FileContent* fcontent,
     uint64_t field2 = 0;
     uint64_t field3 = 0;
     uint64_t field4 = 0;
-    SymbolId name = canonicalSymbols.getId(fileTable.getSymbol(object.m_name));
+    SymbolId name = cacheSymbols.getId(localSymbols.getSymbol(object.m_name));
     // clang-format off
     field1 |= 0x0000000000FFFFFF & (name);
     field1 |= 0x0000000FFF000000 & (((uint64_t)object.m_type)      << (24));
@@ -257,17 +253,13 @@ std::vector<CACHE::VObject> Cache::cacheVObjects(FileContent* fcontent,
 
     object_vec.emplace_back(field1, field2, field3, field4);
   }
-  // std::cout << "SAVE: " << cacheFileName << " "
-  //          << fileTable.getSymbol(fileId)
-  //          << " NB: " <<   fcontent->getVObjects().size()
-  //         << std::endl;
 
   return object_vec;
 }
 
 void Cache::restoreVObjects(
     const flatbuffers::Vector<const SURELOG::CACHE::VObject*>* objects,
-    SymbolTable& canonicalSymbols, SymbolTable& fileTable, SymbolId fileId,
+    const SymbolTable& cacheSymbols, SymbolTable* localSymbols, SymbolId fileId,
     FileContent* fileContent) {
   /* Restore design objects */
   for (unsigned int i = 0; i < objects->size(); i++) {
@@ -302,9 +294,9 @@ void Cache::restoreVObjects(
     unsigned short endColumn = (field4 & 0x000FFF0000000000) >> (16 + 24);
     // clang-format on
 
-    fileContent->getVObjects().emplace_back(
-        fileTable.registerSymbol(canonicalSymbols.getSymbol(name)),
-        fileTable.registerSymbol(canonicalSymbols.getSymbol(fileId)),
+    fileContent->mutableVObjects().emplace_back(
+        localSymbols->registerSymbol(cacheSymbols.getSymbol(name)),
+        localSymbols->registerSymbol(cacheSymbols.getSymbol(fileId)),
         (VObjectType)type, line, column, endLine, endColumn, parent, definition,
         child, sibling);
   }

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -102,9 +102,7 @@ bool ParseCache::restore_(const fs::path& cacheFileName) {
     m_parse->getCompileSourceFile()->getCompiler()->getDesign()->addFileContent(
         m_parse->getFileId(0), fileContent);
   }
-  auto content = ppcache->elements();
-  for (unsigned int i = 0; i < content->size(); i++) {
-    auto elemc = content->Get(i);
+  for (const auto* elemc : *ppcache->elements()) {
     const std::string& elemName = cacheSymbols.getSymbol(elemc->name());
     DesignElement* elem = new DesignElement(
         m_parse->getCompileSourceFile()->getSymbolTable()->registerSymbol(

--- a/src/Cache/header.fbs
+++ b/src/Cache/header.fbs
@@ -1,30 +1,38 @@
 /*
  Copyright 2019 Alain Dargelas
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
  http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
  */
- 
-// Surelog 
+
+// Surelog
 // IDL for Macro cache header.
 
 namespace SURELOG.CACHE;
 
 table Header {
-  sl_version:string;
-  flb_version:string;
-  sl_date_compiled:string;
-  file_date_compiled:string;
-  file:string; 
+  // Making sure that we are compatible with whatever Surelog and schema
+  // this is written.
+  sl_version:string;       // Surelog version
+  flb_version:string;      // schema version.
+  sl_date_compiled:string; // build-timestamp surelog.
+
+  // No file-timestamp as this would violate hermetic build assumptions:
+  // running the same tool on the same file must always yield the same cache.
+
+  // Arguably, the filename should also not be recorded here, as this is
+  // strictly derived from the original filename when reading the cache. It
+  // makes it hard to create hermetic builds in different directories.
+  file_deprecated:string;
 }
 
 table Error {
@@ -50,7 +58,7 @@ table TimeInfo {
   time_precision_value:double;
 }
 
-// This is what we need to encode, 
+// This is what we need to encode,
 //  but we limit all the ulong and uint objects to 20 bits and the ushort stays at 16 bits for the line and 12 bits for the type
 /*
 table VObject {

--- a/src/SourceCompile/CommonListenerHelper.cpp
+++ b/src/SourceCompile/CommonListenerHelper.cpp
@@ -102,10 +102,8 @@ int CommonListenerHelper::addVObject(ParserRuleContext* ctx, SymbolId sym,
   SymbolId fileId;
   auto [line, column, endLine, endColumn] = getFileLine(ctx, fileId);
 
-  VObject& inserted = m_fileContent->mutableVObjects()
-    .emplace_back(sym, fileId, objtype,
-                  line, column,
-                  endLine, endColumn, 0);
+  VObject& inserted = m_fileContent->mutableVObjects().emplace_back(
+      sym, fileId, objtype, line, column, endLine, endColumn, 0);
   const int objectIndex = m_fileContent->getVObjects().size() - 1;
   m_contextToObjectMap.insert(std::make_pair(ctx, objectIndex));
   addParentChildRelations(objectIndex, ctx);


### PR DESCRIPTION
Start documenting the methods used in the cache. Also

   * Fix a bug: the file_id in the VObject was not properly encoded to the symbol table that was written to disk, but whatever symbol ID it had in the local symbol table (`Cache::cacheVObjects()`).
   * If parameters can be `const`, make them so.
   * Make it impossible to forget delete[]-ing buffer returned by `openFlatBuffers()` by making it a unique_ptr. Simplifies the place where it is used quite a bit.
   * Only emit symbols into the cache that are actually referenced in the elements written to the cache. This reduces file-size and removes other elements that would differ depending on the context (e.g. if the file was compiled together with other files - the additional symbol table entries are not needed and break hermetic build assumptions).
   * Remove timestamp when file was compiled in the cache header - this is not needed and also breaks hermetic build contexts (a compiled file should _always_ result in the same output if Surelog didn't change - independent of time).
   *  Use range-based loop on flatbuffer content to improve readability.