### PR TITLE
Reduce memory leaks by purging serializer.

### DIFF
--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -68,6 +68,7 @@ CompileDesign::CompileDesign(Compiler* compiler) : m_compiler(compiler) {}
 CompileDesign::~CompileDesign() {
   // TODO: ownership not clear.
   // delete m_compiler;
+  m_serializer.Purge();
 }
 
 bool CompileDesign::compile() {

--- a/src/DesignCompile/CompileExpression_test.cpp
+++ b/src/DesignCompile/CompileExpression_test.cpp
@@ -55,13 +55,13 @@ TEST(CompileExpression, ExprFromParseTree1) {
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
     NodeId rhs = fC->Sibling(param);
-    std::unique_ptr<UHDM::expr> exp((UHDM::expr*)helper.compileExpression(
+    const UHDM::expr *exp = (UHDM::expr *)helper.compileExpression(
         nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, true,
-        true));
+        true);
     EXPECT_EQ(exp->UhdmType(), UHDM::uhdmconstant);
     bool invalidValue = false;
     UHDM::ExprEval eval;
-    EXPECT_EQ(eval.get_value(invalidValue, exp.get()), 16);
+    EXPECT_EQ(eval.get_value(invalidValue, exp), 16);
   }
 }
 TEST(CompileExpression, ExprFromParseTree2) {
@@ -84,13 +84,13 @@ TEST(CompileExpression, ExprFromParseTree2) {
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
     NodeId rhs = fC->Sibling(param);
-    std::unique_ptr<UHDM::expr> exp((UHDM::expr*)helper.compileExpression(
+    const UHDM::expr *exp = (UHDM::expr *)helper.compileExpression(
         nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, true,
-        true));
+        true);
     EXPECT_EQ(exp->UhdmType(), UHDM::uhdmconstant);
     bool invalidValue = false;
     UHDM::ExprEval eval;
-    EXPECT_EQ(eval.get_value(invalidValue, exp.get()), 1);
+    EXPECT_EQ(eval.get_value(invalidValue, exp), 1);
   }
 }
 TEST(CompileExpression, ExprFromParseTree3) {
@@ -110,20 +110,20 @@ TEST(CompileExpression, ExprFromParseTree3) {
   EXPECT_EQ(assigns.size(), 2);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
-    const std::string& name = fC->SymName(param);
+    const std::string &name = fC->SymName(param);
     NodeId rhs = fC->Sibling(param);
-    std::unique_ptr<UHDM::expr> exp1((UHDM::expr*)helper.compileExpression(
+    const UHDM::expr *exp1 = (UHDM::expr *)helper.compileExpression(
         nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, false,
-        true));
+        true);
     EXPECT_EQ(exp1->UhdmType(), UHDM::uhdmoperation);
-    std::unique_ptr<UHDM::expr> exp2((UHDM::expr*)helper.compileExpression(
+    const UHDM::expr *exp2 = (UHDM::expr *)helper.compileExpression(
         nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, true,
-        true));
+        true);
     if (name == "p1") {
       EXPECT_EQ(exp2->UhdmType(), UHDM::uhdmconstant);
       bool invalidValue = false;
       UHDM::ExprEval eval;
-      EXPECT_EQ(eval.get_value(invalidValue, exp2.get()), 6);
+      EXPECT_EQ(eval.get_value(invalidValue, exp2), 6);
     }
   }
 }
@@ -150,20 +150,20 @@ TEST(CompileExpression, ExprFromPpTree) {
   EXPECT_EQ(assigns.size(), 2);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
-    const std::string& name = fC->SymName(param);
+    const std::string &name = fC->SymName(param);
     NodeId rhs = fC->Sibling(param);
-    std::unique_ptr<UHDM::expr> exp1((UHDM::expr*)helper.compileExpression(
+    const UHDM::expr *exp1 = (UHDM::expr *)helper.compileExpression(
         nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, false,
-        true));
+        true);
     EXPECT_EQ(exp1->UhdmType(), UHDM::uhdmoperation);
-    std::unique_ptr<UHDM::expr> exp2((UHDM::expr*)helper.compileExpression(
+    const UHDM::expr *exp2 = (UHDM::expr *)helper.compileExpression(
         nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, true,
-        true));
+        true);
     if (name == "p1") {
       EXPECT_EQ(exp2->UhdmType(), UHDM::uhdmconstant);
       bool invalidValue = false;
       UHDM::ExprEval eval;
-      EXPECT_EQ(eval.get_value(invalidValue, exp2.get()), 6);
+      EXPECT_EQ(eval.get_value(invalidValue, exp2), 6);
     }
   }
 }


### PR DESCRIPTION
Previously, some leaks were addressed in the unit test by deleting UDHM objects directly. But since they are not the owners, this of course would result in a  double-delete. So also adapt the unit test.

This is the second time I added a manual call to `Serializer::Purge()` (the other was in the [UHDM Yosys Module](https://github.com/chipsalliance/yosys-f4pga-plugins/pull/343)).

Wouldn't it be good if the destructor of the [Serializer](https://github.com/chipsalliance/UHDM/blob/master/templates/Serializer.h#L75) had a call to Purge ? Or is there a reason why it doesn't ?