### PR TITLE
Add workflow for testing Yosys plugin support

### DIFF
--- a/.github/workflows/yosys-plugin.yml
+++ b/.github/workflows/yosys-plugin.yml
@@ -58,6 +58,7 @@ jobs:
     - name: Build binaries
       run: |
         cd yosys-uhdm-plugin-integration
+        pip install cmake==3.22.4
         echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
         ./build_binaries.sh
 

--- a/.github/workflows/yosys-plugin.yml
+++ b/.github/workflows/yosys-plugin.yml
@@ -81,3 +81,10 @@ jobs:
       with:
         name: top_artya7.bit
         path: ./yosys-uhdm-plugin-integration/UHDM-integration-tests/build/lowrisc_ibex_top_artya7_surelog_0.1/synth-symbiflow/top_artya7.bit
+
+    - name: Upload load graphs
+      uses: actions/upload-artifact@v2
+      with:
+        name: plots
+        path: |
+          **/plot_*.svg

--- a/.github/workflows/yosys-plugin.yml
+++ b/.github/workflows/yosys-plugin.yml
@@ -58,8 +58,6 @@ jobs:
     - name: Build binaries
       run: |
         cd yosys-uhdm-plugin-integration
-        # ubuntu bionic have too old cmake, install one from pip
-        pip install cmake
         echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
         ./build_binaries.sh
 

--- a/.github/workflows/yosys-plugin.yml
+++ b/.github/workflows/yosys-plugin.yml
@@ -1,0 +1,79 @@
+name: 'yosys-systemverilog-plugin'
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+
+  test-plugin:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: true
+    env:
+      CC: gcc-9
+      CXX: g++-9
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -qq
+        sudo apt install -y software-properties-common
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+        sudo apt-get update -qq
+        sudo apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev python3-pip uuid uuid-dev tcl-dev flex libfl-dev git pkg-config libreadline-dev bison libffi-dev wget
+        sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+        sudo update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+        pip install orderedmultidict
+
+    - name: Setup integration repository
+      run: |
+        # Github dropped support for unauthorized git: https://github.blog/2021-09-01-improving-git-protocol-security-github/
+        # Make sure we always use https:// instead of git://
+        git config --global url.https://github.com/.insteadOf git://github.com/
+        # Use current main of the integration repository...
+        git clone https://github.com/antmicro/yosys-uhdm-plugin-integration.git
+        cd yosys-uhdm-plugin-integration
+        git submodule update --init --recursive .
+
+    - name: Setup Surelog
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+        path: 'yosys-uhdm-plugin-integration/Surelog'
+
+    - name: Use ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: linux-yosys-submodules
+
+    - name: Build binaries
+      run: |
+        cd yosys-uhdm-plugin-integration
+        # ubuntu bionic have too old cmake, install one from pip
+        pip install cmake
+        echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
+        ./build_binaries.sh
+
+    - name: Build & Test Ibex
+      run: |
+        cd yosys-uhdm-plugin-integration
+        pip install virtualenv
+        make -C UHDM-integration-tests TEST=tests/ibex env
+        ./UHDM-integration-tests/.github/ci.sh
+      env:
+        TARGET: uhdm/yosys/synth-ibex-symbiflow
+        TEST_CASE: tests/ibex
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: top_artya7.bit
+        path: ./yosys-uhdm-plugin-integration/UHDM-integration-tests/build/lowrisc_ibex_top_artya7_surelog_0.1/synth-symbiflow/top_artya7.bit

--- a/.github/workflows/yosys-plugin.yml
+++ b/.github/workflows/yosys-plugin.yml
@@ -9,7 +9,8 @@ on:
 jobs:
 
   test-plugin:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:bionic
     defaults:
       run:
         shell: bash
@@ -18,19 +19,20 @@ jobs:
     env:
       CC: gcc-9
       CXX: g++-9
+      CCACHE_DIR: "/root/Surelog/Surelog/.cache/"
       DEBIAN_FRONTEND: noninteractive
 
     steps:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update -qq
-        sudo apt install -y software-properties-common
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-        sudo apt-get update -qq
-        sudo apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev python3-pip uuid uuid-dev tcl-dev flex libfl-dev git pkg-config libreadline-dev bison libffi-dev wget
-        sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-        sudo update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+        apt-get update -qq
+        apt install -y software-properties-common
+        add-apt-repository ppa:ubuntu-toolchain-r/test
+        apt-get update -qq
+        apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev python3-pip uuid uuid-dev tcl-dev flex libfl-dev git pkg-config libreadline-dev bison libffi-dev wget
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+        update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
         pip install orderedmultidict
 
     - name: Setup integration repository
@@ -50,15 +52,18 @@ jobs:
         fetch-depth: 0
         path: 'yosys-uhdm-plugin-integration/Surelog'
 
-    - name: Use ccache
-      uses: hendrikmuhs/ccache-action@v1
+    - name: Setup cache
+      uses: actions/cache@v2
       with:
-        key: linux-yosys-submodules
+        path: ${{ env.CCACHE_DIR }}
+        key: cache_${{ steps.cache_timestamp.outputs.time }}
+        restore-keys: cache_
 
     - name: Build binaries
       run: |
         cd yosys-uhdm-plugin-integration
-        pip install cmake==3.22.4
+        # ubuntu bionic have too old cmake, install one from pip
+        pip install cmake
         echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
         ./build_binaries.sh
 

--- a/.github/workflows/yosys-plugin.yml
+++ b/.github/workflows/yosys-plugin.yml
@@ -52,6 +52,12 @@ jobs:
         fetch-depth: 0
         path: 'yosys-uhdm-plugin-integration/Surelog'
 
+    - name: Create Cache Timestamp
+      id: cache_timestamp
+      uses: nanzm/get-time-action@v1.1
+      with:
+        format: 'YYYY-MM-DD-HH-mm-ss'
+
     - name: Setup cache
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
This adds a separate CI workflow that:
* checks out current confirmed-to-work tool versions from https://github.com/antmicro/yosys-uhdm-plugin-integration
* builds the tools against current Surelog
* uses the tools to build Ibex as a reasonably complex test case

This aims to help catch regressions that break the SystemVerilog plugin for Yosys.