### PR TITLE
Few improvements to VpiListener & removed dead code

### DIFF
--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -55,9 +55,9 @@
 #include <string.h>
 #include <uhdm/ElaboratorListener.h>
 #include <uhdm/ExprEval.h>
+#include <uhdm/VpiListener.h>
 #include <uhdm/clone_tree.h>
 #include <uhdm/uhdm.h>
-#include <uhdm/vpi_listener.h>
 
 #include <iostream>
 #include <string>
@@ -3111,9 +3111,9 @@ UHDM::any* CompileHelper::compileTfCall(DesignComponent* component,
 
           ElaboratorListener* listener = new ElaboratorListener(&s, false);
           vpiHandle defModule = NewVpiHandle(modTmp);
-          VisitedContainer visited;
-          listen_module(defModule, listener, &visited);
+          listener->listenModule(defModule);
           vpi_free_object(defModule);
+          delete listener;
           return (any*)cts->Rhs();
         } else {
           let_expr* let = s.MakeLet_expr();

--- a/src/hellodesign.cpp
+++ b/src/hellodesign.cpp
@@ -32,13 +32,11 @@
 
 // UHDM
 #include <uhdm/ElaboratorListener.h>
+#include <uhdm/VpiListener.h>
 #include <uhdm/uhdm.h>
-#include <uhdm/vpi_listener.h>
 
 class DesignListener final : public UHDM::VpiListener {
-  void enterModule(const UHDM::module *const object,
-                   const UHDM::any *const parent, vpiHandle handle,
-                   vpiHandle parentHandle) final {
+  void enterModule(const UHDM::module *const object, vpiHandle handle) final {
     const std::string &instName = object->VpiName();
     m_flatTraversal =
         (instName.empty()) && ((object->VpiParent() == 0) ||
@@ -53,8 +51,7 @@ class DesignListener final : public UHDM::VpiListener {
   }
 
   void enterCont_assign(const UHDM::cont_assign *object,
-                        const UHDM::BaseClass *parent, vpiHandle handle,
-                        vpiHandle parentHandle) final {
+                        vpiHandle handle) final {
     if (m_flatTraversal) {
       std::cout << "  Let's skip the cont assigns in the flat traversal and "
                    "only navigate the ones in the hierarchical tree!"
@@ -71,7 +68,7 @@ class DesignListener final : public UHDM::VpiListener {
 
 static bool Build(const vpiHandle &design_handle) {
   DesignListener listener;
-  UHDM::listen_designs({design_handle}, &listener);
+  listener.listenDesigns({design_handle});
   std::cout << "End design traversal" << std::endl;
   return true;
 }

--- a/src/hellouhdm.cpp
+++ b/src/hellouhdm.cpp
@@ -32,8 +32,8 @@
 
 // UHDM
 #include <uhdm/ElaboratorListener.h>
+#include <uhdm/VpiListener.h>
 #include <uhdm/uhdm.h>
-#include <uhdm/vpi_listener.h>
 
 int main(int argc, const char** argv) {
   // Read command line, compile a design, use -parse argument
@@ -68,7 +68,8 @@ int main(int argc, const char** argv) {
     UHDM::Serializer serializer;
     UHDM::ElaboratorListener* listener =
         new UHDM::ElaboratorListener(&serializer, true);
-    listen_designs({the_design}, listener);
+    listener->listenDesigns({the_design});
+    delete listener;
   }
 
   // Browse the UHDM Data Model using the IEEE VPI API.

--- a/src/roundtrip.cpp
+++ b/src/roundtrip.cpp
@@ -30,7 +30,6 @@
 #include <uhdm/UhdmListener.h>
 #include <uhdm/VpiListener.h>
 #include <uhdm/uhdm.h>
-#include <uhdm/vpi_listener.h>
 
 #include <algorithm>
 #include <fstream>
@@ -3458,7 +3457,7 @@ static int run_in_uhdm_mode(int argc, const char **argv) {
         (const UHDM::design *)((const uhdm_handle *)handle)->object;
     if (!design->VpiElaborated()) {
       UHDM::ElaboratorListener listener(&serializer, false);
-      UHDM::listen_designs(restoredDesigns, &listener);
+      listener.listenDesigns(restoredDesigns);
     }
   }
 


### PR DESCRIPTION
Few improvements to VpiListener & removed dead code

* Introducing visited & callback to VpiListener (like UhdmListener)
  Also, merged the logic in vpi_listener into VpiListener itself to get
  access to both these containers easily in enter/leave callbacks.
* Removed parent and parentHandle parameters from VpiListener::enter/leave.
  The parameter itself was misleading since it was called 'parent' but
  it may not actually be the true parent of the object in the callback. The
  pointer was really the object right below the one on top of the callback
  hierarchy. The true parent is available via object->VpiParent() and access
  to the call hierarchy is available via callstack. Thus making both these
  parameters unnecessary.
* VpiListener also has a callback function (enter|leave)Any which gets
  called at most once for every visited object. For logic that's
  identical for a number of types, this is ideal place to implement it
  rather than having to override n number of functions and cloning the
  logic.
* Fixed up all VpiListener sub-classes like UhdmLint and SynthSubset
* Also fixed a few memory leaks in Surelog code.