### PR TITLE
Bugfix: core dump when 3 or more slashes (///) are found in a command-line-argument file ( -f file )

### DIFF
--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -295,7 +295,7 @@ std::string StringUtils::removeComments(std::string_view text) {
   char c1 = '\0';
   bool inComment = 0;
   for (char c2 : text) {
-    if ((c2 == '/') && (c1 == '/')) {
+    if ((c2 == '/') && (c1 == '/') && !inComment) {
       inComment = true;
       result.erase(result.end() - 1);
     }

--- a/src/Utils/StringUtils_test.cpp
+++ b/src/Utils/StringUtils_test.cpp
@@ -216,6 +216,7 @@ TEST(StringUtilsTest, SplitLines) {
 }
 
 TEST(StringUtilsTest, RemoveComments) {
+  EXPECT_EQ("hello ", StringUtils::removeComments("hello /// world"));
   EXPECT_EQ("hello ", StringUtils::removeComments("hello // world"));
   EXPECT_EQ("hello ", StringUtils::removeComments("hello # world"));
   EXPECT_EQ("hello \nworld",


### PR DESCRIPTION
Before this fix:
```
$ cat t.f
//
x.v

$ cat t2.f
///
x.v

$ surelog -f t.f
[INF:CM0023] Creating log file ./slpp_all/surelog.log.

[  FATAL] : 0
[ SYNTAX] : 0
[  ERROR] : 0
[WARNING] : 0
[   NOTE] : 0
$ surelog -f t2.f
tcmalloc: large alloc 72057594037936128 bytes == (nil) @  0x7efd7fd95680 0x7efd7fdb5ff4 0x7efd7fcbd35e 0x560f6915d5e5 0x560f690d747f 0x560f690db11b 0x560f690cdf0a 0x560f690c86c8 0x7efd7f842083 0x560f690cddae
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
Aborted
```