### PR TITLE
Update toplevel clang-tidy rules to allow NodeId, SymbolId by value.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,9 @@
 # performance-inefficient-string-concatenation is good, but until we use
 # absl in this project with absl::StrCat(), the alternatives are not improving
 # readability.
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
 Checks: >
   clang-diagnostic-*,clang-analyzer-*,
   -clang-analyzer-core.CallAndMessage,
@@ -46,7 +49,11 @@ Checks: >
   modernize-raw-string-literal,
   modernize-use-override,
 
-WarningsAsErrors: ''
-HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key: performance-unnecessary-value-param.AllowedTypes
+    value: 'NodeId;SymbolId'
+  - key: performance-unnecessary-copy-initialization.AllowedTypes
+    value: 'NodeId;SymbolId'
+  - key: performance-for-range-copy.AllowedTypes
+    value: 'NodeId;SymbolId'
 ...

--- a/include/Surelog/Common/NodeId.h
+++ b/include/Surelog/Common/NodeId.h
@@ -75,6 +75,8 @@ class NodeId final {
   RawNodeId id;
 };
 
+static_assert(sizeof(NodeId) == sizeof(RawNodeId), "NodeId type grew?");
+
 inline static constexpr NodeId InvalidNodeId(InvalidRawNodeId);
 
 inline std::ostream &operator<<(std::ostream &strm, const NodeId &nodeId) {

--- a/include/Surelog/Common/SymbolId.h
+++ b/include/Surelog/Common/SymbolId.h
@@ -22,7 +22,7 @@ namespace SURELOG {
  *
  * Used to uniquely represent a string in SymbolTable. SymbolId can (and
  * should) be resolved only with the SymbolTable that it was generated with.
- * 
+ *
  */
 typedef uint32_t RawSymbolId;
 inline static constexpr RawSymbolId BadRawSymbolId = 0;
@@ -74,6 +74,10 @@ class SymbolId final {
 
   friend std::ostream &operator<<(std::ostream &strm, const SymbolId &symbolId);
 };
+
+#ifndef SYMBOLID_DEBUG_ENABLED
+static_assert(sizeof(SymbolId) == sizeof(RawSymboldId), "SymboldId type grew?");
+#endif
 
 inline static const SymbolId BadSymbolId(BadRawSymbolId, BadRawSymbol);
 


### PR DESCRIPTION
The size is just an integer as they are wrappers, totally fine to copy
by value.
Adding a static_assert() in the relevant headers to make sure the
size stays the same.

Signed-off-by: Henner Zeller <h.zeller@acm.org>