### PR TITLE
Issue #2898: UHDM coverage point to empty source line

### DIFF
--- a/include/Surelog/SourceCompile/PreprocessFile.h
+++ b/include/Surelog/SourceCompile/PreprocessFile.h
@@ -142,9 +142,14 @@ class PreprocessFile {
   const std::vector<IncludeFileInfo>& getIncludeFileInfo() const {
     return m_includeFileInfo;
   }
-  std::vector<IncludeFileInfo>& getIncludeFileInfo() {
-    return m_includeFileInfo;
-  }
+  int addIncludeFileInfo(IncludeFileInfo::Context context,
+                         unsigned int sectionStartLine, SymbolId sectionFile,
+                         unsigned int originalStartLine,
+                         unsigned int originalStartColumn,
+                         unsigned int originalEndLine,
+                         unsigned int originalEndColumn,
+                         IncludeFileInfo::Action type, int indexOpening = 0,
+                         int indexClosing = 0);
   IncludeFileInfo& getIncludeFileInfo(int index) {
     if (index >= 0 && index < ((int)m_includeFileInfo.size()))
       return m_includeFileInfo[index];

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -159,7 +159,7 @@ bool PPCache::restore_(const fs::path& cacheFileName, bool errorsOnly) {
     // std::cout << "read sectionFile: " << sectionFileName << " s:" <<
     // incinfo->m_sectionStartLine() << " o:" << incinfo->m_originalLine() <<
     // " t:" << incinfo->m_type() << "\n";
-    m_pp->getIncludeFileInfo().emplace_back(
+    m_pp->addIncludeFileInfo(
         static_cast<IncludeFileInfo::Context>(incinfo->context()),
         incinfo->section_start_line(),
         m_pp->getCompileSourceFile()->getSymbolTable()->registerSymbol(

--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
@@ -44,13 +44,11 @@ SV3_1aPpTreeListenerHelper::getFileLine(antlr4::ParserRuleContext* ctx,
                                         SymbolId& fileId) {
   std::pair<int, int> lineCol = ParseUtils::getLineColumn(m_tokens, ctx);
   std::pair<int, int> endLineCol = ParseUtils::getEndLineColumn(m_tokens, ctx);
-  unsigned int line = 0;
+  unsigned int line = m_pp->getLineNb(lineCol.first);
   unsigned short column = lineCol.second;
-  unsigned int endLine = 0;
+  unsigned int endLine = m_pp->getLineNb(endLineCol.first);
   unsigned short endColumn = endLineCol.second;
   fileId = m_pp->getFileId(lineCol.first);
-  line = m_pp->getLineNb(lineCol.first);
-  endLine = m_pp->getLineNb(endLineCol.first);
   return std::make_tuple(line, column, endLine, endColumn);
 }
 


### PR DESCRIPTION
Issue #2898: UHDM coverage point to empty source line

* Fixed +1 indexing issue with line management when evaluating multi-line macros
* Added function to update include file info