### PR TITLE
Issue #3057: RawSymbolId should have been 32 bits not 64 bits

### DIFF
--- a/include/Surelog/Common/SymbolId.h
+++ b/include/Surelog/Common/SymbolId.h
@@ -24,7 +24,7 @@ namespace SURELOG {
  * should) be resolved only with the SymbolTable that it was generated with.
  * 
  */
-typedef uint64_t RawSymbolId;
+typedef uint32_t RawSymbolId;
 inline static constexpr RawSymbolId BadRawSymbolId = 0;
 inline static constexpr std::string_view BadRawSymbol = "@@BAD_SYMBOL@@";
 class SymbolId final {


### PR DESCRIPTION
Issue #3057: RawSymbolId should have been 32 bits not 64 bits

The largest known test case 'BlackParrot' registers around 36864 symbols
which is roughly about 1/3 of the maximum that the cache supports.
Regardless, cache only supports a maximum of 20 bits (i.e. 1048575) for
SymbolId and so 64 bits is unnecessary.