### PR TITLE
Issue #2957: Disable TestSepCompNoHash for Windows

### DIFF
--- a/scripts/blacklisted.py
+++ b/scripts/blacklisted.py
@@ -20,6 +20,7 @@ _windows_black_list = set([name.lower() for name in [
     r'simpleincludeandmacros',
     r'simpleparsertestcache', # race condition
     r'testfilesplit',
+    r'testsepcompnohash',     # Uses shell script to run
     r'unitelabexternnested',
     r'unitpython',
     r'unitsimpleincludeandmacros',


### PR DESCRIPTION
Issue #2957: Disable TestSepCompNoHash for Windows

The test uses shell script to run which is incompatible for Windows.