### PR TITLE
Improve debug printing. Fix types.

### DIFF
--- a/include/Surelog/Cache/Cache.h
+++ b/include/Surelog/Cache/Cache.h
@@ -28,6 +28,7 @@
 #include <Surelog/Cache/header_generated.h>
 #include <Surelog/Common/SymbolId.h>
 #include <flatbuffers/flatbuffers.h>
+#include <Surelog/Design/VObject.h>
 
 #include <filesystem>
 #include <memory>
@@ -116,6 +117,11 @@ class Cache {
       const SymbolTable& cacheSymbols,
       SymbolTable* localSymbols, SymbolId fileId,
       FileContent* fileContent);
+
+  void restoreVObjects(
+    const flatbuffers::Vector<const SURELOG::CACHE::VObject*>* objects,
+    const SymbolTable& cacheSymbols, SymbolTable* localSymbols, SymbolId fileId,
+    std::vector<SURELOG::VObject> *result);
 
  private:
   Cache(const Cache& orig) = delete;

--- a/include/Surelog/Design/DesignElement.h
+++ b/include/Surelog/Design/DesignElement.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/TimeInfo.h>
+#include <ostream>
 
 namespace SURELOG {
 
@@ -49,19 +50,19 @@ class DesignElement final {
   };
 
   DesignElement(SymbolId name, SymbolId fileId, ElemType type,
-                SymbolId uniqueId, unsigned int line, unsigned short column,
+                NodeId uniqueId, unsigned int line, unsigned short column,
                 unsigned int endLine, unsigned short endColumn,
-                SymbolId parent);
+                NodeId parent);
 
   SymbolId m_name;
   SymbolId m_fileId;
   const ElemType m_type;
-  const SymbolId m_uniqueId;
+  const NodeId m_uniqueId;
   const unsigned int m_line;
   const unsigned short m_column;
   const unsigned int m_endLine;
   const unsigned short m_endColumn;
-  SymbolId m_parent;
+  NodeId m_parent;
 
   TimeInfo m_timeInfo;
   NodeId m_node;
@@ -69,6 +70,8 @@ class DesignElement final {
   void* m_context;  // Not persisted field, only used to build the DesignElement
                     // -> VNode relation
 };
+
+std::ostream& operator<<(std::ostream& os, DesignElement::ElemType type);
 
 }  // namespace SURELOG
 

--- a/include/Surelog/Design/VObject.h
+++ b/include/Surelog/Design/VObject.h
@@ -28,6 +28,7 @@
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
+#include <ostream>
 #include <string>
 
 namespace SURELOG {
@@ -75,6 +76,9 @@ class VObject final {
   NodeId m_sibling;
 };
 
+inline std::ostream& operator<<(std::ostream& os, VObjectType type) {
+  return os << VObject::getTypeName(type);
+}
 }  // namespace SURELOG
 
 #endif /* SURELOG_VOBJECT_H */

--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -262,6 +262,14 @@ void Cache::restoreVObjects(
     const flatbuffers::Vector<const SURELOG::CACHE::VObject*>* objects,
     const SymbolTable& cacheSymbols, SymbolTable* localSymbols, SymbolId fileId,
     FileContent* fileContent) {
+  restoreVObjects(objects, cacheSymbols, localSymbols, fileId,
+                  &fileContent->mutableVObjects());
+}
+
+void Cache::restoreVObjects(
+    const flatbuffers::Vector<const SURELOG::CACHE::VObject*>* objects,
+    const SymbolTable& cacheSymbols, SymbolTable* localSymbols, SymbolId fileId,
+    std::vector<VObject>* result) {
   /* Restore design objects */
   for (unsigned int i = 0; i < objects->size(); i++) {
     auto objectc = objects->Get(i);
@@ -295,7 +303,7 @@ void Cache::restoreVObjects(
     unsigned short endColumn = (field4 & 0x000FFF0000000000) >> (16 + 24);
     // clang-format on
 
-    fileContent->mutableVObjects().emplace_back(
+    result->emplace_back(
         localSymbols->registerSymbol(cacheSymbols.getSymbol(name)),
         localSymbols->registerSymbol(cacheSymbols.getSymbol(fileId)),
         (VObjectType)type, line, column, endLine, endColumn, parent, definition,

--- a/src/Design/DesignElement.cpp
+++ b/src/Design/DesignElement.cpp
@@ -25,9 +25,9 @@
 
 namespace SURELOG {
 DesignElement::DesignElement(SymbolId name, SymbolId fileId, ElemType type,
-                             SymbolId uniqueId, unsigned int line,
+                             NodeId uniqueId, unsigned int line,
                              unsigned short column, unsigned int endLine,
-                             unsigned short endColumn, SymbolId parent)
+                             unsigned short endColumn, NodeId parent)
     : m_name(name),
       m_fileId(fileId),
       m_type(type),
@@ -39,4 +39,27 @@ DesignElement::DesignElement(SymbolId name, SymbolId fileId, ElemType type,
       m_parent(parent),
       m_node(0),
       m_context(nullptr) {}
+
+std::ostream& operator<<(std::ostream& os, DesignElement::ElemType type) {
+  switch (type) {
+#define CASE_TYPE_PRINT(e)         \
+  case DesignElement::ElemType::e: \
+    return os << #e
+    CASE_TYPE_PRINT(Module);
+    CASE_TYPE_PRINT(Primitive);
+    CASE_TYPE_PRINT(Interface);
+    CASE_TYPE_PRINT(Program);
+    CASE_TYPE_PRINT(Package);
+    CASE_TYPE_PRINT(Config);
+    CASE_TYPE_PRINT(Checker);
+    CASE_TYPE_PRINT(Class);
+    CASE_TYPE_PRINT(Function);
+    CASE_TYPE_PRINT(Task);
+    CASE_TYPE_PRINT(SLline);
+#undef CASE_TYPE_PRINT
+    // never add a default so that the compiler warns when new choices are added
+  }
+  return os;
+}
+
 }  // namespace SURELOG


### PR DESCRIPTION
 * Fix unique-id and parent-id in DesignElement: these
   are NodeIds, but were confusingly stored as SymbolId.
 * Add a operator<< to pretty-print DesignElement::ElemType
 * Add a operator<< to pretty-print VObjectType
 * Break out the function that fills VObject types in
   the Cache to a separate function to use for
   inspecting the cache independent of FileContent.

Signed-off-by: Henner Zeller <h.zeller@acm.org>