### PR TITLE
Handle -odir/--Mdir before processing arguments

### DIFF
--- a/include/Surelog/CommandLine/CommandLineParser.h
+++ b/include/Surelog/CommandLine/CommandLineParser.h
@@ -221,6 +221,7 @@ class CommandLineParser final {
   CommandLineParser(const CommandLineParser& orig) = delete;
 
   bool plus_arguments_(const std::string& s);
+  void processOutputDirectory_(std::vector<std::string>& args);
   void processArgs_(std::vector<std::string>& args,
                     std::vector<std::string>& container);
   void splitPlusArg_(const std::string& s, const std::string& prefix,


### PR DESCRIPTION
This PR makes sure the output directory is set properly before processing arguments.

Without this the `-link` option always takes the default (`.`) folder (and fails if separate compilation was run elsewhere).