### PR TITLE
Issue #2966: Remove slpp_all & slpp_unit directories from test folders

### DIFF
--- a/scripts/regression.py
+++ b/scripts/regression.py
@@ -115,11 +115,11 @@ def _rmdir(dirpath, retries=10):
   return not os.path.exists(dirpath)
 
 
-def _remove_dirs(dirpath, patterns):
+def _rmdir_recursively(dirpath, patterns):
   for pattern in patterns:
     for path in Path(dirpath).rglob(pattern):
       if os.isdir(path):
-        shutil.rmtree(path)
+        _rmdir(path)
 
 
 def _scan(dirpaths, filters):
@@ -508,6 +508,7 @@ def _run_one(params):
   roundtrip_output_dirpath = os.path.join(output_dirpath, 'roundtrip')
   roundtrip_log_filepath = os.path.join(roundtrip_output_dirpath, 'roundtrip.log')
 
+  _rmdir_recursively(dirpath, ['slpp_all', 'slpp_unit'])
   _rmdir(output_dirpath)
   _mkdir(output_dirpath)
   _mkdir(roundtrip_output_dirpath)


### PR DESCRIPTION
Issue #2966: Remove slpp_all & slpp_unit directories from test folders

Batch tests don't respect the output folder. They end up dirtying the
working directories. If the regression script terminated unexpectedly
for any reason, the folder doesn't get cleaned up as it should. Adding a
step to remove any remnants from past failed run (for successful runs,
the script restores the pristine state of the folder).