### PR TITLE
Prefer empty() to size() when quering containers.

### DIFF
--- a/src/Design/ModuleDefinition.cpp
+++ b/src/Design/ModuleDefinition.cpp
@@ -28,8 +28,8 @@
 namespace SURELOG {
 
 VObjectType ModuleDefinition::getType() const {
-  return (m_fileContents.size()) ? m_fileContents[0]->Type(m_nodeIds[0])
-                                 : VObjectType::slN_input_gate_instance;
+  return (m_fileContents.empty()) ? VObjectType::slN_input_gate_instance
+                                  : m_fileContents[0]->Type(m_nodeIds[0]);
 }
 
 ModuleDefinition::ModuleDefinition(const FileContent* fileContent,


### PR DESCRIPTION
Depending on the container, size() might not be O(1). Also empty()
improves readability.

Signed-off-by: Henner Zeller <h.zeller@acm.org>