### PR TITLE
Add .envrc and .direnv to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ CMakeSettings.json
 
 # compile commands symlink
 /compile_commands.json
+
+# Local user config
+.envrc
+.direnv


### PR DESCRIPTION
These are typical user configuration files never meant to be
submitted anyway.

Signed-off-by: Henner Zeller <h.zeller@acm.org>