### PR TITLE
Fix WinClang stack overflow issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ if(MSVC)
       "${CMAKE_CXX_FLAGS_RELEASE} ${TCMALLOC_COMPILE_OPTIONS} /Zc:__cplusplus /W0 /bigobj ${MY_CXX_WARNING_FLAGS}"
   )
   set(CMAKE_EXE_LINKER_FLAGS /STACK:8388608)  # 8MB stack size
+elseif(WIN32 AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+  # The stack size unnecessarily high here. Investigate and bring it back to something more reasonable.
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Xclang --stack-size=33554432")  # 32MB stack size
 else()
   if(DEFINED ENV{MSYSTEM})
     # Under MSYS some files are too large to build without additional flags

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -773,7 +773,8 @@ expr *CompileHelper::reduceExpr(any *result, bool &invalidValue,
   }
   expr *res =
       eval.reduceExpr(result, invalidValue, m_exprEvalPlaceHolder, pexpr);
-  return res;
+  // If loop was detected, drop the partially constructed new value!
+  return m_unwind ? nullptr : res;
 }
 
 any *CompileHelper::getValue(const std::string &name,

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -75,8 +75,13 @@ void CompileHelper::checkForLoops(bool on) {
 
 bool CompileHelper::loopDetected(const std::filesystem::path& fileName,
                                  int lineNumber, ValuedComponentI* instance) {
+#if defined(_WIN32)
+  constexpr int32_t kMaxAllowedStackDepth = 100;
+#else
+  constexpr int32_t kMaxAllowedStackDepth = 1000;
+#endif
   if (m_checkForLoops) {
-    if ((m_stackLevel > 1000) || (m_unwind)) {
+    if ((m_stackLevel > kMaxAllowedStackDepth) || (m_unwind)) {
       std::string instName;
       if (ModuleInstance* inst =
               valuedcomponenti_cast<ModuleInstance*>(instance)) {

--- a/tests/LoopParam/LoopParam.log
+++ b/tests/LoopParam/LoopParam.log
@@ -141,10 +141,10 @@ design: (work@Foo)
     |vpiParent:
     \_module: work@Foo (work@Foo), file:dut.sv, line:3:1, endln:7:10
     |vpiRhs:
-    \_ref_obj: (P2), line:4:17, endln:4:19
-      |vpiName:P2
+    \_ref_obj: (P1), line:4:17, endln:4:19
+      |vpiName:P1
       |vpiActual:
-      \_parameter: (work@Foo.P2), line:5:12, endln:5:14
+      \_parameter: (work@Foo.P1), line:4:12, endln:4:14
     |vpiLhs:
     \_parameter: (work@Foo.P1), line:4:12, endln:4:14
   |vpiParamAssign:
@@ -152,10 +152,7 @@ design: (work@Foo)
     |vpiParent:
     \_module: work@Foo (work@Foo), file:dut.sv, line:3:1, endln:7:10
     |vpiRhs:
-    \_ref_obj: (P1), line:5:17, endln:5:19
-      |vpiName:P1
-      |vpiActual:
-      \_parameter: (work@Foo.P1), line:4:12, endln:4:14
+    \_ref_obj: (P1), line:4:17, endln:4:19
     |vpiLhs:
     \_parameter: (work@Foo.P2), line:5:12, endln:5:14
   |vpiDefName:work@Foo

--- a/tests/LoopParamOver/LoopParamOver.log
+++ b/tests/LoopParamOver/LoopParamOver.log
@@ -151,11 +151,9 @@ n<> u<128> t<Top_level_rule> c<1> l<1:1> el<15:1>
 
 [ERR:EL0542] dut.sv:11: Expression loop in instance "work@top".
 
-[ERR:EL0542] dut.sv:12: Expression loop in instance "work@top".
+[ERR:EL0542] dut.sv:10: Expression loop in instance "work@top.sub".
 
 [ERR:EL0542] dut.sv:3: Expression loop in instance "work@top.sub".
-
-[ERR:EL0542] dut.sv:11: Expression loop in instance "work@top.sub".
 
 [NTE:EL0508] Nb Top level modules: 1.
 
@@ -312,10 +310,10 @@ design: (work@top)
     |vpiParent:
     \_module: work@top (work@top), file:dut.sv, line:8:1, endln:13:10
     |vpiRhs:
-    \_ref_obj: (P1), line:9:18, endln:9:20
-      |vpiName:P1
+    \_ref_obj: (P2), line:9:18, endln:9:20
+      |vpiName:P2
       |vpiActual:
-      \_parameter: (work@top.P1), line:11:13, endln:11:15
+      \_parameter: (work@top.P2), line:10:13, endln:10:15
     |vpiLhs:
     \_parameter: (work@top.P3), line:9:13, endln:9:15
   |vpiParamAssign:
@@ -323,10 +321,12 @@ design: (work@top)
     |vpiParent:
     \_module: work@top (work@top), file:dut.sv, line:8:1, endln:13:10
     |vpiRhs:
-    \_ref_obj: (P3), line:10:18, endln:10:20
-      |vpiName:P3
+    \_ref_obj: (P2), line:10:18, endln:10:20
+      |vpiTypespec:
+      \_int_typespec: 
+      |vpiName:P2
       |vpiActual:
-      \_parameter: (work@top.P3), line:9:13, endln:9:15
+      \_parameter: (work@top.P2), line:10:13, endln:10:15
     |vpiLhs:
     \_parameter: (work@top.P2), line:10:13, endln:10:15
   |vpiParamAssign:
@@ -334,12 +334,7 @@ design: (work@top)
     |vpiParent:
     \_module: work@top (work@top), file:dut.sv, line:8:1, endln:13:10
     |vpiRhs:
-    \_ref_obj: (P2), line:11:18, endln:11:20
-      |vpiTypespec:
-      \_int_typespec: 
-      |vpiName:P2
-      |vpiActual:
-      \_parameter: (work@top.P2), line:10:13, endln:10:15
+    \_ref_obj: (P2), line:10:18, endln:10:20
     |vpiLhs:
     \_parameter: (work@top.P1), line:11:13, endln:11:15
   |vpiDefName:work@top
@@ -374,15 +369,28 @@ design: (work@top)
       \_module: work@Foo (work@top.sub), file:dut.sv, line:12:1, endln:12:22
       |vpiOverriden:1
       |vpiRhs:
+      \_ref_obj: (P2), line:10:18, endln:10:20
+      |vpiLhs:
+      \_parameter: (work@top.sub.P1), line:2:12, endln:2:14
+    |vpiParamAssign:
+    \_param_assign: , line:3:12, endln:3:24
+      |vpiParent:
+      \_module: work@Foo (work@top.sub), file:dut.sv, line:12:1, endln:12:22
+      |vpiOverriden:1
+      |vpiRhs:
       \_operation: , line:3:17, endln:3:24
         |vpiOpType:24
         |vpiOperand:
-        \_ref_obj: (P1), line:9:18, endln:9:20
+        \_ref_obj: (P2), line:10:18, endln:10:20
           |vpiParent:
           \_operation: , line:3:17, endln:3:24
-          |vpiName:P1
+          |vpiTypespec:
+          \_int_typespec: 
+            |vpiParent:
+            \_ref_obj: (P2), line:10:18, endln:10:20
+          |vpiName:P2
           |vpiActual:
-          \_parameter: (work@top.sub.P1), line:2:12, endln:2:14
+          \_parameter: (work@top.P2), line:10:13, endln:10:15
         |vpiOperand:
         \_operation: , line:3:22, endln:3:24
           |vpiParent:
@@ -403,15 +411,6 @@ design: (work@top)
             |vpiActual:
             \_parameter: (work@top.sub.P2), line:3:12, endln:3:14
       |vpiLhs:
-      \_parameter: (work@top.sub.P1), line:2:12, endln:2:14
-    |vpiParamAssign:
-    \_param_assign: , line:3:12, endln:3:24
-      |vpiParent:
-      \_module: work@Foo (work@top.sub), file:dut.sv, line:12:1, endln:12:22
-      |vpiOverriden:1
-      |vpiRhs:
-      \_operation: , line:3:17, endln:3:24
-      |vpiLhs:
       \_parameter: (work@top.sub.P2), line:3:12, endln:3:14
     |vpiDefName:work@Foo
     |vpiDefFile:dut.sv
@@ -421,7 +420,7 @@ design: (work@top)
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 6
+[  ERROR] : 5
 [WARNING] : 2
 [   NOTE] : 5
 


### PR DESCRIPTION
Shorterm fix for WinClang stack overflow issue

The stack overflow was caused by the check loop functionality for
evaluating/reducing expressions. This needs a better logic than merely
depending on a stack frame counter.

Generally, for windows, the stack size has to be set for the application
but for some unknown/unidentified reason the stack usage for Clang seems
unnecessarily high. The set limit for the recursion was 1000 but even
with 64MB stack size the application kept running into the same
problem. Probably some other undelying issue (potential large objects
crated on stack) but a problem for some other day.
Implementing a short term solution to get the builds working again.

In the process, also found that the same problem happens with MSVC cl
compiler as well. In debug mode, the application blows up the stack.

Short term solution - For Windows only, reduce the limit from 1000 down to
100 and set the stack size to 32MB for clang builds.

A follow up problem - The value post reduction failure was invariably
dependent on the maximum loop counter. Even though the builds and tests
worked independently for the platform, the results were different across
platforms because of different max values for the loop counter. To
resolve this difference in resultant value post failure, use the input
unmodified.
