### PR TITLE
Duplicate vars in local scope

### DIFF
--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -266,13 +266,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
             if (cstmt->UhdmType() == uhdmassign_stmt) {
               assign_stmt* assign = (assign_stmt*)cstmt;
               if (assign->Rhs() == nullptr) {
-                VectorOfvariables* vars = scope->Variables();
-                if (vars == nullptr) {
-                  vars = s.MakeVariablesVec();
-                  scope->Variables(vars);
-                }
                 isDecl = true;
-                vars->push_back((UHDM::variables*)assign->Lhs());
                 ((variables*)assign->Lhs())->VpiParent(stmt);
               }
             } else if (cstmt->UhdmType() == uhdmsequence_decl) {

--- a/tests/CastTypespec/CastTypespec.log
+++ b/tests/CastTypespec/CastTypespec.log
@@ -1610,8 +1610,6 @@ design: (work@tlul_adapter_host)
         \_struct_var: , line:31:12, endln:31:14
           |vpiTypespec:
           \_struct_typespec: (ab_t), line:27:13, endln:27:19, parent:work@top
-      |vpiVariables:
-      \_array_var: (work@top.v1), parent:work@top
       |vpiStmt:
       \_assignment: , line:32:7, endln:32:38, parent:work@top
         |vpiOpType:82
@@ -1892,27 +1890,6 @@ design: (work@tlul_adapter_host)
     |vpiStmt:
     \_begin: (work@top), line:30:13, endln:33:8
       |vpiFullName:work@top
-      |vpiVariables:
-      \_array_var: (work@top.v1), parent:work@top
-        |vpiName:v1
-        |vpiFullName:work@top.v1
-        |vpiRange:
-        \_range: , line:31:15, endln:31:18, parent:work@top.v1
-          |vpiLeftRange:
-          \_constant: , line:31:15, endln:31:16
-          |vpiRightRange:
-          \_constant: , line:31:17, endln:31:18
-        |vpiRange:
-        \_range: , line:31:21, endln:31:24, parent:work@top.v1
-          |vpiLeftRange:
-          \_constant: , line:31:21, endln:31:22
-          |vpiRightRange:
-          \_constant: , line:31:23, endln:31:24
-        |vpiReg:
-        \_struct_var: (work@top.v1), line:31:12, endln:31:14, parent:work@top.v1
-          |vpiTypespec:
-          \_struct_typespec: (ab_t), line:27:13, endln:27:19, parent:work@top
-          |vpiFullName:work@top.v1
       |vpiVariables:
       \_array_var: (work@top.v1), parent:work@top
         |vpiName:v1

--- a/tests/DollarRoot/DollarRoot.log
+++ b/tests/DollarRoot/DollarRoot.log
@@ -12567,8 +12567,6 @@ design: (work@top)
           |vpiName:cmd
           |vpiFullName:work@test_program.cmd
         |vpiVariables:
-        \_struct_var: (work@test_program.cmd), line:251:16, endln:251:19, parent:work@test_program
-        |vpiVariables:
         \_struct_var: (work@test_program.actual_rsp), line:252:16, endln:252:26, parent:work@test_program
           |vpiTypespec:
           \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
@@ -12580,10 +12578,6 @@ design: (work@top)
           \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
           |vpiName:exp_rsp
           |vpiFullName:work@test_program.exp_rsp
-        |vpiVariables:
-        \_struct_var: (work@test_program.actual_rsp), line:252:16, endln:252:26, parent:work@test_program
-        |vpiVariables:
-        \_struct_var: (work@test_program.exp_rsp), line:252:28, endln:252:35, parent:work@test_program
         |vpiStmt:
         \_assignment: , line:254:7, endln:254:53, parent:work@test_program
           |vpiOpType:82
@@ -12734,24 +12728,16 @@ design: (work@top)
           |vpiName:exp_cmd
           |vpiFullName:work@test_program.exp_cmd
         |vpiVariables:
-        \_struct_var: (work@test_program.actual_cmd), line:284:19, endln:284:29, parent:work@test_program
-        |vpiVariables:
-        \_struct_var: (work@test_program.exp_cmd), line:284:31, endln:284:38, parent:work@test_program
-        |vpiVariables:
         \_struct_var: (work@test_program.rsp), line:285:19, endln:285:22, parent:work@test_program
           |vpiTypespec:
           \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
           |vpiName:rsp
           |vpiFullName:work@test_program.rsp
         |vpiVariables:
-        \_struct_var: (work@test_program.rsp), line:285:19, endln:285:22, parent:work@test_program
-        |vpiVariables:
         \_int_var: (work@test_program.backpressure_cycles), line:287:21, endln:287:40, parent:work@test_program
           |vpiName:backpressure_cycles
           |vpiFullName:work@test_program.backpressure_cycles
           |vpiAutomatic:1
-        |vpiVariables:
-        \_int_var: (work@test_program.backpressure_cycles), line:287:21, endln:287:40, parent:work@test_program
         |vpiStmt:
         \_for_stmt: (work@test_program), line:290:7, endln:290:10, parent:work@test_program
           |vpiFullName:work@test_program
@@ -13052,8 +13038,6 @@ design: (work@top)
           |vpiName:cmd
           |vpiFullName:work@test_program.cmd
         |vpiVariables:
-        \_struct_var: (work@test_program.cmd), line:394:16, endln:394:19, parent:work@test_program
-        |vpiVariables:
         \_struct_var: (work@test_program.actual_rsp), line:395:16, endln:395:26, parent:work@test_program
           |vpiTypespec:
           \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
@@ -13065,10 +13049,6 @@ design: (work@top)
           \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
           |vpiName:exp_rsp
           |vpiFullName:work@test_program.exp_rsp
-        |vpiVariables:
-        \_struct_var: (work@test_program.actual_rsp), line:395:16, endln:395:26, parent:work@test_program
-        |vpiVariables:
-        \_struct_var: (work@test_program.exp_rsp), line:395:28, endln:395:35, parent:work@test_program
         |vpiStmt:
         \_assignment: , line:397:7, endln:397:53, parent:work@test_program
           |vpiOpType:82
@@ -13219,24 +13199,16 @@ design: (work@top)
           |vpiName:exp_cmd
           |vpiFullName:work@test_program.exp_cmd
         |vpiVariables:
-        \_struct_var: (work@test_program.actual_cmd), line:427:19, endln:427:29, parent:work@test_program
-        |vpiVariables:
-        \_struct_var: (work@test_program.exp_cmd), line:427:31, endln:427:38, parent:work@test_program
-        |vpiVariables:
         \_struct_var: (work@test_program.rsp), line:428:19, endln:428:22, parent:work@test_program
           |vpiTypespec:
           \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
           |vpiName:rsp
           |vpiFullName:work@test_program.rsp
         |vpiVariables:
-        \_struct_var: (work@test_program.rsp), line:428:19, endln:428:22, parent:work@test_program
-        |vpiVariables:
         \_int_var: (work@test_program.backpressure_cycles), line:430:21, endln:430:40, parent:work@test_program
           |vpiName:backpressure_cycles
           |vpiFullName:work@test_program.backpressure_cycles
           |vpiAutomatic:1
-        |vpiVariables:
-        \_int_var: (work@test_program.backpressure_cycles), line:430:21, endln:430:40, parent:work@test_program
         |vpiStmt:
         \_for_stmt: (work@test_program), line:433:7, endln:433:10, parent:work@test_program
           |vpiFullName:work@test_program
@@ -19209,24 +19181,6 @@ design: (work@top)
           |vpiName:cmd
           |vpiFullName:work@test_program.cmd
         |vpiVariables:
-        \_struct_var: (work@test_program.cmd), line:251:16, endln:251:19, parent:work@test_program
-          |vpiTypespec:
-          \_struct_typespec: (Command), line:45:12, endln:45:18, parent:work@test_program
-          |vpiName:cmd
-          |vpiFullName:work@test_program.cmd
-        |vpiVariables:
-        \_struct_var: (work@test_program.actual_rsp), line:252:16, endln:252:26, parent:work@test_program
-          |vpiTypespec:
-          \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
-          |vpiName:actual_rsp
-          |vpiFullName:work@test_program.actual_rsp
-        |vpiVariables:
-        \_struct_var: (work@test_program.exp_rsp), line:252:28, endln:252:35, parent:work@test_program
-          |vpiTypespec:
-          \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
-          |vpiName:exp_rsp
-          |vpiFullName:work@test_program.exp_rsp
-        |vpiVariables:
         \_struct_var: (work@test_program.actual_rsp), line:252:16, endln:252:26, parent:work@test_program
           |vpiTypespec:
           \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
@@ -19386,34 +19340,11 @@ design: (work@top)
           |vpiName:exp_cmd
           |vpiFullName:work@test_program.exp_cmd
         |vpiVariables:
-        \_struct_var: (work@test_program.actual_cmd), line:284:19, endln:284:29, parent:work@test_program
-          |vpiTypespec:
-          \_struct_typespec: (Command), line:45:12, endln:45:18, parent:work@test_program
-          |vpiName:actual_cmd
-          |vpiFullName:work@test_program.actual_cmd
-        |vpiVariables:
-        \_struct_var: (work@test_program.exp_cmd), line:284:31, endln:284:38, parent:work@test_program
-          |vpiTypespec:
-          \_struct_typespec: (Command), line:45:12, endln:45:18, parent:work@test_program
-          |vpiName:exp_cmd
-          |vpiFullName:work@test_program.exp_cmd
-        |vpiVariables:
         \_struct_var: (work@test_program.rsp), line:285:19, endln:285:22, parent:work@test_program
           |vpiTypespec:
           \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
           |vpiName:rsp
           |vpiFullName:work@test_program.rsp
-        |vpiVariables:
-        \_struct_var: (work@test_program.rsp), line:285:19, endln:285:22, parent:work@test_program
-          |vpiTypespec:
-          \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
-          |vpiName:rsp
-          |vpiFullName:work@test_program.rsp
-        |vpiVariables:
-        \_int_var: (work@test_program.backpressure_cycles), line:287:21, endln:287:40, parent:work@test_program
-          |vpiName:backpressure_cycles
-          |vpiFullName:work@test_program.backpressure_cycles
-          |vpiAutomatic:1
         |vpiVariables:
         \_int_var: (work@test_program.backpressure_cycles), line:287:21, endln:287:40, parent:work@test_program
           |vpiName:backpressure_cycles
@@ -19715,24 +19646,6 @@ design: (work@top)
           |vpiName:cmd
           |vpiFullName:work@test_program.cmd
         |vpiVariables:
-        \_struct_var: (work@test_program.cmd), line:394:16, endln:394:19, parent:work@test_program
-          |vpiTypespec:
-          \_struct_typespec: (Command), line:45:12, endln:45:18, parent:work@test_program
-          |vpiName:cmd
-          |vpiFullName:work@test_program.cmd
-        |vpiVariables:
-        \_struct_var: (work@test_program.actual_rsp), line:395:16, endln:395:26, parent:work@test_program
-          |vpiTypespec:
-          \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
-          |vpiName:actual_rsp
-          |vpiFullName:work@test_program.actual_rsp
-        |vpiVariables:
-        \_struct_var: (work@test_program.exp_rsp), line:395:28, endln:395:35, parent:work@test_program
-          |vpiTypespec:
-          \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
-          |vpiName:exp_rsp
-          |vpiFullName:work@test_program.exp_rsp
-        |vpiVariables:
         \_struct_var: (work@test_program.actual_rsp), line:395:16, endln:395:26, parent:work@test_program
           |vpiTypespec:
           \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
@@ -19892,34 +19805,11 @@ design: (work@top)
           |vpiName:exp_cmd
           |vpiFullName:work@test_program.exp_cmd
         |vpiVariables:
-        \_struct_var: (work@test_program.actual_cmd), line:427:19, endln:427:29, parent:work@test_program
-          |vpiTypespec:
-          \_struct_typespec: (Command), line:45:12, endln:45:18, parent:work@test_program
-          |vpiName:actual_cmd
-          |vpiFullName:work@test_program.actual_cmd
-        |vpiVariables:
-        \_struct_var: (work@test_program.exp_cmd), line:427:31, endln:427:38, parent:work@test_program
-          |vpiTypespec:
-          \_struct_typespec: (Command), line:45:12, endln:45:18, parent:work@test_program
-          |vpiName:exp_cmd
-          |vpiFullName:work@test_program.exp_cmd
-        |vpiVariables:
         \_struct_var: (work@test_program.rsp), line:428:19, endln:428:22, parent:work@test_program
           |vpiTypespec:
           \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
           |vpiName:rsp
           |vpiFullName:work@test_program.rsp
-        |vpiVariables:
-        \_struct_var: (work@test_program.rsp), line:428:19, endln:428:22, parent:work@test_program
-          |vpiTypespec:
-          \_struct_typespec: (Response), line:56:12, endln:56:18, parent:work@test_program
-          |vpiName:rsp
-          |vpiFullName:work@test_program.rsp
-        |vpiVariables:
-        \_int_var: (work@test_program.backpressure_cycles), line:430:21, endln:430:40, parent:work@test_program
-          |vpiName:backpressure_cycles
-          |vpiFullName:work@test_program.backpressure_cycles
-          |vpiAutomatic:1
         |vpiVariables:
         \_int_var: (work@test_program.backpressure_cycles), line:430:21, endln:430:40, parent:work@test_program
           |vpiName:backpressure_cycles

--- a/tests/VarDecl/VarDecl.log
+++ b/tests/VarDecl/VarDecl.log
@@ -173,8 +173,6 @@ design: (work@top)
         \_int_var: (work@top.theta.a), line:4:12, endln:4:13, parent:work@top.theta
           |vpiName:a
           |vpiFullName:work@top.theta.a
-        |vpiVariables:
-        \_int_var: (work@top.theta.a), line:4:12, endln:4:13, parent:work@top.theta
     |vpiInstance:
     \_module: work@top (work@top) dut.sv:1:1: , endln:7:16, parent:work@top
   |vpiNet:
@@ -237,10 +235,6 @@ design: (work@top)
       |vpiStmt:
       \_begin: (work@top.theta), line:3:37, endln:5:10, parent:work@top.theta
         |vpiFullName:work@top.theta
-        |vpiVariables:
-        \_int_var: (work@top.theta.a), line:4:12, endln:4:13, parent:work@top.theta
-          |vpiName:a
-          |vpiFullName:work@top.theta.a
         |vpiVariables:
         \_int_var: (work@top.theta.a), line:4:12, endln:4:13, parent:work@top.theta
           |vpiName:a

--- a/tests/VarDecl2/VarDecl2.log
+++ b/tests/VarDecl2/VarDecl2.log
@@ -200,10 +200,6 @@ design: (work@top)
           \_int_var: (work@top.theta.b), line:4:17, endln:4:18, parent:work@top.theta
             |vpiName:b
             |vpiFullName:work@top.theta.b
-          |vpiVariables:
-          \_int_var: (work@top.theta.a), line:4:14, endln:4:15, parent:work@top.theta
-          |vpiVariables:
-          \_int_var: (work@top.theta.b), line:4:17, endln:4:18, parent:work@top.theta
           |vpiStmt:
           \_return_stmt: , line:6:10, endln:6:16, parent:work@top.theta
             |vpiCondition:
@@ -293,14 +289,6 @@ design: (work@top)
         |vpiStmt:
         \_begin: (work@top.theta), line:3:37, endln:7:10, parent:work@top.theta
           |vpiFullName:work@top.theta
-          |vpiVariables:
-          \_int_var: (work@top.theta.a), line:4:14, endln:4:15, parent:work@top.theta
-            |vpiName:a
-            |vpiFullName:work@top.theta.a
-          |vpiVariables:
-          \_int_var: (work@top.theta.b), line:4:17, endln:4:18, parent:work@top.theta
-            |vpiName:b
-            |vpiFullName:work@top.theta.b
           |vpiVariables:
           \_int_var: (work@top.theta.a), line:4:14, endln:4:15, parent:work@top.theta
             |vpiName:a

--- a/third_party/tests/Google/Google.log
+++ b/third_party/tests/Google/Google.log
@@ -2695,16 +2695,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-prec-uvm.sv -l 16.12--property-prec-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -2714,6 +2704,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -2727,16 +2727,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.9--sequence-fell-uvm.sv -l 16.9--sequence-fell-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -2746,6 +2736,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -2765,16 +2765,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assert-uvm.sv -l 16.2--assert-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -2784,6 +2774,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -2815,16 +2815,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-uvm.sv -l 16.7--sequence-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -2834,6 +2824,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -2847,16 +2847,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.15--property-iff-uvm-fail.sv -l 16.15--property-iff-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -2866,6 +2856,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -2885,16 +2885,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.17--expect-uvm.sv -l 16.17--expect-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -2904,6 +2894,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -2923,16 +2923,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-and-range-uvm.sv -l 16.7--sequence-and-range-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -2942,6 +2932,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -2961,16 +2961,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-uvm.sv -l 16.12--property-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -2980,6 +2970,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3011,16 +3011,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assert-final-uvm.sv -l 16.2--assert-final-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3030,6 +3020,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3055,16 +3055,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.10--property-local-var-uvm.sv -l 16.10--property-local-var-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3074,6 +3064,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3087,16 +3087,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.14--assume-property-uvm-fail.sv -l 16.14--assume-property-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3106,6 +3096,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3119,16 +3119,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.10--sequence-local-var-uvm.sv -l 16.10--sequence-local-var-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3138,6 +3128,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3175,16 +3175,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.9--sequence-stable-uvm.sv -l 16.9--sequence-stable-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3194,6 +3184,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3207,16 +3207,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.11--sequence-subroutine-uvm.sv -l 16.11--sequence-subroutine-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3226,6 +3216,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3245,16 +3245,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-interface-uvm-fail.sv -l 16.12--property-interface-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3264,6 +3254,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3283,16 +3283,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-uvm-fail.sv -l 16.7--sequence-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3302,6 +3292,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3315,16 +3315,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.10--property-local-var-uvm-fail.sv -l 16.10--property-local-var-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3334,6 +3324,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3347,16 +3347,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.17--expect-uvm-fail.sv -l 16.17--expect-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3366,6 +3356,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3379,16 +3379,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.15--property-iff-uvm.sv -l 16.15--property-iff-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3398,6 +3388,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3417,16 +3417,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.13--sequence-multiclock-uvm.sv -l 16.13--sequence-multiclock-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3436,6 +3426,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3455,16 +3455,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-intersect-uvm.sv -l 16.7--sequence-intersect-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3474,6 +3464,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3487,16 +3487,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-or-uvm.sv -l 16.7--sequence-or-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3506,6 +3496,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3519,16 +3519,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.9--sequence-past-uvm.sv -l 16.9--sequence-past-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3538,6 +3528,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3551,16 +3551,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assume-uvm-fail.sv -l 16.2--assume-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3570,6 +3560,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3583,16 +3583,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-throughout-uvm-fail.sv -l 16.7--sequence-throughout-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3602,6 +3592,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3615,16 +3615,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.9--sequence-changed-uvm.sv -l 16.9--sequence-changed-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3634,6 +3624,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3647,16 +3647,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-uvm-fail.sv -l 16.12--property-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3666,6 +3656,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3679,16 +3679,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.14--assume-property-uvm.sv -l 16.14--assume-property-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3698,6 +3688,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3711,16 +3711,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-prec-uvm-fail.sv -l 16.12--property-prec-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3730,6 +3720,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3743,16 +3743,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-and-uvm.sv -l 16.7--sequence-and-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3762,6 +3752,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3793,16 +3793,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-interface-uvm.sv -l 16.12--property-interface-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3812,6 +3802,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3831,16 +3831,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assume-uvm.sv -l 16.2--assume-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3850,6 +3840,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3863,16 +3863,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-intersect-uvm-fail.sv -l 16.7--sequence-intersect-uvm-fail.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3882,6 +3872,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3907,16 +3907,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.7--sequence-throughout-uvm.sv -l 16.7--sequence-throughout-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3926,6 +3916,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3939,16 +3939,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.12--property-interface-prec-uvm.sv -l 16.12--property-interface-prec-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3958,6 +3948,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -3971,16 +3971,6 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 16.2--assert0-uvm.sv -l 16.2--assert0-uvm.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -3990,6 +3980,16 @@ Processing: -cd chapter-16 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "OPER".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "CB".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
 
@@ -7493,8 +7493,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.15--manually-seeding-randomize_1.sv -l 18.15--manually-seeding-randomize_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7502,6 +7500,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7512,12 +7518,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -7537,8 +7537,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.1--urandom_1.sv -l 18.13.1--urandom_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7546,6 +7544,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7556,12 +7562,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -7569,8 +7569,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14--soft-constraints_1.sv -l 18.5.14--soft-constraints_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7578,6 +7576,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7588,12 +7594,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -7601,8 +7601,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.11.1--in-line-constraint-checker_1.sv -l 18.11.1--in-line-constraint-checker_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7610,6 +7608,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7620,12 +7626,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -7633,8 +7633,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14.3--object-stability_1.sv -l 18.14.3--object-stability_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7642,6 +7640,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7652,12 +7658,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -7671,8 +7671,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.2--urandom_range_1.sv -l 18.13.2--urandom_range_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7680,6 +7678,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7690,12 +7696,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -7703,8 +7703,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.4--get_randstate_0.sv -l 18.13.4--get_randstate_0.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7712,6 +7710,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7722,12 +7728,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -7735,8 +7735,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.6--aborting-productions-break-and-return_1.sv -l 18.17.6--aborting-productions-break-and-return_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7744,6 +7742,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7754,12 +7760,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -7767,8 +7767,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.11--static-constraint-blocks_1.sv -l 18.5.11--static-constraint-blocks_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7776,6 +7774,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7786,12 +7792,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [ERR:EL0514] 18.5.11--static-constraint-blocks_1.sv:34: Undefined variable: c1.
 
@@ -7801,8 +7801,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.5--interleaving-productions-rand-join_1.sv -l 18.17.5--interleaving-productions-rand-join_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7810,6 +7808,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7820,12 +7826,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -7839,8 +7839,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14.2--thread-stability_1.sv -l 18.14.2--thread-stability_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7848,6 +7846,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7858,12 +7864,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -7883,8 +7883,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14--random-stability_1.sv -l 18.14--random-stability_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7892,6 +7890,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7902,12 +7908,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -7915,8 +7915,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.4--distribution_1.sv -l 18.5.4--distribution_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7924,6 +7922,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7934,12 +7940,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -7947,8 +7947,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14.2--discarding-soft-constraints_5.sv -l 18.5.14.2--discarding-soft-constraints_5.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7956,6 +7954,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7966,12 +7972,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -7979,8 +7979,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.7--in-line-constraints--randomize_4.sv -l 18.7--in-line-constraints--randomize_4.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -7988,6 +7986,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -7998,12 +8004,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8035,8 +8035,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.12--functions-in-constraint_1.sv -l 18.5.12--functions-in-constraint_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8044,6 +8042,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8054,12 +8060,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8067,8 +8067,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14.2--discarding-soft-constraints_3.sv -l 18.5.14.2--discarding-soft-constraints_3.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8076,6 +8074,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8086,12 +8092,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8105,8 +8105,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.9--global-constraints_1.sv -l 18.5.9--global-constraints_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8114,6 +8112,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8124,12 +8130,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8143,8 +8143,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.1--random-production-weights_1.sv -l 18.17.1--random-production-weights_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8152,6 +8150,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8162,12 +8168,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8181,8 +8181,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.12--randomization-of-scope-variables_1.sv -l 18.12--randomization-of-scope-variables_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8190,6 +8188,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8200,12 +8206,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8231,8 +8231,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.8--disabling-random-variables-with-rand_mode_3.sv -l 18.8--disabling-random-variables-with-rand_mode_3.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8240,6 +8238,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8250,12 +8256,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8263,8 +8263,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.2--if-else-production-statements_3.sv -l 18.17.2--if-else-production-statements_3.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8272,6 +8270,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8282,12 +8288,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8295,8 +8295,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5--constraint-blocks_1.sv -l 18.5--constraint-blocks_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8304,6 +8302,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8314,12 +8320,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8339,8 +8339,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.2--if-else-production-statements_1.sv -l 18.17.2--if-else-production-statements_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8348,6 +8346,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8358,12 +8364,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8383,8 +8383,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.5--set_randstate_0.sv -l 18.13.5--set_randstate_0.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8392,6 +8390,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8402,12 +8408,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8433,8 +8433,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.7--value-passing-between-productions_1.sv -l 18.17.7--value-passing-between-productions_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8442,6 +8440,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8452,12 +8458,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8483,8 +8483,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.3--behavior-of-randomization-methods_3.sv -l 18.6.3--behavior-of-randomization-methods_3.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8492,6 +8490,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8502,12 +8508,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8515,8 +8515,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.1--urandom_3.sv -l 18.13.1--urandom_3.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8524,6 +8522,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8534,12 +8540,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8547,8 +8547,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.13--constraint-guards_1.sv -l 18.5.13--constraint-guards_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8556,6 +8554,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8566,12 +8572,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8579,8 +8579,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.8.2--array-reduction-iterative-constraints_1.sv -l 18.5.8.2--array-reduction-iterative-constraints_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8588,6 +8586,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8598,12 +8604,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8623,8 +8623,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14--random-stability_0.sv -l 18.14--random-stability_0.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8632,6 +8630,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8642,12 +8648,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8655,8 +8655,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.16--random-weighted-case-randcase_3.sv -l 18.16--random-weighted-case-randcase_3.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8664,6 +8662,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8674,12 +8680,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8687,8 +8687,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14.1--soft-constraint-priorities_3.sv -l 18.5.14.1--soft-constraint-priorities_3.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8696,6 +8694,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8706,12 +8712,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8719,8 +8719,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.2--post-randomize_method_1.sv -l 18.6.2--post-randomize_method_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8728,6 +8726,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8738,12 +8744,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8775,8 +8775,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.7--in-line-constraints--randomize_0.sv -l 18.7--in-line-constraints--randomize_0.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8784,6 +8782,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8794,12 +8800,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8821,8 +8821,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14.2--discarding-soft-constraints_1.sv -l 18.5.14.2--discarding-soft-constraints_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8830,6 +8828,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8840,12 +8846,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8853,8 +8853,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.16--random-weighted-case-randcase_1.sv -l 18.16--random-weighted-case-randcase_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8862,6 +8860,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8872,12 +8878,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8885,8 +8885,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.8--disabling-random-variables-with-rand_mode_5.sv -l 18.8--disabling-random-variables-with-rand_mode_5.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8894,6 +8892,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8904,12 +8910,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [ERR:CP0338] 18.8--disabling-random-variables-with-rand_mode_5.sv:23:18: Cannot override builtin method: rand_mode.
 
@@ -8919,8 +8919,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17--random-sequence-generation-randsequence_3.sv -l 18.17--random-sequence-generation-randsequence_3.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8928,6 +8926,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8938,12 +8944,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8963,8 +8963,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.2--pure-constraint_1.sv -l 18.5.2--pure-constraint_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -8972,6 +8970,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -8982,12 +8988,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -8995,8 +8995,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14.1--soft-constraint-priorities_1.sv -l 18.5.14.1--soft-constraint-priorities_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9004,6 +9002,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9014,12 +9020,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9027,8 +9027,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.5--uniqueness-constraints_1.sv -l 18.5.5--uniqueness-constraints_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9036,6 +9034,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9046,12 +9052,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9059,8 +9059,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.4--repeat-production-statements_1.sv -l 18.17.4--repeat-production-statements_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9068,6 +9066,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9078,12 +9084,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9097,8 +9097,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14.2--thread-stability_0.sv -l 18.14.2--thread-stability_0.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9106,6 +9104,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9116,12 +9122,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9129,8 +9129,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.1--randomize-method_0.sv -l 18.6.1--randomize-method_0.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9138,6 +9136,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9148,12 +9154,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9161,8 +9161,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.10--dynamic-constraint-modification_0.sv -l 18.10--dynamic-constraint-modification_0.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9170,6 +9168,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9180,12 +9186,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9199,8 +9199,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14--random-stability_3.sv -l 18.14--random-stability_3.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9208,6 +9206,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9218,12 +9224,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9231,8 +9231,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.2--pre-randomize-method_1.sv -l 18.6.2--pre-randomize-method_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9240,6 +9238,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9250,12 +9256,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9263,8 +9263,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.6--aborting-productions-break-and-return_3.sv -l 18.17.6--aborting-productions-break-and-return_3.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9272,6 +9270,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9282,12 +9288,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9295,8 +9295,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.2--urandom_range_3.sv -l 18.13.2--urandom_range_3.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9304,6 +9302,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9314,12 +9320,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9327,8 +9327,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.2--urandom_range_2.sv -l 18.13.2--urandom_range_2.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9336,6 +9334,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9346,12 +9352,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9359,8 +9359,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.8--disabling-random-variables-with-rand_mode_2.sv -l 18.8--disabling-random-variables-with-rand_mode_2.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9368,6 +9366,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9378,12 +9384,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9403,8 +9403,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.11--in-line-random-variable-control_1.sv -l 18.11--in-line-random-variable-control_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9412,6 +9410,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9422,12 +9428,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9435,8 +9435,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.13.3--srandom_0.sv -l 18.13.3--srandom_0.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9444,6 +9442,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9454,12 +9460,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9467,8 +9467,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.9--controlling-constraints-with-constraint_mode_0.sv -l 18.9--controlling-constraints-with-constraint_mode_0.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9476,6 +9474,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9486,12 +9492,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9499,8 +9499,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.9--controlling-constraints-with-constraint_mode_2.sv -l 18.9--controlling-constraints-with-constraint_mode_2.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9508,6 +9506,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9518,12 +9524,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [ERR:CP0338] 18.9--controlling-constraints-with-constraint_mode_2.sv:23:18: Cannot override builtin method: constraint_mode.
 
@@ -9533,8 +9533,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14.3--object-stability_0.sv -l 18.14.3--object-stability_0.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9542,6 +9540,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9552,12 +9558,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9571,8 +9571,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.11.1--in-line-constraint-checker_0.sv -l 18.11.1--in-line-constraint-checker_0.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9580,6 +9578,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9590,12 +9596,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9615,8 +9615,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17--random-sequence-generation-randsequence_1.sv -l 18.17--random-sequence-generation-randsequence_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9624,6 +9622,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9634,12 +9640,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9671,8 +9671,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.14.1--soft-constraint-priorities_4.sv -l 18.5.14.1--soft-constraint-priorities_4.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9680,6 +9678,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9690,12 +9696,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9703,8 +9703,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.3--set-membership_1.sv -l 18.5.3--set-membership_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9712,6 +9710,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9722,12 +9728,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9753,8 +9753,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.12.1--adding-constraints-to-scope-variables_1.sv -l 18.12.1--adding-constraints-to-scope-variables_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9762,6 +9760,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9772,12 +9778,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9785,8 +9785,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.11--in-line-random-variable-control_0.sv -l 18.11--in-line-random-variable-control_0.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9794,6 +9792,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9804,12 +9810,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9817,8 +9817,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.1--implicit-external-constraint_2.sv -l 18.5.1--implicit-external-constraint_2.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9826,6 +9824,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9836,12 +9842,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9861,8 +9861,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.6--implication_1.sv -l 18.5.6--implication_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9870,6 +9868,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9880,12 +9886,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9899,8 +9899,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.1--explicit-external-constraint_2.sv -l 18.5.1--explicit-external-constraint_2.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9908,6 +9906,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9918,12 +9924,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9937,8 +9937,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.2--constraint-inheritance_1.sv -l 18.5.2--constraint-inheritance_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9946,6 +9944,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9956,12 +9962,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -9969,8 +9969,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.8.1--foreach-iterative-constraints_1.sv -l 18.5.8.1--foreach-iterative-constraints_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -9978,6 +9976,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -9988,12 +9994,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -10001,8 +10001,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.17.3--case-production-statements_1.sv -l 18.17.3--case-production-statements_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -10010,6 +10008,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -10020,12 +10026,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [SNT:PA0207] 18.17.3--case-production-statements_1.sv:32:20: Syntax error: extraneous input ';' expecting {''b0', ''b1', ''B0', ''B1', ''0', ''1', '1'b0', '1'b1', '1'bx', '1'bX', '1'B0', '1'B1', '1'Bx', '1'BX', Integral_number, Real_number, String, 'default', '(', 'type', 'const', 'local', 'super', '{', 'string', 'byte', 'shortint', 'int', 'longint', 'integer', 'time', 'bit', 'logic', 'reg', 'shortreal', 'real', 'realtime', 'signed', 'unsigned', '$', '++', '+', '--', '-', DOLLAR_UNIT, '!', 'endcase', 'tagged', ''', 'null', 'this', DOLLAR_ROOT, 'randomize', 'sample', '&', '|', '~|', '~&', '^~', Escaped_identifier, '~', '^', '~^', Simple_identifier},
             0 : zero;
@@ -10037,8 +10037,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.3--behavior-of-randomization-methods_2.sv -l 18.6.3--behavior-of-randomization-methods_2.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -10046,6 +10044,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -10056,12 +10062,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -10069,8 +10069,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.7--in-line-constraints--randomize_6.sv -l 18.7--in-line-constraints--randomize_6.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -10078,6 +10076,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -10088,12 +10094,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -10115,8 +10115,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.14--random-stability_2.sv -l 18.14--random-stability_2.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -10124,6 +10122,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -10134,12 +10140,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -10147,8 +10147,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.8--disabling-random-variables-with-rand_mode_0.sv -l 18.8--disabling-random-variables-with-rand_mode_0.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -10156,6 +10154,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -10166,12 +10172,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -10179,8 +10179,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.8--disabling-random-variables-with-rand_mode_1.sv -l 18.8--disabling-random-variables-with-rand_mode_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -10188,6 +10186,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -10198,12 +10204,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -10217,8 +10217,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.7.1--local-scope-resolution_1.sv -l 18.7.1--local-scope-resolution_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -10226,6 +10224,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -10236,12 +10242,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -10261,8 +10261,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.7--in-line-constraints--randomize_2.sv -l 18.7--in-line-constraints--randomize_2.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -10270,6 +10268,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -10280,12 +10286,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -10293,8 +10293,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WARNING] : 13
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.3--behavior-of-randomization-methods_5.sv -l 18.6.3--behavior-of-randomization-methods_5.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -10302,6 +10300,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -10312,12 +10318,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [ERR:CP0338] 18.6.3--behavior-of-randomization-methods_5.sv:25:19: Cannot override builtin method: randomize.
 
@@ -10333,8 +10333,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.5.7--if-else-constraints_4.sv -l 18.5.7--if-else-constraints_4.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -10342,6 +10340,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -10352,12 +10358,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0
@@ -10375,8 +10375,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800.2-2017-1.0/src//uvm_pkg.sv -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns 18.6.3--behavior-of-randomization-methods_1.sv -l 18.6.3--behavior-of-randomization-methods_1.sv.log
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
-
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:793:9: Unused macro argument "FLAG".
@@ -10384,6 +10382,14 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:797:9: Unused macro argument "ARG".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_object_defines.svh:806:9: Unused macro argument "OP".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_recorder_defines.svh:81:13: Unused macro argument "TR_HANDLE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
+
+[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:301:9: Unused macro argument "CB".
 
@@ -10394,12 +10400,6 @@ Processing: -cd chapter-18 -I../../../UVM/1800.2-2017-1.0/src/ ../../../UVM/1800
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OBJ".
 
 [WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_callback_defines.svh:302:9: Unused macro argument "OPER".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:496:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:523:9: Unused macro argument "TYPE".
-
-[WRN:PP0113] ../../../UVM/1800.2-2017-1.0/src/macros/uvm_packer_defines.svh:550:9: Unused macro argument "TYPE".
 
 [  FATAL] : 0
 [ SYNTAX] : 0


### PR DESCRIPTION
After another CI that added missing vars, some got duplicated because of the code below that needed to be removed. 