### PR TITLE
Issue #2962: Disabling Rsd

### DIFF
--- a/scripts/blacklisted.py
+++ b/scripts/blacklisted.py
@@ -43,9 +43,13 @@ _msys2_black_list = _unix_black_list.union([
   r'earlgrey_verilator_01_05_21', # lowmem is unsupported
 ])
 
+_unix_ci_black_list = _unix_black_list.union(set([name.lower() for name in [
+    'rsd' # Temporarily disabled on CI as this test seems to be stalling
+]]))
+
 def is_blacklisted(name):
     if platform.system() == 'Windows':
         blacklist = _msys2_black_list if 'MSYSTEM' in os.environ else _windows_black_list
     else:
-        blacklist =  _unix_black_list
+        blacklist = _unix_ci_black_list if 'GITHUB_JOB' in os.environ else _unix_black_list
     return name.lower() in blacklist


### PR DESCRIPTION
Issue #2962: Disabling Rsd

Early investigation is pointing to Rsd test being the culprit for
stalling the regression on CI. The root cause of why isn't identified
yet but disabling the test to see if this fixes the next few builds.
This is by all means is a temporary solution only to confirm whether or
not this is the root cause. There are problems identified in the Rsd.log
which might be more clue to fixing the test itself rather than disabling
it.