### PR TITLE
Improve readability of prefix/suffix removal in string-views

### DIFF
--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -301,7 +301,7 @@ bool UhdmChecker::reportHtml(CompileDesign* compileDesign,
     for (auto lineText : fileContentLines) {
       while (!lineText.empty() &&
              (lineText.back() == '\n' || lineText.back() == '\r')) {
-        lineText = lineText.substr(0, lineText.size() - 1);
+        lineText.remove_suffix(1);
       }
       ++line;
       RangesMap::const_iterator cItr = uhdmCover.find(line);

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -263,15 +263,10 @@ std::string StringUtils::replaceAll(std::string_view str, std::string_view from,
 static std::string_view SplitNext(std::string_view* src, char separator) {
   if (src->empty()) return {nullptr, 0};  // Done.
 
-  std::string_view result;
-  if (auto pos = src->find_first_of(separator); pos != std::string_view::npos) {
-    const size_t element_len = pos + 1;
-    result = src->substr(0, element_len);
-    *src = src->substr(element_len);
-  } else {
-    result = *src;                    // Remainder.
-    *src = src->substr(src->size());  // Empty string, placed at end.
-  }
+  const auto pos = src->find_first_of(separator);
+  const auto part_len = (pos != std::string_view::npos) ? pos + 1 : src->size();
+  std::string_view result = src->substr(0, part_len);
+  src->remove_prefix(part_len);
   return result;
 }
 


### PR DESCRIPTION
Use self-explaining named methods specifically meant for that.