### PR TITLE
Make snapshotting of SymbolTable explicit.

### DIFF
--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -292,7 +292,7 @@ bool CompileDesign::compilation_() {
   int index = 0;
   do {
     SymbolTable* symbols =
-        new SymbolTable(m_compiler->getCommandLineParser()->getSymbolTable());
+        m_compiler->getCommandLineParser()->getSymbolTable().CreateSnapshot();
     m_symbolTables.push_back(symbols);
     ErrorContainer* errors = new ErrorContainer(symbols);
     errors->registerCmdLine(m_compiler->getCommandLineParser());

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -158,7 +158,7 @@ bool Compiler::ppinit_() {
         builtin->addBuiltinMacros(comp_unit);
       }
       m_compilationUnits.push_back(comp_unit);
-      symbols = new SymbolTable(m_commandLineParser->getSymbolTable());
+      symbols = m_commandLineParser->getSymbolTable().CreateSnapshot();
       m_symbolTables.push_back(symbols);
     }
     ErrorContainer* errors = new ErrorContainer(symbols);
@@ -220,7 +220,7 @@ bool Compiler::ppinit_() {
     if (m_commandLineParser->fileunit()) {
       comp_unit = new CompilationUnit(true);
       m_compilationUnits.push_back(comp_unit);
-      symbols = new SymbolTable(m_commandLineParser->getSymbolTable());
+      symbols = m_commandLineParser->getSymbolTable().CreateSnapshot();
       m_symbolTables.push_back(symbols);
     }
     ErrorContainer* errors = new ErrorContainer(symbols);
@@ -264,7 +264,7 @@ bool Compiler::ppinit_() {
       if (m_commandLineParser->fileunit()) {
         comp_unit = new CompilationUnit(true);
         m_compilationUnits.push_back(comp_unit);
-        symbols = new SymbolTable(m_commandLineParser->getSymbolTable());
+        symbols = m_commandLineParser->getSymbolTable().CreateSnapshot();
         m_symbolTables.push_back(symbols);
       }
       ErrorContainer* errors = new ErrorContainer(symbols);
@@ -720,7 +720,7 @@ bool Compiler::parseinit_() {
 
       if (!m_commandLineParser->fileunit()) {
         SymbolTable* symbols =
-            new SymbolTable(m_commandLineParser->getSymbolTable());
+            m_commandLineParser->getSymbolTable().CreateSnapshot();
         m_symbolTables.push_back(symbols);
         compiler->setSymbolTable(symbols);
         // fileContent->setSymbolTable(symbols);
@@ -738,7 +738,7 @@ bool Compiler::parseinit_() {
       int j = 0;
       for (auto& chunk : fileAnalyzer->getSplitFiles()) {
         SymbolTable* symbols =
-            new SymbolTable(m_commandLineParser->getSymbolTable());
+            m_commandLineParser->getSymbolTable().CreateSnapshot();
         m_symbolTables.push_back(symbols);
         SymbolId ppId = symbols->registerSymbol(chunk.string());
         symbols->registerSymbol(
@@ -768,7 +768,7 @@ bool Compiler::parseinit_() {
     } else {
       if ((!m_commandLineParser->fileunit()) && m_text.empty()) {
         SymbolTable* symbols =
-            new SymbolTable(m_commandLineParser->getSymbolTable());
+            m_commandLineParser->getSymbolTable().CreateSnapshot();
         m_symbolTables.push_back(symbols);
         compiler->setSymbolTable(symbols);
         ErrorContainer* errors = new ErrorContainer(symbols);

--- a/src/SourceCompile/SymbolTable.cpp
+++ b/src/SourceCompile/SymbolTable.cpp
@@ -27,9 +27,15 @@
 
 namespace SURELOG {
 
-SymbolTable::SymbolTable() { registerSymbol(getBadSymbol()); }
+SymbolTable::SymbolTable() : m_parent(nullptr), m_idOffset(0) {
+  registerSymbol(getBadSymbol());
+}
 
 SymbolTable::~SymbolTable() {}
+
+SymbolTable* SymbolTable::CreateSnapshot() const {
+  return new SymbolTable(*this);
+}
 
 const std::string& SymbolTable::getBadSymbol() {
   static const std::string k_badSymbol(BadRawSymbol);

--- a/src/SourceCompile/SymbolTable_test.cpp
+++ b/src/SourceCompile/SymbolTable_test.cpp
@@ -63,7 +63,7 @@ TEST(SymbolTableTest, SymbolStringsAreStable) {
 
   // Deliberately using .data() here so that API change to getSymbol() returning
   // std::string_view later will keep this test source-code compatible.
-  const char *before_data = table.getSymbol(foo_id).data();
+  const void *before_data = table.getSymbol(foo_id).data();
 
   // We want to make sure that even after reallocing the underlying
   // data structure, the symbol reference does not change. Let's enforce
@@ -72,7 +72,7 @@ TEST(SymbolTableTest, SymbolStringsAreStable) {
     table.registerSymbol("bar" + std::to_string(i));
   }
 
-  const char *after_data = table.getSymbol(foo_id).data();
+  const void *after_data = table.getSymbol(foo_id).data();
 
   EXPECT_EQ(before_data, after_data);
 }
@@ -86,11 +86,11 @@ TEST(SymbolTableTest, SymbolStringsAreStableAfterTableCopy) {
 
   const SymbolId foo_id = table.registerSymbol("foo");
 
-  const char *before_data = table.getSymbol(foo_id).data();
+  const void *before_data = table.getSymbol(foo_id).data();
 
   {
     std::unique_ptr<SymbolTable> table_copy(table.CreateSnapshot());
-    const char *after_data = table_copy->getSymbol(foo_id).data();
+    const void *after_data = table_copy->getSymbol(foo_id).data();
     EXPECT_EQ(before_data, after_data);
   }
 }


### PR DESCRIPTION
The copy constructor of the SymbolTable is creating
a snapshot of it; this change names it accordingly.

We do want to avoid accidental copying of a SymbolTable,
so the copy constructor is now private, requring to
call CreateSnapshot() when explicitly needed.

No functional change.

Signed-off-by: Henner Zeller <h.zeller@acm.org>