### PR TITLE
IWYU: add some missing headers after NodeId/SymbolId header split.

### DIFF
--- a/include/Surelog/Design/Design.h
+++ b/include/Surelog/Design/Design.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>
+#include <Surelog/Common/SymbolId.h>
 
 #include <map>
 #include <mutex>

--- a/include/Surelog/Testbench/Constraint.h
+++ b/include/Surelog/Testbench/Constraint.h
@@ -25,7 +25,7 @@
 #define SURELOG_CONSTRAINT_H
 #pragma once
 
-#include <Surelog/Common/SymbolId.h>
+#include <Surelog/Common/NodeId.h>
 
 #include <string>
 #include <string_view>

--- a/include/Surelog/Testbench/CoverGroupDefinition.h
+++ b/include/Surelog/Testbench/CoverGroupDefinition.h
@@ -25,7 +25,7 @@
 #define SURELOG_COVERGROUPDEFINITION_H
 #pragma once
 
-#include <Surelog/Common/SymbolId.h>
+#include <Surelog/Common/NodeId.h>
 
 #include <string>
 #include <string_view>


### PR DESCRIPTION
Signed-off-by: Henner Zeller <h.zeller@acm.org>