### PR TITLE
Reduce code bloat

### DIFF
--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -214,6 +214,9 @@ class FileContent : public DesignComponent {
   bool isLibraryCellFile() const { return m_isLibraryCellFile; }
   void setLibraryCellFile() { m_isLibraryCellFile = true; }
 
+  void populateCoreMembers(NodeId startIndex, NodeId endIndex,
+                           UHDM::any* instance) const;
+
  protected:
   std::vector<DesignElement*> m_elements;
   std::map<std::string, DesignElement*, StringViewCompare> m_elementMap;

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -659,4 +659,64 @@ const DesignElement* FileContent::getDesignElement(
   }
   return nullptr;
 }
+
+void FileContent::populateCoreMembers(NodeId startIndex, NodeId endIndex,
+                                      UHDM::any* instance) const {
+  if (!startIndex && !endIndex) return;
+  if (startIndex) {
+    if (startIndex < m_objects.size()) {
+      const VObject& object = m_objects[startIndex];
+      instance->VpiLineNo(object.m_line);
+      instance->VpiColumnNo(object.m_column);
+    } else {
+      Location loc(m_fileId);
+      Error err(ErrorDefinition::COMP_INTERNAL_ERROR_OUT_OF_BOUND, loc);
+      m_errors->addError(err);
+      std::cerr << "\nINTERNAL OUT OF BOUND ERROR\n\n";
+    }
+  }
+
+  if (endIndex) {
+    if (endIndex < m_objects.size()) {
+      const VObject& object = m_objects[endIndex];
+      instance->VpiEndLineNo(object.m_endLine);
+      instance->VpiEndColumnNo(object.m_endColumn);
+    } else {
+      Location loc(m_fileId);
+      Error err(ErrorDefinition::COMP_INTERNAL_ERROR_OUT_OF_BOUND, loc);
+      m_errors->addError(err);
+      std::cerr << "\nINTERNAL OUT OF BOUND ERROR\n\n";
+    }
+  }
+
+  SymbolId fileId;
+  if (startIndex && endIndex) {
+    const VObject& startObject = m_objects[startIndex];
+    const VObject& endObject = m_objects[endIndex];
+    if (startObject.m_fileId == endObject.m_fileId) {
+      fileId = startObject.m_fileId;
+    } else {
+      Location loc(m_fileId);
+      Error err(ErrorDefinition::COMP_INTERNAL_ERROR_OUT_OF_BOUND, loc);
+      m_errors->addError(err);
+      std::cerr << "\nFILE INDEX MISMATCH\n\n";
+    }
+  } else if (startIndex) {
+    const VObject& object = m_objects[startIndex];
+    fileId = object.m_fileId;
+  } else if (endIndex) {
+    const VObject& object = m_objects[endIndex];
+    fileId = object.m_fileId;
+  } else {
+    fileId = m_fileId;
+  }
+
+  if (!fileId) {
+    fileId = m_fileId;
+  }
+
+  if (fileId) {
+    instance->VpiFile(m_symbolTable->getSymbol(fileId));
+  }
+}
 }  // namespace SURELOG

--- a/src/DesignCompile/CompileAssertion.cpp
+++ b/src/DesignCompile/CompileAssertion.cpp
@@ -127,11 +127,7 @@ UHDM::any* CompileHelper::compileConcurrentAssertion(
           component, fC, Property_expr, compileDesign, pstmt, instance, false);
       property_expr = createPropertyInst(property_expr, s);
       prop_spec->VpiPropertyExpr(property_expr);
-      prop_spec->VpiFile(fC->getFileName());
-      prop_spec->VpiLineNo(fC->Line(Property_spec));
-      prop_spec->VpiColumnNo(fC->Column(Property_spec));
-      prop_spec->VpiEndLineNo(fC->EndLine(Property_spec));
-      prop_spec->VpiEndColumnNo(fC->EndColumn(Property_spec));
+      fC->populateCoreMembers(Property_spec, Property_spec, prop_spec);
       assert_stmt->VpiProperty(prop_spec);
       assert_stmt->Stmt(if_stmt);
       assert_stmt->Else_stmt(else_stmt);
@@ -154,11 +150,7 @@ UHDM::any* CompileHelper::compileConcurrentAssertion(
       property_expr = createPropertyInst(property_expr, s);
       prop_spec->VpiClockingEvent(clocking_event);
       prop_spec->VpiPropertyExpr(property_expr);
-      prop_spec->VpiFile(fC->getFileName());
-      prop_spec->VpiLineNo(fC->Line(Property_spec));
-      prop_spec->VpiColumnNo(fC->Column(Property_spec));
-      prop_spec->VpiEndLineNo(fC->EndLine(Property_spec));
-      prop_spec->VpiEndColumnNo(fC->EndColumn(Property_spec));
+      fC->populateCoreMembers(Property_spec, Property_spec, prop_spec);
       assume_stmt->VpiProperty(prop_spec);
       if (if_stmt)
         assume_stmt->Stmt(if_stmt);
@@ -175,11 +167,7 @@ UHDM::any* CompileHelper::compileConcurrentAssertion(
           component, fC, Property_expr, compileDesign, pstmt, instance, false);
       property_expr = createPropertyInst(property_expr, s);
       prop_spec->VpiPropertyExpr(property_expr);
-      prop_spec->VpiFile(fC->getFileName());
-      prop_spec->VpiLineNo(fC->Line(Property_spec));
-      prop_spec->VpiColumnNo(fC->Column(Property_spec));
-      prop_spec->VpiEndLineNo(fC->EndLine(Property_spec));
-      prop_spec->VpiEndColumnNo(fC->EndColumn(Property_spec));
+      fC->populateCoreMembers(Property_spec, Property_spec, prop_spec);
       cover_stmt->VpiProperty(prop_spec);
       cover_stmt->Stmt(if_stmt);
       stmt = cover_stmt;
@@ -194,11 +182,7 @@ UHDM::any* CompileHelper::compileConcurrentAssertion(
           component, fC, Property_expr, compileDesign, pstmt, instance, false);
       property_expr = createPropertyInst(property_expr, s);
       prop_spec->VpiPropertyExpr(property_expr);
-      prop_spec->VpiFile(fC->getFileName());
-      prop_spec->VpiLineNo(fC->Line(Property_expr));
-      prop_spec->VpiColumnNo(fC->Column(Property_expr));
-      prop_spec->VpiEndLineNo(fC->EndLine(Property_expr));
-      prop_spec->VpiEndColumnNo(fC->EndColumn(Property_expr));
+      fC->populateCoreMembers(Property_expr, Property_expr, prop_spec);
       cover_stmt->VpiProperty(prop_spec);
       cover_stmt->Stmt(if_stmt);
       stmt = cover_stmt;
@@ -212,11 +196,7 @@ UHDM::any* CompileHelper::compileConcurrentAssertion(
           component, fC, Property_expr, compileDesign, pstmt, instance, false);
       property_expr = createPropertyInst(property_expr, s);
       prop_spec->VpiPropertyExpr(property_expr);
-      prop_spec->VpiFile(fC->getFileName());
-      prop_spec->VpiLineNo(fC->Line(Property_spec));
-      prop_spec->VpiColumnNo(fC->Column(Property_spec));
-      prop_spec->VpiEndLineNo(fC->EndLine(Property_spec));
-      prop_spec->VpiEndColumnNo(fC->EndColumn(Property_spec));
+      fC->populateCoreMembers(Property_spec, Property_spec, prop_spec);
       restrict_stmt->VpiProperty(prop_spec);
       restrict_stmt->Stmt(if_stmt);
       stmt = restrict_stmt;

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -1235,11 +1235,7 @@ UHDM::any *CompileHelper::compileSelectExpression(
       }
       path->VpiName(hname);
       path->VpiFullName(hname);
-      path->VpiFile(fC->getFileName());
-      path->VpiLineNo(fC->Line(Bit_select));
-      path->VpiColumnNo(fC->Column(Bit_select));
-      path->VpiEndLineNo(fC->EndLine(Bit_select));
-      path->VpiEndColumnNo(fC->EndColumn(Bit_select));
+      fC->populateCoreMembers(Bit_select, Bit_select, path);
       path->VpiParent(pexpr);
       result = path;
       break;
@@ -1313,18 +1309,9 @@ UHDM::any *CompileHelper::compileExpression(
           operands->push_back(op);
         }
       }
-      list_op->VpiFile(fC->getFileName());
-      list_op->VpiLineNo(fC->Line(child));
-      list_op->VpiColumnNo(fC->Column(child));
-      list_op->VpiEndLineNo(fC->EndLine(child));
-      list_op->VpiEndColumnNo(fC->EndColumn(child));
       list_op->Attributes(attributes);
       result = list_op;
-      result->VpiFile(fC->getFileName(parent));
-      result->VpiLineNo(fC->Line(parent));
-      result->VpiColumnNo(fC->Column(parent));
-      result->VpiEndLineNo(fC->EndLine(parent));
-      result->VpiEndColumnNo(fC->EndColumn(parent));
+      fC->populateCoreMembers(parent, parent, result);
       return result;
     }
     case VObjectType::slNet_lvalue: {
@@ -1335,11 +1322,7 @@ UHDM::any *CompileHelper::compileExpression(
       operation->VpiParent(pexpr);
       operation->Operands(operands);
       operation->VpiOpType(vpiConcatOp);
-      result->VpiFile(fC->getFileName(parent));
-      result->VpiLineNo(fC->Line(parent));
-      result->VpiColumnNo(fC->Column(parent));
-      result->VpiEndLineNo(fC->EndLine(parent));
-      result->VpiEndColumnNo(fC->EndColumn(parent));
+      fC->populateCoreMembers(parent, parent, result);
       NodeId Expression = parent;
       while (Expression) {
         UHDM::any *exp = compileExpression(component, fC, fC->Child(Expression),
@@ -1366,11 +1349,7 @@ UHDM::any *CompileHelper::compileExpression(
       operation->VpiParent(pexpr);
       operation->Operands(operands);
       operation->VpiOpType(vpiConcatOp);
-      result->VpiFile(fC->getFileName());
-      result->VpiLineNo(fC->Line(parent));
-      result->VpiColumnNo(fC->Column(parent));
-      result->VpiEndLineNo(fC->EndLine(parent));
-      result->VpiEndColumnNo(fC->EndColumn(parent));
+      fC->populateCoreMembers(parent, parent, result);
       NodeId Expression = fC->Child(parent);
       while (Expression) {
         UHDM::any *exp =
@@ -1469,11 +1448,7 @@ UHDM::any *CompileHelper::compileExpression(
     operation->VpiParent(pexpr);
     operation->Operands(operands);
     operation->VpiOpType(vpiConcatOp);
-    result->VpiFile(fC->getFileName(child));
-    result->VpiLineNo(fC->Line(child));
-    result->VpiColumnNo(fC->Column(child));
-    result->VpiEndLineNo(fC->EndLine(child));
-    result->VpiEndColumnNo(fC->EndColumn(child));
+    fC->populateCoreMembers(child, child, result);
     NodeId Expression = child;
     while (Expression) {
       NodeId n = fC->Child(Expression);
@@ -1527,11 +1502,7 @@ UHDM::any *CompileHelper::compileExpression(
           operation->VpiParent(pexpr);
           operation->Operands(operands);
           operation->VpiOpType(vpiConcatOp);
-          result->VpiFile(fC->getFileName(child));
-          result->VpiLineNo(fC->Line(child));
-          result->VpiColumnNo(fC->Column(child));
-          result->VpiEndLineNo(fC->EndLine(child));
-          result->VpiEndColumnNo(fC->EndColumn(child));
+          fC->populateCoreMembers(child, child, result);
           NodeId Expression = child;
           bool odd = true;
           while (Expression) {
@@ -1591,11 +1562,7 @@ UHDM::any *CompileHelper::compileExpression(
               operands->push_back(operand);
             }
             op->Operands(operands);
-            op->VpiFile(fC->getFileName());
-            op->VpiLineNo(fC->Line(parent));
-            op->VpiColumnNo(fC->Column(parent));
-            op->VpiEndLineNo(fC->EndLine(parent));
-            op->VpiEndColumnNo(fC->EndColumn(parent));
+            fC->populateCoreMembers(parent, parent, op);
             result = op;
           }
           break;
@@ -1611,11 +1578,7 @@ UHDM::any *CompileHelper::compileExpression(
             UHDM::VectorOfany *operands = s.MakeAnyVec();
             operands->push_back(operand);
             op->Operands(operands);
-            op->VpiFile(fC->getFileName());
-            op->VpiLineNo(fC->Line(parent));
-            op->VpiColumnNo(fC->Column(parent));
-            op->VpiEndLineNo(fC->EndLine(parent));
-            op->VpiEndColumnNo(fC->EndColumn(parent));
+            fC->populateCoreMembers(parent, parent, op);
           }
           result = op;
           break;
@@ -1631,11 +1594,7 @@ UHDM::any *CompileHelper::compileExpression(
             UHDM::VectorOfany *operands = s.MakeAnyVec();
             operands->push_back(operand);
             op->Operands(operands);
-            op->VpiFile(fC->getFileName());
-            op->VpiLineNo(fC->Line(parent));
-            op->VpiColumnNo(fC->Column(parent));
-            op->VpiEndLineNo(fC->EndLine(parent));
-            op->VpiEndColumnNo(fC->EndColumn(parent));
+            fC->populateCoreMembers(parent, parent, op);
           }
           result = op;
           break;
@@ -1651,11 +1610,7 @@ UHDM::any *CompileHelper::compileExpression(
             UHDM::VectorOfany *operands = s.MakeAnyVec();
             operands->push_back(operand);
             op->Operands(operands);
-            op->VpiFile(fC->getFileName());
-            op->VpiLineNo(fC->Line(parent));
-            op->VpiColumnNo(fC->Column(parent));
-            op->VpiEndLineNo(fC->EndLine(parent));
-            op->VpiEndColumnNo(fC->EndColumn(parent));
+            fC->populateCoreMembers(parent, parent, op);
           }
           result = op;
           break;
@@ -1717,11 +1672,7 @@ UHDM::any *CompileHelper::compileExpression(
           NodeId Identifier = fC->Sibling(child);
           ref_obj *ref = s.MakeRef_obj();
           ref->VpiName(fC->SymName(Identifier));
-          ref->VpiFile(fC->getFileName());
-          ref->VpiLineNo(fC->Line(Identifier));
-          ref->VpiColumnNo(fC->Column(Identifier));
-          ref->VpiEndLineNo(fC->EndLine(Identifier));
-          ref->VpiEndColumnNo(fC->EndColumn(Identifier));
+          fC->populateCoreMembers(Identifier, Identifier, ref);
           result = ref;
           break;
         }
@@ -1800,11 +1751,7 @@ UHDM::any *CompileHelper::compileExpression(
           NodeId Expression = fC->Sibling(Identifier);
           UHDM::tagged_pattern *pattern = s.MakeTagged_pattern();
           pattern->VpiName(fC->SymName(Identifier));
-          pattern->VpiFile(fC->getFileName());
-          pattern->VpiLineNo(fC->Line(child));
-          pattern->VpiColumnNo(fC->Column(child));
-          pattern->VpiEndLineNo(fC->EndLine(child));
-          pattern->VpiEndColumnNo(fC->EndColumn(child));
+          fC->populateCoreMembers(child, child, pattern);
           if (Expression)
             pattern->Pattern(compileExpression(component, fC, Expression,
                                                compileDesign, pattern, instance,
@@ -1849,11 +1796,7 @@ UHDM::any *CompileHelper::compileExpression(
             }
           }
           if ((operation != nullptr) && (operation->VpiLineNo() == 0)) {
-            operation->VpiFile(fC->getFileName());
-            operation->VpiLineNo(fC->Line(parent));
-            operation->VpiColumnNo(fC->Column(parent));
-            operation->VpiEndLineNo(fC->EndLine(parent));
-            operation->VpiEndColumnNo(fC->EndColumn(parent));
+            fC->populateCoreMembers(parent, parent, operation);
           }
           break;
         }
@@ -1960,11 +1903,7 @@ UHDM::any *CompileHelper::compileExpression(
               operands->push_back(opR);
             }
           }
-          operation->VpiFile(fC->getFileName());
-          operation->VpiLineNo(fC->Line(child));
-          operation->VpiColumnNo(fC->Column(child));
-          operation->VpiEndLineNo(fC->EndLine(rval));
-          operation->VpiEndColumnNo(fC->EndColumn(rval));
+          fC->populateCoreMembers(child, rval, operation);
           break;
         }
         case VObjectType::slSystem_task_names: {
@@ -2023,11 +1962,7 @@ UHDM::any *CompileHelper::compileExpression(
                                 pexpr, instance, reduce, muteErrors);
           NodeId op = fC->Sibling(child);
           if (op) {
-            variable->VpiFile(fC->getFileName());
-            variable->VpiLineNo(fC->Line(child));
-            variable->VpiColumnNo(fC->Column(child));
-            variable->VpiEndLineNo(fC->EndLine(child));
-            variable->VpiEndColumnNo(fC->EndColumn(child));
+            fC->populateCoreMembers(child, child, variable);
 
             VObjectType opType = fC->Type(op);
             unsigned int vopType = UhdmWriter::getVpiOpType(opType);
@@ -2036,11 +1971,7 @@ UHDM::any *CompileHelper::compileExpression(
               UHDM::operation *operation = s.MakeOperation();
               UHDM::VectorOfany *operands = s.MakeAnyVec();
               operation->Attributes(attributes);
-              operation->VpiFile(fC->getFileName());
-              operation->VpiLineNo(fC->Line(parent));
-              operation->VpiColumnNo(fC->Column(parent));
-              operation->VpiEndLineNo(fC->EndLine(parent));
-              operation->VpiEndColumnNo(fC->EndColumn(parent));
+              fC->populateCoreMembers(parent, parent, operation);
               operation->VpiParent(pexpr);
               operation->VpiOpType(vopType);
               operation->Operands(operands);
@@ -2061,11 +1992,7 @@ UHDM::any *CompileHelper::compileExpression(
               UHDM::operation *operation = s.MakeOperation();
               UHDM::VectorOfany *operands = s.MakeAnyVec();
               operation->Attributes(attributes);
-              operation->VpiFile(fC->getFileName());
-              operation->VpiLineNo(fC->Line(parent));
-              operation->VpiColumnNo(fC->Column(parent));
-              operation->VpiEndLineNo(fC->EndLine(parent));
-              operation->VpiEndColumnNo(fC->EndColumn(parent));
+              fC->populateCoreMembers(parent, parent, operation);
               operation->VpiParent(pexpr);
               operation->VpiOpType(vpiAssignmentOp);
               operation->Operands(operands);
@@ -2128,11 +2055,8 @@ UHDM::any *CompileHelper::compileExpression(
               c->VpiDecompile("0");
               c->VpiSize(64);
               c->VpiConstType(vpiIntConst);
-              c->VpiFile(fC->getFileName());
-              c->VpiLineNo(fC->Line(Sequence_actual_arg));
-              c->VpiColumnNo(fC->Column(Sequence_actual_arg));
-              c->VpiEndLineNo(fC->EndLine(Sequence_actual_arg));
-              c->VpiEndColumnNo(fC->EndColumn(Sequence_actual_arg));
+              fC->populateCoreMembers(Sequence_actual_arg, Sequence_actual_arg,
+                                      c);
               args->push_back(c);
             }
             Sequence_actual_arg = fC->Sibling(Sequence_actual_arg);
@@ -2178,11 +2102,7 @@ UHDM::any *CompileHelper::compileExpression(
                   c->VpiDecompile(val);
                   c->VpiSize(64);
                   c->VpiConstType(vpiUIntConst);
-                  c->VpiFile(fC->getFileName());
-                  c->VpiLineNo(fC->Line(subOp1));
-                  c->VpiColumnNo(fC->Column(subOp1));
-                  c->VpiEndLineNo(fC->EndLine(subOp1));
-                  c->VpiEndColumnNo(fC->EndColumn(subOp1));
+                  fC->populateCoreMembers(subOp1, subOp1, c);
                   operands->push_back(c);
                 }
               }
@@ -2274,11 +2194,7 @@ UHDM::any *CompileHelper::compileExpression(
                           ElaboratorListener listener(&s, false, true);
                           result = UHDM::clone_tree((any *)param->Rhs(), s,
                                                     &listener);
-                          result->VpiFile(fC->getFileName(child));
-                          result->VpiLineNo(fC->Line(child));
-                          result->VpiColumnNo(fC->Column(child));
-                          result->VpiEndLineNo(fC->EndLine(child));
-                          result->VpiEndColumnNo(fC->EndColumn(child));
+                          fC->populateCoreMembers(child, child, result);
                         }
                         break;
                       }
@@ -2324,11 +2240,7 @@ UHDM::any *CompileHelper::compileExpression(
                           ElaboratorListener listener(&s, false, true);
                           result = UHDM::clone_tree((any *)param->Rhs(), s,
                                                     &listener);
-                          result->VpiFile(fC->getFileName(child));
-                          result->VpiLineNo(fC->Line(child));
-                          result->VpiColumnNo(fC->Column(child));
-                          result->VpiEndLineNo(fC->EndLine(child));
-                          result->VpiEndColumnNo(fC->EndColumn(child));
+                          fC->populateCoreMembers(child, child, result);
                         }
                         break;
                       }
@@ -2370,11 +2282,7 @@ UHDM::any *CompileHelper::compileExpression(
                                                  name, compileDesign, pexpr,
                                                  instance, reduce, muteErrors);
                 if (result != nullptr) {
-                  result->VpiFile(fC->getFileName(rhsbackup));
-                  result->VpiLineNo(fC->Line(rhsbackup));
-                  result->VpiColumnNo(fC->Column(rhsbackup));
-                  result->VpiEndLineNo(fC->EndLine(rhs));
-                  result->VpiEndColumnNo(fC->EndColumn(rhs));
+                  fC->populateCoreMembers(rhsbackup, rhs, result);
                 }
               }
               if (result) break;
@@ -2407,11 +2315,7 @@ UHDM::any *CompileHelper::compileExpression(
                               ElaboratorListener listener(&s, false, true);
                               result = UHDM::clone_tree((any *)param_ass->Rhs(),
                                                         s, &listener);
-                              result->VpiFile(fC->getFileName(child));
-                              result->VpiLineNo(fC->Line(child));
-                              result->VpiColumnNo(fC->Column(child));
-                              result->VpiEndLineNo(fC->EndLine(child));
-                              result->VpiEndColumnNo(fC->EndColumn(child));
+                              fC->populateCoreMembers(child, child, result);
                               const any *lhs = param_ass->Lhs();
                               expr *res = (expr *)result;
                               const typespec *tps = nullptr;
@@ -2467,11 +2371,7 @@ UHDM::any *CompileHelper::compileExpression(
                             ElaboratorListener listener(&s, false, true);
                             result = UHDM::clone_tree((any *)param_ass->Rhs(),
                                                       s, &listener);
-                            result->VpiFile(fC->getFileName(child));
-                            result->VpiLineNo(fC->Line(child));
-                            result->VpiColumnNo(fC->Column(child));
-                            result->VpiEndLineNo(fC->EndLine(child));
-                            result->VpiEndColumnNo(fC->EndColumn(child));
+                            fC->populateCoreMembers(child, child, result);
                           }
                           const any *lhs = param_ass->Lhs();
                           expr *res = (expr *)result;
@@ -2592,11 +2492,8 @@ UHDM::any *CompileHelper::compileExpression(
           UHDM::operation *operation = s.MakeOperation();
           UHDM::VectorOfany *operands = s.MakeAnyVec();
           operation->Attributes(attributes);
-          operation->VpiFile(fC->getFileName());
-          operation->VpiLineNo(fC->Line(Stream_concatenation));
-          operation->VpiColumnNo(fC->Column(Stream_concatenation));
-          operation->VpiEndLineNo(fC->EndLine(Stream_concatenation));
-          operation->VpiEndColumnNo(fC->EndColumn(Stream_concatenation));
+          fC->populateCoreMembers(Stream_concatenation, Stream_concatenation,
+                                  operation);
           result = operation;
           operation->VpiParent(pexpr);
           operation->Operands(operands);
@@ -2612,11 +2509,7 @@ UHDM::any *CompileHelper::compileExpression(
           concat_op->VpiParent(operation);
           concat_op->Operands(concat_ops);
           concat_op->VpiOpType(vpiConcatOp);
-          concat_op->VpiFile(fC->getFileName());
-          concat_op->VpiLineNo(fC->Line(parent));
-          concat_op->VpiColumnNo(fC->Column(parent));
-          concat_op->VpiEndLineNo(fC->EndLine(parent));
-          concat_op->VpiEndColumnNo(fC->EndColumn(parent));
+          fC->populateCoreMembers(parent, parent, concat_op);
 
           NodeId Stream_expression = fC->Child(Stream_concatenation);
           while (Stream_expression) {
@@ -2656,11 +2549,7 @@ UHDM::any *CompileHelper::compileExpression(
           operation->VpiParent(pexpr);
           operation->Operands(operands);
           operation->VpiOpType(vpiConcatOp);
-          operation->VpiFile(fC->getFileName());
-          operation->VpiLineNo(fC->Line(parent));
-          operation->VpiColumnNo(fC->Column(parent));
-          operation->VpiEndLineNo(fC->EndLine(parent));
-          operation->VpiEndColumnNo(fC->EndColumn(parent));
+          fC->populateCoreMembers(parent, parent, operation);
           break;
         }
         case VObjectType::slConstant_multiple_concatenation:
@@ -2737,11 +2626,7 @@ UHDM::any *CompileHelper::compileExpression(
             } else {
               bool invalidValue = false;
               UHDM::func_call *fcall = s.MakeFunc_call();
-              fcall->VpiFile(fC->getFileName());
-              fcall->VpiLineNo(fC->Line(Dollar_keyword));
-              fcall->VpiColumnNo(fC->Column(Dollar_keyword));
-              fcall->VpiEndLineNo(fC->EndLine(Dollar_keyword));
-              fcall->VpiEndColumnNo(fC->EndColumn(Dollar_keyword));
+              fC->populateCoreMembers(Dollar_keyword, Dollar_keyword, fcall);
               fcall->VpiName(name);
 
               auto [func, actual_comp] =
@@ -2822,11 +2707,7 @@ UHDM::any *CompileHelper::compileExpression(
                 c->VpiDecompile(val);
                 c->VpiSize(64);
                 c->VpiConstType(vpiUIntConst);
-                c->VpiFile(fC->getFileName());
-                c->VpiLineNo(fC->Line(subOp1));
-                c->VpiColumnNo(fC->Column(subOp1));
-                c->VpiEndLineNo(fC->EndLine(subOp1));
-                c->VpiEndColumnNo(fC->EndColumn(subOp1));
+                fC->populateCoreMembers(subOp1, subOp1, c);
                 operands->push_back(c);
               }
             }
@@ -3040,11 +2921,7 @@ UHDM::any *CompileHelper::compileExpression(
       Error err(ErrorDefinition::UHDM_UNSUPPORTED_EXPR, loc);
       errors->addError(err);
       exp->VpiValue(StrCat("STRING:", lineText));
-      exp->VpiFile(fC->getFileName(the_node));
-      exp->VpiLineNo(fC->Line(the_node));
-      exp->VpiColumnNo(fC->Column(the_node));
-      exp->VpiEndLineNo(fC->EndLine(the_node));
-      exp->VpiEndColumnNo(fC->EndColumn(the_node));
+      fC->populateCoreMembers(the_node, the_node, exp);
       exp->VpiParent(pexpr);
       result = exp;
     }
@@ -3063,17 +2940,9 @@ UHDM::any *CompileHelper::compileExpression(
 
   if (result && (result->VpiLineNo() == 0)) {
     if (child) {
-      result->VpiFile(fC->getFileName(child));
-      result->VpiLineNo(fC->Line(child));
-      result->VpiColumnNo(fC->Column(child));
-      result->VpiEndLineNo(fC->EndLine(child));
-      result->VpiEndColumnNo(fC->EndColumn(child));
+      fC->populateCoreMembers(child, child, result);
     } else {
-      result->VpiFile(fC->getFileName(parent));
-      result->VpiLineNo(fC->Line(parent));
-      result->VpiColumnNo(fC->Column(parent));
-      result->VpiEndLineNo(fC->EndLine(parent));
-      result->VpiEndColumnNo(fC->EndColumn(parent));
+      fC->populateCoreMembers(parent, parent, result);
     }
   }
 
@@ -3122,11 +2991,7 @@ UHDM::any *CompileHelper::compileAssignmentPattern(DesignComponent *component,
       operation->VpiOpType(vpiMultiAssignmentPatternOp);
       UHDM::operation *concat = s.MakeOperation();
       concat->VpiOpType(vpiConcatOp);
-      concat->VpiFile(fC->getFileName());
-      concat->VpiLineNo(fC->Line(Expression));
-      concat->VpiColumnNo(fC->Column(Expression));
-      concat->VpiEndLineNo(fC->EndLine(Expression));
-      concat->VpiEndColumnNo(fC->EndColumn(Expression));
+      fC->populateCoreMembers(Expression, Expression, concat);
       operands->push_back(concat);
       concat->VpiParent(operation);
       UHDM::VectorOfany *suboperands = s.MakeAnyVec();
@@ -3195,11 +3060,7 @@ UHDM::any *CompileHelper::compileAssignmentPattern(DesignComponent *component,
             }
           }
           tagged_pattern *pattern = s.MakeTagged_pattern();
-          pattern->VpiFile(fC->getFileName(Expression));
-          pattern->VpiLineNo(fC->Line(Expression));
-          pattern->VpiColumnNo(fC->Column(Expression));
-          pattern->VpiEndLineNo(fC->EndLine(Expression));
-          pattern->VpiEndColumnNo(fC->EndColumn(Expression));
+          fC->populateCoreMembers(Expression, Expression, pattern);
           pattern->Pattern(exp);
           NodeId Constant_expression = fC->Child(Structure_pattern_key);
           NodeId Constant_primary = fC->Child(Constant_expression);
@@ -3210,11 +3071,8 @@ UHDM::any *CompileHelper::compileAssignmentPattern(DesignComponent *component,
             } else {
               tps->VpiName("default");
             }
-            tps->VpiFile(fC->getFileName());
-            tps->VpiLineNo(fC->Line(Constant_expression));
-            tps->VpiColumnNo(fC->Column(Constant_expression));
-            tps->VpiEndLineNo(fC->EndLine(Constant_expression));
-            tps->VpiEndColumnNo(fC->EndColumn(Constant_expression));
+            fC->populateCoreMembers(Constant_expression, Constant_expression,
+                                    tps);
             pattern->Typespec(tps);
           } else {
             NodeId Primary_literal = Constant_primary;
@@ -3399,11 +3257,7 @@ std::vector<UHDM::range *> *CompileHelper::compileRanges(
         }
         if (rexp) rexp->VpiParent(range);
         range->Right_expr(rexp);
-        range->VpiFile(fC->getFileName());
-        range->VpiLineNo(fC->Line(Packed_dimension));
-        range->VpiColumnNo(fC->Column(Packed_dimension));
-        range->VpiEndLineNo(fC->EndLine(Packed_dimension));
-        range->VpiEndColumnNo(fC->EndColumn(Packed_dimension));
+        fC->populateCoreMembers(Packed_dimension, Packed_dimension, range);
         ranges->push_back(range);
         range->VpiParent(pexpr);
       } else if (fC->Type(Constant_range) ==
@@ -3417,10 +3271,7 @@ std::vector<UHDM::range *> *CompileHelper::compileRanges(
         lexpc->VpiSize(64);
         lexpc->VpiValue("UINT:0");
         lexpc->VpiDecompile("0");
-        lexpc->VpiFile(fC->getFileName());
-        lexpc->VpiLineNo(fC->Line(rexpr));
-        lexpc->VpiColumnNo(fC->Column(rexpr));
-        lexpc->VpiEndLineNo(fC->EndLine(rexpr));
+        fC->populateCoreMembers(rexpr, rexpr, lexpc);
         lexpc->VpiEndColumnNo(fC->Column(rexpr) + 1);
         expr *lexp = lexpc;
 
@@ -3487,10 +3338,8 @@ std::vector<UHDM::range *> *CompileHelper::compileRanges(
               lexpc->VpiSize(64);
               lexpc->VpiValue("UINT:0");
               lexpc->VpiDecompile("0");
-              lexpc->VpiFile(fC->getFileName());
-              lexpc->VpiLineNo(fC->Line(Packed_dimension));
-              lexpc->VpiColumnNo(fC->Column(Packed_dimension));
-              lexpc->VpiEndLineNo(fC->EndLine(Packed_dimension));
+              fC->populateCoreMembers(Packed_dimension, Packed_dimension,
+                                      lexpc);
               lexpc->VpiEndColumnNo(fC->Column(Packed_dimension) + 1);
               expr *lexp = lexpc;
 
@@ -3502,10 +3351,8 @@ std::vector<UHDM::range *> *CompileHelper::compileRanges(
               rexpc->VpiSize(0);
               rexpc->VpiValue("STRING:associative");
               rexpc->VpiDecompile("associative");
-              rexpc->VpiFile(fC->getFileName());
-              rexpc->VpiLineNo(fC->Line(Packed_dimension));
-              rexpc->VpiColumnNo(fC->Column(Packed_dimension));
-              rexpc->VpiEndLineNo(fC->EndLine(Packed_dimension));
+              fC->populateCoreMembers(Packed_dimension, Packed_dimension,
+                                      rexpc);
               rexpc->VpiEndColumnNo(fC->Column(Packed_dimension) + 1);
 
               rexpc->Typespec(assoc_tps);
@@ -3535,11 +3382,7 @@ std::vector<UHDM::range *> *CompileHelper::compileRanges(
 
         if (rexp) rexp->VpiParent(range);
         range->Right_expr(rexp);
-        range->VpiFile(fC->getFileName());
-        range->VpiLineNo(fC->Line(Constant_range));
-        range->VpiColumnNo(fC->Column(Constant_range));
-        range->VpiEndLineNo(fC->EndLine(Constant_range));
-        range->VpiEndColumnNo(fC->EndColumn(Constant_range));
+        fC->populateCoreMembers(Constant_range, Constant_range, range);
         ranges->push_back(range);
         range->VpiParent(pexpr);
       } else if ((fC->Type(fC->Child(Packed_dimension)) ==
@@ -3553,10 +3396,7 @@ std::vector<UHDM::range *> *CompileHelper::compileRanges(
         lexpc->VpiSize(64);
         lexpc->VpiValue("UINT:0");
         lexpc->VpiDecompile("0");
-        lexpc->VpiFile(fC->getFileName());
-        lexpc->VpiLineNo(fC->Line(Packed_dimension));
-        lexpc->VpiColumnNo(fC->Column(Packed_dimension));
-        lexpc->VpiEndLineNo(fC->EndLine(Packed_dimension));
+        fC->populateCoreMembers(Packed_dimension, Packed_dimension, lexpc);
         lexpc->VpiEndColumnNo(fC->Column(Packed_dimension) + 1);
         expr *lexp = lexpc;
 
@@ -3568,10 +3408,7 @@ std::vector<UHDM::range *> *CompileHelper::compileRanges(
         rexpc->VpiSize(0);
         rexpc->VpiValue("STRING:unsized");
         rexpc->VpiDecompile("unsized");
-        rexpc->VpiFile(fC->getFileName());
-        rexpc->VpiLineNo(fC->Line(Packed_dimension));
-        rexpc->VpiColumnNo(fC->Column(Packed_dimension));
-        rexpc->VpiEndLineNo(fC->EndLine(Packed_dimension));
+        fC->populateCoreMembers(Packed_dimension, Packed_dimension, rexpc);
         rexpc->VpiEndColumnNo(fC->Column(Packed_dimension) + 1);
         expr *rexp = rexpc;
 
@@ -3589,10 +3426,7 @@ std::vector<UHDM::range *> *CompileHelper::compileRanges(
         lexpc->VpiSize(64);
         lexpc->VpiValue("UINT:0");
         lexpc->VpiDecompile("0");
-        lexpc->VpiFile(fC->getFileName());
-        lexpc->VpiLineNo(fC->Line(Packed_dimension));
-        lexpc->VpiColumnNo(fC->Column(Packed_dimension));
-        lexpc->VpiEndLineNo(fC->EndLine(Packed_dimension));
+        fC->populateCoreMembers(Packed_dimension, Packed_dimension, lexpc);
         lexpc->VpiEndColumnNo(fC->Column(Packed_dimension) + 1);
         expr *lexp = lexpc;
 
@@ -3604,10 +3438,7 @@ std::vector<UHDM::range *> *CompileHelper::compileRanges(
         rexpc->VpiSize(0);
         rexpc->VpiValue("STRING:associative");
         rexpc->VpiDecompile("associative");
-        rexpc->VpiFile(fC->getFileName());
-        rexpc->VpiLineNo(fC->Line(Packed_dimension));
-        rexpc->VpiColumnNo(fC->Column(Packed_dimension));
-        rexpc->VpiEndLineNo(fC->EndLine(Packed_dimension));
+        fC->populateCoreMembers(Packed_dimension, Packed_dimension, rexpc);
         rexpc->VpiEndColumnNo(fC->Column(Packed_dimension) + 1);
 
         typespec *assoc_tps =
@@ -3764,11 +3595,7 @@ UHDM::any *CompileHelper::compilePartSelectRange(
     }
   }
   if (result != nullptr) {
-    result->VpiFile(fC->getFileName());
-    result->VpiLineNo(fC->Line(Constant_range));
-    result->VpiColumnNo(fC->Column(Constant_range));
-    result->VpiEndLineNo(fC->EndLine(Constant_range));
-    result->VpiEndColumnNo(fC->EndColumn(Constant_range));
+    fC->populateCoreMembers(Constant_range, Constant_range, result);
   }
   return result;
 }
@@ -4561,13 +4388,9 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
           (expr *)compileExpression(component, fC, Handle, compileDesign, pexpr,
                                     instance, reduce, muteErrors);
       fcall->Prefix(object);
-      std::string methodName = fC->SymName(Method);
+      const std::string &methodName = fC->SymName(Method);
       fcall->VpiName(methodName);
-      fcall->VpiFile(fC->getFileName());
-      fcall->VpiLineNo(fC->Line(Method));
-      fcall->VpiColumnNo(fC->Column(Method));
-      fcall->VpiEndLineNo(fC->EndLine(Method));
-      fcall->VpiEndColumnNo(fC->EndColumn(Method));
+      fC->populateCoreMembers(Method, Method, fcall);
       VectorOfany *arguments = compileTfCallArguments(
           component, fC, List_of_arguments, compileDesign, fcall, instance,
           reduce, muteErrors);
@@ -4622,11 +4445,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
       // TODO: make name part of the prefix, get vpiName from sibling
       fcall->Prefix(object);
       fcall->VpiName(rootName);
-      fcall->VpiFile(fC->getFileName());
-      fcall->VpiLineNo(fC->Line(Method));
-      fcall->VpiColumnNo(fC->Column(Method));
-      fcall->VpiEndLineNo(fC->EndLine(Method));
-      fcall->VpiEndColumnNo(fC->EndColumn(Method));
+      fC->populateCoreMembers(Method, Method, fcall);
       fcall->Tf_call_args(arguments);
       result = fcall;
     } else if (fC->Type(List_of_arguments) == slStringConst) {
@@ -4667,11 +4486,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
         tcall->Task(any_cast<task *>(tf));
         call = tcall;
       }
-      call->VpiFile(fC->getFileName());
-      call->VpiLineNo(fC->Line(Class_type_name));
-      call->VpiColumnNo(fC->Column(Class_type_name));
-      call->VpiEndLineNo(fC->EndLine(Class_type_name));
-      call->VpiEndColumnNo(fC->EndColumn(Class_type_name));
+      fC->populateCoreMembers(Class_type_name, Class_type_name, call);
     }
     Design *design = compileDesign->getCompiler()->getDesign();
     Package *pack = design->getPackage(packagename);
@@ -4717,11 +4532,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
               ref->VpiFullName(packagename + "::" + functionname);
               ref->Actual_group(param);
               ref->VpiParent(pexpr);
-              ref->VpiFile(fC->getFileName());
-              ref->VpiLineNo(fC->Line(name));
-              ref->VpiColumnNo(fC->Column(name));
-              ref->VpiEndLineNo(fC->EndLine(name));
-              ref->VpiEndColumnNo(fC->EndColumn(name));
+              fC->populateCoreMembers(name, name, ref);
               result = ref;
             }
             break;
@@ -4767,17 +4578,11 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
                                            compileDesign, pexpr, instance,
                                            reduce, muteErrors);
           if (result && (result->UhdmType() == UHDM::uhdmpart_select)) {
-            result->VpiLineNo(fC->Line(name));
-            result->VpiColumnNo(fC->Column(name));
-            result->VpiEndLineNo(fC->EndLine(dotedName));
-            result->VpiEndColumnNo(fC->EndColumn(dotedName));
+            fC->populateCoreMembers(name, dotedName, result);
             if ((result->VpiParent() != nullptr) &&
                 (result->VpiParent()->UhdmType() == UHDM::uhdmref_obj)) {
               ref_obj *const parent = (ref_obj *)result->VpiParent();
-              parent->VpiLineNo(fC->Line(name));
-              parent->VpiColumnNo(fC->Column(name));
-              parent->VpiEndLineNo(fC->EndLine(name));
-              parent->VpiEndColumnNo(fC->EndColumn(name));
+              fC->populateCoreMembers(name, name, parent);
             }
           }
           return result;
@@ -4807,11 +4612,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
             ref->VpiParent(pexpr);
             result = ref;
           }
-          result->VpiFile(fC->getFileName());
-          result->VpiLineNo(fC->Line(name));
-          result->VpiColumnNo(fC->Column(name));
-          result->VpiEndLineNo(fC->EndLine(name));
-          result->VpiEndColumnNo(fC->EndColumn(name));
+          fC->populateCoreMembers(name, name, result);
           return result;
         }
       }
@@ -4857,11 +4658,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
             ref->VpiName(tmpName);
             ref->VpiFullName(tmpName);
             ref->VpiParent(path);
-            ref->VpiFile(fC->getFileName());
-            ref->VpiLineNo(fC->Line(name));
-            ref->VpiColumnNo(fC->Column(name));
-            ref->VpiEndLineNo(fC->EndLine(name));
-            ref->VpiEndColumnNo(fC->EndColumn(name));
+            fC->populateCoreMembers(name, name, ref);
             tmpName.clear();
             is_hierarchical = true;
           }
@@ -4926,11 +4723,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
                 select->VpiIndex(index);
                 select->VpiName(tmpName);
                 select->VpiFullName(tmpName);
-                select->VpiFile(fC->getFileName());
-                select->VpiLineNo(fC->Line(name));
-                select->VpiColumnNo(fC->Column(name));
-                select->VpiEndLineNo(fC->EndLine(name));
-                select->VpiEndColumnNo(fC->EndColumn(name));
+                fC->populateCoreMembers(name, name, select);
                 std::string indexName = decompileHelper(index);
                 the_name += indexName;
                 if (!tmpName.empty()) ref->VpiName(tmpName + indexName);
@@ -4940,11 +4733,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
               elems->push_back(ref);
               ref->VpiName(tmpName);
               ref->VpiFullName(tmpName);
-              ref->VpiFile(fC->getFileName());
-              ref->VpiLineNo(fC->Line(name));
-              ref->VpiColumnNo(fC->Column(name));
-              ref->VpiEndLineNo(fC->EndLine(name));
-              ref->VpiEndColumnNo(fC->EndColumn(name));
+              fC->populateCoreMembers(name, name, ref);
             }
             tmpName.clear();
             if (dtype == VObjectType::slSelect)
@@ -4992,11 +4781,8 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
             } else {
               fcall = s.MakeMethod_func_call();
               fcall->VpiName(method_name);
-              fcall->VpiFile(fC->getFileName());
-              fcall->VpiLineNo(fC->Line(method_name_node));
-              fcall->VpiColumnNo(fC->Column(method_name_node));
-              fcall->VpiEndLineNo(fC->EndLine(method_name_node));
-              fcall->VpiEndColumnNo(fC->EndColumn(method_name_node));
+              fC->populateCoreMembers(method_name_node, method_name_node,
+                                      fcall);
               NodeId list_of_arguments =
                   fC->Sibling(fC->Child(fC->Child(method_child)));
               NodeId with_conditions_node;
@@ -5025,11 +4811,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
             fcall = s.MakeMethod_func_call();
             std::string methodName = fC->SymName(dotedName);
             fcall->VpiName(methodName);
-            fcall->VpiFile(fC->getFileName());
-            fcall->VpiLineNo(fC->Line(dotedName));
-            fcall->VpiColumnNo(fC->Column(dotedName));
-            fcall->VpiEndLineNo(fC->EndLine(dotedName));
-            fcall->VpiEndColumnNo(fC->EndColumn(dotedName));
+            fC->populateCoreMembers(dotedName, dotedName, fcall);
             VectorOfany *arguments = compileTfCallArguments(
                 component, fC, List_of_arguments, compileDesign, fcall,
                 instance, reduce, muteErrors);

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -715,12 +715,8 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
       if (typespecs) typespecs->push_back(enum_t);
     }
 
-    enum_t->VpiFile(the_enum->getFileContent()->getFileName());
-    enum_t->VpiLineNo(the_enum->getFileContent()->Line(type_declaration));
-    enum_t->VpiColumnNo(the_enum->getFileContent()->Column(type_declaration));
-    enum_t->VpiEndLineNo(the_enum->getFileContent()->EndLine(type_declaration));
-    enum_t->VpiEndColumnNo(
-        the_enum->getFileContent()->EndColumn(type_declaration));
+    the_enum->getFileContent()->populateCoreMembers(type_declaration,
+                                                    type_declaration, enum_t);
 
     // Enum basetype
     enum_t->Base_typespec(the_enum->getBaseTypespec());
@@ -765,11 +761,8 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
 
       enum_const* econst = s.MakeEnum_const();
       econst->VpiName(enumName);
-      econst->VpiFile(fC->getFileName());
-      econst->VpiLineNo(fC->Line(enum_name_declaration));
-      econst->VpiColumnNo(fC->Column(enum_name_declaration));
-      econst->VpiEndLineNo(fC->EndLine(enum_name_declaration));
-      econst->VpiEndColumnNo(fC->EndColumn(enum_name_declaration));
+      fC->populateCoreMembers(enum_name_declaration, enum_name_declaration,
+                              econst);
       econst->VpiValue(value->uhdmValue());
       if (enumValueId) {
         any* exp = compileExpression(scope, fC, enumValueId, compileDesign,
@@ -1941,11 +1934,8 @@ void CompileHelper::compileImportDeclaration(DesignComponent* component,
   Serializer& s = compileDesign->getSerializer();
   while (package_import_item_id) {
     import_typespec* import_stmt = s.MakeImport_typespec();
-    import_stmt->VpiFile(fC->getFileName());
-    import_stmt->VpiLineNo(fC->Line(package_import_item_id));
-    import_stmt->VpiColumnNo(fC->Column(package_import_item_id));
-    import_stmt->VpiEndLineNo(fC->EndLine(package_import_item_id));
-    import_stmt->VpiEndColumnNo(fC->EndColumn(package_import_item_id));
+    fC->populateCoreMembers(package_import_item_id, package_import_item_id,
+                            import_stmt);
     import_stmt->VpiName(fC->SymName(package_import_item_id));
     NodeId package_name_id = fC->Child(package_import_item_id);
 
@@ -2211,11 +2201,8 @@ n<> u<17> t<Continuous_assign> p<18> c<16> l<4>
       cassign->Rhs((UHDM::expr*)rhs_exp);
       setParentNoOverride(lhs_exp, cassign);
       setParentNoOverride(rhs_exp, cassign);
-      cassign->VpiFile(fC->getFileName());
-      cassign->VpiLineNo(fC->Line(List_of_net_assignments));
-      cassign->VpiColumnNo(fC->Column(List_of_net_assignments));
-      cassign->VpiEndLineNo(fC->EndLine(List_of_net_assignments));
-      cassign->VpiEndColumnNo(fC->EndColumn(List_of_net_assignments));
+      fC->populateCoreMembers(List_of_net_assignments, List_of_net_assignments,
+                              cassign);
       if (component->getContAssigns() == nullptr) {
         component->setContAssigns(s.MakeCont_assignVec());
       }
@@ -2280,11 +2267,7 @@ bool CompileHelper::compileInitialBlock(DesignComponent* component,
     processes = component->getProcesses();
   }
   processes->push_back(init);
-  init->VpiFile(fC->getFileName());
-  init->VpiLineNo(fC->Line(initial_construct));
-  init->VpiColumnNo(fC->Column(initial_construct));
-  init->VpiEndLineNo(fC->EndLine(initial_construct));
-  init->VpiEndColumnNo(fC->EndColumn(initial_construct));
+  fC->populateCoreMembers(initial_construct, initial_construct, init);
   NodeId Statement_or_null = fC->Child(initial_construct);
   VectorOfany* stmts =
       compileStmt(component, fC, Statement_or_null, compileDesign, init);
@@ -2334,11 +2317,7 @@ UHDM::atomic_stmt* CompileHelper::compileProceduralTimingControlStmt(
   std::string value = fC->SymName(IntConst);
   UHDM::delay_control* dc = s.MakeDelay_control();
   dc->VpiDelay(value);
-  dc->VpiFile(fC->getFileName());
-  dc->VpiLineNo(fC->Line(fC->Child(Delay_control)));
-  dc->VpiColumnNo(fC->Column(fC->Child(Delay_control)));
-  dc->VpiEndLineNo(fC->EndLine(fC->Child(Delay_control)));
-  dc->VpiEndColumnNo(fC->EndColumn(fC->Child(Delay_control)));
+  fC->populateCoreMembers(Delay_control, Delay_control, dc);
   NodeId Statement_or_null = fC->Sibling(Procedural_timing_control);
   if (Statement_or_null) {
     VectorOfany* st = compileStmt(component, fC, Statement_or_null,
@@ -2368,11 +2347,7 @@ UHDM::atomic_stmt* CompileHelper::compileProceduralTimingControlStmt(
           }
         }
         if (call) {
-          call->VpiFile(fC->getFileName());
-          call->VpiLineNo(fC->Line(fC->Child(unit)));
-          call->VpiColumnNo(fC->Column(fC->Child(unit)));
-          call->VpiEndLineNo(fC->EndLine(fC->Child(unit)));
-          call->VpiEndColumnNo(fC->EndColumn(fC->Child(unit)));
+          fC->populateCoreMembers(fC->Child(unit), fC->Child(unit), call);
           dc->Stmt(call);
           call->VpiParent(dc);
         }
@@ -2397,11 +2372,8 @@ UHDM::atomic_stmt* CompileHelper::compileDelayControl(
   std::string value = fC->SymName(IntConst);
   UHDM::delay_control* dc = s.MakeDelay_control();
   dc->VpiDelay(value);
-  dc->VpiFile(fC->getFileName());
-  dc->VpiLineNo(fC->Line(fC->Child(Delay_control)));
-  dc->VpiColumnNo(fC->Column(fC->Child(Delay_control)));
-  dc->VpiEndLineNo(fC->EndLine(fC->Child(Delay_control)));
-  dc->VpiEndColumnNo(fC->EndColumn(fC->Child(Delay_control)));
+  fC->populateCoreMembers(fC->Child(Delay_control), fC->Child(Delay_control),
+                          dc);
   return dc;
 }
 
@@ -2452,11 +2424,7 @@ bool CompileHelper::compileAlwaysBlock(DesignComponent* component,
     stmt->VpiParent(always);
   }
 
-  always->VpiFile(fC->getFileName());
-  always->VpiLineNo(fC->Line(id));
-  always->VpiColumnNo(fC->Column(id));
-  always->VpiEndLineNo(fC->EndLine(id));
-  always->VpiEndColumnNo(fC->EndColumn(id));
+  fC->populateCoreMembers(id, id, always);
   compileDesign->unlockSerializer();
   return true;
 }
@@ -2561,11 +2529,7 @@ bool CompileHelper::compileParameterDeclaration(
       }
       UHDM::type_parameter* p = s.MakeType_parameter();
       p->VpiName(fC->SymName(typeNameId));
-      p->VpiFile(fC->getFileName());
-      p->VpiLineNo(fC->Line(typeNameId));
-      p->VpiColumnNo(fC->Column(typeNameId));
-      p->VpiEndLineNo(fC->Line(typeNameId));
-      p->VpiEndColumnNo(fC->Column(typeNameId));
+      fC->populateCoreMembers(typeNameId, typeNameId, p);
       typespec* tps = compileTypespec(component, fC, ntype, compileDesign, p,
                                       nullptr, false);
       p->Typespec(tps);
@@ -2592,11 +2556,7 @@ bool CompileHelper::compileParameterDeclaration(
       NodeId Constant_param_expression = fC->Sibling(Identifier);
       UHDM::type_parameter* p = s.MakeType_parameter();
       p->VpiName(fC->SymName(Identifier));
-      p->VpiFile(fC->getFileName());
-      p->VpiLineNo(fC->Line(Identifier));
-      p->VpiColumnNo(fC->Column(Identifier));
-      p->VpiEndLineNo(fC->EndLine(Identifier));
-      p->VpiEndColumnNo(fC->EndColumn(Identifier));
+      fC->populateCoreMembers(Identifier, Identifier, p);
       NodeId Data_type = fC->Child(Constant_param_expression);
       typespec* tps = compileTypespec(component, fC, Data_type, compileDesign,
                                       p, nullptr, false);
@@ -2752,11 +2712,7 @@ bool CompileHelper::compileParameterDeclaration(
         ts->VpiParent(param);
       }
       param->VpiSigned(isSigned);
-      param->VpiFile(fC->getFileName());
-      param->VpiLineNo(fC->Line(name));
-      param->VpiColumnNo(fC->Column(name));
-      param->VpiEndLineNo(fC->EndLine(name));
-      param->VpiEndColumnNo(fC->EndColumn(name));
+      fC->populateCoreMembers(name, name, param);
       param->VpiName(fC->SymName(name));
 
       if (localParam) {
@@ -2769,11 +2725,7 @@ bool CompileHelper::compileParameterDeclaration(
       UHDM::param_assign* param_assign = s.MakeParam_assign();
       assign->setUhdmParamAssign(param_assign);
       component->addParamAssign(assign);
-      param_assign->VpiFile(fC->getFileName());
-      param_assign->VpiLineNo(fC->Line(Param_assignment));
-      param_assign->VpiColumnNo(fC->Column(Param_assignment));
-      param_assign->VpiEndLineNo(fC->EndLine(Param_assignment));
-      param_assign->VpiEndColumnNo(fC->EndColumn(Param_assignment));
+      fC->populateCoreMembers(Param_assignment, Param_assignment, param_assign);
       param_assigns->push_back(param_assign);
       param_assign->Lhs(param);
 
@@ -2785,11 +2737,8 @@ bool CompileHelper::compileParameterDeclaration(
           expr* rhs = (expr*)compileExpression(
               component, fC, value, compileDesign, nullptr, instance, false);
           UHDM::param_assign* param_assign = s.MakeParam_assign();
-          param_assign->VpiFile(fC->getFileName());
-          param_assign->VpiLineNo(fC->Line(Param_assignment));
-          param_assign->VpiColumnNo(fC->Column(Param_assignment));
-          param_assign->VpiEndLineNo(fC->EndLine(Param_assignment));
-          param_assign->VpiEndColumnNo(fC->EndColumn(Param_assignment));
+          fC->populateCoreMembers(Param_assignment, Param_assignment,
+                                  param_assign);
           ElaboratorListener listener(&s, false, true);
           any* pclone = UHDM::clone_tree(param, s, &listener);
           param_assign->Lhs(pclone);
@@ -3046,19 +2995,11 @@ UHDM::any* CompileHelper::compileTfCall(DesignComponent* component,
       tfNameNode = fC->Sibling(Constant_bit_select);
       method_func_call* fcall = s.MakeMethod_func_call();
       const std::string& mname = fC->SymName(tfNameNode);
-      fcall->VpiFile(fC->getFileName());
-      fcall->VpiLineNo(fC->Line(tfNameNode));
-      fcall->VpiColumnNo(fC->Column(tfNameNode));
-      fcall->VpiEndLineNo(fC->EndLine(tfNameNode));
-      fcall->VpiEndColumnNo(fC->EndColumn(tfNameNode));
+      fC->populateCoreMembers(tfNameNode, tfNameNode, fcall);
       fcall->VpiName(mname);
       ref_obj* prefix = s.MakeRef_obj();
       prefix->VpiName(name);
-      prefix->VpiFile(fC->getFileName());
-      prefix->VpiLineNo(fC->Line(dollar_or_string));
-      prefix->VpiColumnNo(fC->Column(dollar_or_string));
-      prefix->VpiEndLineNo(fC->EndLine(dollar_or_string));
-      prefix->VpiEndColumnNo(fC->EndColumn(dollar_or_string));
+      fC->populateCoreMembers(dollar_or_string, dollar_or_string, prefix);
       fcall->Prefix(prefix);
       call = fcall;
     }
@@ -3141,11 +3082,7 @@ UHDM::any* CompileHelper::compileTfCall(DesignComponent* component,
   }
   if (call->VpiName().empty()) call->VpiName(name);
   if (call->VpiLineNo() == 0) {
-    call->VpiFile(fC->getFileName());
-    call->VpiLineNo(fC->Line(Tf_call_stmt));
-    call->VpiColumnNo(fC->Column(Tf_call_stmt));
-    call->VpiEndLineNo(fC->EndLine(Tf_call_stmt));
-    call->VpiEndColumnNo(fC->EndColumn(Tf_call_stmt));
+    fC->populateCoreMembers(Tf_call_stmt, Tf_call_stmt, call);
   }
   NodeId argListNode = fC->Sibling(tfNameNode);
   if (fC->Type(argListNode) == slAttribute_instance) {
@@ -3231,11 +3168,7 @@ VectorOfany* CompileHelper::compileTfCallArguments(
         c->VpiDecompile("0");
         c->VpiSize(64);
         c->VpiConstType(vpiIntConst);
-        c->VpiFile(fC->getFileName());
-        c->VpiLineNo(fC->Line(argumentNode));
-        c->VpiColumnNo(fC->Column(argumentNode));
-        c->VpiEndLineNo(fC->EndLine(argumentNode));
-        c->VpiEndColumnNo(fC->EndColumn(argumentNode));
+        fC->populateCoreMembers(argumentNode, argumentNode, c);
         arguments->push_back(c);
       }
     }
@@ -3305,11 +3238,8 @@ UHDM::assignment* CompileHelper::compileBlockingAssignment(
     AssignOp_Assign = InvalidNodeId;
     if (fC->Type(Delay_or_event_control) == slDynamic_array_new) {
       method_func_call* fcall = s.MakeMethod_func_call();
-      fcall->VpiFile(fC->getFileName());
-      fcall->VpiLineNo(fC->Line(Delay_or_event_control));
-      fcall->VpiColumnNo(fC->Column(Delay_or_event_control));
-      fcall->VpiEndLineNo(fC->EndLine(Delay_or_event_control));
-      fcall->VpiEndColumnNo(fC->EndColumn(Delay_or_event_control));
+      fC->populateCoreMembers(Delay_or_event_control, Delay_or_event_control,
+                              fcall);
       fcall->VpiName("new");
       NodeId List_of_arguments = fC->Child(Delay_or_event_control);
       if (List_of_arguments) {
@@ -3364,11 +3294,8 @@ UHDM::assignment* CompileHelper::compileBlockingAssignment(
                                                compileDesign, pstmt, instance));
     method_func_call* fcall = s.MakeMethod_func_call();
     fcall->VpiName("new");
-    fcall->VpiFile(fC->getFileName());
-    fcall->VpiLineNo(fC->Line(Hierarchical_identifier));
-    fcall->VpiColumnNo(fC->Column(Hierarchical_identifier));
-    fcall->VpiEndLineNo(fC->EndLine(Hierarchical_identifier));
-    fcall->VpiEndColumnNo(fC->EndColumn(Hierarchical_identifier));
+    fC->populateCoreMembers(Hierarchical_identifier, Hierarchical_identifier,
+                            fcall);
     if (List_of_arguments) {
       VectorOfany* arguments =
           compileTfCallArguments(component, fC, List_of_arguments,
@@ -3390,11 +3317,8 @@ UHDM::assignment* CompileHelper::compileBlockingAssignment(
     NodeId IntConst = fC->Child(Delay_control);
     const std::string& value = fC->SymName(IntConst);
     delay_control->VpiDelay(value);
-    delay_control->VpiFile(fC->getFileName());
-    delay_control->VpiLineNo(fC->Line(fC->Child(Delay_control)));
-    delay_control->VpiColumnNo(fC->Column(fC->Child(Delay_control)));
-    delay_control->VpiEndLineNo(fC->EndLine(fC->Child(Delay_control)));
-    delay_control->VpiEndColumnNo(fC->EndColumn(fC->Child(Delay_control)));
+    fC->populateCoreMembers(fC->Child(Delay_control), fC->Child(Delay_control),
+                            delay_control);
   }
   if (AssignOp_Assign)
     assign->VpiOpType(UhdmWriter::getVpiOpType(fC->Type(AssignOp_Assign)));
@@ -3447,11 +3371,7 @@ std::vector<UHDM::attribute*>* CompileHelper::compileAttributes(
       NodeId Constant_expression = fC->Sibling(Attr_name);
       const std::string& name = fC->SymName(fC->Child(Attr_name));
       attribute->VpiName(name);
-      attribute->VpiFile(fC->getFileName());
-      attribute->VpiLineNo(fC->Line(Attr_spec));
-      attribute->VpiColumnNo(fC->Column(Attr_spec));
-      attribute->VpiEndLineNo(fC->EndLine(Attr_spec));
-      attribute->VpiEndColumnNo(fC->EndColumn(Attr_spec));
+      fC->populateCoreMembers(Attr_spec, Attr_spec, attribute);
       results->push_back(attribute);
       if (Constant_expression) {
         UHDM::expr* expr = (UHDM::expr*)compileExpression(
@@ -3489,11 +3409,7 @@ UHDM::clocking_block* CompileHelper::compileClockingBlock(
   else
     name = "unnamed_clocking_block";
   cblock->VpiName(name);
-  cblock->VpiFile(fC->getFileName());
-  cblock->VpiLineNo(fC->Line(nodeId));
-  cblock->VpiColumnNo(fC->Column(nodeId));
-  cblock->VpiEndLineNo(fC->EndLine(nodeId));
-  cblock->VpiEndColumnNo(fC->EndColumn(nodeId));
+  fC->populateCoreMembers(nodeId, nodeId, cblock);
   event_control* ctrl = compileClocking_event(component, fC, clocking_event,
                                               compileDesign, cblock, instance);
   cblock->Clocking_event(ctrl);
@@ -3691,11 +3607,8 @@ UHDM::clocking_block* CompileHelper::compileClockingBlock(
           UHDM::clocking_io_decl* io = s.MakeClocking_io_decl();
           io->VpiInputEdge(inputEdge);
           io->VpiOutputEdge(outputEdge);
-          io->VpiFile(fC->getFileName());
-          io->VpiLineNo(fC->Line(Clocking_decl_assign));
-          io->VpiColumnNo(fC->Column(Clocking_decl_assign));
-          io->VpiEndLineNo(fC->EndLine(Clocking_decl_assign));
-          io->VpiEndColumnNo(fC->EndColumn(Clocking_decl_assign));
+          fC->populateCoreMembers(Clocking_decl_assign, Clocking_decl_assign,
+                                  io);
           if (Expr) {
             UHDM::expr* exp = (expr*)compileExpression(
                 component, fC, Expr, compileDesign, ctrl, instance);
@@ -3733,11 +3646,7 @@ UHDM::event_control* CompileHelper::compileClocking_event(
     ValuedComponentI* instance) {
   UHDM::Serializer& s = compileDesign->getSerializer();
   event_control* ctrl = s.MakeEvent_control();
-  ctrl->VpiFile(fC->getFileName());
-  ctrl->VpiLineNo(fC->Line(nodeId));
-  ctrl->VpiColumnNo(fC->Column(nodeId));
-  ctrl->VpiEndLineNo(fC->EndLine(nodeId));
-  ctrl->VpiEndColumnNo(fC->EndColumn(nodeId));
+  fC->populateCoreMembers(nodeId, nodeId, ctrl);
   NodeId identifier = fC->Child(nodeId);
   UHDM::any* exp = compileExpression(component, fC, identifier, compileDesign,
                                      pexpr, instance);
@@ -3938,11 +3847,7 @@ void CompileHelper::compileLetDeclaration(DesignComponent* component,
   component->lateBinding(true);
   let_decl* decl = s.MakeLet_decl();
   decl->VpiName(name);
-  decl->VpiFile(fC->getFileName());
-  decl->VpiLineNo(fC->Line(Let_declaration));
-  decl->VpiColumnNo(fC->Column(Let_declaration));
-  decl->VpiEndLineNo(fC->EndLine(Let_declaration));
-  decl->VpiEndColumnNo(fC->EndColumn(Let_declaration));
+  fC->populateCoreMembers(Let_declaration, Let_declaration, decl);
   VectorOfexpr* exprs = s.MakeExprVec();
   exprs->push_back(exp);
   decl->Expressions(exprs);

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -243,11 +243,7 @@ bool CompileModule::collectUdpObjects_() {
         while (port) {
           UHDM::io_decl* io = s.MakeIo_decl();
           const std::string& name = fC->SymName(port);
-          io->VpiFile(fC->getFileName());
-          io->VpiLineNo(fC->Line(port));
-          io->VpiColumnNo(fC->Column(port));
-          io->VpiEndLineNo(fC->EndLine(port));
-          io->VpiEndColumnNo(fC->EndColumn(port));
+          fC->populateCoreMembers(port, port, io);
           io->VpiName(name);
           io->VpiParent(defn);
           ios->push_back(io);
@@ -269,11 +265,7 @@ bool CompileModule::collectUdpObjects_() {
         const std::string& outputname = fC->SymName(Output);
         std::vector<UHDM::io_decl*>* ios = defn->Io_decls();
         UHDM::logic_net* net = s.MakeLogic_net();
-        net->VpiFile(fC->getFileName());
-        net->VpiLineNo(fC->Line(id));
-        net->VpiColumnNo(fC->Column(id));
-        net->VpiEndLineNo(fC->EndLine(id));
-        net->VpiEndColumnNo(fC->EndColumn(id));
+        fC->populateCoreMembers(id, id, net);
         net->Attributes(attributes);
         net->VpiParent(defn);
         if (ios) {
@@ -305,11 +297,7 @@ bool CompileModule::collectUdpObjects_() {
           std::vector<UHDM::io_decl*>* ios = defn->Io_decls();
           if (ios) {
             UHDM::logic_net* net = s.MakeLogic_net();
-            net->VpiFile(fC->getFileName());
-            net->VpiLineNo(fC->Line(id));
-            net->VpiColumnNo(fC->Column(id));
-            net->VpiEndLineNo(fC->EndLine(id));
-            net->VpiEndColumnNo(fC->EndColumn(id));
+            fC->populateCoreMembers(id, id, net);
             net->Attributes(attributes);
             net->VpiParent(defn);
             for (auto io : *ios) {
@@ -365,11 +353,7 @@ bool CompileModule::collectUdpObjects_() {
         entry->VpiParent(defn);
         entry->VpiValue(ventry);
         entry->VpiSize(nb);
-        entry->VpiFile(fC->getFileName());
-        entry->VpiLineNo(fC->Line(Level_input_list));
-        entry->VpiColumnNo(fC->Column(Level_input_list));
-        entry->VpiEndLineNo(fC->EndLine(Level_input_list));
-        entry->VpiEndColumnNo(fC->EndColumn(Level_input_list));
+        fC->populateCoreMembers(Level_input_list, Level_input_list, entry);
         entries->push_back(entry);
         break;
       }
@@ -466,11 +450,7 @@ bool CompileModule::collectUdpObjects_() {
         entry->VpiParent(defn);
         entry->VpiValue(ventry);
         entry->VpiSize(nb);
-        entry->VpiFile(fC->getFileName());
-        entry->VpiLineNo(fC->Line(Level_input_list));
-        entry->VpiColumnNo(fC->Column(Level_input_list));
-        entry->VpiEndLineNo(fC->EndLine(Level_input_list));
-        entry->VpiEndColumnNo(fC->EndColumn(Level_input_list));
+        fC->populateCoreMembers(Level_input_list, Level_input_list, entry);
         entries->push_back(entry);
         break;
       }
@@ -478,11 +458,7 @@ bool CompileModule::collectUdpObjects_() {
         NodeId Identifier = fC->Child(id);
         NodeId Value = fC->Sibling(Identifier);
         UHDM::initial* init = s.MakeInitial();
-        init->VpiFile(fC->getFileName());
-        init->VpiLineNo(fC->Line(id));
-        init->VpiColumnNo(fC->Column(id));
-        init->VpiEndLineNo(fC->EndLine(id));
-        init->VpiEndColumnNo(fC->EndColumn(id));
+        fC->populateCoreMembers(id, id, init);
         init->VpiParent(defn);
         defn->Initial(init);
         UHDM::assign_stmt* assign_stmt = s.MakeAssign_stmt();
@@ -490,17 +466,9 @@ bool CompileModule::collectUdpObjects_() {
         UHDM::ref_obj* ref = s.MakeRef_obj();
         ref->VpiName(fC->SymName(Identifier));
         ref->VpiParent(assign_stmt);
-        ref->VpiFile(fC->getFileName());
-        ref->VpiLineNo(fC->Line(Identifier));
-        ref->VpiColumnNo(fC->Column(Identifier));
-        ref->VpiEndLineNo(fC->EndLine(Identifier));
-        ref->VpiEndColumnNo(fC->EndColumn(Identifier));
+        fC->populateCoreMembers(Identifier, Identifier, ref);
         assign_stmt->Lhs(ref);
-        assign_stmt->VpiFile(fC->getFileName());
-        assign_stmt->VpiLineNo(fC->Line(id));
-        assign_stmt->VpiColumnNo(fC->Column(id));
-        assign_stmt->VpiEndLineNo(fC->EndLine(id));
-        assign_stmt->VpiEndColumnNo(fC->EndColumn(id));
+        fC->populateCoreMembers(id, id, assign_stmt);
         assign_stmt->VpiParent(init);
         UHDM::constant* c = s.MakeConstant();
         assign_stmt->Rhs(c);
@@ -510,11 +478,7 @@ bool CompileModule::collectUdpObjects_() {
         c->VpiSize(64);
         c->VpiConstType(vpiUIntConst);
         c->VpiParent(assign_stmt);
-        c->VpiFile(fC->getFileName());
-        c->VpiLineNo(fC->Line(Value));
-        c->VpiColumnNo(fC->Column(Value));
-        c->VpiEndLineNo(fC->EndLine(Value));
-        c->VpiEndColumnNo(fC->EndColumn(Value));
+        fC->populateCoreMembers(Value, Value, c);
         break;
       }
       default:

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -436,18 +436,10 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
         while (loopVarId) {
           ref_var* ref = s.MakeRef_var();
           ref->VpiName(fC->SymName(loopVarId));
-          ref->VpiFile(fC->getFileName());
-          ref->VpiLineNo(fC->Line(loopVarId));
-          ref->VpiColumnNo(fC->Column(loopVarId));
-          ref->VpiEndLineNo(fC->EndLine(loopVarId));
-          ref->VpiEndColumnNo(fC->EndColumn(loopVarId));
+          fC->populateCoreMembers(loopVarId, loopVarId, ref);
           typespec* tps = s.MakeUnsupported_typespec();
           tps->VpiName(fC->SymName(loopVarId));
-          tps->VpiFile(fC->getFileName());
-          tps->VpiLineNo(fC->Line(loopVarId));
-          tps->VpiColumnNo(fC->Column(loopVarId));
-          tps->VpiEndLineNo(fC->EndLine(loopVarId));
-          tps->VpiEndColumnNo(fC->EndColumn(loopVarId));
+          fC->populateCoreMembers(loopVarId, loopVarId, tps);
           tps->VpiParent(ref);
           ref->Typespec(tps);
           component->needLateTypedefBinding(ref);
@@ -495,11 +487,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
         NodeId value = fC->Sibling(name);
         expr* unpacked = nullptr;
         UHDM::parameter* param = s.MakeParameter();
-        param->VpiFile(fC->getFileName());
-        param->VpiLineNo(fC->Line(Param_assignment));
-        param->VpiColumnNo(fC->Column(Param_assignment));
-        param->VpiEndLineNo(fC->EndLine(Param_assignment));
-        param->VpiEndColumnNo(fC->EndColumn(Param_assignment));
+        fC->populateCoreMembers(Param_assignment, Param_assignment, param);
         // Unpacked dimensions
         if (fC->Type(value) == VObjectType::slUnpacked_dimension) {
           int unpackedSize;
@@ -514,11 +502,8 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
         }
         param->VpiLocalParam(true);
         UHDM::param_assign* param_assign = s.MakeParam_assign();
-        param_assign->VpiFile(fC->getFileName());
-        param_assign->VpiLineNo(fC->Line(Param_assignment));
-        param_assign->VpiColumnNo(fC->Column(Param_assignment));
-        param_assign->VpiEndLineNo(fC->EndLine(Param_assignment));
-        param_assign->VpiEndColumnNo(fC->EndColumn(Param_assignment));
+        fC->populateCoreMembers(Param_assignment, Param_assignment,
+                                param_assign);
         param_assigns->push_back(param_assign);
         param->VpiName(fC->SymName(name));
         param->Typespec(ts);
@@ -585,11 +570,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
           compileExpression(component, fC, Condition, compileDesign);
       do_while->VpiCondition((UHDM::expr*)cond_exp);
       if (cond_exp) cond_exp->VpiParent(do_while);
-      do_while->VpiFile(fC->getFileName());
-      do_while->VpiLineNo(fC->Line(the_stmt));
-      do_while->VpiColumnNo(fC->Column(the_stmt));
-      do_while->VpiEndLineNo(fC->EndLine(Condition));
-      do_while->VpiEndColumnNo(fC->EndColumn(Condition));
+      fC->populateCoreMembers(the_stmt, Condition, do_while);
       stmt = do_while;
       break;
     }
@@ -785,13 +766,11 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
         for (any* st : *stmts) {
           if (UHDM::atomic_stmt* stm = any_cast<atomic_stmt*>(st)) {
             stm->VpiName(label);
-            stm->VpiLineNo(fC->Line(the_stmt));
-            stm->VpiColumnNo(fC->Column(the_stmt));
+            fC->populateCoreMembers(the_stmt, InvalidNodeId, stm);
           } else if (UHDM::concurrent_assertions* stm =
                          any_cast<concurrent_assertions*>(st)) {
             stm->VpiName(label);
-            stm->VpiLineNo(fC->Line(the_stmt));
-            stm->VpiColumnNo(fC->Column(the_stmt));
+            fC->populateCoreMembers(the_stmt, InvalidNodeId, stm);
           }
         }
       }
@@ -840,11 +819,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
           compileExpression(component, fC, Clocking_event, compileDesign, pstmt,
                             instance, false));
       prop_spec->VpiPropertyExpr(property_expr);
-      prop_spec->VpiFile(fC->getFileName());
-      prop_spec->VpiLineNo(fC->Line(Property_expr));
-      prop_spec->VpiColumnNo(fC->Column(Property_expr));
-      prop_spec->VpiEndLineNo(fC->EndLine(Property_expr));
-      prop_spec->VpiEndColumnNo(fC->EndColumn(Property_expr));
+      fC->populateCoreMembers(Property_expr, Property_expr, prop_spec);
       expect->Property_spec(prop_spec);
       expect->Stmt(if_stmt);
       expect->Else_stmt(else_stmt);
@@ -860,12 +835,9 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
       if (UHDM::atomic_stmt* stm = any_cast<atomic_stmt*>(stmt))
         stm->Attributes(attributes);
     }
-    stmt->VpiFile(fC->getFileName(the_stmt));
+
     if (stmt->VpiLineNo() == 0) {
-      stmt->VpiLineNo(fC->Line(the_stmt));
-      stmt->VpiColumnNo(fC->Column(the_stmt));
-      stmt->VpiEndLineNo(fC->EndLine(the_stmt));
-      stmt->VpiEndColumnNo(fC->EndColumn(the_stmt));
+      fC->populateCoreMembers(the_stmt, the_stmt, stmt);
     }
     stmt->VpiParent(pstmt);
     results = s.MakeAnyVec();
@@ -897,11 +869,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
       Error err(ErrorDefinition::UHDM_UNSUPPORTED_STMT, loc);
       errors->addError(err);
       ustmt->VpiValue(StrCat("STRING:", lineText));
-      ustmt->VpiFile(fC->getFileName(the_stmt));
-      ustmt->VpiLineNo(fC->Line(the_stmt));
-      ustmt->VpiColumnNo(fC->Column(the_stmt));
-      ustmt->VpiEndLineNo(fC->EndLine(the_stmt));
-      ustmt->VpiEndColumnNo(fC->EndColumn(the_stmt));
+      fC->populateCoreMembers(the_stmt, the_stmt, ustmt);
       ustmt->VpiParent(pstmt);
       stmt = ustmt;  // NOLINT
       // std::cout << "UNSUPPORTED STATEMENT: " << fC->getFileName(the_stmt)
@@ -969,11 +937,7 @@ VectorOfany* CompileHelper::compileDataDeclaration(
                                         pstmt, instance, false, false);
 
         if (var) {
-          var->VpiFile(fC->getFileName());
-          var->VpiLineNo(fC->Line(Var));
-          var->VpiColumnNo(fC->Column(Var));
-          var->VpiEndLineNo(fC->EndLine(Var));
-          var->VpiEndColumnNo(fC->EndColumn(Var));
+          fC->populateCoreMembers(Var, Var, var);
           var->VpiConstantVariable(const_status);
           var->VpiAutomatic(automatic_status);
           var->VpiName(fC->SymName(Var));
@@ -1012,11 +976,8 @@ VectorOfany* CompileHelper::compileDataDeclaration(
         if (var) {
           var->VpiParent(assign_stmt);
         }
-        assign_stmt->VpiFile(fC->getFileName());
-        assign_stmt->VpiLineNo(fC->Line(Variable_decl_assignment));
-        assign_stmt->VpiColumnNo(fC->Column(Variable_decl_assignment));
-        assign_stmt->VpiEndLineNo(fC->EndLine(Variable_decl_assignment));
-        assign_stmt->VpiEndColumnNo(fC->EndColumn(Variable_decl_assignment));
+        fC->populateCoreMembers(Variable_decl_assignment,
+                                Variable_decl_assignment, assign_stmt);
         assign_stmt->Lhs(var);
         results->push_back(assign_stmt);
         if (Expression) {
@@ -1134,11 +1095,8 @@ UHDM::atomic_stmt* CompileHelper::compileEventControlStmt(
 
   NodeId Event_expression = fC->Child(Event_control);
   UHDM::event_control* event = s.MakeEvent_control();
-  event->VpiFile(fC->getFileName());
-  event->VpiLineNo(fC->Line(Event_control));
-  event->VpiColumnNo(fC->Column(Event_control));
-  event->VpiEndLineNo(fC->EndLine(Event_control));
-  event->VpiEndColumnNo(fC->EndColumn(Event_control));
+  fC->populateCoreMembers(Event_control, Event_control, event);
+
   if (Event_expression) {
     UHDM::any* exp =
         compileExpression(component, fC, Event_expression, compileDesign);
@@ -1258,11 +1216,7 @@ UHDM::atomic_stmt* CompileHelper::compileCaseStmt(DesignComponent* component,
         fC->Type(Case_item) == VObjectType::slCase_inside_item) {
       case_item = s.MakeCase_item();
       case_items->push_back(case_item);
-      case_item->VpiFile(fC->getFileName());
-      case_item->VpiLineNo(fC->Line(Case_item));
-      case_item->VpiColumnNo(fC->Column(Case_item));
-      case_item->VpiEndLineNo(fC->EndLine(Case_item));
-      case_item->VpiEndColumnNo(fC->EndColumn(Case_item));
+      fC->populateCoreMembers(Case_item, Case_item, case_item);
       case_item->VpiParent(case_stmt);
     }
     bool isDefault = false;
@@ -1396,11 +1350,7 @@ n<> u<142> t<Tf_item_declaration> p<386> c<141> s<384> l<28>
               compileRanges(component, fC, Data_type, compileDesign, parent,
                             nullptr, false, size, false);
           packed_array_typespec* pts = s.MakePacked_array_typespec();
-          pts->VpiFile(fC->getFileName());
-          pts->VpiLineNo(fC->Line(Data_type));
-          pts->VpiColumnNo(fC->Column(Data_type));
-          pts->VpiEndLineNo(fC->EndLine(Data_type));
-          pts->VpiEndColumnNo(fC->EndColumn(Data_type));
+          fC->populateCoreMembers(Data_type, Data_type, pts);
           pts->Ranges(ranges);
           int_typespec* its = s.MakeInt_typespec();
           pts->Typespec(its);
@@ -1427,12 +1377,8 @@ n<> u<142> t<Tf_item_declaration> p<386> c<141> s<384> l<28>
               UhdmWriter::getVpiDirection(tf_port_direction_type));
           decl->VpiName(name);
           ioMap.insert(std::make_pair(name, decl));
-          decl->VpiFile(fC->getFileName());
-          decl->VpiLineNo(fC->Line(nameId));
+          fC->populateCoreMembers(nameId, nameId, decl);
           decl->Typespec(ts);
-          decl->VpiColumnNo(fC->Column(nameId));
-          decl->VpiEndLineNo(fC->EndLine(nameId));
-          decl->VpiEndColumnNo(fC->EndColumn(nameId));
           decl->Ranges(ranges);
           if (fC->Type(Variable_dimension) == slVariable_dimension) {
             nameId = fC->Sibling(nameId);
@@ -1549,11 +1495,7 @@ std::vector<io_decl*>* CompileHelper::compileTfPortList(
       tf_data_type = fC->Sibling(tf_data_type_or_implicit);
       tf_param_name = fC->Sibling(tf_data_type);
     }
-    decl->VpiFile(fC->getFileName());
-    decl->VpiLineNo(fC->Line(tf_param_name));
-    decl->VpiColumnNo(fC->Column(tf_param_name));
-    decl->VpiEndLineNo(fC->EndLine(tf_param_name));
-    decl->VpiEndColumnNo(fC->EndColumn(tf_param_name));
+    fC->populateCoreMembers(tf_param_name, tf_param_name, decl);
     NodeId type = fC->Child(tf_data_type);
 
     NodeId unpackedDimension =
@@ -1750,22 +1692,14 @@ bool CompileHelper::compileTask(DesignComponent* component,
     // make placeholder first
     task = s.MakeTask();
     task->VpiName(name);
-    task->VpiFile(fC->getFileName());
-    task->VpiLineNo(fC->Line(task_decl));
-    task->VpiColumnNo(fC->Column(task_decl));
-    task->VpiEndLineNo(fC->EndLine(task_decl));
-    task->VpiEndColumnNo(fC->EndColumn(task_decl));
+    fC->populateCoreMembers(task_decl, task_decl, task);
     task_funcs->push_back(task);
     return true;
   }
   if (task->Io_decls() || task->Variables() || task->Stmt()) return true;
   setFuncTaskQualifiers(fC, nodeId, task);
   task->VpiMethod(isMethod);
-  task->VpiFile(fC->getFileName());
-  task->VpiLineNo(fC->Line(nodeId));
-  task->VpiColumnNo(fC->Column(nodeId));
-  task->VpiEndLineNo(fC->EndLine(task_decl));
-  task->VpiEndColumnNo(fC->EndColumn(task_decl));
+  fC->populateCoreMembers(nodeId, task_decl, task);
   NodeId Tf_port_list = fC->Sibling(task_name);
   NodeId Statement_or_null;
   if (fC->Type(Tf_port_list) == slTf_port_list) {
@@ -1923,11 +1857,7 @@ bool CompileHelper::compileClassConstructorDeclaration(
   UHDM::function* func = s.MakeFunction();
   func->VpiMethod(true);
   task_funcs->push_back(func);
-  func->VpiFile(fC->getFileName());
-  func->VpiLineNo(fC->Line(nodeId));
-  func->VpiColumnNo(fC->Column(nodeId));
-  func->VpiEndLineNo(fC->EndLine(nodeId));
-  func->VpiEndColumnNo(fC->EndColumn(nodeId));
+  fC->populateCoreMembers(nodeId, nodeId, func);
   std::string name = "new";
   std::string className;
   NodeId Tf_port_list;
@@ -2114,11 +2044,7 @@ bool CompileHelper::compileFunction(DesignComponent* component,
   if (func->Io_decls() || func->Variables() || func->Stmt()) return true;
   setFuncTaskQualifiers(fC, nodeId, func);
   func->VpiMethod(isMethod);
-  func->VpiFile(fC->getFileName());
-  func->VpiLineNo(fC->Line(nodeId));
-  func->VpiColumnNo(fC->Column(nodeId));
-  func->VpiEndLineNo(fC->EndLine(nodeId));
-  func->VpiEndColumnNo(fC->EndColumn(nodeId));
+  fC->populateCoreMembers(nodeId, nodeId, func);
   if (constructor) {
     UHDM::class_var* var = s.MakeClass_var();
     func->Return(var);
@@ -2326,11 +2252,7 @@ Task* CompileHelper::compileTaskPrototype(DesignComponent* scope,
   NodeId task_prototype = prop;
   NodeId task_name = fC->Child(task_prototype);
   std::string taskName = fC->SymName(task_name);
-  task->VpiFile(fC->getFileName());
-  task->VpiLineNo(fC->Line(id));
-  task->VpiColumnNo(fC->Column(id));
-  task->VpiEndLineNo(fC->EndLine(id));
-  task->VpiEndColumnNo(fC->EndColumn(id));
+  fC->populateCoreMembers(id, id, task);
   NodeId Tf_port_list;
   if (fC->Type(task_name) == VObjectType::slStringConst) {
     Tf_port_list = fC->Sibling(task_name);
@@ -2415,11 +2337,7 @@ Function* CompileHelper::compileFunctionPrototype(
     funcName = fC->SymName(function_name);
   }
 
-  func->VpiFile(fC->getFileName());
-  func->VpiLineNo(fC->Line(id));
-  func->VpiColumnNo(fC->Column(id));
-  func->VpiEndLineNo(fC->EndLine(id));
-  func->VpiEndColumnNo(fC->EndColumn(id));
+  fC->populateCoreMembers(id, id, func);
   func->Return(any_cast<variables*>(compileVariable(
       scope, fC, type, compileDesign, nullptr, nullptr, true, false)));
   NodeId Tf_port_list;
@@ -2593,11 +2511,8 @@ UHDM::any* CompileHelper::compileForLoop(DesignComponent* component,
         NodeId Expression = fC->Sibling(Var);
         assign_stmt* assign_stmt = s.MakeAssign_stmt();
         assign_stmt->VpiParent(for_stmt);
-        assign_stmt->VpiFile(fC->getFileName());
-        assign_stmt->VpiLineNo(fC->Line(For_variable_declaration));
-        assign_stmt->VpiColumnNo(fC->Column(For_variable_declaration));
-        assign_stmt->VpiEndLineNo(fC->EndLine(For_variable_declaration));
-        assign_stmt->VpiEndColumnNo(fC->EndColumn(For_variable_declaration));
+        fC->populateCoreMembers(For_variable_declaration,
+                                For_variable_declaration, assign_stmt);
 
         variables* var =
             (variables*)compileVariable(component, fC, Data_type, compileDesign,
@@ -2606,11 +2521,7 @@ UHDM::any* CompileHelper::compileForLoop(DesignComponent* component,
           assign_stmt->Lhs(var);
           var->VpiParent(assign_stmt);
           var->VpiName(fC->SymName(Var));
-          var->VpiFile(fC->getFileName());
-          var->VpiLineNo(fC->Line(Var));
-          var->VpiColumnNo(fC->Column(Var));
-          var->VpiEndLineNo(fC->EndLine(Var));
-          var->VpiEndColumnNo(fC->EndColumn(Var));
+          fC->populateCoreMembers(Var, Var, var);
         }
 
         expr* rhs =
@@ -2647,11 +2558,8 @@ UHDM::any* CompileHelper::compileForLoop(DesignComponent* component,
 
         assign_stmt* assign_stmt = s.MakeAssign_stmt();
         assign_stmt->VpiParent(for_stmt);
-        assign_stmt->VpiFile(fC->getFileName());
-        assign_stmt->VpiLineNo(fC->Line(Variable_assignment));
-        assign_stmt->VpiColumnNo(fC->Column(Variable_assignment));
-        assign_stmt->VpiEndLineNo(fC->EndLine(Variable_assignment));
-        assign_stmt->VpiEndColumnNo(fC->EndColumn(Variable_assignment));
+        fC->populateCoreMembers(Variable_assignment, Variable_assignment,
+                                assign_stmt);
 
         variables* var = (variables*)compileVariable(
             component, fC, Hierarchical_identifier, compileDesign, assign_stmt,

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -299,11 +299,7 @@ UHDM::any* CompileHelper::compileVariable(
           class_typespec* tps = s.MakeClass_typespec();
           var->Typespec(tps);
           tps->Class_defn(cl->getUhdmDefinition());
-          var->VpiFile(fC->getFileName());
-          var->VpiLineNo(fC->Line(declarationId));
-          var->VpiColumnNo(fC->Column(declarationId));
-          var->VpiEndLineNo(fC->EndLine(declarationId));
-          var->VpiEndColumnNo(fC->EndColumn(declarationId));
+          fC->populateCoreMembers(declarationId, declarationId, var);
           result = var;
         }
       }
@@ -313,11 +309,7 @@ UHDM::any* CompileHelper::compileVariable(
             if (ts->UhdmType() == uhdmclass_typespec) {
               class_var* var = s.MakeClass_var();
               var->Typespec(ts);
-              var->VpiFile(fC->getFileName());
-              var->VpiLineNo(fC->Line(declarationId));
-              var->VpiColumnNo(fC->Column(declarationId));
-              var->VpiEndLineNo(fC->EndLine(declarationId));
-              var->VpiEndColumnNo(fC->EndColumn(declarationId));
+              fC->populateCoreMembers(declarationId, declarationId, var);
               result = var;
             }
           }
@@ -344,11 +336,7 @@ UHDM::any* CompileHelper::compileVariable(
     case VObjectType::slIntVec_TypeReg: {
       logic_var* var = s.MakeLogic_var();
       var->Typespec(ts);
-      var->VpiFile(fC->getFileName());
-      var->VpiLineNo(fC->Line(declarationId));
-      var->VpiColumnNo(fC->Column(declarationId));
-      var->VpiEndLineNo(fC->EndLine(declarationId));
-      var->VpiEndColumnNo(fC->EndColumn(declarationId));
+      fC->populateCoreMembers(declarationId, declarationId, var);
       result = var;
       break;
     }
@@ -500,11 +488,7 @@ UHDM::any* CompileHelper::compileVariable(
     }
   }
   if (result && (result->VpiLineNo() == 0)) {
-    result->VpiFile(fC->getFileName());
-    result->VpiLineNo(fC->Line(declarationId));
-    result->VpiColumnNo(fC->Column(declarationId));
-    result->VpiEndLineNo(fC->EndLine(declarationId));
-    result->VpiEndColumnNo(fC->EndColumn(declarationId));
+    fC->populateCoreMembers(declarationId, declarationId, result);
   }
   return result;
 }
@@ -737,11 +721,7 @@ typespec* CompileHelper::compileDatastructureTypespec(
         class_typespec* ref = s.MakeClass_typespec();
         ref->Class_defn(classDefn->getUhdmDefinition());
         ref->VpiName(typeName);
-        ref->VpiFile(fC->getFileName());
-        ref->VpiLineNo(fC->Line(type));
-        ref->VpiColumnNo(fC->Column(type));
-        ref->VpiEndLineNo(fC->EndLine(type));
-        ref->VpiEndColumnNo(fC->EndColumn(type));
+        fC->populateCoreMembers(type, type, ref);
         result = ref;
 
         const FileContent* actualFC = fC;
@@ -842,11 +822,7 @@ typespec* CompileHelper::compileDatastructureTypespec(
         if (def->getType() == slInterface_declaration) {
           interface_typespec* tps = s.MakeInterface_typespec();
           tps->VpiName(typeName);
-          tps->VpiFile(fC->getFileName());
-          tps->VpiLineNo(fC->Line(type));
-          tps->VpiColumnNo(fC->Column(type));
-          tps->VpiEndLineNo(fC->EndLine(type));
-          tps->VpiEndColumnNo(fC->EndColumn(type));
+          fC->populateCoreMembers(type, type, tps);
           result = tps;
           if (!suffixname.empty()) {
             const DataType* defType = def->getDataType(suffixname);
@@ -870,11 +846,7 @@ typespec* CompileHelper::compileDatastructureTypespec(
             if (def->getModPort(name)) {
               interface_typespec* mptps = s.MakeInterface_typespec();
               mptps->VpiName(name);
-              mptps->VpiFile(fC->getFileName());
-              mptps->VpiLineNo(fC->Line(type));
-              mptps->VpiColumnNo(fC->Column(type));
-              mptps->VpiEndLineNo(fC->EndLine(type));
-              mptps->VpiEndColumnNo(fC->EndColumn(type));
+              fC->populateCoreMembers(type, type, mptps);
               mptps->VpiParent(tps);
               mptps->VpiIsModPort(true);
               result = mptps;
@@ -887,21 +859,13 @@ typespec* CompileHelper::compileDatastructureTypespec(
     if (result == nullptr) {
       unsupported_typespec* tps = s.MakeUnsupported_typespec();
       tps->VpiName(typeName);
-      tps->VpiFile(fC->getFileName());
-      tps->VpiLineNo(fC->Line(type));
-      tps->VpiColumnNo(fC->Column(type));
-      tps->VpiEndLineNo(fC->EndLine(type));
-      tps->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, tps);
       result = tps;
     }
   } else {
     unsupported_typespec* tps = s.MakeUnsupported_typespec();
     tps->VpiName(typeName);
-    tps->VpiFile(fC->getFileName());
-    tps->VpiLineNo(fC->Line(type));
-    tps->VpiColumnNo(fC->Column(type));
-    tps->VpiEndLineNo(fC->EndLine(type));
-    tps->VpiEndColumnNo(fC->EndColumn(type));
+    fC->populateCoreMembers(type, type, tps);
     result = tps;
   }
   return result;
@@ -979,128 +943,80 @@ UHDM::typespec* CompileHelper::compileBuiltinTypespec(
     case VObjectType::slIntVec_TypeReg: {
       logic_typespec* var = s.MakeLogic_typespec();
       var->Ranges(ranges);
-      var->VpiFile(fC->getFileName());
-      var->VpiLineNo(fC->Line(type));
-      var->VpiColumnNo(fC->Column(type));
-      var->VpiEndLineNo(fC->EndLine(type));
-      var->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, var);
       result = var;
       break;
     }
     case VObjectType::slIntegerAtomType_Int: {
       int_typespec* var = s.MakeInt_typespec();
       var->VpiSigned(isSigned);
-      var->VpiFile(fC->getFileName());
-      var->VpiLineNo(fC->Line(type));
-      var->VpiColumnNo(fC->Column(type));
-      var->VpiEndLineNo(fC->EndLine(isSigned ? type : sign));
-      var->VpiEndColumnNo(fC->EndColumn(isSigned ? type : sign));
+      fC->populateCoreMembers(type, isSigned ? type : sign, var);
       result = var;
       break;
     }
     case VObjectType::slIntegerAtomType_Integer: {
       integer_typespec* var = s.MakeInteger_typespec();
       var->VpiSigned(isSigned);
-      var->VpiFile(fC->getFileName());
-      var->VpiLineNo(fC->Line(type));
-      var->VpiColumnNo(fC->Column(type));
-      var->VpiEndLineNo(fC->EndLine(isSigned ? type : sign));
-      var->VpiEndColumnNo(fC->EndColumn(isSigned ? type : sign));
+      fC->populateCoreMembers(type, isSigned ? type : sign, var);
       result = var;
       break;
     }
     case VObjectType::slIntegerAtomType_Byte: {
       byte_typespec* var = s.MakeByte_typespec();
       var->VpiSigned(isSigned);
-      var->VpiFile(fC->getFileName());
-      var->VpiLineNo(fC->Line(type));
-      var->VpiColumnNo(fC->Column(type));
-      var->VpiEndLineNo(fC->EndLine(isSigned ? type : sign));
-      var->VpiEndColumnNo(fC->EndColumn(isSigned ? type : sign));
+      fC->populateCoreMembers(type, isSigned ? type : sign, var);
       result = var;
       break;
     }
     case VObjectType::slIntegerAtomType_LongInt: {
       long_int_typespec* var = s.MakeLong_int_typespec();
       var->VpiSigned(isSigned);
-      var->VpiFile(fC->getFileName());
-      var->VpiLineNo(fC->Line(type));
-      var->VpiColumnNo(fC->Column(type));
-      var->VpiEndLineNo(fC->EndLine(isSigned ? type : sign));
-      var->VpiEndColumnNo(fC->EndColumn(isSigned ? type : sign));
+      fC->populateCoreMembers(type, isSigned ? type : sign, var);
       result = var;
       break;
     }
     case VObjectType::slIntegerAtomType_Shortint: {
       short_int_typespec* var = s.MakeShort_int_typespec();
       var->VpiSigned(isSigned);
-      var->VpiFile(fC->getFileName());
-      var->VpiLineNo(fC->Line(type));
-      var->VpiColumnNo(fC->Column(type));
-      var->VpiEndLineNo(fC->EndLine(isSigned ? type : sign));
-      var->VpiEndColumnNo(fC->EndColumn(isSigned ? type : sign));
+      fC->populateCoreMembers(type, isSigned ? type : sign, var);
       result = var;
       break;
     }
     case VObjectType::slIntegerAtomType_Time: {
       time_typespec* var = s.MakeTime_typespec();
-      var->VpiFile(fC->getFileName());
-      var->VpiLineNo(fC->Line(type));
-      var->VpiColumnNo(fC->Column(type));
-      var->VpiEndLineNo(fC->EndLine(type));
-      var->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, var);
       result = var;
       break;
     }
     case VObjectType::slIntVec_TypeBit: {
       bit_typespec* var = s.MakeBit_typespec();
       var->Ranges(ranges);
-      var->VpiFile(fC->getFileName());
-      var->VpiLineNo(fC->Line(type));
-      var->VpiColumnNo(fC->Column(type));
-      var->VpiEndLineNo(fC->EndLine(type));
-      var->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, var);
       result = var;
       break;
     }
     case VObjectType::slNonIntType_ShortReal: {
       short_real_typespec* var = s.MakeShort_real_typespec();
-      var->VpiFile(fC->getFileName());
-      var->VpiLineNo(fC->Line(type));
-      var->VpiColumnNo(fC->Column(type));
-      var->VpiEndLineNo(fC->EndLine(type));
-      var->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, var);
       result = var;
       break;
     }
     case VObjectType::slNonIntType_Real: {
       real_typespec* var = s.MakeReal_typespec();
-      var->VpiFile(fC->getFileName());
-      var->VpiLineNo(fC->Line(type));
-      var->VpiColumnNo(fC->Column(type));
-      var->VpiEndLineNo(fC->EndLine(type));
-      var->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, var);
       result = var;
       break;
     }
     case VObjectType::slString_type: {
       UHDM::string_typespec* tps = s.MakeString_typespec();
-      tps->VpiFile(fC->getFileName());
-      tps->VpiLineNo(fC->Line(type));
-      tps->VpiColumnNo(fC->Column(type));
-      tps->VpiEndLineNo(fC->EndLine(type));
-      tps->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, tps);
       result = tps;
       break;
     }
     default:
       logic_typespec* var = s.MakeLogic_typespec();
       var->Ranges(ranges);
-      var->VpiFile(fC->getFileName());
-      var->VpiLineNo(fC->Line(type));
-      var->VpiColumnNo(fC->Column(type));
-      var->VpiEndLineNo(fC->EndLine(type));
-      var->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, var);
       result = var;
       break;
   }
@@ -1161,11 +1077,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
                                          nullptr, instance, reduce);
       if (res) {
         integer_typespec* var = s.MakeInteger_typespec();
-        var->VpiFile(fC->getFileName());
-        var->VpiLineNo(fC->Line(type));
-        var->VpiColumnNo(fC->Column(type));
-        var->VpiEndLineNo(fC->EndLine(type));
-        var->VpiEndColumnNo(fC->EndColumn(type));
+        fC->populateCoreMembers(type, type, var);
         result = var;
         if (UHDM::constant* constant = any_cast<UHDM::constant*>(res)) {
           var->VpiValue(constant->VpiValue());
@@ -1174,11 +1086,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
         }
       } else {
         unsupported_typespec* tps = s.MakeUnsupported_typespec();
-        tps->VpiFile(fC->getFileName());
-        tps->VpiLineNo(fC->Line(type));
-        tps->VpiColumnNo(fC->Column(type));
-        tps->VpiEndLineNo(fC->EndLine(type));
-        tps->VpiEndColumnNo(fC->EndColumn(type));
+        fC->populateCoreMembers(type, type, tps);
         result = tps;
       }
       break;
@@ -1198,7 +1106,6 @@ UHDM::typespec* CompileHelper::compileTypespec(
                  fC->getFileName(), baseType->VpiLineNo(), reduce, true);
       }
       enum_typespec* en = s.MakeEnum_typespec();
-      en->VpiFile(fC->getFileName());
       en->Base_typespec(baseType);
       VectorOfenum_const* econsts = s.MakeEnum_constVec();
       en->Enum_consts(econsts);
@@ -1226,11 +1133,8 @@ UHDM::typespec* CompileHelper::compileTypespec(
         enum_const* econst = s.MakeEnum_const();
         econst->VpiName(enumName);
         econst->VpiParent(en);
-        econst->VpiFile(fC->getFileName());
-        econst->VpiLineNo(fC->Line(enum_name_declaration));
-        econst->VpiColumnNo(fC->Column(enum_name_declaration));
-        econst->VpiEndLineNo(fC->EndLine(enum_name_declaration));
-        econst->VpiEndColumnNo(fC->EndColumn(enum_name_declaration));
+        fC->populateCoreMembers(enum_name_declaration, enum_name_declaration,
+                                econst);
         econst->VpiValue(value->uhdmValue());
         if (enumValueId) {
           any* exp = compileExpression(component, fC, enumValueId,
@@ -1252,11 +1156,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
       NodeId Name = fC->Child(type);
       const std::string& name = fC->SymName(Name);
       tps->VpiName(name);
-      tps->VpiFile(fC->getFileName());
-      tps->VpiLineNo(fC->Line(type));
-      tps->VpiColumnNo(fC->Column(type));
-      tps->VpiEndLineNo(fC->EndLine(type));
-      tps->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, tps);
       result = tps;
       break;
     }
@@ -1273,11 +1173,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
         result = tps;
       }
 
-      result->VpiFile(fC->getFileName());
-      result->VpiLineNo(fC->Line(type));
-      result->VpiColumnNo(fC->Column(type));
-      result->VpiEndLineNo(fC->EndLine(type));
-      result->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, result);
       break;
     }
     case VObjectType::slSigning_Unsigned: {
@@ -1291,11 +1187,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
         result = tps;
       }
 
-      result->VpiFile(fC->getFileName());
-      result->VpiLineNo(fC->Line(type));
-      result->VpiColumnNo(fC->Column(type));
-      result->VpiEndLineNo(fC->EndLine(type));
-      result->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, result);
       break;
     }
     case VObjectType::slPacked_dimension: {
@@ -1310,11 +1202,8 @@ UHDM::typespec* CompileHelper::compileTypespec(
         tps->Ranges(ranges);
         result = tps;
       }
-      result->VpiFile(fC->getFileName());
-      result->VpiLineNo(fC->Line(type));
-      result->VpiColumnNo(fC->Column(type));
-      result->VpiEndLineNo(fC->EndLine(type));
-      result->VpiEndColumnNo(fC->EndColumn(type));
+
+      fC->populateCoreMembers(type, type, result);
       break;
     }
     case VObjectType::slExpression: {
@@ -1337,11 +1226,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
         integer_typespec* var = s.MakeInteger_typespec();
         std::string value = "INT:" + fC->SymName(literal);
         var->VpiValue(value);
-        var->VpiFile(fC->getFileName());
-        var->VpiLineNo(fC->Line(type));
-        var->VpiColumnNo(fC->Column(type));
-        var->VpiEndLineNo(fC->EndLine(type));
-        var->VpiEndColumnNo(fC->EndColumn(type));
+        fC->populateCoreMembers(type, type, var);
         result = var;
       }
       break;
@@ -1379,8 +1264,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
         while ((next_Packed_dimension = fC->Sibling(next_Packed_dimension))) {
           last_Packed_dimension = next_Packed_dimension;
         }
-        result->VpiEndLineNo(fC->EndLine(last_Packed_dimension));
-        result->VpiEndColumnNo(fC->EndColumn(last_Packed_dimension));
+        fC->populateCoreMembers(InvalidNodeId, last_Packed_dimension, result);
       }
       break;
     }
@@ -1410,11 +1294,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
             class_typespec* ref = s.MakeClass_typespec();
             ref->Class_defn(classDefn->getUhdmDefinition());
             ref->VpiName(typeName);
-            ref->VpiFile(fC->getFileName());
-            ref->VpiLineNo(fC->Line(type));
-            ref->VpiColumnNo(fC->Column(type));
-            ref->VpiEndLineNo(fC->EndLine(type));
-            ref->VpiEndColumnNo(fC->EndColumn(type));
+            fC->populateCoreMembers(type, type, ref);
             result = ref;
             break;
           }
@@ -1465,11 +1345,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
       if (result == nullptr) {
         unsupported_typespec* ref = s.MakeUnsupported_typespec();
         ref->VpiName(typeName);
-        ref->VpiFile(fC->getFileName());
-        ref->VpiLineNo(fC->Line(type));
-        ref->VpiColumnNo(fC->Column(type));
-        ref->VpiEndLineNo(fC->EndLine(type));
-        ref->VpiEndColumnNo(fC->EndColumn(type));
+        fC->populateCoreMembers(type, type, ref);
         result = ref;
       }
       break;
@@ -1496,11 +1372,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
         ts->Members(members);
         result = ts;
       }
-      result->VpiFile(fC->getFileName());
-      result->VpiLineNo(fC->Line(type));
-      result->VpiColumnNo(fC->Column(type));
-      result->VpiEndLineNo(fC->EndLine(type));
-      result->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, result);
 
       if (ranges) {
         if (isPacked) {
@@ -1530,11 +1402,8 @@ UHDM::typespec* CompileHelper::compileTypespec(
                                         result, instance, reduce);
           } else {
             void_typespec* tps = s.MakeVoid_typespec();
-            tps->VpiFile(fC->getFileName());
-            tps->VpiLineNo(fC->Line(Data_type_or_void));
-            tps->VpiColumnNo(fC->Column(Variable_decl_assignment));
-            tps->VpiEndLineNo(fC->EndLine(Data_type_or_void));
-            tps->VpiEndColumnNo(fC->EndColumn(Variable_decl_assignment));
+            fC->populateCoreMembers(Data_type_or_void, Variable_decl_assignment,
+                                    tps);
             member_ts = tps;
           }
           NodeId member_name = fC->Child(Variable_decl_assignment);
@@ -1584,28 +1453,16 @@ UHDM::typespec* CompileHelper::compileTypespec(
       if (typeName == "logic") {
         logic_typespec* var = s.MakeLogic_typespec();
         var->Ranges(ranges);
-        var->VpiFile(fC->getFileName());
-        var->VpiLineNo(fC->Line(type));
-        var->VpiColumnNo(fC->Column(type));
-        var->VpiEndLineNo(fC->EndLine(type));
-        var->VpiEndColumnNo(fC->EndColumn(type));
+        fC->populateCoreMembers(type, type, var);
         result = var;
       } else if (typeName == "bit") {
         bit_typespec* var = s.MakeBit_typespec();
         var->Ranges(ranges);
-        var->VpiFile(fC->getFileName());
-        var->VpiLineNo(fC->Line(type));
-        var->VpiColumnNo(fC->Column(type));
-        var->VpiEndLineNo(fC->EndLine(type));
-        var->VpiEndColumnNo(fC->EndColumn(type));
+        fC->populateCoreMembers(type, type, var);
         result = var;
       } else if (typeName == "byte") {
         byte_typespec* var = s.MakeByte_typespec();
-        var->VpiFile(fC->getFileName());
-        var->VpiLineNo(fC->Line(type));
-        var->VpiColumnNo(fC->Column(type));
-        var->VpiEndLineNo(fC->EndLine(type));
-        var->VpiEndColumnNo(fC->EndColumn(type));
+        fC->populateCoreMembers(type, type, var);
         result = var;
       } else if (reduce) {
         if (any* cast_to =
@@ -1615,19 +1472,11 @@ UHDM::typespec* CompileHelper::compileTypespec(
           if (c) {
             integer_typespec* var = s.MakeInteger_typespec();
             var->VpiValue(c->VpiValue());
-            var->VpiFile(fC->getFileName());
-            var->VpiLineNo(fC->Line(type));
-            var->VpiColumnNo(fC->Column(type));
-            var->VpiEndLineNo(fC->EndLine(type));
-            var->VpiEndColumnNo(fC->EndColumn(type));
+            fC->populateCoreMembers(type, type, var);
             result = var;
           } else {
             void_typespec* tps = s.MakeVoid_typespec();
-            tps->VpiFile(fC->getFileName());
-            tps->VpiLineNo(fC->Line(type));
-            tps->VpiColumnNo(fC->Column(type));
-            tps->VpiEndLineNo(fC->EndLine(type));
-            tps->VpiEndColumnNo(fC->EndColumn(type));
+            fC->populateCoreMembers(type, type, tps);
             result = tps;
           }
         }
@@ -1728,11 +1577,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
             class_typespec* tps = s.MakeClass_typespec();
             tps->VpiName(typeName);
             tps->Class_defn(cl->getUhdmDefinition());
-            tps->VpiFile(fC->getFileName());
-            tps->VpiLineNo(fC->Line(type));
-            tps->VpiColumnNo(fC->Column(type));
-            tps->VpiEndLineNo(fC->EndLine(type));
-            tps->VpiEndColumnNo(fC->EndColumn(type));
+            fC->populateCoreMembers(type, type, tps);
             result = tps;
           }
         }
@@ -1766,11 +1611,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
           }
         }
         if (result && (result->VpiLineNo() == 0)) {
-          result->VpiFile(fC->getFileName());
-          result->VpiLineNo(fC->Line(type));
-          result->VpiColumnNo(fC->Column(type));
-          result->VpiEndLineNo(fC->EndLine(type));
-          result->VpiEndColumnNo(fC->EndColumn(type));
+          fC->populateCoreMembers(type, type, result);
         }
       }
       if ((!result) && component) {
@@ -1804,32 +1645,20 @@ UHDM::typespec* CompileHelper::compileTypespec(
         } else {
           var->Expr(exp);
         }
-        var->VpiFile(fC->getFileName());
-        var->VpiLineNo(fC->Line(type));
-        var->VpiColumnNo(fC->Column(type));
-        var->VpiEndLineNo(fC->EndLine(type));
-        var->VpiEndColumnNo(fC->EndColumn(type));
+        fC->populateCoreMembers(type, type, var);
         result = var;
       }
       break;
     }
     case VObjectType::slChandle_type: {
       UHDM::chandle_typespec* tps = s.MakeChandle_typespec();
-      tps->VpiFile(fC->getFileName());
-      tps->VpiLineNo(fC->Line(type));
-      tps->VpiColumnNo(fC->Column(type));
-      tps->VpiEndLineNo(fC->EndLine(type));
-      tps->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, tps);
       result = tps;
       break;
     }
     case VObjectType::slConstant_range: {
       UHDM::logic_typespec* tps = s.MakeLogic_typespec();
-      tps->VpiFile(fC->getFileName());
-      tps->VpiLineNo(fC->Line(type));
-      tps->VpiColumnNo(fC->Column(type));
-      tps->VpiEndLineNo(fC->EndLine(type));
-      tps->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, tps);
       VectorOfrange* ranges =
           compileRanges(component, fC, type, compileDesign, pstmt, instance,
                         reduce, size, false);
@@ -1839,21 +1668,13 @@ UHDM::typespec* CompileHelper::compileTypespec(
     }
     case VObjectType::slEvent_type: {
       UHDM::event_typespec* tps = s.MakeEvent_typespec();
-      tps->VpiFile(fC->getFileName());
-      tps->VpiLineNo(fC->Line(type));
-      tps->VpiColumnNo(fC->Column(type));
-      tps->VpiEndLineNo(fC->EndLine(type));
-      tps->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, tps);
       result = tps;
       break;
     }
     case VObjectType::slNonIntType_RealTime: {
       UHDM::time_typespec* tps = s.MakeTime_typespec();
-      tps->VpiFile(fC->getFileName());
-      tps->VpiLineNo(fC->Line(type));
-      tps->VpiColumnNo(fC->Column(type));
-      tps->VpiEndLineNo(fC->EndLine(type));
-      tps->VpiEndColumnNo(fC->EndColumn(type));
+      fC->populateCoreMembers(type, type, tps);
       result = tps;
       break;
     }
@@ -1889,11 +1710,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
               time_typespec* tps = s.MakeTime_typespec();
               result = tps;
             }
-            result->VpiFile(fC->getFileName());
-            result->VpiLineNo(fC->Line(type));
-            result->VpiColumnNo(fC->Column(type));
-            result->VpiEndLineNo(fC->EndLine(type));
-            result->VpiEndColumnNo(fC->EndColumn(type));
+            fC->populateCoreMembers(type, type, result);
           }
         } else {
           ErrorContainer* errors =

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -1669,15 +1669,11 @@ any* ElaborationStep::makeVar_(DesignComponent* component, Signal* sig,
       logicv->Ranges(packedDimensions);
       logic_typespec* ltps = s.MakeLogic_typespec();
       ltps->Ranges(packedDimensions);
-      ltps->VpiFile(fC->getFileName());
       NodeId id;
       if (sig->getPackedDimension()) id = fC->Parent(sig->getPackedDimension());
       if (!id) id = sig->getNodeId();
       if (id) {
-        ltps->VpiLineNo(fC->Line(id));
-        ltps->VpiColumnNo(fC->Column(id));
-        ltps->VpiEndLineNo(fC->EndLine(id));
-        ltps->VpiEndColumnNo(fC->EndColumn(id));
+        fC->populateCoreMembers(id, id, ltps);
       }
       tps = ltps;
       logicv->Typespec(tps);
@@ -1849,11 +1845,7 @@ any* ElaborationStep::makeVar_(DesignComponent* component, Signal* sig,
       array_var->Typespec(s.MakeArray_typespec());
     }
     array_var->Expr(assignExp);
-    obj->VpiFile(fC->getFileName());
-    obj->VpiLineNo(fC->Line(sig->getNodeId()));
-    obj->VpiColumnNo(fC->Column(sig->getNodeId()));
-    obj->VpiEndLineNo(fC->EndLine(sig->getNodeId()));
-    obj->VpiEndColumnNo(fC->EndColumn(sig->getNodeId()));
+    fC->populateCoreMembers(sig->getNodeId(), sig->getNodeId(), obj);
     obj = array_var;
   } else {
     if (obj->UhdmType() == uhdmenum_var) {

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -333,15 +333,10 @@ bool NetlistElaboration::elab_parameters_(ModuleInstance* instance,
         }
         c->VpiValue(value->uhdmValue());
         c->VpiDecompile(value->decompiledValue());
-        c->VpiFile(assign->getFileContent()->getFileName());
         c->VpiSize(value->getSize());
         c->VpiConstType(value->vpiValType());
-        c->VpiLineNo(assign->getFileContent()->Line(assign->getAssignId()));
-        c->VpiColumnNo(assign->getFileContent()->Column(assign->getAssignId()));
-        c->VpiEndLineNo(
-            assign->getFileContent()->EndLine(assign->getAssignId()));
-        c->VpiEndColumnNo(
-            assign->getFileContent()->EndColumn(assign->getAssignId()));
+        assign->getFileContent()->populateCoreMembers(assign->getAssignId(),
+                                                      assign->getAssignId(), c);
         inst_assign->Rhs(c);
         m_helper.adjustSize(c->Typespec(), instance->getDefinition(),
                             m_compileDesign, instance, c);
@@ -404,16 +399,10 @@ bool NetlistElaboration::elab_parameters_(ModuleInstance* instance,
           }
           c->VpiValue(value->uhdmValue());
           c->VpiDecompile(value->decompiledValue());
-          c->VpiFile(assign->getFileContent()->getFileName());
           c->VpiSize(value->getSize());
           c->VpiConstType(value->vpiValType());
-          c->VpiLineNo(assign->getFileContent()->Line(assign->getAssignId()));
-          c->VpiColumnNo(
-              assign->getFileContent()->Column(assign->getAssignId()));
-          c->VpiEndLineNo(
-              assign->getFileContent()->EndLine(assign->getAssignId()));
-          c->VpiEndColumnNo(
-              assign->getFileContent()->EndColumn(assign->getAssignId()));
+          assign->getFileContent()->populateCoreMembers(
+              assign->getAssignId(), assign->getAssignId(), c);
           inst_assign->Rhs(c);
           overriden = true;
         }
@@ -767,11 +756,7 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
 
             if ((!bit_or_part_select) && (fC->Type(sigId) == slStringConst)) {
               ref_obj* ref = s.MakeRef_obj();
-              ref->VpiFile(fC->getFileName());
-              ref->VpiLineNo(fC->Line(sigId));
-              ref->VpiColumnNo(fC->Column(sigId));
-              ref->VpiEndLineNo(fC->EndLine(sigId));
-              ref->VpiEndColumnNo(fC->EndColumn(sigId));
+              fC->populateCoreMembers(sigId, sigId, ref);
               p->High_conn(ref);
               ref->VpiName(sigName);
               if (parent) {
@@ -814,18 +799,10 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
             ports = s.MakePortVec();
             netlist->ports(ports);
           }
-          p->VpiFile(fC->getFileName());
-          p->VpiLineNo(fC->Line(Net_lvalue));
-          p->VpiColumnNo(fC->Column(Net_lvalue));
-          p->VpiEndLineNo(fC->EndLine(Net_lvalue));
-          p->VpiEndColumnNo(fC->EndColumn(Net_lvalue));
+          fC->populateCoreMembers(Net_lvalue, Net_lvalue, p);
           if (fC->Type(sigId) == slStringConst) {
             ref_obj* ref = s.MakeRef_obj();
-            ref->VpiFile(fC->getFileName());
-            ref->VpiLineNo(fC->Line(sigId));
-            ref->VpiColumnNo(fC->Column(sigId));
-            ref->VpiEndLineNo(fC->EndLine(sigId));
-            ref->VpiEndColumnNo(fC->EndColumn(sigId));
+            fC->populateCoreMembers(sigId, sigId, ref);
             p->High_conn(ref);
             ref->VpiName(sigName);
             if (parent) {
@@ -972,19 +949,11 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
                 p = s.MakePort();
                 ports->push_back(p);
                 p->VpiName(formalName);
-                p->VpiFile(fC->getFileName());
-                p->VpiLineNo(fC->Line(formalId));
-                p->VpiColumnNo(fC->Column(formalId));
-                p->VpiEndLineNo(fC->EndLine(formalId));
-                p->VpiEndColumnNo(fC->EndColumn(formalId));
+                fC->populateCoreMembers(formalId, formalId, p);
               }
               operation* op = s.MakeOperation();
               op->VpiOpType(vpiNullOp);
-              op->VpiFile(fC->getFileName());
-              op->VpiLineNo(fC->Line(tmp));
-              op->VpiColumnNo(fC->EndColumn(tmp));
-              op->VpiEndLineNo(fC->EndLine(tmp));
-              op->VpiEndColumnNo(fC->Column(tmp));
+              fC->populateCoreMembers(tmp, tmp, op);
               p->High_conn(op);
               index++;
               continue;
@@ -1055,11 +1024,7 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
 
         if ((!sigName.empty()) && (hexpr == nullptr)) {
           ref_obj* ref = s.MakeRef_obj();
-          ref->VpiFile(fC->getFileName());
-          ref->VpiLineNo(fC->Line(sigId));
-          ref->VpiColumnNo(fC->Column(sigId));
-          ref->VpiEndLineNo(fC->EndLine(sigId));
-          ref->VpiEndColumnNo(fC->EndColumn(sigId));
+          fC->populateCoreMembers(sigId, sigId, ref);
           ref->VpiName(sigName);
           if (parent) {
             ref->VpiFullName(parent->getFullPathName() + "." + sigName);
@@ -1080,21 +1045,13 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
         p->VpiName(formalName);
         p->Attributes(attributes);
         if (p->VpiLineNo() == 0) {
-          p->VpiFile(fC->getFileName());
-          p->VpiLineNo(fC->Line(formalId));
-          p->VpiColumnNo(fC->Column(formalId));
-          p->VpiEndLineNo(fC->EndLine(formalId));
-          p->VpiEndColumnNo(fC->EndColumn(formalId));
+          fC->populateCoreMembers(formalId, formalId, p);
         }
         bool lowconn_is_nettype = false;
         if (const any* lc = p->Low_conn()) {
           if (lc->UhdmType() == uhdmref_obj) {
             ref_obj* rf = (ref_obj*)lc;
-            rf->VpiFile(fC->getFileName());
-            rf->VpiLineNo(fC->Line(formalId));
-            rf->VpiColumnNo(fC->Column(formalId));
-            rf->VpiEndLineNo(fC->EndLine(formalId));
-            rf->VpiEndColumnNo(fC->EndColumn(formalId));
+            fC->populateCoreMembers(formalId, formalId, rf);
             const any* act = rf->Actual_group();
             if (act && (act->UhdmType() == uhdmlogic_net))
               lowconn_is_nettype = true;
@@ -1163,11 +1120,8 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
           if (sm) {
             ref_obj* ref = s.MakeRef_obj();
             ref->Actual_group(sm);
-            ref->VpiFile(fC->getFileName());
-            ref->VpiLineNo(fC->Line(Named_port_connection));
-            ref->VpiColumnNo(fC->Column(Named_port_connection));
-            ref->VpiEndLineNo(fC->EndLine(Named_port_connection));
-            ref->VpiEndColumnNo(fC->EndColumn(Named_port_connection));
+            fC->populateCoreMembers(Named_port_connection,
+                                    Named_port_connection, ref);
             p->Low_conn(ref);
           }
         }
@@ -1278,11 +1232,7 @@ interface* NetlistElaboration::elab_interface_(
     dest_modport->VpiParent(sm);
     const FileContent* orig_fC = orig_modport.second.getFileContent();
     const NodeId orig_nodeId = orig_modport.second.getNodeId();
-    dest_modport->VpiFile(orig_fC->getFileName());
-    dest_modport->VpiLineNo(orig_fC->Line(orig_nodeId));
-    dest_modport->VpiColumnNo(orig_fC->Column(orig_nodeId));
-    dest_modport->VpiEndLineNo(orig_fC->EndLine(orig_nodeId));
-    dest_modport->VpiEndColumnNo(orig_fC->EndColumn(orig_nodeId));
+    orig_fC->populateCoreMembers(orig_nodeId, orig_nodeId, dest_modport);
     netlist->getModPortMap().insert(std::make_pair(
         modportfullname, std::make_pair(&orig_modport.second, dest_modport)));
     netlist->getSymbolTable().insert(
@@ -1297,11 +1247,7 @@ interface* NetlistElaboration::elab_interface_(
       io->VpiName(sigName);
       unsigned int direction = UhdmWriter::getVpiDirection(sig.getDirection());
       io->VpiDirection(direction);
-      io->VpiFile(fC->getFileName());
-      io->VpiLineNo(fC->Line(nodeId));
-      io->VpiColumnNo(fC->Column(nodeId));
-      io->VpiEndLineNo(fC->EndLine(nodeId));
-      io->VpiEndColumnNo(fC->EndColumn(nodeId));
+      fC->populateCoreMembers(nodeId, nodeId, io);
       any* net = bind_net_(instance, sigName);
       if (net == nullptr) {
         net = bind_net_(interf_instance, sigName);
@@ -1310,11 +1256,7 @@ interface* NetlistElaboration::elab_interface_(
         ref_obj* n = s.MakeRef_obj();
         n->VpiName(sigName);
         n->VpiFullName(instance->getFullPathName() + "." + sigName);
-        n->VpiFile(fC->getFileName());
-        n->VpiLineNo(fC->Line(nodeId));
-        n->VpiColumnNo(fC->Column(nodeId));
-        n->VpiEndLineNo(fC->EndLine(nodeId));
-        n->VpiEndColumnNo(fC->EndColumn(nodeId));
+        fC->populateCoreMembers(nodeId, nodeId, n);
         if (sigName != instName)  // prevent loop in listener
           n->Actual_group(net);
         net = n;
@@ -1385,17 +1327,11 @@ bool NetlistElaboration::elab_generates_(ModuleInstance* instance) {
       gen_scope* gen_scope = s.MakeGen_scope();
       vec->push_back(gen_scope);
       gen_scope_array->Gen_scopes(vec);
-      gen_scope->VpiFile(fC->getFileName());
-      gen_scope->VpiLineNo(fC->Line(mm->getGenBlockId()));
-      gen_scope->VpiColumnNo(fC->Column(mm->getGenBlockId()));
-      gen_scope->VpiEndLineNo(fC->EndLine(mm->getGenBlockId()));
-      gen_scope->VpiEndColumnNo(fC->EndColumn(mm->getGenBlockId()));
+      fC->populateCoreMembers(mm->getGenBlockId(), mm->getGenBlockId(),
+                              gen_scope);
       gen_scope->VpiName(instance->getInstanceName());
-      gen_scope_array->VpiFile(fC->getFileName());
-      gen_scope_array->VpiLineNo(fC->Line(mm->getGenBlockId()));
-      gen_scope_array->VpiColumnNo(fC->Column(mm->getGenBlockId()));
-      gen_scope_array->VpiEndLineNo(fC->EndLine(mm->getGenBlockId()));
-      gen_scope_array->VpiEndColumnNo(fC->EndColumn(mm->getGenBlockId()));
+      fC->populateCoreMembers(mm->getGenBlockId(), mm->getGenBlockId(),
+                              gen_scope_array);
       gen_scopes->push_back(gen_scope_array);
 
       if (mm->getContAssigns()) gen_scope->Cont_assigns(mm->getContAssigns());
@@ -1801,11 +1737,7 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
         array_net->Ranges(unpackedDimensions);
         array_net->VpiName(signame);
         array_net->VpiSize(unpackedSize);
-        array_net->VpiFile(fC->getFileName());
-        array_net->VpiLineNo(fC->Line(sig->getNodeId()));
-        array_net->VpiColumnNo(fC->Column(sig->getNodeId()));
-        array_net->VpiEndLineNo(fC->EndLine(sig->getNodeId()));
-        array_net->VpiEndColumnNo(fC->EndColumn(sig->getNodeId()));
+        fC->populateCoreMembers(sig->getNodeId(), sig->getNodeId(), array_net);
         if (array_nets == nullptr) {
           array_nets = s.MakeArray_netVec();
           netlist->array_nets(array_nets);
@@ -1855,11 +1787,7 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
         array_net->Ranges(unpackedDimensions);
         array_net->VpiName(signame);
         array_net->VpiSize(unpackedSize);
-        array_net->VpiFile(fC->getFileName());
-        array_net->VpiLineNo(fC->Line(sig->getNodeId()));
-        array_net->VpiColumnNo(fC->Column(sig->getNodeId()));
-        array_net->VpiEndLineNo(fC->EndLine(sig->getNodeId()));
-        array_net->VpiEndColumnNo(fC->EndColumn(sig->getNodeId()));
+        fC->populateCoreMembers(sig->getNodeId(), sig->getNodeId(), array_net);
         if (array_nets == nullptr) {
           array_nets = s.MakeArray_netVec();
           netlist->array_nets(array_nets);
@@ -1892,21 +1820,13 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
       logicn->Attributes(sig->attributes());
       logicn->Typespec(tps);
       if (unpackedDimensions) {
-        logicn->VpiLineNo(fC->Line(id));
-        logicn->VpiColumnNo(fC->Column(id));
-        logicn->VpiEndLineNo(fC->EndLine(id));
-        logicn->VpiEndColumnNo(fC->EndColumn(id));
-        logicn->VpiFile(fC->getFileName());
+        fC->populateCoreMembers(id, id, logicn);
         array_net* array_net = s.MakeArray_net();
         array_net->Nets(s.MakeNetVec());
         array_net->Ranges(unpackedDimensions);
         array_net->VpiName(signame);
         array_net->VpiSize(unpackedSize);
-        array_net->VpiFile(fC->getFileName());
-        array_net->VpiLineNo(fC->Line(sig->getNodeId()));
-        array_net->VpiColumnNo(fC->Column(sig->getNodeId()));
-        array_net->VpiEndLineNo(fC->EndLine(sig->getNodeId()));
-        array_net->VpiEndColumnNo(fC->EndColumn(sig->getNodeId()));
+        fC->populateCoreMembers(sig->getNodeId(), sig->getNodeId(), array_net);
         if (array_nets == nullptr) {
           array_nets = s.MakeArray_netVec();
           netlist->array_nets(array_nets);
@@ -1934,11 +1854,7 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
     if (exp) {
       cont_assign* assign = s.MakeCont_assign();
       assign->VpiNetDeclAssign(true);
-      assign->VpiFile(fC->getFileName());
-      assign->VpiLineNo(fC->Line(id));
-      assign->VpiColumnNo(fC->Column(id));
-      assign->VpiEndLineNo(fC->EndLine(id));
-      assign->VpiEndColumnNo(fC->EndColumn(id));
+      fC->populateCoreMembers(id, id, assign);
       assign->Lhs((expr*)obj);
       assign->Rhs(exp);
       m_helper.setParentNoOverride((expr*)obj, assign);
@@ -1965,15 +1881,10 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
 
   if (obj) {
     if (obj->VpiLineNo() == 0) {
-      obj->VpiFile(fC->getFileName());
-      obj->VpiLineNo(fC->Line(id));
-      obj->VpiColumnNo(fC->Column(id));
       if (unpackedDimension) {
-        obj->VpiEndLineNo(fC->EndLine(unpackedDimension));
-        obj->VpiEndColumnNo(fC->EndColumn(unpackedDimension));
+        fC->populateCoreMembers(id, unpackedDimension, obj);
       } else {
-        obj->VpiEndLineNo(fC->EndLine(id));
-        obj->VpiEndColumnNo(fC->EndColumn(id));
+        fC->populateCoreMembers(id, id, obj);
       }
     }
     if (parentNetlist)
@@ -2047,11 +1958,7 @@ bool NetlistElaboration::elab_ports_nets_(
           signame = sig->getName();
           dest_port->VpiName(signame);
         }
-        dest_port->VpiLineNo(fC->Line(id));
-        dest_port->VpiColumnNo(fC->Column(id));
-        dest_port->VpiEndLineNo(fC->EndLine(id));
-        dest_port->VpiEndColumnNo(fC->EndColumn(id));
-        dest_port->VpiFile(fC->getFileName());
+        fC->populateCoreMembers(id, id, dest_port);
         if (ports == nullptr) {
           ports = s.MakePortVec();
           netlist->ports(ports);
@@ -2086,11 +1993,7 @@ bool NetlistElaboration::elab_ports_nets_(
           portInterf.insert(sig->getName());
           ref_obj* ref = s.MakeRef_obj();
           ref->VpiFullName(instance->getFullPathName() + "." + sig->getName());
-          ref->VpiFile(fC->getFileName());
-          ref->VpiLineNo(fC->Line(sig->getNodeId()));
-          ref->VpiColumnNo(fC->Column(sig->getNodeId()));
-          ref->VpiEndLineNo(fC->EndLine(sig->getNodeId()));
-          ref->VpiEndColumnNo(fC->EndColumn(sig->getNodeId()));
+          fC->populateCoreMembers(sig->getNodeId(), sig->getNodeId(), ref);
           dest_port->Low_conn(ref);
           Netlist::ModPortMap::iterator itr =
               netlist->getModPortMap().find(signame);
@@ -2189,11 +2092,7 @@ bool NetlistElaboration::elab_ports_nets_(
           portInterf.insert(sig->getName());
           ref_obj* ref = s.MakeRef_obj();
           ref->VpiFullName(instance->getFullPathName() + "." + sig->getName());
-          ref->VpiFile(fC->getFileName());
-          ref->VpiLineNo(fC->Line(sig->getNodeId()));
-          ref->VpiColumnNo(fC->Column(sig->getNodeId()));
-          ref->VpiEndLineNo(fC->EndLine(sig->getNodeId()));
-          ref->VpiEndColumnNo(fC->EndColumn(sig->getNodeId()));
+          fC->populateCoreMembers(sig->getNodeId(), sig->getNodeId(), ref);
           dest_port->Low_conn(ref);
           Netlist::InstanceMap::iterator itr =
               netlist->getInstanceMap().find(signame);
@@ -2284,11 +2183,7 @@ bool NetlistElaboration::elab_ports_nets_(
             ref->VpiName(signame);
             ref->VpiFullName(netlist->getParent()->getFullPathName() + "." +
                              signame);
-            ref->VpiFile(fC->getFileName());
-            ref->VpiLineNo(fC->Line(sig->getNodeId()));
-            ref->VpiColumnNo(fC->Column(sig->getNodeId()));
-            ref->VpiEndLineNo(fC->EndLine(sig->getNodeId()));
-            ref->VpiEndColumnNo(fC->EndColumn(sig->getNodeId()));
+            fC->populateCoreMembers(sig->getNodeId(), sig->getNodeId(), ref);
             ref->Actual_group(n);
             dest_port->Low_conn(ref);
           }
@@ -2397,11 +2292,7 @@ UHDM::any* NetlistElaboration::bind_net_(const FileContent* origfC, NodeId id,
         logic_net* net = s.MakeLogic_net();
         net->VpiName(name);
         net->VpiNetType(UhdmWriter::getVpiNetType(implicitNetType));
-        net->VpiFile(origfC->getFileName());
-        net->VpiLineNo(origfC->Line(id));
-        net->VpiColumnNo(origfC->Column(id));
-        net->VpiEndLineNo(origfC->EndLine(id));
-        net->VpiEndColumnNo(origfC->EndColumn(id));
+        origfC->populateCoreMembers(id, id, net);
         result = net;
         Netlist::SymbolTable& symbols = netlist->getSymbolTable();
         std::vector<UHDM::net*>* nets = netlist->nets();

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -250,17 +250,11 @@ bool TestbenchElaboration::bindBaseClasses_() {
         UHDM::class_defn* parent = bdef->getUhdmDefinition();
         classDefinition->insertProperty(prop);
         UHDM::extends* extends = s.MakeExtends();
-        extends->VpiFile(fCDef->getFileName());
-        extends->VpiLineNo(fCDef->Line(placeHolder->getNodeId()));
-        extends->VpiColumnNo(fCDef->Column(placeHolder->getNodeId()));
-        extends->VpiEndLineNo(fCDef->EndLine(placeHolder->getNodeId()));
-        extends->VpiEndColumnNo(fCDef->EndColumn(placeHolder->getNodeId()));
+        fCDef->populateCoreMembers(placeHolder->getNodeId(),
+                                   placeHolder->getNodeId(), extends);
         UHDM::class_typespec* tps = s.MakeClass_typespec();
-        tps->VpiFile(fCDef->getFileName());
-        tps->VpiLineNo(fCDef->Line(placeHolder->getNodeId()));
-        tps->VpiColumnNo(fCDef->Column(placeHolder->getNodeId()));
-        tps->VpiEndLineNo(fCDef->EndLine(placeHolder->getNodeId()));
-        tps->VpiEndColumnNo(fCDef->EndColumn(placeHolder->getNodeId()));
+        fCDef->populateCoreMembers(placeHolder->getNodeId(),
+                                   placeHolder->getNodeId(), tps);
         extends->Class_typespec(tps);
         tps->Class_defn(parent);
         tps->VpiName(placeHolder->getName());
@@ -285,11 +279,8 @@ bool TestbenchElaboration::bindBaseClasses_() {
                            false, false, false, false, false);
           classDefinition->insertProperty(prop);
           UHDM::extends* extends = s.MakeExtends();
-          extends->VpiFile(fCDef->getFileName());
-          extends->VpiLineNo(fCDef->Line(placeHolder->getNodeId()));
-          extends->VpiColumnNo(fCDef->Column(placeHolder->getNodeId()));
-          extends->VpiEndLineNo(fCDef->EndLine(placeHolder->getNodeId()));
-          extends->VpiEndColumnNo(fCDef->EndColumn(placeHolder->getNodeId()));
+          fCDef->populateCoreMembers(placeHolder->getNodeId(),
+                                     placeHolder->getNodeId(), extends);
           UHDM::class_typespec* tps = s.MakeClass_typespec();
           tps->VpiName(class_def.second->getName());
           extends->Class_typespec(tps);
@@ -764,11 +755,7 @@ bool TestbenchElaboration::bindProperties_() {
           events->push_back((UHDM::named_event*)obj);
         }
 
-        obj->VpiLineNo(fC->Line(id));
-        obj->VpiColumnNo(fC->Column(id));
-        obj->VpiEndLineNo(fC->EndLine(id));
-        obj->VpiEndColumnNo(fC->EndColumn(id));
-        obj->VpiFile(fC->getFileName());
+        fC->populateCoreMembers(id, id, obj);
         obj->VpiParent(defn);
       } else {
         // Unsupported type

--- a/tests/ArrayMethodIterator/ArrayMethodIterator.log
+++ b/tests/ArrayMethodIterator/ArrayMethodIterator.log
@@ -231,7 +231,7 @@ design: (work@top)
     |vpiName:uvm_callbacks
     |vpiFullName:pkg::uvm_callbacks
     |vpiParameter:
-    \_type_parameter: (pkg::uvm_callbacks::T), line:10:28, endln:10:28
+    \_type_parameter: (pkg::uvm_callbacks::T), line:10:28, endln:10:29
       |vpiParent:
       \_class_defn: (pkg::uvm_callbacks), file:dut.sv, line:10:1, endln:23:9
       |vpiName:T
@@ -239,12 +239,12 @@ design: (work@top)
       |vpiTypespec:
       \_class_typespec: (uvm_object), line:10:30, endln:10:40
         |vpiParent:
-        \_type_parameter: (pkg::uvm_callbacks::T), line:10:28, endln:10:28
+        \_type_parameter: (pkg::uvm_callbacks::T), line:10:28, endln:10:29
         |vpiName:uvm_object
         |vpiClassDefn:
         \_class_defn: (pkg::uvm_object), file:dut.sv, line:3:3, endln:4:11
     |vpiParameter:
-    \_type_parameter: (pkg::uvm_callbacks::CB), line:10:47, endln:10:47
+    \_type_parameter: (pkg::uvm_callbacks::CB), line:10:47, endln:10:49
       |vpiParent:
       \_class_defn: (pkg::uvm_callbacks), file:dut.sv, line:10:1, endln:23:9
       |vpiName:CB
@@ -252,7 +252,7 @@ design: (work@top)
       |vpiTypespec:
       \_class_typespec: (uvm_callback), line:10:50, endln:10:62
         |vpiParent:
-        \_type_parameter: (pkg::uvm_callbacks::CB), line:10:47, endln:10:47
+        \_type_parameter: (pkg::uvm_callbacks::CB), line:10:47, endln:10:49
         |vpiName:uvm_callback
         |vpiClassDefn:
         \_class_defn: (pkg::uvm_callback), file:dut.sv, line:6:3, endln:8:11

--- a/tests/ClassExtendParam/ClassExtendParam.log
+++ b/tests/ClassExtendParam/ClassExtendParam.log
@@ -260,7 +260,7 @@ design: (unnamed)
     |vpiName:uvm_reg_sequence
     |vpiFullName:uvm::uvm_reg_sequence
     |vpiParameter:
-    \_type_parameter: (uvm::uvm_reg_sequence::BASE), line:7:31, endln:7:31
+    \_type_parameter: (uvm::uvm_reg_sequence::BASE), line:7:31, endln:7:35
       |vpiParent:
       \_class_defn: (uvm::uvm_reg_sequence), file:dut.sv, line:7:1, endln:13:9
       |vpiName:BASE
@@ -268,7 +268,7 @@ design: (unnamed)
       |vpiTypespec:
       \_class_typespec: (uvm_sequence), line:7:36, endln:7:48
         |vpiParent:
-        \_type_parameter: (uvm::uvm_reg_sequence::BASE), line:7:31, endln:7:31
+        \_type_parameter: (uvm::uvm_reg_sequence::BASE), line:7:31, endln:7:35
         |vpiName:uvm_sequence
         |vpiClassDefn:
         \_class_defn: (uvm::uvm_sequence), file:dut.sv, line:3:9, endln:5:9
@@ -330,7 +330,7 @@ design: (unnamed)
     |vpiName:uvm_sequence
     |vpiFullName:uvm::uvm_sequence
     |vpiParameter:
-    \_type_parameter: (uvm::uvm_sequence::REQ), line:3:35, endln:3:35
+    \_type_parameter: (uvm::uvm_sequence::REQ), line:3:35, endln:3:38
       |vpiParent:
       \_class_defn: (uvm::uvm_sequence), file:dut.sv, line:3:9, endln:5:9
       |vpiName:REQ
@@ -338,12 +338,12 @@ design: (unnamed)
       |vpiTypespec:
       \_class_typespec: (uvm_sequence_item), line:3:41, endln:3:58
         |vpiParent:
-        \_type_parameter: (uvm::uvm_sequence::RSP), line:4:35, endln:4:35
+        \_type_parameter: (uvm::uvm_sequence::RSP), line:4:35, endln:4:38
         |vpiName:uvm_sequence_item
         |vpiClassDefn:
         \_class_defn: (uvm::uvm_sequence_item), file:dut.sv, line:25:1, endln:31:9
     |vpiParameter:
-    \_type_parameter: (uvm::uvm_sequence::RSP), line:4:35, endln:4:35
+    \_type_parameter: (uvm::uvm_sequence::RSP), line:4:35, endln:4:38
       |vpiParent:
       \_class_defn: (uvm::uvm_sequence), file:dut.sv, line:3:9, endln:5:9
       |vpiName:RSP

--- a/tests/ClassFuncTask/ClassFuncTask.log
+++ b/tests/ClassFuncTask/ClassFuncTask.log
@@ -75,7 +75,7 @@ design: (unnamed)
       |vpiAutomatic:1
       |vpiVisibility:1
     |vpiParameter:
-    \_type_parameter: (pack::C::T), line:12:16, endln:12:16
+    \_type_parameter: (pack::C::T), line:12:16, endln:12:17
       |vpiParent:
       \_class_defn: (pack::C), file:dut.sv, line:12:1, endln:25:9
       |vpiName:T
@@ -83,7 +83,7 @@ design: (unnamed)
       |vpiTypespec:
       \_int_typespec: , line:12:18, endln:12:21
         |vpiParent:
-        \_type_parameter: (pack::C::T), line:12:16, endln:12:16
+        \_type_parameter: (pack::C::T), line:12:16, endln:12:17
         |vpiSigned:1
     |vpiMethod:
     \_function: (pack::C::new), line:15:3, endln:17:14
@@ -293,7 +293,7 @@ design: (unnamed)
     |vpiName:ovm_queue
     |vpiFullName:pack::ovm_queue
     |vpiParameter:
-    \_type_parameter: (pack::ovm_queue::T), line:9:24, endln:9:24
+    \_type_parameter: (pack::ovm_queue::T), line:9:24, endln:9:25
       |vpiParent:
       \_class_defn: (pack::ovm_queue), file:dut.sv, line:9:1, endln:10:9
       |vpiName:T
@@ -301,10 +301,10 @@ design: (unnamed)
       |vpiTypespec:
       \_int_typespec: , line:9:26, endln:9:29
         |vpiParent:
-        \_type_parameter: (pack::ovm_queue::T), line:9:24, endln:9:24
+        \_type_parameter: (pack::ovm_queue::T), line:9:24, endln:9:25
         |vpiSigned:1
     |vpiParameter:
-    \_type_parameter: (pack::ovm_queue::Q), line:9:36, endln:9:36
+    \_type_parameter: (pack::ovm_queue::Q), line:9:36, endln:9:37
       |vpiParent:
       \_class_defn: (pack::ovm_queue), file:dut.sv, line:9:1, endln:10:9
       |vpiName:Q
@@ -312,7 +312,7 @@ design: (unnamed)
       |vpiTypespec:
       \_short_int_typespec: , line:9:38, endln:9:46
         |vpiParent:
-        \_type_parameter: (pack::ovm_queue::Q), line:9:36, endln:9:36
+        \_type_parameter: (pack::ovm_queue::Q), line:9:36, endln:9:37
         |vpiSigned:1
 ===================
 [  FATAL] : 0

--- a/tests/ClassParamAsParam/ClassParamAsParam.log
+++ b/tests/ClassParamAsParam/ClassParamAsParam.log
@@ -50,7 +50,7 @@ design: (work@top)
   \_design: (work@top)
   |vpiName:work@config_db
   |vpiParameter:
-  \_type_parameter: (work@config_db::T), line:14:23, endln:14:23
+  \_type_parameter: (work@config_db::T), line:14:23, endln:14:24
     |vpiParent:
     \_class_defn: (work@config_db), file:dut.sv, line:14:1, endln:15:9
     |vpiName:T
@@ -58,7 +58,7 @@ design: (work@top)
     |vpiTypespec:
     \_int_typespec: , line:14:25, endln:14:28
       |vpiParent:
-      \_type_parameter: (work@config_db::T), line:14:23, endln:14:23
+      \_type_parameter: (work@config_db::T), line:14:23, endln:14:24
       |vpiSigned:1
   |vpiParamAssign:
   \_param_assign: 
@@ -89,7 +89,7 @@ design: (work@top)
           |vpiRhs:
           \_type_parameter: (config_db.T.object.T)
           |vpiLhs:
-          \_type_parameter: (work@object::T), line:1:28, endln:1:28
+          \_type_parameter: (work@object::T), line:1:28, endln:1:29
             |vpiParent:
             \_class_defn: (work@object), file:dut.sv, line:1:9, endln:2:9
             |vpiName:T
@@ -97,12 +97,12 @@ design: (work@top)
             |vpiTypespec:
             \_int_typespec: , line:1:30, endln:1:33
               |vpiParent:
-              \_type_parameter: (work@object::T), line:1:28, endln:1:28
+              \_type_parameter: (work@object::T), line:1:28, endln:1:29
               |vpiSigned:1
         |vpiClassDefn:
         \_class_defn: (work@object), file:dut.sv, line:1:9, endln:2:9
     |vpiLhs:
-    \_type_parameter: (work@config_db::T), line:14:23, endln:14:23
+    \_type_parameter: (work@config_db::T), line:14:23, endln:14:24
   |vpiExtends:
   \_extends: , line:14:38, endln:14:49
     |vpiParent:
@@ -120,7 +120,7 @@ design: (work@top)
   \_design: (work@top)
   |vpiName:work@object
   |vpiParameter:
-  \_type_parameter: (work@object::T), line:1:28, endln:1:28
+  \_type_parameter: (work@object::T), line:1:28, endln:1:29
   |vpiVirtual:1
 |uhdmallClasses:
 \_class_defn: (work@resource), file:dut.sv, line:4:1, endln:5:9
@@ -128,7 +128,7 @@ design: (work@top)
   \_design: (work@top)
   |vpiName:work@resource
   |vpiParameter:
-  \_type_parameter: (work@resource::T), line:4:23, endln:4:23
+  \_type_parameter: (work@resource::T), line:4:23, endln:4:24
     |vpiParent:
     \_class_defn: (work@resource), file:dut.sv, line:4:1, endln:5:9
     |vpiName:T
@@ -136,14 +136,14 @@ design: (work@top)
     |vpiTypespec:
     \_int_typespec: , line:4:25, endln:4:28
       |vpiParent:
-      \_type_parameter: (work@resource::T), line:4:23, endln:4:23
+      \_type_parameter: (work@resource::T), line:4:23, endln:4:24
       |vpiSigned:1
   |vpiParamAssign:
   \_param_assign: 
     |vpiRhs:
     \_type_parameter: (work@top.misc2.config_db.T)
     |vpiLhs:
-    \_type_parameter: (work@resource::T), line:4:23, endln:4:23
+    \_type_parameter: (work@resource::T), line:4:23, endln:4:24
 |uhdmallClasses:
 \_class_defn: (work@resource_db), file:dut.sv, line:7:1, endln:12:9
   |vpiParent:
@@ -165,7 +165,7 @@ design: (work@top)
     |vpiAutomatic:1
     |vpiVisibility:1
   |vpiParameter:
-  \_type_parameter: (work@resource_db::T), line:7:26, endln:7:26
+  \_type_parameter: (work@resource_db::T), line:7:26, endln:7:27
     |vpiParent:
     \_class_defn: (work@resource_db), file:dut.sv, line:7:1, endln:12:9
     |vpiName:T
@@ -173,14 +173,14 @@ design: (work@top)
     |vpiTypespec:
     \_int_typespec: , line:7:28, endln:7:31
       |vpiParent:
-      \_type_parameter: (work@resource_db::T), line:7:26, endln:7:26
+      \_type_parameter: (work@resource_db::T), line:7:26, endln:7:27
       |vpiSigned:1
   |vpiParamAssign:
   \_param_assign: 
     |vpiRhs:
     \_type_parameter: (work@top.misc2.config_db.T)
     |vpiLhs:
-    \_type_parameter: (work@resource_db::T), line:7:26, endln:7:26
+    \_type_parameter: (work@resource_db::T), line:7:26, endln:7:27
   |vpiTypedef:
   \_class_typespec: (rsrc_t), line:9:10, endln:9:18
     |vpiParent:
@@ -229,7 +229,7 @@ design: (work@top)
         |vpiRhs:
         \_type_parameter: (work@top.misc2.config_db.T)
         |vpiLhs:
-        \_type_parameter: (work@top.misc2.config_db.T), line:14:23, endln:14:23
+        \_type_parameter: (work@top.misc2.config_db.T), line:14:23, endln:14:24
           |vpiParent:
           \_param_assign: 
           |vpiName:T

--- a/tests/ClassTypeParam/ClassTypeParam.log
+++ b/tests/ClassTypeParam/ClassTypeParam.log
@@ -50,7 +50,7 @@ design: (work@top)
   \_design: (work@top)
   |vpiName:work@uvm_config_db
   |vpiParameter:
-  \_type_parameter: (work@uvm_config_db::T), line:16:27, endln:16:27
+  \_type_parameter: (work@uvm_config_db::T), line:16:27, endln:16:28
     |vpiParent:
     \_class_defn: (work@uvm_config_db), file:dut.sv, line:16:1, endln:17:9
     |vpiName:T
@@ -58,10 +58,10 @@ design: (work@top)
     |vpiTypespec:
     \_int_typespec: , line:16:29, endln:16:32
       |vpiParent:
-      \_type_parameter: (work@uvm_config_db::T), line:16:27, endln:16:27
+      \_type_parameter: (work@uvm_config_db::T), line:16:27, endln:16:28
       |vpiSigned:1
   |vpiParameter:
-  \_type_parameter: (work@uvm_config_db::T2), line:16:39, endln:16:39
+  \_type_parameter: (work@uvm_config_db::T2), line:16:39, endln:16:41
     |vpiParent:
     \_class_defn: (work@uvm_config_db), file:dut.sv, line:16:1, endln:17:9
     |vpiName:T2
@@ -69,7 +69,7 @@ design: (work@top)
     |vpiTypespec:
     \_int_typespec: , line:16:42, endln:16:45
       |vpiParent:
-      \_type_parameter: (work@uvm_config_db::T2), line:16:39, endln:16:39
+      \_type_parameter: (work@uvm_config_db::T2), line:16:39, endln:16:41
       |vpiSigned:1
   |vpiParamAssign:
   \_param_assign: 
@@ -87,7 +87,7 @@ design: (work@top)
         |vpiClassDefn:
         \_class_defn: (work@uvm_object), file:dut.sv, line:1:9, endln:2:9
     |vpiLhs:
-    \_type_parameter: (work@uvm_config_db::T), line:16:27, endln:16:27
+    \_type_parameter: (work@uvm_config_db::T), line:16:27, endln:16:28
   |vpiParamAssign:
   \_param_assign: 
     |vpiRhs:
@@ -101,7 +101,7 @@ design: (work@top)
         |vpiParent:
         \_type_parameter: (m_uvm_config_obj_misc.T2)
     |vpiLhs:
-    \_type_parameter: (work@uvm_config_db::T2), line:16:39, endln:16:39
+    \_type_parameter: (work@uvm_config_db::T2), line:16:39, endln:16:41
   |vpiParamAssign:
   \_param_assign: 
     |vpiRhs:
@@ -118,7 +118,7 @@ design: (work@top)
         |vpiClassDefn:
         \_class_defn: (work@uvm_object), file:dut.sv, line:1:9, endln:2:9
     |vpiLhs:
-    \_type_parameter: (work@uvm_config_db::T), line:16:27, endln:16:27
+    \_type_parameter: (work@uvm_config_db::T), line:16:27, endln:16:28
   |vpiParamAssign:
   \_param_assign: 
     |vpiRhs:
@@ -132,7 +132,7 @@ design: (work@top)
         |vpiParent:
         \_type_parameter: (uvm_config_db.T2)
     |vpiLhs:
-    \_type_parameter: (work@uvm_config_db::T2), line:16:39, endln:16:39
+    \_type_parameter: (work@uvm_config_db::T2), line:16:39, endln:16:41
   |vpiExtends:
   \_extends: , line:16:55, endln:16:70
     |vpiParent:
@@ -156,7 +156,7 @@ design: (work@top)
   \_design: (work@top)
   |vpiName:work@uvm_resource
   |vpiParameter:
-  \_type_parameter: (work@uvm_resource::T), line:4:27, endln:4:27
+  \_type_parameter: (work@uvm_resource::T), line:4:27, endln:4:28
     |vpiParent:
     \_class_defn: (work@uvm_resource), file:dut.sv, line:4:1, endln:5:9
     |vpiName:T
@@ -164,20 +164,20 @@ design: (work@top)
     |vpiTypespec:
     \_int_typespec: , line:4:29, endln:4:32
       |vpiParent:
-      \_type_parameter: (work@uvm_resource::T), line:4:27, endln:4:27
+      \_type_parameter: (work@uvm_resource::T), line:4:27, endln:4:28
       |vpiSigned:1
   |vpiParamAssign:
   \_param_assign: 
     |vpiRhs:
     \_type_parameter: (work@top.misc1.m_uvm_config_obj_misc.T)
     |vpiLhs:
-    \_type_parameter: (work@uvm_resource::T), line:4:27, endln:4:27
+    \_type_parameter: (work@uvm_resource::T), line:4:27, endln:4:28
   |vpiParamAssign:
   \_param_assign: 
     |vpiRhs:
     \_type_parameter: (work@top.misc2.uvm_config_db.T)
     |vpiLhs:
-    \_type_parameter: (work@uvm_resource::T), line:4:27, endln:4:27
+    \_type_parameter: (work@uvm_resource::T), line:4:27, endln:4:28
 |uhdmallClasses:
 \_class_defn: (work@uvm_resource_db), file:dut.sv, line:7:1, endln:14:9
   |vpiParent:
@@ -199,7 +199,7 @@ design: (work@top)
     |vpiAutomatic:1
     |vpiVisibility:1
   |vpiParameter:
-  \_type_parameter: (work@uvm_resource_db::T), line:7:30, endln:7:30
+  \_type_parameter: (work@uvm_resource_db::T), line:7:30, endln:7:31
     |vpiParent:
     \_class_defn: (work@uvm_resource_db), file:dut.sv, line:7:1, endln:14:9
     |vpiName:T
@@ -207,20 +207,20 @@ design: (work@top)
     |vpiTypespec:
     \_int_typespec: , line:7:32, endln:7:35
       |vpiParent:
-      \_type_parameter: (work@uvm_resource_db::T), line:7:30, endln:7:30
+      \_type_parameter: (work@uvm_resource_db::T), line:7:30, endln:7:31
       |vpiSigned:1
   |vpiParamAssign:
   \_param_assign: 
     |vpiRhs:
     \_type_parameter: (work@top.misc1.m_uvm_config_obj_misc.T)
     |vpiLhs:
-    \_type_parameter: (work@uvm_resource_db::T), line:7:30, endln:7:30
+    \_type_parameter: (work@uvm_resource_db::T), line:7:30, endln:7:31
   |vpiParamAssign:
   \_param_assign: 
     |vpiRhs:
     \_type_parameter: (work@top.misc2.uvm_config_db.T)
     |vpiLhs:
-    \_type_parameter: (work@uvm_resource_db::T), line:7:30, endln:7:30
+    \_type_parameter: (work@uvm_resource_db::T), line:7:30, endln:7:31
   |vpiTypedef:
   \_class_typespec: (rsrc_t), line:9:10, endln:9:22
     |vpiParent:
@@ -295,13 +295,13 @@ design: (work@top)
     |vpiRhs:
     \_type_parameter: (m_uvm_config_obj_misc.T)
     |vpiLhs:
-    \_type_parameter: (work@uvm_config_db::T), line:16:27, endln:16:27
+    \_type_parameter: (work@uvm_config_db::T), line:16:27, endln:16:28
   |vpiParamAssign:
   \_param_assign: 
     |vpiRhs:
     \_type_parameter: (m_uvm_config_obj_misc.T2)
     |vpiLhs:
-    \_type_parameter: (work@uvm_config_db::T2), line:16:39, endln:16:39
+    \_type_parameter: (work@uvm_config_db::T2), line:16:39, endln:16:41
   |vpiClassDefn:
   \_class_defn: (work@uvm_config_db), file:dut.sv, line:16:1, endln:17:9
 |uhdmtopModules:
@@ -341,7 +341,7 @@ design: (work@top)
         |vpiRhs:
         \_type_parameter: (work@top.misc1.m_uvm_config_obj_misc.T)
         |vpiLhs:
-        \_type_parameter: (work@top.misc1.m_uvm_config_obj_misc.T), line:16:27, endln:16:27
+        \_type_parameter: (work@top.misc1.m_uvm_config_obj_misc.T), line:16:27, endln:16:28
           |vpiParent:
           \_param_assign: 
           |vpiName:T
@@ -355,7 +355,7 @@ design: (work@top)
         |vpiRhs:
         \_type_parameter: (work@top.misc1.m_uvm_config_obj_misc.T2)
         |vpiLhs:
-        \_type_parameter: (work@top.misc1.m_uvm_config_obj_misc.T2), line:16:39, endln:16:39
+        \_type_parameter: (work@top.misc1.m_uvm_config_obj_misc.T2), line:16:39, endln:16:41
           |vpiParent:
           \_param_assign: 
           |vpiName:T2
@@ -402,7 +402,7 @@ design: (work@top)
         |vpiRhs:
         \_type_parameter: (work@top.misc2.uvm_config_db.T)
         |vpiLhs:
-        \_type_parameter: (work@top.misc2.uvm_config_db.T), line:16:27, endln:16:27
+        \_type_parameter: (work@top.misc2.uvm_config_db.T), line:16:27, endln:16:28
           |vpiParent:
           \_param_assign: 
           |vpiName:T
@@ -416,7 +416,7 @@ design: (work@top)
         |vpiRhs:
         \_type_parameter: (work@top.misc2.uvm_config_db.T2)
         |vpiLhs:
-        \_type_parameter: (work@top.misc2.uvm_config_db.T2), line:16:39, endln:16:39
+        \_type_parameter: (work@top.misc2.uvm_config_db.T2), line:16:39, endln:16:41
           |vpiParent:
           \_param_assign: 
           |vpiName:T2

--- a/tests/ClassVirtual/ClassVirtual.log
+++ b/tests/ClassVirtual/ClassVirtual.log
@@ -70,7 +70,7 @@ design: (unnamed)
       |vpiName:uvm_port_base2
       |vpiFullName:pack::uvm_port_base2
       |vpiParameter:
-      \_type_parameter: (pack::uvm_port_base2::IF), line:12:29, endln:12:29
+      \_type_parameter: (pack::uvm_port_base2::IF), line:12:29, endln:12:31
         |vpiParent:
         \_class_defn: (pack::uvm_port_base2), file:dut.sv, line:12:1, endln:13:9
         |vpiName:IF
@@ -78,7 +78,7 @@ design: (unnamed)
         |vpiTypespec:
         \_class_typespec: (uvm_void), line:12:32, endln:12:40
           |vpiParent:
-          \_type_parameter: (pack::uvm_port_base2::IF), line:12:29, endln:12:29
+          \_type_parameter: (pack::uvm_port_base2::IF), line:12:29, endln:12:31
           |vpiName:uvm_void
           |vpiClassDefn:
           \_class_defn: (pack::uvm_void), file:dut.sv, line:3:1, endln:4:9
@@ -100,7 +100,7 @@ design: (unnamed)
     |vpiName:uvm_port_base1
     |vpiFullName:pack::uvm_port_base1
     |vpiParameter:
-    \_type_parameter: (pack::uvm_port_base1::IF), line:9:37, endln:9:37
+    \_type_parameter: (pack::uvm_port_base1::IF), line:9:37, endln:9:39
       |vpiParent:
       \_class_defn: (pack::uvm_port_base1), file:dut.sv, line:9:9, endln:10:9
       |vpiName:IF
@@ -108,7 +108,7 @@ design: (unnamed)
       |vpiTypespec:
       \_class_typespec: (uvm_void), line:9:40, endln:9:48
         |vpiParent:
-        \_type_parameter: (pack::uvm_port_base1::IF), line:9:37, endln:9:37
+        \_type_parameter: (pack::uvm_port_base1::IF), line:9:37, endln:9:39
         |vpiName:uvm_void
         |vpiClassDefn:
         \_class_defn: (pack::uvm_void), file:dut.sv, line:3:1, endln:4:9

--- a/tests/Connection/Connection.log
+++ b/tests/Connection/Connection.log
@@ -733,7 +733,7 @@ design: (work@top)
       |vpiName:rd_disconn
       |vpiDirection:2
       |vpiHighConn:
-      \_operation: , line:6:19, endln:6:18
+      \_operation: , line:6:18, endln:6:19
         |vpiOpType:36
       |vpiLowConn:
       \_ref_obj: (work@top.u_mie_csr.rd_disconn), line:15:49, endln:15:59

--- a/tests/ExtendClassMember/ExtendClassMember.log
+++ b/tests/ExtendClassMember/ExtendClassMember.log
@@ -221,7 +221,7 @@ design: (unnamed)
     |vpiName:uvm_sequencer_analysis_fifo
     |vpiFullName:pkg::uvm_sequencer_analysis_fifo
     |vpiParameter:
-    \_type_parameter: (pkg::uvm_sequencer_analysis_fifo::RSP), line:9:42, endln:9:42
+    \_type_parameter: (pkg::uvm_sequencer_analysis_fifo::RSP), line:9:42, endln:9:45
       |vpiParent:
       \_class_defn: (pkg::uvm_sequencer_analysis_fifo), file:dut.sv, line:9:1, endln:10:9
       |vpiName:RSP
@@ -229,7 +229,7 @@ design: (unnamed)
       |vpiTypespec:
       \_unsupported_typespec: (uvm_sequence_item), line:9:48, endln:9:65
         |vpiParent:
-        \_type_parameter: (pkg::uvm_sequencer_analysis_fifo::RSP), line:9:42, endln:9:42
+        \_type_parameter: (pkg::uvm_sequencer_analysis_fifo::RSP), line:9:42, endln:9:45
         |vpiName:uvm_sequence_item
     |vpiExtends:
     \_extends: , line:9:75, endln:9:87
@@ -264,7 +264,7 @@ design: (unnamed)
       |vpiAutomatic:1
       |vpiVisibility:1
     |vpiParameter:
-    \_type_parameter: (pkg::uvm_sequencer_param_base::REQ), line:12:39, endln:12:39
+    \_type_parameter: (pkg::uvm_sequencer_param_base::REQ), line:12:39, endln:12:42
       |vpiParent:
       \_class_defn: (pkg::uvm_sequencer_param_base), file:dut.sv, line:12:1, endln:16:9
       |vpiName:REQ
@@ -272,10 +272,10 @@ design: (unnamed)
       |vpiTypespec:
       \_unsupported_typespec: (uvm_sequence_item), line:12:45, endln:12:62
         |vpiParent:
-        \_type_parameter: (pkg::uvm_sequencer_param_base::RSP), line:13:39, endln:13:39
+        \_type_parameter: (pkg::uvm_sequencer_param_base::RSP), line:13:39, endln:13:42
         |vpiName:uvm_sequence_item
     |vpiParameter:
-    \_type_parameter: (pkg::uvm_sequencer_param_base::RSP), line:13:39, endln:13:39
+    \_type_parameter: (pkg::uvm_sequencer_param_base::RSP), line:13:39, endln:13:42
       |vpiParent:
       \_class_defn: (pkg::uvm_sequencer_param_base), file:dut.sv, line:12:1, endln:16:9
       |vpiName:RSP

--- a/third_party/tests/CoresSweRVMP/CoresSweRVMP.log
+++ b/third_party/tests/CoresSweRVMP/CoresSweRVMP.log
@@ -2,13 +2,20 @@
 
 [WRN:CM0010] Command line argument "-Wno-UNOPTFLAT" ignored.
 
-Running: cd "../../../build/regression/CoresSweRVMP/slpp_all"; cmake -G "Unix Makefiles" .; make -j 16
+Running: cd "../../../build/regression/CoresSweRVMP/slpp_all"; cmake -G "Unix Makefiles" .; make -j 2
 -- Configuring done
 -- Generating done
 -- Build files have been written to: ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all
-Scanning dependencies of target Parse
+make[1]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
+make[2]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
+make[3]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
+make[3]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
+make[3]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
 [100%] Generating preprocessing
+make[3]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
 [100%] Built target Parse
+make[2]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
+make[1]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
 Surelog preproc status: 0
 [INF:PP0122] Preprocessing source file "../../UVM/1800.2-2017-1.0/src/uvm_pkg.sv".
 
@@ -114,27 +121,21 @@ Surelog preproc status: 0
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/CoresSweRVMP/design/lib/axi4_to_ahb.sv".
 
-Running: cd "../../../build/regression/CoresSweRVMP/slpp_all"; cmake -G "Unix Makefiles" .; make -j 16
+Running: cd "../../../build/regression/CoresSweRVMP/slpp_all"; cmake -G "Unix Makefiles" .; make -j 2
 -- Configuring done
 -- Generating done
 -- Build files have been written to: ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all
-[  6%] Generating 1_lsu_stbuf.sv
-[ 18%] Generating 8_ifu_aln_ctl.sv
-[ 18%] Generating 2_ahb_to_axi4.sv
-[ 25%] Generating 3_rvjtag_tap.sv
-[ 31%] Generating 4_dec_tlu_ctl.sv
-[ 37%] Generating 5_lsu_bus_buffer.sv
-[ 43%] Generating 6_dbg.sv
-[ 50%] Generating 7_axi4_to_ahb.sv
-[ 56%] Generating 9_tb_top.sv
-[ 62%] Generating 10_lsu_bus_intf.sv
-[ 75%] Generating 12_beh_lib.sv
-[ 75%] Generating 11_ifu_bp_ctl.sv
-[ 81%] Generating 13_ifu_mem_ctl.sv
-[ 87%] Generating 14_mem_lib.sv
-[ 93%] Generating 15_exu.sv
-[100%] Generating 16_dec_decode_ctl.sv
+make[1]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
+make[2]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
+make[3]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
+make[3]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
+make[3]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
+[ 50%] Generating 1_axi4_to_ahb.sv
+[100%] Generating 2_mem_lib.sv
+make[3]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
 [100%] Built target Parse
+make[2]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
+make[1]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all'
 Surelog parsing status: 0
 [INF:PA0201] Parsing source file "../../UVM/1800.2-2017-1.0/src/uvm_pkg.sv".
 


### PR DESCRIPTION
 Reduce code bloat

Introducing a new helper function in FileContent to fill core (line,
column, endline, endcolumn and file) fields of UDHM model and reroute all
usages thru' this function. The helper function also implements a few
checks to ensure integrity.

In the process of implementing this, found few typo errors that resulted
in bad location information:

* CompileHelper.cpp:2564
* UhdmWriter.cpp:788
* NetlistElaboration:983
* 