### PR TITLE
PR: fix preprocessor macro bug with no param macro instance followed by parenthesis

### DIFF
--- a/grammar/SV3_1aPpParser.g4
+++ b/grammar/SV3_1aPpParser.g4
@@ -36,9 +36,9 @@ parser grammar SV3_1aPpParser;
     if (clp->getDefineList().count(macroId))
       return false;
     MacroInfo* m = pp->getMacro(macro_name);
-    if (m && m->m_type == MacroInfo::Type::WITH_ARGS)
-      return true;
-    return false;
+    if (m && m->m_type == MacroInfo::Type::NO_ARGS)
+      return false;
+    return true;
   }
 }
 

--- a/grammar/SV3_1aPpParser.g4
+++ b/grammar/SV3_1aPpParser.g4
@@ -30,9 +30,9 @@ parser grammar SV3_1aPpParser;
     this->clp = pp->getCompileSourceFile()->getCommandLineParser();
   }
   bool isParamMacro() {
-    const std::string macro_name = getCurrentToken()->getText().substr(1);
+    const std::string macro_name = getTokenStream()->LT(-1)->getText().substr(1);
     SymbolId macroId = pp->registerSymbol(macro_name);
-    // if it's inm the +define override list, it has no macro arguments
+    // if it's in the +define override list, it has no macro arguments
     if (clp->getDefineList().count(macroId))
       return false;
     MacroInfo* m = pp->getMacro(macro_name);
@@ -125,7 +125,7 @@ description :
 
 escaped_identifier : Escaped_identifier;
 
-macro_instance : {isParamMacro()}? (Macro_identifier | Macro_Escaped_identifier) Spaces* PARENS_OPEN macro_actual_args PARENS_CLOSE # MacroInstanceWithArgs
+macro_instance : (Macro_identifier | Macro_Escaped_identifier) {isParamMacro()}? Spaces* PARENS_OPEN macro_actual_args PARENS_CLOSE # MacroInstanceWithArgs
                | (Macro_identifier | Macro_Escaped_identifier)                                                    # MacroInstanceNoArgs
                ;
 

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -459,6 +459,7 @@ bool PreprocessFile::preprocess() {
 
     m_antlrParserHandler->m_ppparser =
         new SV3_1aPpParser(m_antlrParserHandler->m_pptokens);
+    m_antlrParserHandler->m_ppparser->setPreprocessFile(this);
     m_antlrParserHandler->m_ppparser->getInterpreter<atn::ParserATNSimulator>()
         ->setPredictionMode(atn::PredictionMode::SLL);
     m_antlrParserHandler->m_ppparser->removeErrorListeners();


### PR DESCRIPTION
This is my effort to fix #3145 . It is NOT working.
I'm putting this draft PR only as a base for discussion, it should **not** be merged as-is.