### PR TITLE
Print formatted object stats during regression runs

### DIFF
--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -3443,19 +3443,6 @@ void UhdmWriter::writeInstance(ModuleDefinition* mod, ModuleInstance* instance,
   }
 }
 
-void printUhdmStats(Serializer& s) {
-  std::cout << "UHDM Objects Stats:\n";
-  auto stats = s.ObjectStats();
-  std::multimap<unsigned long, std::string> rstats;
-  for (const auto& stat : stats) {
-    if (stat.second) rstats.insert(std::make_pair(stat.second, stat.first));
-  }
-  for (const auto& stat : rstats) {
-    std::cout << stat.second << " " << stat.first << "\n";
-  }
-  std::cout << "\n";
-}
-
 vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
   ComponentMap componentMap;
   ModPortMap modPortMap;
@@ -3753,8 +3740,9 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
     d->TopModules(uhdm_top_modules);
   }
 
-  if (m_compileDesign->getCompiler()->getCommandLineParser()->getUhdmStats())
-    printUhdmStats(s);
+  if (m_compileDesign->getCompiler()->getCommandLineParser()->getUhdmStats()) {
+    s.PrintStats(std::cerr, "Non-Elaborated Model");
+  }
 
   // ----------------------------------
   // Lint only the elaborated model
@@ -3785,8 +3773,9 @@ vpiHandle UhdmWriter::write(const std::string& uhdmFile) {
     delete listener;
   }
 
-  if (m_compileDesign->getCompiler()->getCommandLineParser()->getUhdmStats())
-    printUhdmStats(s);
+  if (m_compileDesign->getCompiler()->getCommandLineParser()->getUhdmStats()) {
+    s.PrintStats(std::cerr, "Elaborated Model");
+  }
 
   if (m_compileDesign->getCompiler()->getCommandLineParser()->writeUhdm()) {
     {


### PR DESCRIPTION
Print formatted object stats during regression runs

Regression runs used merely the count i.e. number of lines of UHDM dump
output to identify differences. This has proved very unreliable with
some of the recent changes where the number of output lines are exactly
the same but the type of UHDM model has changed (for instance, from
int_typespec to logic_typespec or vice versa).

To make the reporting a little more reliable, force dumping of object
stats and compare them.

Until logs are updated, missing stats dump in golden will not report an
error (to prevent immediate failures because of this change).