### PR TITLE
Issue #2962: Regression script update

### DIFF
--- a/scripts/blacklisted.py
+++ b/scripts/blacklisted.py
@@ -40,11 +40,15 @@ _unix_black_list = set([name.lower() for name in [
 ]])
 
 _msys2_black_list = _unix_black_list.union([
-  r'earlgrey_verilator_01_05_21', # lowmem is unsupported
+    r'earlgrey_verilator_01_05_21', # lowmem is unsupported
 ])
 
+# Temporarily disabled on CI as this test seems to be stalling
 _unix_ci_black_list = _unix_black_list.union(set([name.lower() for name in [
-    'rsd' # Temporarily disabled on CI as this test seems to be stalling
+#     'rsd',
+#     'compl1001',
+#     'google',
+#     'unisim'
 ]]))
 
 def is_blacklisted(name):


### PR DESCRIPTION
Issue #2962: Regression script update

* Fixed formatting for the cpu time column to always print float
* Flush often to show progress (helps identify when long running
  processes crash).
* Delete a few _large_ files post execution so we don't run into disk
  space problems. This is only for CI builds.
* Re-enable all tests for CI (Rsd was disabled earlier)