### PR TITLE
Issue #2962: Investigate regression stalling on posix systems

### DIFF
--- a/scripts/regression.py
+++ b/scripts/regression.py
@@ -118,7 +118,7 @@ def _rmdir(dirpath, retries=10):
 def _rmdir_recursively(dirpath, patterns):
   for pattern in patterns:
     for path in Path(dirpath).rglob(pattern):
-      if os.isdir(path):
+      if os.path.isdir(path):
         _rmdir(path)
 
 
@@ -364,7 +364,7 @@ def _run_surelog(
         max_vms_memory = max(max_vms_memory, vms_memory)
         max_rss_memory = max(max_rss_memory, rss_memory)
 
-        time.sleep(0.05)
+        time.sleep(0.25)
 
       returncode = process.poll()
       surelog_timedelta = datetime.now() - surelog_start_dt
@@ -646,6 +646,7 @@ def _run_one(params):
 
     regression_log_strm.flush()
 
+  log(f'... {name} Completed.')
   return result
 
 


### PR DESCRIPTION
Issue #2962: Investigate regression stalling on posix systems

Two hunches on what might be going on here.
1. Regression script is hogging the resources. To counter it, raising
   the sleep timer to 250 ms (from 50 ms).
2. Two large tests are running in parallel and possibly competing for
   resources. There is no indication of what tests are actively working.
   Added a log statemnent to declare when a specific test has completed
   (regardless of success or failure) to narrow down the possible scenario.