### PR TITLE
Issue #2861: IncludeFileInfo was being duplicated when cache is enabled

### DIFF
--- a/include/Surelog/Cache/PPCache.h
+++ b/include/Surelog/Cache/PPCache.h
@@ -46,10 +46,10 @@ class PPCache : Cache {
   std::filesystem::path getCacheFileName_(
       const std::filesystem::path& fileName = "");
   bool restore_(const std::filesystem::path& cacheFileName, bool errorsOnly,
-                bool skipLineTranslationInfo);
+                int recursionDepth);
   bool restore_(const std::filesystem::path& cacheFileName,
                 const std::unique_ptr<uint8_t[]>& buffer, bool errorsOnly,
-                bool skipLineTranslationInfo);
+                int recursionDepth);
   bool checkCacheIsValid_(const std::filesystem::path& cacheFileName);
   bool checkCacheIsValid_(const std::filesystem::path& cacheFileName,
                           const std::unique_ptr<uint8_t[]>& buffer);

--- a/include/Surelog/SourceCompile/PreprocessFile.h
+++ b/include/Surelog/SourceCompile/PreprocessFile.h
@@ -150,6 +150,8 @@ class PreprocessFile {
                          unsigned int originalEndColumn,
                          IncludeFileInfo::Action type, int indexOpening = 0,
                          int indexClosing = 0);
+  void resetIncludeFileInfo();
+  void clearIncludeFileInfo();
   IncludeFileInfo& getIncludeFileInfo(int index) {
     if (index >= 0 && index < ((int)m_includeFileInfo.size()))
       return m_includeFileInfo[index];

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -229,11 +229,7 @@ PreprocessFile::PreprocessFile(SymbolId fileId, CompileSourceFile* csf,
       m_fileContent(nullptr),
       m_verilogVersion(VerilogVersion::NoVersion) {
   setDebug(m_compileSourceFile->m_commandLineParser->getDebugLevel());
-  if ((!m_compileSourceFile->m_commandLineParser->parseOnly()) &&
-      (!m_compileSourceFile->m_commandLineParser->lowMem())) {
-    addIncludeFileInfo(IncludeFileInfo::Context::NONE, 0, m_fileId, 0, 0, 0, 0,
-                       IncludeFileInfo::Action::POP, 0, 0);
-  }
+  resetIncludeFileInfo();
 }
 
 PreprocessFile::PreprocessFile(SymbolId fileId, PreprocessFile* includedIn,
@@ -340,6 +336,9 @@ bool PreprocessFile::preprocess() {
       std::cout << m_fileContent->printObjects();
     if (precompiled || clp->noCacheHash()) {
       return true;
+    }
+    if (!clp->parseOnly() && !clp->lowMem()) {
+      resetIncludeFileInfo();
     }
   }
   if (clp->parseOnly() || clp->lowMem() || clp->link()) return true;
@@ -545,6 +544,17 @@ int PreprocessFile::addIncludeFileInfo(
                                  indexOpening, indexClosing);
   return index;
 }
+
+void PreprocessFile::resetIncludeFileInfo() {
+  clearIncludeFileInfo();
+  if ((!m_compileSourceFile->m_commandLineParser->parseOnly()) &&
+      (!m_compileSourceFile->m_commandLineParser->lowMem())) {
+    addIncludeFileInfo(IncludeFileInfo::Context::NONE, 0, m_fileId, 0, 0, 0, 0,
+                       IncludeFileInfo::Action::POP, 0, 0);
+  }
+}
+
+void PreprocessFile::clearIncludeFileInfo() { m_includeFileInfo.clear(); }
 
 void PreprocessFile::append(const std::string& s) {
   if (!m_pauseAppend) {


### PR DESCRIPTION
Issue #2861: IncludeFileInfo was being duplicated when cache is enabled

Clear the IncludeFileInfo container if using PP cache to allow the walk
to populate it again. Also, clear the IncludeFileInfo before popilating
it from cache (there's a default element in the container which gets
added from the PreprocessFile constructor).