### PR TITLE
Bug fix for PR#3153

### DIFF
--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -547,7 +547,6 @@ void CommandLineParser::processArgs_(const std::vector<std::string>& args,
         arg.append("+");
         arg.append(args[i + 1]);
         i += 1;
-        continue;
       } else {
         std::cerr << "Missing arguments to renamed command " << arg
                   << std::endl;


### PR DESCRIPTION
After defining `-cmd_mrg <oldcmd> <new_cmd>` , using `<oldcmd>` would construct the new command , but
silently drop it instead of pushing the new command into the command line (caused by a minor copy/paste bug).

For example:
`surelog -cmd_mrg -incdir +incdir -incdir tmpdir test.v`
should be equivalent to:
`surelog +incdir+tmpdir test.v`
But would in fact translate to:
`surelog test.v`
