### PR TITLE
New approach for vendor command line parsing

### DIFF
--- a/include/Surelog/CommandLine/CommandLineParser.h
+++ b/include/Surelog/CommandLine/CommandLineParser.h
@@ -233,7 +233,6 @@ class CommandLineParser final {
   CommandLineParser(const CommandLineParser& orig) = delete;
 
   bool plus_arguments_(const std::string& s);
-  bool style_c_arguments_(const std::string& s, const std::string& s_val);
   void processOutputDirectory_(const std::vector<std::string>& args);
   void processArgs_(const std::vector<std::string>& args,
                     std::vector<std::string>& container);


### PR DESCRIPTION
This PR, like the previous one, #3149 aims to solve the problem where we want to run Surelog on an existing file containing command line arguments for a large legacy project. The legacy file might call dozens of smaller command line files for various IP blocks, and it is very tedious to replicate this entire tree, just to rename or remove vendor commands that are not recognized by Surelog, or written differently.

The previous implementation for foreign vendor command line parsing tried to hardcode several known command line "dialects" used by commercial tools, but this approach had several problems:
1. It required Surelog to know of potentially thousands of legacy command line arguments from each vendor (I just checked one of the tools and I see there are close to 1600 different flags possible).
2. It may pose legal issues due to trademark and/or copyright claims over the exact commands (IANAL).
3. It requires a PR for every new flag that needs to be added.

The new approach is to add 3 new generic commands to define vendor commands which are to be ignored, renamed into other Surelog commands, or converted from the usual (`<cmd> <args>`) into the plusarg syntax (`+<cmd>+<args>`).
The commands are then put together in a command file and called like this:
`surelog <other surelog flags> -f vendor_compatibility_layer.f -f legacy_file_list.f`
This shifts the burden of maintaining vendor compatibility to the actual user requiring it, instead of the Surelog team. In most cases, the legacy scripts will use only a very small subset of the vendor command line flags.
For more detailed description please see https://github.com/chipsalliance/Surelog/issues/3142#issuecomment-1214499878 .

I've tested this with a large project using many flags not supported by Surelog. Unfortunately, I did not add unit tests because all the modified methods are private and adding unit tests requires either turning them into public methods or adding a friend declaration to the code.
