### PR TITLE
Optimize Cache Restoration

### DIFF
--- a/include/Surelog/Cache/PPCache.h
+++ b/include/Surelog/Cache/PPCache.h
@@ -46,7 +46,11 @@ class PPCache : Cache {
   std::filesystem::path getCacheFileName_(
       const std::filesystem::path& fileName = "");
   bool restore_(const std::filesystem::path& cacheFileName, bool errorsOnly);
+  bool restore_(const std::filesystem::path& cacheFileName,
+                const std::unique_ptr<uint8_t[]>& buffer, bool errorsOnly);
   bool checkCacheIsValid_(const std::filesystem::path& cacheFileName);
+  bool checkCacheIsValid_(const std::filesystem::path& cacheFileName,
+                          const std::unique_ptr<uint8_t[]>& buffer);
 
   PreprocessFile* m_pp;
   bool m_isPrecompiled;

--- a/include/Surelog/Cache/ParseCache.h
+++ b/include/Surelog/Cache/ParseCache.h
@@ -27,6 +27,8 @@
 
 #include <Surelog/Cache/Cache.h>
 
+#include <memory>
+
 namespace SURELOG {
 
 class ParseFile;
@@ -44,8 +46,10 @@ class ParseCache : Cache {
 
   std::filesystem::path getCacheFileName_(
       const std::filesystem::path& fileName = "");
-  bool restore_(const std::filesystem::path& cacheFileName);
-  bool checkCacheIsValid_(const std::filesystem::path& cacheFileName);
+  bool restore_(const std::filesystem::path& cacheFileName,
+                const std::unique_ptr<uint8_t[]>& buffer);
+  bool checkCacheIsValid_(const std::filesystem::path& cacheFileName,
+                          const std::unique_ptr<uint8_t[]>& buffer);
 
   ParseFile* m_parse;
   bool m_isPrecompiled;


### PR DESCRIPTION
Optimize Cache Restoration

Avoid loading the cache file twice, once for validation and again for restore.
Instead load the file once and use the buffer for both operations.