### PR TITLE
Resolve shell-utilities such as time and bash with /usr/bin/env

### DIFF
--- a/tests/TestNoHash/runsurelog.sh
+++ b/tests/TestNoHash/runsurelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 rm -rf slpp_unit
 $1 pkg1.sv -fileunit -parse -noelab -nouhdm -nobuiltin -nocomp -nohash -d cache
 $1 pkg2.sv -fileunit -parse -noelab -nouhdm -nobuiltin -nocomp -nohash -d cache

--- a/tests/regression.tcl
+++ b/tests/regression.tcl
@@ -68,7 +68,7 @@ proc log_nonewline { text } {
 }
 
 set UPDATE 0
-set TIME "time"
+set TIME "/usr/bin/env time"
 set DEBUG_TOOL ""
 set PRIOR_USER 0
 set PRIOR_ELAPSED 0
@@ -423,7 +423,7 @@ proc run_regression { } {
         if {($ONETEST != "")} {
             log "\ncd $testdir"
             if [regexp {\.sh} $command] {
-                log "$command [lindex $SURELOG_COMMAND 1]\n"
+                log "$command [lindex $SURELOG_COMMAND end]\n"
             } else {
                 log "$SURELOG_COMMAND $command\n"
             }
@@ -473,7 +473,7 @@ proc run_regression { } {
             }
             set output_path "-o ${root}build/tests/$test/"
             if [regexp {\.sh} $command] {
-                catch {set time_result [exec $SHELL $SHELL_ARGS "$TIME $command [lindex $SURELOG_COMMAND 1] > $REGRESSION_PATH/tests/$test/${testname}.log"]} time_result
+                catch {set time_result [exec $SHELL $SHELL_ARGS "$TIME $command [lindex $SURELOG_COMMAND end] > $REGRESSION_PATH/tests/$test/${testname}.log"]} time_result
             } else {
                 if [regexp {\*/\*\.v} $command] {
                     regsub -all {[\*/]+\*\.v} $command "" command
@@ -500,7 +500,7 @@ proc run_regression { } {
                 }
                 set FINAL_COMMAND $SURELOG_COMMAND
                 if {$DEBUG == "valgrind"} {
-                    set surelog [lindex $SURELOG_COMMAND 1]
+                    set surelog [lindex $SURELOG_COMMAND end]
                     set FINAL_COMMAND "$TIME valgrind --tool=memcheck --log-file=$REGRESSION_PATH/tests/$test/valgrind.log $surelog"
                     puts "\n$FINAL_COMMAND\n"
                 }
@@ -544,7 +544,7 @@ proc run_regression { } {
                     file delete -force $f
                 }
                 if [regexp {\.sh} $command] {
-                    catch {set time_result [exec $SHELL $SHELL_ARGS "$TIME $command [lindex $SURELOG_COMMAND 1] > $REGRESSION_PATH/tests/$test/${testname}.log"]} time_result
+                    catch {set time_result [exec $SHELL $SHELL_ARGS "$TIME $command [lindex $SURELOG_COMMAND end] > $REGRESSION_PATH/tests/$test/${testname}.log"]} time_result
                 } else {
                     catch {set time_result [exec $SHELL $SHELL_ARGS "$SURELOG_COMMAND $command > $REGRESSION_PATH/tests/$test/${testname}.log"]} time_result
                 }

--- a/third_party/tests/ariane/runsurelog.sh
+++ b/third_party/tests/ariane/runsurelog.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 make RISCV=blah verilator="$1 -DVERILATOR=1 -sverilog -parse -d coveruhdm -verbose -timescale=1ps/1ps" verilate CFLAGS="" LDFLAGS=""

--- a/third_party/tests/black-parrot/bp_be/syn/runsurelog.sh
+++ b/third_party/tests/black-parrot/bp_be/syn/runsurelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 { # try
    make build_cov.sc sim.sc SUITE=riscv_tests PROG=rsort VERILATOR="$1 -sverilog -parse -nopython -verbose -timescale=1ps/1ps -elabuhdm -d coveruhdm -verbose -lowmem"  && echo "OK"
     #save your output

--- a/third_party/tests/black-parrot/bp_top/syn/runsurelog.sh
+++ b/third_party/tests/black-parrot/bp_top/syn/runsurelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 { # try
    rm -rf results/verilator/bp_tethered.e_bp_multicore_1_cfg.none.build/multicore
    make build.sc CFG=e_bp_multicore_1_cfg VERILATOR="$1 -DVERILATOR=1 -sverilog -parse -nopython -verbose -timescale=1ps/1ps -elabuhdm -d coveruhdm -d uhdmstats -verbose -lowmem -o multicore"  && echo "OK"


### PR DESCRIPTION
A strict posix system does not guarantee that the utilities
are available in /bin/bash or in the path, but should be
resolved by /usr/bin/env

While at it, make tcl regression more robust by choosing
the _last_ element in the SURELOG_COMMAND with lindex
instead of a hard-coded index (as this will change with
a double-element 'time' or even with a debug tool).

Signed-off-by: Henner Zeller <hzeller@google.com>