### PR TITLE
Ports are variables

### DIFF
--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -665,13 +665,13 @@ void UhdmWriter::writePorts(std::vector<Signal*>& orig_ports, BaseClass* parent,
 
           if (typespec* typespec = m_helper.compileTypespec(
                   mod, fC, orig_port->getTypeSpecId(), m_compileDesign, nullptr,
-                  nullptr, false)) {
+                  nullptr, false, true)) {
             array_ts->Elem_typespec(typespec);
           }
         }
       } else if (typespec* typespec = m_helper.compileTypespec(
                      mod, fC, orig_port->getTypeSpecId(), m_compileDesign,
-                     nullptr, nullptr, false)) {
+                     nullptr, nullptr, false, true)) {
         dest_port->Typespec(typespec);
       }
     }

--- a/tests/Bindings/Bindings.log
+++ b/tests/Bindings/Bindings.log
@@ -2465,7 +2465,7 @@ design: (work@dut1)
       |vpiActual:
       \_logic_net: (work@dut2.i), line:37:36, endln:37:37
     |vpiTypedef:
-    \_int_typespec: , line:37:12, endln:37:35
+    \_logic_typespec: , line:37:12, endln:37:35
       |vpiRange:
       \_range: , line:37:12, endln:37:35
         |vpiLeftRange:

--- a/tests/CaseFullElab/CaseFullElab.log
+++ b/tests/CaseFullElab/CaseFullElab.log
@@ -1489,7 +1489,7 @@ design: (work@FSM)
       |vpiActual:
       \_logic_net: (work@FSM.Speed), line:5:13, endln:5:18
     |vpiTypedef:
-    \_int_typespec: , line:4:10, endln:4:15
+    \_logic_typespec: , line:4:10, endln:4:15
       |vpiRange:
       \_range: , line:4:10, endln:4:15
         |vpiLeftRange:

--- a/tests/ClockingSntx/ClockingSntx.log
+++ b/tests/ClockingSntx/ClockingSntx.log
@@ -348,7 +348,7 @@ design: (work@top)
       |vpiActual:
       \_logic_net: (work@top.data), line:8:28, endln:8:32
     |vpiTypedef:
-    \_int_typespec: , line:8:21, endln:8:27
+    \_logic_typespec: , line:8:21, endln:8:27
       |vpiRange:
       \_range: , line:8:21, endln:8:27
         |vpiLeftRange:
@@ -402,7 +402,7 @@ design: (work@top)
       |vpiActual:
       \_logic_net: (work@top.cmd), line:9:27, endln:9:30
     |vpiTypedef:
-    \_int_typespec: , line:9:21, endln:9:26
+    \_logic_typespec: , line:9:21, endln:9:26
       |vpiRange:
       \_range: , line:9:21, endln:9:26
         |vpiLeftRange:

--- a/tests/DelayAssign/DelayAssign.log
+++ b/tests/DelayAssign/DelayAssign.log
@@ -1670,7 +1670,7 @@ design: (work@SimDTM)
       |vpiActual:
       \_logic_net: (work@SimDTM.debug_req_bits_addr), line:22:17, endln:22:36
     |vpiTypedef:
-    \_int_typespec: , line:22:10, endln:22:16
+    \_logic_typespec: , line:22:10, endln:22:16
       |vpiRange:
       \_range: , line:22:10, endln:22:16
         |vpiLeftRange:
@@ -1700,7 +1700,7 @@ design: (work@SimDTM)
       |vpiActual:
       \_logic_net: (work@SimDTM.debug_req_bits_op), line:23:17, endln:23:34
     |vpiTypedef:
-    \_int_typespec: , line:23:10, endln:23:16
+    \_logic_typespec: , line:23:10, endln:23:16
       |vpiRange:
       \_range: , line:23:10, endln:23:16
         |vpiLeftRange:
@@ -1730,7 +1730,7 @@ design: (work@SimDTM)
       |vpiActual:
       \_logic_net: (work@SimDTM.debug_req_bits_data), line:24:17, endln:24:36
     |vpiTypedef:
-    \_int_typespec: , line:24:10, endln:24:16
+    \_logic_typespec: , line:24:10, endln:24:16
       |vpiRange:
       \_range: , line:24:10, endln:24:16
         |vpiLeftRange:
@@ -1784,7 +1784,7 @@ design: (work@SimDTM)
       |vpiActual:
       \_logic_net: (work@SimDTM.debug_resp_bits_resp), line:28:17, endln:28:37
     |vpiTypedef:
-    \_int_typespec: , line:28:10, endln:28:16
+    \_logic_typespec: , line:28:10, endln:28:16
       |vpiRange:
       \_range: , line:28:10, endln:28:16
         |vpiLeftRange:
@@ -1814,7 +1814,7 @@ design: (work@SimDTM)
       |vpiActual:
       \_logic_net: (work@SimDTM.debug_resp_bits_data), line:29:17, endln:29:37
     |vpiTypedef:
-    \_int_typespec: , line:29:10, endln:29:16
+    \_logic_typespec: , line:29:10, endln:29:16
       |vpiRange:
       \_range: , line:29:10, endln:29:16
         |vpiLeftRange:
@@ -1844,7 +1844,7 @@ design: (work@SimDTM)
       |vpiActual:
       \_logic_net: (work@SimDTM.exit), line:31:17, endln:31:21
     |vpiTypedef:
-    \_int_typespec: , line:31:10, endln:31:16
+    \_logic_typespec: , line:31:10, endln:31:16
       |vpiRange:
       \_range: , line:31:10, endln:31:16
         |vpiLeftRange:

--- a/tests/ElabParam/ElabParam.log
+++ b/tests/ElabParam/ElabParam.log
@@ -1157,7 +1157,7 @@ design: (work@dut)
       |vpiActual:
       \_logic_net: (work@dut.a), line:14:15, endln:14:16
     |vpiTypedef:
-    \_int_typespec: , line:12:10, endln:12:15
+    \_logic_typespec: , line:12:10, endln:12:15
       |vpiRange:
       \_range: , line:12:10, endln:12:15
         |vpiLeftRange:
@@ -1187,7 +1187,7 @@ design: (work@dut)
       |vpiActual:
       \_logic_net: (work@dut.b), line:15:14, endln:15:15
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:16
+    \_logic_typespec: , line:13:11, endln:13:16
       |vpiRange:
       \_range: , line:13:11, endln:13:16
         |vpiLeftRange:

--- a/tests/EvalFuncNamed/EvalFuncNamed.log
+++ b/tests/EvalFuncNamed/EvalFuncNamed.log
@@ -2072,7 +2072,7 @@ design: (work@t)
       |vpiActual:
       \_logic_net: (work@t.i_d), line:27:27, endln:27:30
     |vpiTypedef:
-    \_int_typespec: , line:27:11, endln:27:25
+    \_logic_typespec: , line:27:11, endln:27:25
       |vpiRange:
       \_range: , line:27:11, endln:27:25
         |vpiLeftRange:

--- a/tests/FSMBsp13/FSMBsp13.log
+++ b/tests/FSMBsp13/FSMBsp13.log
@@ -11332,7 +11332,7 @@ design: (work@top)
       |vpiActual:
       \_logic_net: (work@FSM2.y), line:4:11, endln:4:12
     |vpiTypedef:
-    \_int_typespec: , line:3:8, endln:3:13
+    \_logic_typespec: , line:3:8, endln:3:13
       |vpiRange:
       \_range: , line:3:8, endln:3:13
         |vpiLeftRange:
@@ -13209,7 +13209,7 @@ design: (work@top)
       |vpiActual:
       \_logic_net: (work@FSM3.Speed), line:4:11, endln:4:16
     |vpiTypedef:
-    \_int_typespec: , line:3:8, endln:3:13
+    \_logic_typespec: , line:3:8, endln:3:13
       |vpiRange:
       \_range: , line:3:8, endln:3:13
         |vpiLeftRange:

--- a/tests/FuncIoTypespec/FuncIoTypespec.log
+++ b/tests/FuncIoTypespec/FuncIoTypespec.log
@@ -3250,7 +3250,7 @@ design: (work@top)
       |vpiActual:
       \_logic_net: (work@shift.a), line:1:14, endln:1:15
     |vpiTypedef:
-    \_int_typespec: , line:7:9, endln:7:22
+    \_logic_typespec: , line:7:9, endln:7:22
       |vpiRange:
       \_range: , line:7:9, endln:7:22
         |vpiLeftRange:
@@ -3290,7 +3290,7 @@ design: (work@top)
       |vpiActual:
       \_logic_net: (work@shift.s), line:1:16, endln:1:17
     |vpiTypedef:
-    \_int_typespec: , line:8:9, endln:8:22
+    \_logic_typespec: , line:8:9, endln:8:22
       |vpiRange:
       \_range: , line:8:9, endln:8:22
         |vpiLeftRange:
@@ -3330,7 +3330,7 @@ design: (work@top)
       |vpiActual:
       \_logic_net: (work@shift.z), line:1:18, endln:1:19
     |vpiTypedef:
-    \_int_typespec: , line:9:10, endln:9:24
+    \_logic_typespec: , line:9:10, endln:9:24
       |vpiRange:
       \_range: , line:9:10, endln:9:24
         |vpiLeftRange:
@@ -3463,7 +3463,7 @@ design: (work@top)
       |vpiActual:
       \_logic_net: (work@top.a), line:83:13, endln:83:14
     |vpiTypedef:
-    \_int_typespec: , line:89:9, endln:89:22
+    \_logic_typespec: , line:89:9, endln:89:22
       |vpiRange:
       \_range: , line:89:9, endln:89:22
         |vpiLeftRange:
@@ -3503,7 +3503,7 @@ design: (work@top)
       |vpiActual:
       \_logic_net: (work@top.s), line:83:15, endln:83:16
     |vpiTypedef:
-    \_int_typespec: , line:90:9, endln:90:22
+    \_logic_typespec: , line:90:9, endln:90:22
       |vpiRange:
       \_range: , line:90:9, endln:90:22
         |vpiLeftRange:
@@ -3543,7 +3543,7 @@ design: (work@top)
       |vpiActual:
       \_logic_net: (work@top.z), line:83:17, endln:83:18
     |vpiTypedef:
-    \_int_typespec: , line:91:10, endln:91:23
+    \_logic_typespec: , line:91:10, endln:91:23
       |vpiRange:
       \_range: , line:91:10, endln:91:23
         |vpiLeftRange:

--- a/tests/GenNet/GenNet.log
+++ b/tests/GenNet/GenNet.log
@@ -361,7 +361,7 @@ design: (work@dut)
       |vpiActual:
       \_logic_net: (work@prim_subreg_arb.q), line:5:18, endln:5:19
     |vpiTypedef:
-    \_int_typespec: , line:5:9, endln:5:17
+    \_logic_typespec: , line:5:9, endln:5:17
       |vpiRange:
       \_range: , line:5:9, endln:5:17
         |vpiLeftRange:

--- a/tests/GenerateInterface/GenerateInterface.log
+++ b/tests/GenerateInterface/GenerateInterface.log
@@ -1358,7 +1358,7 @@ design: (work@top)
       |vpiActual:
       \_logic_net: (work@top2.pins), line:34:61, endln:34:65
     |vpiTypedef:
-    \_int_typespec: , line:34:49, endln:34:60
+    \_logic_typespec: , line:34:49, endln:34:60
       |vpiRange:
       \_range: , line:34:49, endln:34:60
         |vpiLeftRange:

--- a/tests/GenerateModule/GenerateModule.log
+++ b/tests/GenerateModule/GenerateModule.log
@@ -1301,7 +1301,7 @@ design: (work@small_test)
       |vpiActual:
       \_logic_net: (work@top.a), line:21:24, endln:21:25
     |vpiTypedef:
-    \_int_typespec: , line:21:18, endln:21:23
+    \_logic_typespec: , line:21:18, endln:21:23
       |vpiRange:
       \_range: , line:21:18, endln:21:23
         |vpiLeftRange:
@@ -1331,7 +1331,7 @@ design: (work@small_test)
       |vpiActual:
       \_logic_net: (work@top.b), line:21:40, endln:21:41
     |vpiTypedef:
-    \_int_typespec: , line:21:34, endln:21:39
+    \_logic_typespec: , line:21:34, endln:21:39
       |vpiRange:
       \_range: , line:21:34, endln:21:39
         |vpiLeftRange:

--- a/tests/GenerateRegion/GenerateRegion.log
+++ b/tests/GenerateRegion/GenerateRegion.log
@@ -1537,7 +1537,7 @@ design: (work@oh_delay)
       |vpiActual:
       \_logic_net: (work@shift.a), line:24:14, endln:24:15
     |vpiTypedef:
-    \_int_typespec: , line:30:7, endln:30:20
+    \_logic_typespec: , line:30:7, endln:30:20
       |vpiRange:
       \_range: , line:30:7, endln:30:20
         |vpiLeftRange:
@@ -1577,7 +1577,7 @@ design: (work@oh_delay)
       |vpiActual:
       \_logic_net: (work@shift.s), line:24:16, endln:24:17
     |vpiTypedef:
-    \_int_typespec: , line:31:7, endln:31:20
+    \_logic_typespec: , line:31:7, endln:31:20
       |vpiRange:
       \_range: , line:31:7, endln:31:20
         |vpiLeftRange:
@@ -1617,7 +1617,7 @@ design: (work@oh_delay)
       |vpiActual:
       \_logic_net: (work@shift.z), line:24:18, endln:24:19
     |vpiTypedef:
-    \_int_typespec: , line:32:8, endln:32:22
+    \_logic_typespec: , line:32:8, endln:32:22
       |vpiRange:
       \_range: , line:32:8, endln:32:22
         |vpiLeftRange:

--- a/tests/ImplicitPort/ImplicitPort.log
+++ b/tests/ImplicitPort/ImplicitPort.log
@@ -875,7 +875,7 @@ design: (work@add)
       |vpiActual:
       \_logic_net: (work@add.a), line:2:16, endln:2:17
     |vpiTypedef:
-    \_int_typespec: , line:2:9, endln:2:15
+    \_logic_typespec: , line:2:9, endln:2:15
       |vpiRange:
       \_range: , line:2:9, endln:2:15
         |vpiLeftRange:
@@ -905,7 +905,7 @@ design: (work@add)
       |vpiActual:
       \_logic_net: (work@add.b), line:2:18, endln:2:19
     |vpiTypedef:
-    \_int_typespec: , line:2:9, endln:2:15
+    \_logic_typespec: , line:2:9, endln:2:15
       |vpiRange:
       \_range: , line:2:9, endln:2:15
         |vpiLeftRange:

--- a/tests/MBAdder/MBadder.log
+++ b/tests/MBAdder/MBadder.log
@@ -567,7 +567,7 @@ design: (work@MultibitAdder)
       |vpiActual:
       \_logic_net: (work@MultibitAdder.a), line:1:22, endln:1:23
     |vpiTypedef:
-    \_int_typespec: , line:2:8, endln:2:13
+    \_logic_typespec: , line:2:8, endln:2:13
       |vpiRange:
       \_range: , line:2:8, endln:2:13
         |vpiLeftRange:
@@ -597,7 +597,7 @@ design: (work@MultibitAdder)
       |vpiActual:
       \_logic_net: (work@MultibitAdder.b), line:1:24, endln:1:25
     |vpiTypedef:
-    \_int_typespec: , line:2:8, endln:2:13
+    \_logic_typespec: , line:2:8, endln:2:13
       |vpiRange:
       \_range: , line:2:8, endln:2:13
         |vpiLeftRange:
@@ -639,7 +639,7 @@ design: (work@MultibitAdder)
       |vpiActual:
       \_logic_net: (work@MultibitAdder.sum), line:1:30, endln:1:33
     |vpiTypedef:
-    \_int_typespec: , line:4:9, endln:4:14
+    \_logic_typespec: , line:4:9, endln:4:14
       |vpiRange:
       \_range: , line:4:9, endln:4:14
         |vpiLeftRange:

--- a/tests/OneImport/OneImport.log
+++ b/tests/OneImport/OneImport.log
@@ -499,7 +499,7 @@ design: (work@dut)
       |vpiActual:
       \_logic_net: (work@dut.a), line:16:14, endln:16:15
     |vpiTypedef:
-    \_int_typespec: , line:14:9, endln:14:14
+    \_logic_typespec: , line:14:9, endln:14:14
       |vpiRange:
       \_range: , line:14:9, endln:14:14
         |vpiLeftRange:
@@ -529,7 +529,7 @@ design: (work@dut)
       |vpiActual:
       \_logic_net: (work@dut.b), line:17:13, endln:17:14
     |vpiTypedef:
-    \_int_typespec: , line:15:10, endln:15:15
+    \_logic_typespec: , line:15:10, endln:15:15
       |vpiRange:
       \_range: , line:15:10, endln:15:15
         |vpiLeftRange:

--- a/tests/ParamMultiConcat/ParamMultiConcat.log
+++ b/tests/ParamMultiConcat/ParamMultiConcat.log
@@ -241,7 +241,7 @@ design: (work@top)
       |vpiActual:
       \_logic_net: (work@dut.wmask_i), line:5:22, endln:5:29
     |vpiTypedef:
-    \_int_typespec: , line:5:10, endln:5:21
+    \_logic_typespec: , line:5:10, endln:5:21
       |vpiRange:
       \_range: , line:5:10, endln:5:21
         |vpiLeftRange:

--- a/tests/PortRanges/PortRanges.log
+++ b/tests/PortRanges/PortRanges.log
@@ -1062,7 +1062,7 @@ design: (work@DFlipflop8Bit)
       |vpiActual:
       \_logic_net: (work@DFlipflop8Bit.A2), line:1:30, endln:1:32
     |vpiTypedef:
-    \_int_typespec: , line:7:8, endln:7:13
+    \_logic_typespec: , line:7:8, endln:7:13
       |vpiRange:
       \_range: , line:7:8, endln:7:13
         |vpiLeftRange:
@@ -1092,7 +1092,7 @@ design: (work@DFlipflop8Bit)
       |vpiActual:
       \_logic_net: (work@DFlipflop8Bit.Q2), line:1:34, endln:1:36
     |vpiTypedef:
-    \_int_typespec: , line:6:9, endln:6:14
+    \_logic_typespec: , line:6:9, endln:6:14
       |vpiRange:
       \_range: , line:6:9, endln:6:14
         |vpiLeftRange:
@@ -1154,7 +1154,7 @@ design: (work@DFlipflop8Bit)
       |vpiActual:
       \_logic_net: (work@DFlipflop8Bit2.A3), line:12:35, endln:12:37
     |vpiTypedef:
-    \_int_typespec: , line:12:29, endln:12:34
+    \_logic_typespec: , line:12:29, endln:12:34
       |vpiRange:
       \_range: , line:12:29, endln:12:34
         |vpiLeftRange:
@@ -1214,7 +1214,7 @@ design: (work@DFlipflop8Bit)
       |vpiActual:
       \_logic_net: (work@DFlipflop8Bit2.Q3), line:14:36, endln:14:38
     |vpiTypedef:
-    \_int_typespec: , line:14:30, endln:14:35
+    \_logic_typespec: , line:14:30, endln:14:35
       |vpiRange:
       \_range: , line:14:30, endln:14:35
         |vpiLeftRange:

--- a/tests/PrimTermExpr/PrimTermExpr.log
+++ b/tests/PrimTermExpr/PrimTermExpr.log
@@ -250,7 +250,7 @@ design: (work@encoder_4to2_gates)
       |vpiActual:
       \_logic_net: (work@encoder_4to2_gates.y), line:1:40, endln:1:41
     |vpiTypedef:
-    \_int_typespec: , line:3:8, endln:3:13
+    \_logic_typespec: , line:3:8, endln:3:13
       |vpiRange:
       \_range: , line:3:8, endln:3:13
         |vpiLeftRange:

--- a/tests/RangeInf/RangeInf.log
+++ b/tests/RangeInf/RangeInf.log
@@ -1016,7 +1016,7 @@ design: (work@FullAdder)
       |vpiActual:
       \_logic_net: (work@FullAdder.A), line:1:18, endln:1:19
     |vpiTypedef:
-    \_int_typespec: , line:2:10, endln:2:15
+    \_logic_typespec: , line:2:10, endln:2:15
       |vpiRange:
       \_range: , line:2:10, endln:2:15
         |vpiLeftRange:
@@ -1046,7 +1046,7 @@ design: (work@FullAdder)
       |vpiActual:
       \_logic_net: (work@FullAdder.B), line:1:20, endln:1:21
     |vpiTypedef:
-    \_int_typespec: , line:2:10, endln:2:15
+    \_logic_typespec: , line:2:10, endln:2:15
       |vpiRange:
       \_range: , line:2:10, endln:2:15
         |vpiLeftRange:

--- a/tests/TypedefPack/TypedefPack.log
+++ b/tests/TypedefPack/TypedefPack.log
@@ -322,7 +322,7 @@ design: (work@prim_lc_sender)
       |vpiActual:
       \_logic_net: (work@prim_lc_sender.lc_en_i), line:11:16, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:10, endln:11:15
+    \_logic_typespec: , line:11:10, endln:11:15
       |vpiRange:
       \_range: , line:11:10, endln:11:15
         |vpiLeftRange:

--- a/tests/UnitElab/UnitElab.log
+++ b/tests/UnitElab/UnitElab.log
@@ -14475,7 +14475,7 @@ design: (work@bottom1)
       |vpiActual:
       \_logic_net: (work@top.a), line:26:13, endln:26:14
     |vpiTypedef:
-    \_int_typespec: , line:27:7, endln:27:12
+    \_logic_typespec: , line:27:7, endln:27:12
       |vpiRange:
       \_range: , line:27:7, endln:27:12
         |vpiLeftRange:
@@ -14505,7 +14505,7 @@ design: (work@bottom1)
       |vpiActual:
       \_logic_net: (work@top.b), line:26:16, endln:26:17
     |vpiTypedef:
-    \_int_typespec: , line:27:7, endln:27:12
+    \_logic_typespec: , line:27:7, endln:27:12
       |vpiRange:
       \_range: , line:27:7, endln:27:12
         |vpiLeftRange:
@@ -14535,7 +14535,7 @@ design: (work@bottom1)
       |vpiActual:
       \_logic_net: (work@top.c), line:26:19, endln:26:20
     |vpiTypedef:
-    \_int_typespec: , line:28:8, endln:28:13
+    \_logic_typespec: , line:28:8, endln:28:13
       |vpiRange:
       \_range: , line:28:8, endln:28:13
         |vpiLeftRange:

--- a/tests/UnitPartSelect/UnitPartSelect.log
+++ b/tests/UnitPartSelect/UnitPartSelect.log
@@ -1344,7 +1344,7 @@ design: (work@toto)
       |vpiActual:
       \_logic_net: (work@dut.a), line:24:16, endln:24:17
     |vpiTypedef:
-    \_int_typespec: , line:22:11, endln:22:16
+    \_logic_typespec: , line:22:11, endln:22:16
       |vpiRange:
       \_range: , line:22:11, endln:22:16
         |vpiLeftRange:
@@ -1374,7 +1374,7 @@ design: (work@toto)
       |vpiActual:
       \_logic_net: (work@dut.o), line:25:15, endln:25:16
     |vpiTypedef:
-    \_int_typespec: , line:23:12, endln:23:17
+    \_logic_typespec: , line:23:12, endln:23:17
       |vpiRange:
       \_range: , line:23:12, endln:23:17
         |vpiLeftRange:
@@ -1456,7 +1456,7 @@ design: (work@toto)
       |vpiActual:
       \_logic_net: (work@dut_no_decl.a), line:38:32, endln:38:33
     |vpiTypedef:
-    \_int_typespec: , line:38:26, endln:38:31
+    \_logic_typespec: , line:38:26, endln:38:31
       |vpiRange:
       \_range: , line:38:26, endln:38:31
         |vpiLeftRange:
@@ -1486,7 +1486,7 @@ design: (work@toto)
       |vpiActual:
       \_logic_net: (work@dut_no_decl.b), line:38:48, endln:38:49
     |vpiTypedef:
-    \_int_typespec: , line:38:42, endln:38:47
+    \_logic_typespec: , line:38:42, endln:38:47
       |vpiRange:
       \_range: , line:38:42, endln:38:47
         |vpiLeftRange:
@@ -1636,7 +1636,7 @@ design: (work@toto)
       |vpiActual:
       \_logic_net: (work@dut_part_select.a), line:31:14, endln:31:15
     |vpiTypedef:
-    \_int_typespec: , line:30:30, endln:30:35
+    \_logic_typespec: , line:30:30, endln:30:35
       |vpiRange:
       \_range: , line:30:30, endln:30:35
         |vpiLeftRange:
@@ -1666,7 +1666,7 @@ design: (work@toto)
       |vpiActual:
       \_logic_net: (work@dut_part_select.b), line:32:13, endln:32:14
     |vpiTypedef:
-    \_int_typespec: , line:30:46, endln:30:51
+    \_logic_typespec: , line:30:46, endln:30:51
       |vpiRange:
       \_range: , line:30:46, endln:30:51
         |vpiLeftRange:

--- a/tests/VarInFunc/VarInFunc.log
+++ b/tests/VarInFunc/VarInFunc.log
@@ -1028,7 +1028,7 @@ design: (work@top)
       |vpiActual:
       \_logic_net: (work@top.b), line:1:34, endln:1:35
     |vpiTypedef:
-    \_int_typespec: , line:1:28, endln:1:33
+    \_logic_typespec: , line:1:28, endln:1:33
       |vpiRange:
       \_range: , line:1:28, endln:1:33
         |vpiLeftRange:

--- a/third_party/tests/SimpleParserTest/SimpleParserTest.log
+++ b/third_party/tests/SimpleParserTest/SimpleParserTest.log
@@ -1350,7 +1350,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@LFSR_TASK.seed1), line:2:33, endln:2:38
     |vpiTypedef:
-    \_int_typespec: , line:4:7, endln:4:12
+    \_logic_typespec: , line:4:7, endln:4:12
       |vpiRange:
       \_range: , line:4:7, endln:4:12
         |vpiLeftRange:
@@ -1390,7 +1390,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@LFSR_TASK.random1), line:6:11, endln:6:18
     |vpiTypedef:
-    \_int_typespec: , line:5:8, endln:5:13
+    \_logic_typespec: , line:5:8, endln:5:13
       |vpiRange:
       \_range: , line:5:8, endln:5:13
         |vpiLeftRange:
@@ -1420,7 +1420,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@LFSR_TASK.random2), line:6:20, endln:6:27
     |vpiTypedef:
-    \_int_typespec: , line:5:8, endln:5:13
+    \_logic_typespec: , line:5:8, endln:5:13
       |vpiRange:
       \_range: , line:5:8, endln:5:13
         |vpiLeftRange:
@@ -1919,7 +1919,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@arbiter.request), line:2:47, endln:2:54
     |vpiTypedef:
-    \_int_typespec: , line:15:8, endln:15:24
+    \_logic_typespec: , line:15:8, endln:15:24
       |vpiRange:
       \_range: , line:15:8, endln:15:24
         |vpiLeftRange:
@@ -1959,7 +1959,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@arbiter.tpriority), line:2:56, endln:2:65
     |vpiTypedef:
-    \_int_typespec: , line:16:8, endln:16:37
+    \_logic_typespec: , line:16:8, endln:16:37
       |vpiRange:
       \_range: , line:16:8, endln:16:37
         |vpiLeftRange:
@@ -2009,7 +2009,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@arbiter.grant), line:30:23, endln:30:28
     |vpiTypedef:
-    \_int_typespec: , line:17:9, endln:17:25
+    \_logic_typespec: , line:17:9, endln:17:25
       |vpiRange:
       \_range: , line:17:9, endln:17:25
         |vpiLeftRange:
@@ -4899,7 +4899,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@case1.in1), line:2:15, endln:2:18
     |vpiTypedef:
-    \_int_typespec: , line:3:7, endln:3:12
+    \_logic_typespec: , line:3:7, endln:3:12
       |vpiRange:
       \_range: , line:3:7, endln:3:12
         |vpiLeftRange:
@@ -4929,7 +4929,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@case1.in2), line:2:20, endln:2:23
     |vpiTypedef:
-    \_int_typespec: , line:4:7, endln:4:12
+    \_logic_typespec: , line:4:7, endln:4:12
       |vpiRange:
       \_range: , line:4:7, endln:4:12
         |vpiLeftRange:
@@ -5391,7 +5391,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@case2.in1), line:21:15, endln:21:18
     |vpiTypedef:
-    \_int_typespec: , line:22:7, endln:22:12
+    \_logic_typespec: , line:22:7, endln:22:12
       |vpiRange:
       \_range: , line:22:7, endln:22:12
         |vpiLeftRange:
@@ -5421,7 +5421,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@case2.sel), line:21:20, endln:21:23
     |vpiTypedef:
-    \_int_typespec: , line:23:7, endln:23:12
+    \_logic_typespec: , line:23:7, endln:23:12
       |vpiRange:
       \_range: , line:23:7, endln:23:12
         |vpiLeftRange:
@@ -5451,7 +5451,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@case2.out2), line:21:25, endln:21:29
     |vpiTypedef:
-    \_int_typespec: , line:24:8, endln:24:14
+    \_logic_typespec: , line:24:8, endln:24:14
       |vpiRange:
       \_range: , line:24:8, endln:24:14
         |vpiLeftRange:
@@ -6446,7 +6446,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@encoder_using_case.binary_out), line:17:11, endln:17:21
     |vpiTypedef:
-    \_int_typespec: , line:12:8, endln:12:13
+    \_logic_typespec: , line:12:8, endln:12:13
       |vpiRange:
       \_range: , line:12:8, endln:12:13
         |vpiLeftRange:
@@ -6476,7 +6476,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@encoder_using_case.encoder_in), line:9:1, endln:9:11
     |vpiTypedef:
-    \_int_typespec: , line:14:7, endln:14:13
+    \_logic_typespec: , line:14:7, endln:14:13
       |vpiRange:
       \_range: , line:14:7, endln:14:13
         |vpiLeftRange:
@@ -7362,7 +7362,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@pri_encooder.Op), line:49:22, endln:49:24
     |vpiTypedef:
-    \_int_typespec: , line:50:7, endln:50:12
+    \_logic_typespec: , line:50:7, endln:50:12
       |vpiRange:
       \_range: , line:50:7, endln:50:12
         |vpiLeftRange:
@@ -7392,7 +7392,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@pri_encooder.Funct), line:49:26, endln:49:31
     |vpiTypedef:
-    \_int_typespec: , line:51:7, endln:51:12
+    \_logic_typespec: , line:51:7, endln:51:12
       |vpiRange:
       \_range: , line:51:7, endln:51:12
         |vpiLeftRange:
@@ -7422,7 +7422,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@pri_encooder.Sel), line:49:33, endln:49:36
     |vpiTypedef:
-    \_int_typespec: , line:52:8, endln:52:13
+    \_logic_typespec: , line:52:8, endln:52:13
       |vpiRange:
       \_range: , line:52:8, endln:52:13
         |vpiLeftRange:
@@ -8006,7 +8006,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@syn_fifo.data_in), line:13:1, endln:13:8
     |vpiTypedef:
-    \_int_typespec: , line:32:7, endln:32:23
+    \_logic_typespec: , line:32:7, endln:32:23
       |vpiRange:
       \_range: , line:32:7, endln:32:23
         |vpiLeftRange:
@@ -8070,7 +8070,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@syn_fifo.data_out), line:41:22, endln:41:30
     |vpiTypedef:
-    \_int_typespec: , line:35:8, endln:35:24
+    \_logic_typespec: , line:35:8, endln:35:24
       |vpiRange:
       \_range: , line:35:8, endln:35:24
         |vpiLeftRange:
@@ -9894,7 +9894,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@uart.tx_data), line:12:1, endln:12:8
     |vpiTypedef:
-    \_int_typespec: , line:27:8, endln:27:13
+    \_logic_typespec: , line:27:8, endln:27:13
       |vpiRange:
       \_range: , line:27:8, endln:27:13
         |vpiLeftRange:
@@ -9984,7 +9984,7 @@ design: (work@dff_async_reset)
       |vpiActual:
       \_logic_net: (work@uart.rx_data), line:45:14, endln:45:21
     |vpiTypedef:
-    \_int_typespec: , line:33:8, endln:33:13
+    \_logic_typespec: , line:33:8, endln:33:13
       |vpiRange:
       \_range: , line:33:8, endln:33:13
         |vpiLeftRange:

--- a/third_party/tests/UVMSwitch/UVMSwitch.log
+++ b/third_party/tests/UVMSwitch/UVMSwitch.log
@@ -6,7 +6,6 @@
 
 [INF:PP0122] Preprocessing source file "../../UVM/uvm-1.2/src/uvm_pkg.sv".
 
-mac 0,0:0,0 ../../UVM/uvm-1.2/src/uvm_pkg.sv 0 out
 mac 0,0:0,0 1800.2-2017-1.0/src/uvm_pkg.sv 0 out
 inc 26,10:26,26 1800.2-2017-1.0/src/uvm_macros.svh 1 in
 inc 92,10:92,42 1800.2-2017-1.0/src/macros/uvm_version_defines.svh 1 in

--- a/third_party/tests/oh/BasicOh.log
+++ b/third_party/tests/oh/BasicOh.log
@@ -2,563 +2,563 @@
 
 [INF:PP0122] Preprocessing source file "stdlib/hdl/oh_fifo_async.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrqn.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockdiv.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and3.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux5.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_sync.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux6.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa92.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_debouncer.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao222.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_cdc.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao21.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai31.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa42.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao221.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_stretcher.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rsync.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_par2ser.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao211.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi22.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bitreverse.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa33.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_datagate.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pulse2pulse.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2gray.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa62.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa31.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockor.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa311.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai222.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa221.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pll.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux12.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_sp.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai33.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai311.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi221.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat1.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa22.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai22.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux8.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi211.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2onehot.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_shift.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobuflo.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffqn.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_arbiter.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_7seg_decode.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobufhi.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_gray2bin.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fall2pulse.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockgate.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_standby.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrqn.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buffer.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latnq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rise2pulse.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_regfile.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao22.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi21.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_dp.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_abs.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edgealign.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_parity.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa222.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux9.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_delay.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffqn.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_counter.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi311.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao33.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi33.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat0.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsqn.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux7.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mult.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffqn.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao311.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_datagate.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa31.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao22.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux12.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_debouncer.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edge2pulse.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_arbiter.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobuflo.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rsync.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobufhi.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_tristate.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao222.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai21.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latnq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockgate.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pulse2pulse.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux9.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi211.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bitreverse.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_standby.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2onehot.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockor.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_stretcher.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai311.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oddr.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrq.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao31.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi2.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ser2par.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa211.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux4.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_header.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai221.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_dp.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai21.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrq.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao221.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or3.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux3.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao32.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_inv.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi21.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao211.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa222.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffnq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi221.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffq.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa21.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_shift.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_sync.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_cdc.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_iddr.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi31.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edge2pulse.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg0.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg1.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai32.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_add.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_inv.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao33.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockdiv.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux6.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fall2pulse.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buffer.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai22.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi33.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_iddr.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_delay.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_abs.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor3.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa211.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi222.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi3.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_add.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edgealign.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux5.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2gray.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao31.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rise2pulse.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat1.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dsync.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa221.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ser2par.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat0.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa62.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrqn.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa33.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_sp.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or3.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buf.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi32.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_par2ser.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi31.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi22.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pll.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux8.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai33.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_regfile.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa22.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao311.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_tristate.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pwr_buf.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_gray2bin.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_header.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi311.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oddr.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao21.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai31.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai221.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa311.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa32.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_counter.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_7seg_decode.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai222.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsqn.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa32.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_parity.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa92.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffqn.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrqn.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsqn.v".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dsync.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffnq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or2.v".
+
 [INF:PA0201] Parsing source file "stdlib/hdl/oh_fifo_async.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrqn.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockdiv.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and3.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux5.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_sync.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux6.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa92.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_debouncer.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao222.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_cdc.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao21.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai31.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa42.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao221.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_stretcher.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rsync.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_par2ser.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao211.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi22.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bitreverse.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa33.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_datagate.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pulse2pulse.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2gray.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa62.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa31.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockor.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa311.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai222.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa221.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pll.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux12.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_sp.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai33.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai311.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi221.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat1.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa22.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai22.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux8.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi211.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2onehot.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_shift.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobuflo.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_arbiter.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_7seg_decode.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobufhi.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_gray2bin.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fall2pulse.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockgate.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_standby.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buffer.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latnq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rise2pulse.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_regfile.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao22.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi21.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_dp.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_abs.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edgealign.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_parity.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa222.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux9.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_delay.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_counter.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi311.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao33.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi33.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat0.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsqn.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux7.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mult.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffqn.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao311.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_datagate.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa31.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao22.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux12.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_debouncer.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edge2pulse.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_arbiter.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobuflo.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rsync.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobufhi.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_tristate.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao222.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai21.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latnq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockgate.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pulse2pulse.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux9.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi211.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bitreverse.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_standby.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2onehot.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockor.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_stretcher.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai311.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oddr.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrq.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao31.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi2.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ser2par.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa211.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux4.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_header.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai221.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_dp.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai21.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrq.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao221.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or3.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux3.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao32.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_inv.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi21.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao211.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa222.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffnq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi221.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffq.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa21.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_shift.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_sync.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_cdc.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_iddr.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi31.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edge2pulse.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg0.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg1.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai32.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_add.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_inv.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao33.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockdiv.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux6.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fall2pulse.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buffer.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai22.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi33.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_iddr.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_delay.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_abs.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor3.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa211.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi222.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi3.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_add.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edgealign.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux5.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2gray.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao31.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rise2pulse.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat1.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dsync.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa221.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ser2par.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat0.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa62.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrqn.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa33.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_sp.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or3.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buf.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi32.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_par2ser.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi31.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi22.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pll.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux8.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai33.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_regfile.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa22.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao311.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_tristate.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pwr_buf.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_gray2bin.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_header.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi311.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oddr.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao21.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai31.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai221.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa311.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa32.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_counter.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_7seg_decode.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai222.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsqn.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa32.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_parity.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa92.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffqn.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrqn.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dsync.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffnq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or2.v".
 
 [INF:CM0029] Using global timescale: "1ns/1ns".
 
@@ -1815,7 +1815,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_7seg_decode.bcd), line:10:17, endln:10:20
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:16
+    \_logic_typespec: , line:10:11, endln:10:16
       |vpiRange:
       \_range: , line:10:11, endln:10:16
         |vpiLeftRange:
@@ -2938,7 +2938,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_abs.in), line:14:20, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:18
+    \_logic_typespec: , line:14:11, endln:14:18
       |vpiRange:
       \_range: , line:14:11, endln:14:18
         |vpiLeftRange:
@@ -2978,7 +2978,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_abs.out), line:15:20, endln:15:23
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:19
+    \_logic_typespec: , line:15:12, endln:15:19
       |vpiRange:
       \_range: , line:15:12, endln:15:19
         |vpiLeftRange:
@@ -3148,7 +3148,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_add.a), line:14:20, endln:14:21
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:18
+    \_logic_typespec: , line:14:11, endln:14:18
       |vpiRange:
       \_range: , line:14:11, endln:14:18
         |vpiLeftRange:
@@ -3188,7 +3188,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_add.b), line:15:20, endln:15:21
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -3228,7 +3228,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_add.k), line:16:20, endln:16:21
     |vpiTypedef:
-    \_int_typespec: , line:16:11, endln:16:18
+    \_logic_typespec: , line:16:11, endln:16:18
       |vpiRange:
       \_range: , line:16:11, endln:16:18
         |vpiLeftRange:
@@ -3280,7 +3280,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_add.sum), line:19:20, endln:19:23
     |vpiTypedef:
-    \_int_typespec: , line:19:12, endln:19:19
+    \_logic_typespec: , line:19:12, endln:19:19
       |vpiRange:
       \_range: , line:19:12, endln:19:19
         |vpiLeftRange:
@@ -3320,7 +3320,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_add.carry), line:20:20, endln:20:25
     |vpiTypedef:
-    \_int_typespec: , line:20:12, endln:20:19
+    \_logic_typespec: , line:20:12, endln:20:19
       |vpiRange:
       \_range: , line:20:12, endln:20:19
         |vpiLeftRange:
@@ -3466,7 +3466,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_and2.a), line:14:20, endln:14:21
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:18
+    \_logic_typespec: , line:14:11, endln:14:18
       |vpiRange:
       \_range: , line:14:11, endln:14:18
         |vpiLeftRange:
@@ -3506,7 +3506,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_and2.b), line:15:20, endln:15:21
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -3546,7 +3546,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_and2.z), line:16:20, endln:16:21
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:19
+    \_logic_typespec: , line:16:12, endln:16:19
       |vpiRange:
       \_range: , line:16:12, endln:16:19
         |vpiLeftRange:
@@ -3640,7 +3640,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_and3.a), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -3680,7 +3680,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_and3.b), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -3720,7 +3720,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_and3.c), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -3760,7 +3760,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_and3.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -3898,7 +3898,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_and4.a), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -3938,7 +3938,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_and4.b), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -3978,7 +3978,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_and4.c), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -4018,7 +4018,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_and4.d), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -4058,7 +4058,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_and4.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -4201,7 +4201,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao21.a0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -4241,7 +4241,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao21.a1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -4281,7 +4281,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao21.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -4321,7 +4321,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao21.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -4459,7 +4459,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao211.a0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -4499,7 +4499,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao211.a1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -4539,7 +4539,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao211.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -4579,7 +4579,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao211.c0), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -4619,7 +4619,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao211.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -4768,7 +4768,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao22.a0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -4808,7 +4808,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao22.a1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -4848,7 +4848,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao22.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -4888,7 +4888,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao22.b1), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -4928,7 +4928,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao22.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -5083,7 +5083,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao221.a0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -5123,7 +5123,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao221.a1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -5163,7 +5163,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao221.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -5203,7 +5203,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao221.b1), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -5243,7 +5243,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao221.c0), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -5283,7 +5283,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao221.z), line:15:21, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:20
+    \_logic_typespec: , line:15:12, endln:15:20
       |vpiRange:
       \_range: , line:15:12, endln:15:20
         |vpiLeftRange:
@@ -5455,7 +5455,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao222.a0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -5495,7 +5495,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao222.a1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -5535,7 +5535,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao222.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -5575,7 +5575,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao222.b1), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -5615,7 +5615,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao222.c0), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -5655,7 +5655,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao222.c1), line:15:21, endln:15:23
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:19
+    \_logic_typespec: , line:15:11, endln:15:19
       |vpiRange:
       \_range: , line:15:11, endln:15:19
         |vpiLeftRange:
@@ -5695,7 +5695,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao222.z), line:16:21, endln:16:22
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:20
+    \_logic_typespec: , line:16:12, endln:16:20
       |vpiRange:
       \_range: , line:16:12, endln:16:20
         |vpiLeftRange:
@@ -5866,7 +5866,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao31.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -5906,7 +5906,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao31.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -5946,7 +5946,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao31.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -5986,7 +5986,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao31.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -6026,7 +6026,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao31.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -6181,7 +6181,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao311.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -6221,7 +6221,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao311.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -6261,7 +6261,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao311.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -6301,7 +6301,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao311.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -6341,7 +6341,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao311.c0), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -6381,7 +6381,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao311.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -6547,7 +6547,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao32.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -6587,7 +6587,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao32.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -6627,7 +6627,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao32.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -6667,7 +6667,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao32.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -6707,7 +6707,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao32.b1), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -6747,7 +6747,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao32.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -6919,7 +6919,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao33.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -6959,7 +6959,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao33.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -6999,7 +6999,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao33.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -7039,7 +7039,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao33.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -7079,7 +7079,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao33.b1), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -7119,7 +7119,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao33.b2), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -7159,7 +7159,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ao33.z), line:15:21, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:20
+    \_logic_typespec: , line:15:12, endln:15:20
       |vpiRange:
       \_range: , line:15:12, endln:15:20
         |vpiLeftRange:
@@ -7324,7 +7324,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi21.a0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -7364,7 +7364,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi21.a1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -7404,7 +7404,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi21.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -7444,7 +7444,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi21.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -7587,7 +7587,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi211.a0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -7627,7 +7627,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi211.a1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -7667,7 +7667,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi211.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -7707,7 +7707,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi211.c0), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -7747,7 +7747,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi211.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -7901,7 +7901,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi22.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -7941,7 +7941,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi22.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -7981,7 +7981,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi22.b0), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -8021,7 +8021,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi22.b1), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -8061,7 +8061,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi22.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -8221,7 +8221,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi221.a0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -8261,7 +8261,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi221.a1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -8301,7 +8301,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi221.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -8341,7 +8341,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi221.b1), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -8381,7 +8381,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi221.c0), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -8421,7 +8421,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi221.z), line:15:21, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:20
+    \_logic_typespec: , line:15:12, endln:15:20
       |vpiRange:
       \_range: , line:15:12, endln:15:20
         |vpiLeftRange:
@@ -8598,7 +8598,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi222.a0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -8638,7 +8638,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi222.a1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -8678,7 +8678,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi222.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -8718,7 +8718,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi222.b1), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -8758,7 +8758,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi222.c0), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -8798,7 +8798,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi222.c1), line:15:21, endln:15:23
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:19
+    \_logic_typespec: , line:15:11, endln:15:19
       |vpiRange:
       \_range: , line:15:11, endln:15:19
         |vpiLeftRange:
@@ -8838,7 +8838,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi222.z), line:16:21, endln:16:22
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:20
+    \_logic_typespec: , line:16:12, endln:16:20
       |vpiRange:
       \_range: , line:16:12, endln:16:20
         |vpiLeftRange:
@@ -9014,7 +9014,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi31.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -9054,7 +9054,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi31.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -9094,7 +9094,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi31.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -9134,7 +9134,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi31.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -9174,7 +9174,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi31.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -9334,7 +9334,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi311.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -9374,7 +9374,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi311.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -9414,7 +9414,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi311.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -9454,7 +9454,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi311.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -9494,7 +9494,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi311.c0), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -9534,7 +9534,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi311.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -9705,7 +9705,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi32.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -9745,7 +9745,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi32.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -9785,7 +9785,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi32.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -9825,7 +9825,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi32.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -9865,7 +9865,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi32.b1), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -9905,7 +9905,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi32.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -10082,7 +10082,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi33.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -10122,7 +10122,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi33.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -10162,7 +10162,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi33.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -10202,7 +10202,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi33.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -10242,7 +10242,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi33.b1), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -10282,7 +10282,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi33.b2), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -10322,7 +10322,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_aoi33.z), line:15:21, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:20
+    \_logic_typespec: , line:15:12, endln:15:20
       |vpiRange:
       \_range: , line:15:12, endln:15:20
         |vpiLeftRange:
@@ -10510,7 +10510,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_arbiter.requests), line:13:20, endln:13:28
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:18
+    \_logic_typespec: , line:13:11, endln:13:18
       |vpiRange:
       \_range: , line:13:11, endln:13:18
         |vpiLeftRange:
@@ -10550,7 +10550,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_arbiter.grants), line:14:20, endln:14:26
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:19
+    \_logic_typespec: , line:14:12, endln:14:19
       |vpiRange:
       \_range: , line:14:12, endln:14:19
         |vpiLeftRange:
@@ -10762,7 +10762,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_bin2gray.in), line:12:20, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:18
+    \_logic_typespec: , line:12:11, endln:12:18
       |vpiRange:
       \_range: , line:12:11, endln:12:18
         |vpiLeftRange:
@@ -10802,7 +10802,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_bin2gray.out), line:13:20, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:19
+    \_logic_typespec: , line:13:12, endln:13:19
       |vpiRange:
       \_range: , line:13:12, endln:13:19
         |vpiLeftRange:
@@ -11286,7 +11286,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_bin2onehot.in), line:13:20, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -11326,7 +11326,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_bin2onehot.out), line:14:20, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:19
+    \_logic_typespec: , line:14:12, endln:14:19
       |vpiRange:
       \_range: , line:14:12, endln:14:19
         |vpiLeftRange:
@@ -11408,7 +11408,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_bitreverse.in), line:12:20, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:18
+    \_logic_typespec: , line:12:11, endln:12:18
       |vpiRange:
       \_range: , line:12:11, endln:12:18
         |vpiLeftRange:
@@ -11448,7 +11448,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_bitreverse.out), line:13:20, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:19
+    \_logic_typespec: , line:13:12, endln:13:19
       |vpiRange:
       \_range: , line:13:12, endln:13:19
         |vpiLeftRange:
@@ -11530,7 +11530,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_buf.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -11570,7 +11570,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_buf.z), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:12, endln:10:20
+    \_logic_typespec: , line:10:12, endln:10:20
       |vpiRange:
       \_range: , line:10:12, endln:10:20
         |vpiLeftRange:
@@ -11714,7 +11714,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_buffer.in), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:19
+    \_logic_typespec: , line:13:12, endln:13:19
       |vpiRange:
       \_range: , line:13:12, endln:13:19
         |vpiLeftRange:
@@ -11754,7 +11754,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_buffer.out), line:14:21, endln:14:24
     |vpiTypedef:
-    \_int_typespec: , line:14:13, endln:14:20
+    \_logic_typespec: , line:14:13, endln:14:20
       |vpiRange:
       \_range: , line:14:13, endln:14:20
         |vpiLeftRange:
@@ -12095,7 +12095,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockdiv.clkdiv), line:21:18, endln:21:24
     |vpiTypedef:
-    \_int_typespec: , line:21:11, endln:21:16
+    \_logic_typespec: , line:21:11, endln:21:16
       |vpiRange:
       \_range: , line:21:11, endln:21:16
         |vpiLeftRange:
@@ -12125,7 +12125,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockdiv.clkphase0), line:22:18, endln:22:27
     |vpiTypedef:
-    \_int_typespec: , line:22:11, endln:22:17
+    \_logic_typespec: , line:22:11, endln:22:17
       |vpiRange:
       \_range: , line:22:11, endln:22:17
         |vpiLeftRange:
@@ -12155,7 +12155,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockdiv.clkphase1), line:23:18, endln:23:27
     |vpiTypedef:
-    \_int_typespec: , line:23:11, endln:23:17
+    \_logic_typespec: , line:23:11, endln:23:17
       |vpiRange:
       \_range: , line:23:11, endln:23:17
         |vpiLeftRange:
@@ -14014,7 +14014,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux.en), line:14:19, endln:14:21
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:18
+    \_logic_typespec: , line:14:11, endln:14:18
       |vpiRange:
       \_range: , line:14:11, endln:14:18
         |vpiLeftRange:
@@ -14054,7 +14054,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux.clkin), line:15:19, endln:15:24
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -14212,7 +14212,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux2.en0), line:14:20, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:18
+    \_logic_typespec: , line:14:11, endln:14:18
       |vpiRange:
       \_range: , line:14:11, endln:14:18
         |vpiLeftRange:
@@ -14252,7 +14252,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux2.en1), line:15:20, endln:15:23
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -14292,7 +14292,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux2.clkin0), line:16:20, endln:16:26
     |vpiTypedef:
-    \_int_typespec: , line:16:11, endln:16:18
+    \_logic_typespec: , line:16:11, endln:16:18
       |vpiRange:
       \_range: , line:16:11, endln:16:18
         |vpiLeftRange:
@@ -14332,7 +14332,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux2.clkin1), line:17:20, endln:17:26
     |vpiTypedef:
-    \_int_typespec: , line:17:11, endln:17:18
+    \_logic_typespec: , line:17:11, endln:17:18
       |vpiRange:
       \_range: , line:17:11, endln:17:18
         |vpiLeftRange:
@@ -14372,7 +14372,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux2.clkout), line:18:20, endln:18:26
     |vpiTypedef:
-    \_int_typespec: , line:18:12, endln:18:19
+    \_logic_typespec: , line:18:12, endln:18:19
       |vpiRange:
       \_range: , line:18:12, endln:18:19
         |vpiLeftRange:
@@ -14542,7 +14542,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux4.en0), line:14:20, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:18
+    \_logic_typespec: , line:14:11, endln:14:18
       |vpiRange:
       \_range: , line:14:11, endln:14:18
         |vpiLeftRange:
@@ -14582,7 +14582,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux4.en1), line:15:20, endln:15:23
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -14622,7 +14622,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux4.en2), line:16:20, endln:16:23
     |vpiTypedef:
-    \_int_typespec: , line:16:11, endln:16:18
+    \_logic_typespec: , line:16:11, endln:16:18
       |vpiRange:
       \_range: , line:16:11, endln:16:18
         |vpiLeftRange:
@@ -14662,7 +14662,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux4.en3), line:17:20, endln:17:23
     |vpiTypedef:
-    \_int_typespec: , line:17:11, endln:17:18
+    \_logic_typespec: , line:17:11, endln:17:18
       |vpiRange:
       \_range: , line:17:11, endln:17:18
         |vpiLeftRange:
@@ -14702,7 +14702,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux4.clkin0), line:18:20, endln:18:26
     |vpiTypedef:
-    \_int_typespec: , line:18:11, endln:18:18
+    \_logic_typespec: , line:18:11, endln:18:18
       |vpiRange:
       \_range: , line:18:11, endln:18:18
         |vpiLeftRange:
@@ -14742,7 +14742,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux4.clkin1), line:19:20, endln:19:26
     |vpiTypedef:
-    \_int_typespec: , line:19:11, endln:19:18
+    \_logic_typespec: , line:19:11, endln:19:18
       |vpiRange:
       \_range: , line:19:11, endln:19:18
         |vpiLeftRange:
@@ -14782,7 +14782,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux4.clkin2), line:20:20, endln:20:26
     |vpiTypedef:
-    \_int_typespec: , line:20:11, endln:20:18
+    \_logic_typespec: , line:20:11, endln:20:18
       |vpiRange:
       \_range: , line:20:11, endln:20:18
         |vpiLeftRange:
@@ -14822,7 +14822,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux4.clkin3), line:21:20, endln:21:26
     |vpiTypedef:
-    \_int_typespec: , line:21:11, endln:21:18
+    \_logic_typespec: , line:21:11, endln:21:18
       |vpiRange:
       \_range: , line:21:11, endln:21:18
         |vpiLeftRange:
@@ -14862,7 +14862,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockmux4.clkout), line:22:20, endln:22:26
     |vpiTypedef:
-    \_int_typespec: , line:22:12, endln:22:19
+    \_logic_typespec: , line:22:12, endln:22:19
       |vpiRange:
       \_range: , line:22:12, endln:22:19
         |vpiLeftRange:
@@ -14990,7 +14990,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_clockor.clkin), line:14:19, endln:14:24
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:18
+    \_logic_typespec: , line:14:11, endln:14:18
       |vpiRange:
       \_range: , line:14:11, endln:14:18
         |vpiLeftRange:
@@ -15259,7 +15259,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_counter.load_data), line:21:24, endln:21:33
     |vpiTypedef:
-    \_int_typespec: , line:21:11, endln:21:18
+    \_logic_typespec: , line:21:11, endln:21:18
       |vpiRange:
       \_range: , line:21:11, endln:21:18
         |vpiLeftRange:
@@ -16003,7 +16003,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa32.in0), line:13:21, endln:13:24
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:19
+    \_logic_typespec: , line:13:12, endln:13:19
       |vpiRange:
       \_range: , line:13:12, endln:13:19
         |vpiLeftRange:
@@ -16043,7 +16043,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa32.in1), line:14:21, endln:14:24
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:19
+    \_logic_typespec: , line:14:12, endln:14:19
       |vpiRange:
       \_range: , line:14:12, endln:14:19
         |vpiLeftRange:
@@ -16083,7 +16083,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa32.in2), line:15:21, endln:15:24
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:19
+    \_logic_typespec: , line:15:12, endln:15:19
       |vpiRange:
       \_range: , line:15:12, endln:15:19
         |vpiLeftRange:
@@ -16123,7 +16123,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa32.s), line:16:21, endln:16:22
     |vpiTypedef:
-    \_int_typespec: , line:16:13, endln:16:20
+    \_logic_typespec: , line:16:13, endln:16:20
       |vpiRange:
       \_range: , line:16:13, endln:16:20
         |vpiLeftRange:
@@ -16163,7 +16163,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa32.c), line:17:21, endln:17:22
     |vpiTypedef:
-    \_int_typespec: , line:17:13, endln:17:20
+    \_logic_typespec: , line:17:13, endln:17:20
       |vpiRange:
       \_range: , line:17:13, endln:17:20
         |vpiLeftRange:
@@ -16327,7 +16327,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa42.in0), line:13:21, endln:13:24
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:19
+    \_logic_typespec: , line:13:12, endln:13:19
       |vpiRange:
       \_range: , line:13:12, endln:13:19
         |vpiLeftRange:
@@ -16367,7 +16367,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa42.in1), line:14:21, endln:14:24
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:19
+    \_logic_typespec: , line:14:12, endln:14:19
       |vpiRange:
       \_range: , line:14:12, endln:14:19
         |vpiLeftRange:
@@ -16407,7 +16407,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa42.in2), line:15:21, endln:15:24
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:19
+    \_logic_typespec: , line:15:12, endln:15:19
       |vpiRange:
       \_range: , line:15:12, endln:15:19
         |vpiLeftRange:
@@ -16447,7 +16447,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa42.in3), line:16:21, endln:16:24
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:19
+    \_logic_typespec: , line:16:12, endln:16:19
       |vpiRange:
       \_range: , line:16:12, endln:16:19
         |vpiLeftRange:
@@ -16511,7 +16511,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa42.s), line:19:21, endln:19:22
     |vpiTypedef:
-    \_int_typespec: , line:19:13, endln:19:20
+    \_logic_typespec: , line:19:13, endln:19:20
       |vpiRange:
       \_range: , line:19:13, endln:19:20
         |vpiLeftRange:
@@ -16551,7 +16551,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa42.c), line:20:21, endln:20:22
     |vpiTypedef:
-    \_int_typespec: , line:20:13, endln:20:20
+    \_logic_typespec: , line:20:13, endln:20:20
       |vpiRange:
       \_range: , line:20:13, endln:20:20
         |vpiLeftRange:
@@ -16765,7 +16765,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.in0), line:13:21, endln:13:24
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:19
+    \_logic_typespec: , line:13:12, endln:13:19
       |vpiRange:
       \_range: , line:13:12, endln:13:19
         |vpiLeftRange:
@@ -16805,7 +16805,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.in1), line:14:21, endln:14:24
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:19
+    \_logic_typespec: , line:14:12, endln:14:19
       |vpiRange:
       \_range: , line:14:12, endln:14:19
         |vpiLeftRange:
@@ -16845,7 +16845,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.in2), line:15:21, endln:15:24
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:19
+    \_logic_typespec: , line:15:12, endln:15:19
       |vpiRange:
       \_range: , line:15:12, endln:15:19
         |vpiLeftRange:
@@ -16885,7 +16885,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.in3), line:16:21, endln:16:24
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:19
+    \_logic_typespec: , line:16:12, endln:16:19
       |vpiRange:
       \_range: , line:16:12, endln:16:19
         |vpiLeftRange:
@@ -16925,7 +16925,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.in4), line:17:21, endln:17:24
     |vpiTypedef:
-    \_int_typespec: , line:17:12, endln:17:19
+    \_logic_typespec: , line:17:12, endln:17:19
       |vpiRange:
       \_range: , line:17:12, endln:17:19
         |vpiLeftRange:
@@ -16965,7 +16965,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.in5), line:18:21, endln:18:24
     |vpiTypedef:
-    \_int_typespec: , line:18:12, endln:18:19
+    \_logic_typespec: , line:18:12, endln:18:19
       |vpiRange:
       \_range: , line:18:12, endln:18:19
         |vpiLeftRange:
@@ -17005,7 +17005,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.cin0), line:19:21, endln:19:25
     |vpiTypedef:
-    \_int_typespec: , line:19:12, endln:19:19
+    \_logic_typespec: , line:19:12, endln:19:19
       |vpiRange:
       \_range: , line:19:12, endln:19:19
         |vpiLeftRange:
@@ -17045,7 +17045,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.cin1), line:20:21, endln:20:25
     |vpiTypedef:
-    \_int_typespec: , line:20:12, endln:20:19
+    \_logic_typespec: , line:20:12, endln:20:19
       |vpiRange:
       \_range: , line:20:12, endln:20:19
         |vpiLeftRange:
@@ -17085,7 +17085,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.cin2), line:21:21, endln:21:25
     |vpiTypedef:
-    \_int_typespec: , line:21:12, endln:21:19
+    \_logic_typespec: , line:21:12, endln:21:19
       |vpiRange:
       \_range: , line:21:12, endln:21:19
         |vpiLeftRange:
@@ -17125,7 +17125,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.s), line:22:21, endln:22:22
     |vpiTypedef:
-    \_int_typespec: , line:22:13, endln:22:20
+    \_logic_typespec: , line:22:13, endln:22:20
       |vpiRange:
       \_range: , line:22:13, endln:22:20
         |vpiLeftRange:
@@ -17165,7 +17165,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.c), line:23:21, endln:23:22
     |vpiTypedef:
-    \_int_typespec: , line:23:13, endln:23:20
+    \_logic_typespec: , line:23:13, endln:23:20
       |vpiRange:
       \_range: , line:23:13, endln:23:20
         |vpiLeftRange:
@@ -17205,7 +17205,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.cout0), line:24:21, endln:24:26
     |vpiTypedef:
-    \_int_typespec: , line:24:13, endln:24:20
+    \_logic_typespec: , line:24:13, endln:24:20
       |vpiRange:
       \_range: , line:24:13, endln:24:20
         |vpiLeftRange:
@@ -17245,7 +17245,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.cout1), line:25:21, endln:25:26
     |vpiTypedef:
-    \_int_typespec: , line:25:13, endln:25:20
+    \_logic_typespec: , line:25:13, endln:25:20
       |vpiRange:
       \_range: , line:25:13, endln:25:20
         |vpiLeftRange:
@@ -17285,7 +17285,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa62.cout2), line:26:21, endln:26:26
     |vpiTypedef:
-    \_int_typespec: , line:26:13, endln:26:20
+    \_logic_typespec: , line:26:13, endln:26:20
       |vpiRange:
       \_range: , line:26:13, endln:26:20
         |vpiLeftRange:
@@ -17560,7 +17560,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.in0), line:13:21, endln:13:24
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:19
+    \_logic_typespec: , line:13:12, endln:13:19
       |vpiRange:
       \_range: , line:13:12, endln:13:19
         |vpiLeftRange:
@@ -17600,7 +17600,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.in1), line:14:21, endln:14:24
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:19
+    \_logic_typespec: , line:14:12, endln:14:19
       |vpiRange:
       \_range: , line:14:12, endln:14:19
         |vpiLeftRange:
@@ -17640,7 +17640,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.in2), line:15:21, endln:15:24
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:19
+    \_logic_typespec: , line:15:12, endln:15:19
       |vpiRange:
       \_range: , line:15:12, endln:15:19
         |vpiLeftRange:
@@ -17680,7 +17680,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.in3), line:16:21, endln:16:24
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:19
+    \_logic_typespec: , line:16:12, endln:16:19
       |vpiRange:
       \_range: , line:16:12, endln:16:19
         |vpiLeftRange:
@@ -17720,7 +17720,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.in4), line:17:21, endln:17:24
     |vpiTypedef:
-    \_int_typespec: , line:17:12, endln:17:19
+    \_logic_typespec: , line:17:12, endln:17:19
       |vpiRange:
       \_range: , line:17:12, endln:17:19
         |vpiLeftRange:
@@ -17760,7 +17760,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.in5), line:18:21, endln:18:24
     |vpiTypedef:
-    \_int_typespec: , line:18:12, endln:18:19
+    \_logic_typespec: , line:18:12, endln:18:19
       |vpiRange:
       \_range: , line:18:12, endln:18:19
         |vpiLeftRange:
@@ -17800,7 +17800,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.in6), line:19:21, endln:19:24
     |vpiTypedef:
-    \_int_typespec: , line:19:12, endln:19:19
+    \_logic_typespec: , line:19:12, endln:19:19
       |vpiRange:
       \_range: , line:19:12, endln:19:19
         |vpiLeftRange:
@@ -17840,7 +17840,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.in7), line:20:21, endln:20:24
     |vpiTypedef:
-    \_int_typespec: , line:20:12, endln:20:19
+    \_logic_typespec: , line:20:12, endln:20:19
       |vpiRange:
       \_range: , line:20:12, endln:20:19
         |vpiLeftRange:
@@ -17880,7 +17880,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.in8), line:21:21, endln:21:24
     |vpiTypedef:
-    \_int_typespec: , line:21:12, endln:21:19
+    \_logic_typespec: , line:21:12, endln:21:19
       |vpiRange:
       \_range: , line:21:12, endln:21:19
         |vpiLeftRange:
@@ -17920,7 +17920,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.cin0), line:22:21, endln:22:25
     |vpiTypedef:
-    \_int_typespec: , line:22:12, endln:22:19
+    \_logic_typespec: , line:22:12, endln:22:19
       |vpiRange:
       \_range: , line:22:12, endln:22:19
         |vpiLeftRange:
@@ -17960,7 +17960,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.cin1), line:23:21, endln:23:25
     |vpiTypedef:
-    \_int_typespec: , line:23:12, endln:23:19
+    \_logic_typespec: , line:23:12, endln:23:19
       |vpiRange:
       \_range: , line:23:12, endln:23:19
         |vpiLeftRange:
@@ -18000,7 +18000,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.cin2), line:24:21, endln:24:25
     |vpiTypedef:
-    \_int_typespec: , line:24:12, endln:24:19
+    \_logic_typespec: , line:24:12, endln:24:19
       |vpiRange:
       \_range: , line:24:12, endln:24:19
         |vpiLeftRange:
@@ -18040,7 +18040,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.cin3), line:25:21, endln:25:25
     |vpiTypedef:
-    \_int_typespec: , line:25:12, endln:25:19
+    \_logic_typespec: , line:25:12, endln:25:19
       |vpiRange:
       \_range: , line:25:12, endln:25:19
         |vpiLeftRange:
@@ -18080,7 +18080,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.cin4), line:26:21, endln:26:25
     |vpiTypedef:
-    \_int_typespec: , line:26:12, endln:26:19
+    \_logic_typespec: , line:26:12, endln:26:19
       |vpiRange:
       \_range: , line:26:12, endln:26:19
         |vpiLeftRange:
@@ -18120,7 +18120,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.cin5), line:27:21, endln:27:25
     |vpiTypedef:
-    \_int_typespec: , line:27:12, endln:27:19
+    \_logic_typespec: , line:27:12, endln:27:19
       |vpiRange:
       \_range: , line:27:12, endln:27:19
         |vpiLeftRange:
@@ -18160,7 +18160,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.s), line:28:21, endln:28:22
     |vpiTypedef:
-    \_int_typespec: , line:28:13, endln:28:20
+    \_logic_typespec: , line:28:13, endln:28:20
       |vpiRange:
       \_range: , line:28:13, endln:28:20
         |vpiLeftRange:
@@ -18200,7 +18200,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.c), line:29:21, endln:29:22
     |vpiTypedef:
-    \_int_typespec: , line:29:13, endln:29:20
+    \_logic_typespec: , line:29:13, endln:29:20
       |vpiRange:
       \_range: , line:29:13, endln:29:20
         |vpiLeftRange:
@@ -18240,7 +18240,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.cout0), line:30:21, endln:30:26
     |vpiTypedef:
-    \_int_typespec: , line:30:13, endln:30:20
+    \_logic_typespec: , line:30:13, endln:30:20
       |vpiRange:
       \_range: , line:30:13, endln:30:20
         |vpiLeftRange:
@@ -18280,7 +18280,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.cout1), line:31:21, endln:31:26
     |vpiTypedef:
-    \_int_typespec: , line:31:13, endln:31:20
+    \_logic_typespec: , line:31:13, endln:31:20
       |vpiRange:
       \_range: , line:31:13, endln:31:20
         |vpiLeftRange:
@@ -18320,7 +18320,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.cout2), line:32:21, endln:32:26
     |vpiTypedef:
-    \_int_typespec: , line:32:13, endln:32:20
+    \_logic_typespec: , line:32:13, endln:32:20
       |vpiRange:
       \_range: , line:32:13, endln:32:20
         |vpiLeftRange:
@@ -18360,7 +18360,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.cout3), line:33:21, endln:33:26
     |vpiTypedef:
-    \_int_typespec: , line:33:13, endln:33:20
+    \_logic_typespec: , line:33:13, endln:33:20
       |vpiRange:
       \_range: , line:33:13, endln:33:20
         |vpiLeftRange:
@@ -18400,7 +18400,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.cout4), line:34:21, endln:34:26
     |vpiTypedef:
-    \_int_typespec: , line:34:13, endln:34:20
+    \_logic_typespec: , line:34:13, endln:34:20
       |vpiRange:
       \_range: , line:34:13, endln:34:20
         |vpiLeftRange:
@@ -18440,7 +18440,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_csa92.cout5), line:35:21, endln:35:26
     |vpiTypedef:
-    \_int_typespec: , line:35:13, endln:35:20
+    \_logic_typespec: , line:35:13, endln:35:20
       |vpiRange:
       \_range: , line:35:13, endln:35:20
         |vpiLeftRange:
@@ -18604,7 +18604,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_datagate.in), line:17:20, endln:17:22
     |vpiTypedef:
-    \_int_typespec: , line:17:11, endln:17:18
+    \_logic_typespec: , line:17:11, endln:17:18
       |vpiRange:
       \_range: , line:17:11, endln:17:18
         |vpiLeftRange:
@@ -18644,7 +18644,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_datagate.out), line:18:20, endln:18:23
     |vpiTypedef:
-    \_int_typespec: , line:18:12, endln:18:19
+    \_logic_typespec: , line:18:12, endln:18:19
       |vpiRange:
       \_range: , line:18:12, endln:18:19
         |vpiLeftRange:
@@ -19235,7 +19235,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_delay.in), line:15:20, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -19275,7 +19275,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_delay.sel), line:16:20, endln:16:23
     |vpiTypedef:
-    \_int_typespec: , line:16:11, endln:16:18
+    \_logic_typespec: , line:16:11, endln:16:18
       |vpiRange:
       \_range: , line:16:11, endln:16:18
         |vpiLeftRange:
@@ -19315,7 +19315,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_delay.out), line:17:20, endln:17:23
     |vpiTypedef:
-    \_int_typespec: , line:17:12, endln:17:19
+    \_logic_typespec: , line:17:12, endln:17:19
       |vpiRange:
       \_range: , line:17:12, endln:17:19
         |vpiLeftRange:
@@ -19479,7 +19479,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffnq.d), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -19519,7 +19519,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffnq.clk), line:10:21, endln:10:24
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -19685,7 +19685,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffq.d), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -19725,7 +19725,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffq.clk), line:11:21, endln:11:24
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -19891,7 +19891,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffqn.d), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -19931,7 +19931,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffqn.clk), line:10:21, endln:10:24
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -20108,7 +20108,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffrq.d), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -20148,7 +20148,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffrq.clk), line:12:21, endln:12:24
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -20188,7 +20188,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffrq.nreset), line:13:21, endln:13:27
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -20403,7 +20403,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffrqn.d), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -20443,7 +20443,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffrqn.clk), line:11:21, endln:11:24
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -20483,7 +20483,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffrqn.nreset), line:12:21, endln:12:27
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -20718,7 +20718,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffsq.d), line:10:24, endln:10:25
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -20758,7 +20758,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffsq.clk), line:11:24, endln:11:27
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -20798,7 +20798,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffsq.nset), line:12:24, endln:12:28
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -21028,7 +21028,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffsqn.d), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -21068,7 +21068,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffsqn.clk), line:11:21, endln:11:24
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -21108,7 +21108,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_dffsqn.nset), line:12:21, endln:12:25
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -21529,7 +21529,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_edge2pulse.in), line:13:20, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:18
+    \_logic_typespec: , line:13:11, endln:13:18
       |vpiRange:
       \_range: , line:13:11, endln:13:18
         |vpiLeftRange:
@@ -21569,7 +21569,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_edge2pulse.out), line:14:20, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:19
+    \_logic_typespec: , line:14:12, endln:14:19
       |vpiRange:
       \_range: , line:14:12, endln:14:19
         |vpiLeftRange:
@@ -22157,7 +22157,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fall2pulse.in), line:13:20, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:18
+    \_logic_typespec: , line:13:11, endln:13:18
       |vpiRange:
       \_range: , line:13:11, endln:13:18
         |vpiLeftRange:
@@ -22197,7 +22197,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fall2pulse.out), line:14:20, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:19
+    \_logic_typespec: , line:14:12, endln:14:19
       |vpiRange:
       \_range: , line:14:12, endln:14:19
         |vpiLeftRange:
@@ -22976,7 +22976,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.wr_din), line:26:20, endln:26:26
     |vpiTypedef:
-    \_int_typespec: , line:26:11, endln:26:18
+    \_logic_typespec: , line:26:11, endln:26:18
       |vpiRange:
       \_range: , line:26:11, endln:26:18
         |vpiLeftRange:
@@ -23064,7 +23064,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.wr_count), line:31:21, endln:31:29
     |vpiTypedef:
-    \_int_typespec: , line:31:12, endln:31:20
+    \_logic_typespec: , line:31:12, endln:31:20
       |vpiRange:
       \_range: , line:31:12, endln:31:20
         |vpiLeftRange:
@@ -23116,7 +23116,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.rd_dout), line:34:20, endln:34:27
     |vpiTypedef:
-    \_int_typespec: , line:34:12, endln:34:19
+    \_logic_typespec: , line:34:12, endln:34:19
       |vpiRange:
       \_range: , line:34:12, endln:34:19
         |vpiLeftRange:
@@ -23180,7 +23180,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.rd_count), line:37:21, endln:37:29
     |vpiTypedef:
-    \_int_typespec: , line:37:12, endln:37:20
+    \_logic_typespec: , line:37:12, endln:37:20
       |vpiRange:
       \_range: , line:37:12, endln:37:20
         |vpiLeftRange:
@@ -23244,7 +23244,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.bist_wem), line:41:20, endln:41:28
     |vpiTypedef:
-    \_int_typespec: , line:41:11, endln:41:18
+    \_logic_typespec: , line:41:11, endln:41:18
       |vpiRange:
       \_range: , line:41:11, endln:41:18
         |vpiLeftRange:
@@ -23284,7 +23284,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.bist_addr), line:42:21, endln:42:30
     |vpiTypedef:
-    \_int_typespec: , line:42:11, endln:42:19
+    \_logic_typespec: , line:42:11, endln:42:19
       |vpiRange:
       \_range: , line:42:11, endln:42:19
         |vpiLeftRange:
@@ -23324,7 +23324,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.bist_din), line:43:20, endln:43:28
     |vpiTypedef:
-    \_int_typespec: , line:43:11, endln:43:18
+    \_logic_typespec: , line:43:11, endln:43:18
       |vpiRange:
       \_range: , line:43:11, endln:43:18
         |vpiLeftRange:
@@ -23364,7 +23364,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.bist_dout), line:44:20, endln:44:29
     |vpiTypedef:
-    \_int_typespec: , line:44:11, endln:44:18
+    \_logic_typespec: , line:44:11, endln:44:18
       |vpiRange:
       \_range: , line:44:11, endln:44:18
         |vpiLeftRange:
@@ -23452,7 +23452,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.memconfig), line:50:21, endln:50:30
     |vpiTypedef:
-    \_int_typespec: , line:50:11, endln:50:16
+    \_logic_typespec: , line:50:11, endln:50:16
       |vpiRange:
       \_range: , line:50:11, endln:50:16
         |vpiLeftRange:
@@ -23482,7 +23482,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_async.memrepair), line:51:21, endln:51:30
     |vpiTypedef:
-    \_int_typespec: , line:51:11, endln:51:16
+    \_logic_typespec: , line:51:11, endln:51:16
       |vpiRange:
       \_range: , line:51:11, endln:51:16
         |vpiLeftRange:
@@ -24281,7 +24281,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_cdc.packet_in), line:20:20, endln:20:29
     |vpiTypedef:
-    \_int_typespec: , line:20:11, endln:20:18
+    \_logic_typespec: , line:20:11, endln:20:18
       |vpiRange:
       \_range: , line:20:11, endln:20:18
         |vpiLeftRange:
@@ -24357,7 +24357,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_cdc.packet_out), line:25:20, endln:25:30
     |vpiTypedef:
-    \_int_typespec: , line:25:12, endln:25:19
+    \_logic_typespec: , line:25:12, endln:25:19
       |vpiRange:
       \_range: , line:25:12, endln:25:19
         |vpiLeftRange:
@@ -25097,7 +25097,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_sync.wr_din), line:26:20, endln:26:26
     |vpiTypedef:
-    \_int_typespec: , line:26:11, endln:26:18
+    \_logic_typespec: , line:26:11, endln:26:18
       |vpiRange:
       \_range: , line:26:11, endln:26:18
         |vpiLeftRange:
@@ -25237,7 +25237,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_sync.rd_dout), line:34:21, endln:34:28
     |vpiTypedef:
-    \_int_typespec: , line:34:12, endln:34:19
+    \_logic_typespec: , line:34:12, endln:34:19
       |vpiRange:
       \_range: , line:34:12, endln:34:19
         |vpiLeftRange:
@@ -25325,7 +25325,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_sync.bist_wem), line:40:20, endln:40:28
     |vpiTypedef:
-    \_int_typespec: , line:40:11, endln:40:18
+    \_logic_typespec: , line:40:11, endln:40:18
       |vpiRange:
       \_range: , line:40:11, endln:40:18
         |vpiLeftRange:
@@ -25365,7 +25365,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_sync.bist_addr), line:41:21, endln:41:30
     |vpiTypedef:
-    \_int_typespec: , line:41:11, endln:41:19
+    \_logic_typespec: , line:41:11, endln:41:19
       |vpiRange:
       \_range: , line:41:11, endln:41:19
         |vpiLeftRange:
@@ -25405,7 +25405,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_sync.bist_din), line:42:20, endln:42:28
     |vpiTypedef:
-    \_int_typespec: , line:42:11, endln:42:18
+    \_logic_typespec: , line:42:11, endln:42:18
       |vpiRange:
       \_range: , line:42:11, endln:42:18
         |vpiLeftRange:
@@ -25445,7 +25445,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_sync.bist_dout), line:43:20, endln:43:29
     |vpiTypedef:
-    \_int_typespec: , line:43:11, endln:43:18
+    \_logic_typespec: , line:43:11, endln:43:18
       |vpiRange:
       \_range: , line:43:11, endln:43:18
         |vpiLeftRange:
@@ -25533,7 +25533,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_sync.memconfig), line:49:18, endln:49:27
     |vpiTypedef:
-    \_int_typespec: , line:49:11, endln:49:16
+    \_logic_typespec: , line:49:11, endln:49:16
       |vpiRange:
       \_range: , line:49:11, endln:49:16
         |vpiLeftRange:
@@ -25563,7 +25563,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_fifo_sync.memrepair), line:50:18, endln:50:27
     |vpiTypedef:
-    \_int_typespec: , line:50:11, endln:50:16
+    \_logic_typespec: , line:50:11, endln:50:16
       |vpiRange:
       \_range: , line:50:11, endln:50:16
         |vpiLeftRange:
@@ -26841,7 +26841,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_gray2bin.in), line:10:20, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:18
+    \_logic_typespec: , line:10:11, endln:10:18
       |vpiRange:
       \_range: , line:10:11, endln:10:18
         |vpiLeftRange:
@@ -26881,7 +26881,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_gray2bin.out), line:11:20, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:12, endln:11:19
+    \_logic_typespec: , line:11:12, endln:11:19
       |vpiRange:
       \_range: , line:11:12, endln:11:19
         |vpiLeftRange:
@@ -27632,7 +27632,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_iddr.in), line:17:21, endln:17:23
     |vpiTypedef:
-    \_int_typespec: , line:17:11, endln:17:18
+    \_logic_typespec: , line:17:11, endln:17:18
       |vpiRange:
       \_range: , line:17:11, endln:17:18
         |vpiLeftRange:
@@ -27767,7 +27767,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_inv.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -27807,7 +27807,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_inv.z), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:12, endln:10:20
+    \_logic_typespec: , line:10:12, endln:10:20
       |vpiRange:
       \_range: , line:10:12, endln:10:20
         |vpiLeftRange:
@@ -27974,7 +27974,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_isobufhi.in), line:15:20, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -28014,7 +28014,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_isobufhi.out), line:16:20, endln:16:23
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:19
+    \_logic_typespec: , line:16:12, endln:16:19
       |vpiRange:
       \_range: , line:16:12, endln:16:19
         |vpiLeftRange:
@@ -28160,7 +28160,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_isobuflo.in), line:15:20, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -28200,7 +28200,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_isobuflo.out), line:16:20, endln:16:23
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:19
+    \_logic_typespec: , line:16:12, endln:16:19
       |vpiRange:
       \_range: , line:16:12, endln:16:19
         |vpiLeftRange:
@@ -28346,7 +28346,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_lat0.in), line:14:20, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:18
+    \_logic_typespec: , line:14:11, endln:14:18
       |vpiRange:
       \_range: , line:14:11, endln:14:18
         |vpiLeftRange:
@@ -28386,7 +28386,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_lat0.out), line:15:20, endln:15:23
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:19
+    \_logic_typespec: , line:15:12, endln:15:19
       |vpiRange:
       \_range: , line:15:12, endln:15:19
         |vpiLeftRange:
@@ -28532,7 +28532,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_lat1.in), line:14:20, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:18
+    \_logic_typespec: , line:14:11, endln:14:18
       |vpiRange:
       \_range: , line:14:11, endln:14:18
         |vpiLeftRange:
@@ -28572,7 +28572,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_lat1.out), line:15:20, endln:15:23
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:19
+    \_logic_typespec: , line:15:12, endln:15:19
       |vpiRange:
       \_range: , line:15:12, endln:15:19
         |vpiLeftRange:
@@ -28661,7 +28661,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_latnq.d), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -28701,7 +28701,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_latnq.gn), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -28867,7 +28867,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_latq.d), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -28907,7 +28907,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_latq.g), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -29328,7 +29328,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_dp.wr_wem), line:20:20, endln:20:26
     |vpiTypedef:
-    \_int_typespec: , line:20:11, endln:20:18
+    \_logic_typespec: , line:20:11, endln:20:18
       |vpiRange:
       \_range: , line:20:11, endln:20:18
         |vpiLeftRange:
@@ -29368,7 +29368,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_dp.wr_addr), line:21:21, endln:21:28
     |vpiTypedef:
-    \_int_typespec: , line:21:11, endln:21:19
+    \_logic_typespec: , line:21:11, endln:21:19
       |vpiRange:
       \_range: , line:21:11, endln:21:19
         |vpiLeftRange:
@@ -29408,7 +29408,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_dp.wr_din), line:22:20, endln:22:26
     |vpiTypedef:
-    \_int_typespec: , line:22:11, endln:22:18
+    \_logic_typespec: , line:22:11, endln:22:18
       |vpiRange:
       \_range: , line:22:11, endln:22:18
         |vpiLeftRange:
@@ -29472,7 +29472,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_dp.rd_addr), line:25:21, endln:25:28
     |vpiTypedef:
-    \_int_typespec: , line:25:11, endln:25:19
+    \_logic_typespec: , line:25:11, endln:25:19
       |vpiRange:
       \_range: , line:25:11, endln:25:19
         |vpiLeftRange:
@@ -29512,7 +29512,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_dp.rd_dout), line:26:20, endln:26:27
     |vpiTypedef:
-    \_int_typespec: , line:26:12, endln:26:19
+    \_logic_typespec: , line:26:12, endln:26:19
       |vpiRange:
       \_range: , line:26:12, endln:26:19
         |vpiLeftRange:
@@ -29576,7 +29576,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_dp.bist_wem), line:30:20, endln:30:28
     |vpiTypedef:
-    \_int_typespec: , line:30:11, endln:30:18
+    \_logic_typespec: , line:30:11, endln:30:18
       |vpiRange:
       \_range: , line:30:11, endln:30:18
         |vpiLeftRange:
@@ -29616,7 +29616,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_dp.bist_addr), line:31:21, endln:31:30
     |vpiTypedef:
-    \_int_typespec: , line:31:11, endln:31:19
+    \_logic_typespec: , line:31:11, endln:31:19
       |vpiRange:
       \_range: , line:31:11, endln:31:19
         |vpiLeftRange:
@@ -29656,7 +29656,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_dp.bist_din), line:32:20, endln:32:28
     |vpiTypedef:
-    \_int_typespec: , line:32:11, endln:32:18
+    \_logic_typespec: , line:32:11, endln:32:18
       |vpiRange:
       \_range: , line:32:11, endln:32:18
         |vpiLeftRange:
@@ -29744,7 +29744,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_dp.memconfig), line:38:21, endln:38:30
     |vpiTypedef:
-    \_int_typespec: , line:38:11, endln:38:16
+    \_logic_typespec: , line:38:11, endln:38:16
       |vpiRange:
       \_range: , line:38:11, endln:38:16
         |vpiLeftRange:
@@ -29774,7 +29774,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_dp.memrepair), line:39:21, endln:39:30
     |vpiTypedef:
-    \_int_typespec: , line:39:11, endln:39:16
+    \_logic_typespec: , line:39:11, endln:39:16
       |vpiRange:
       \_range: , line:39:11, endln:39:16
         |vpiLeftRange:
@@ -30095,7 +30095,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_sp.wem), line:20:20, endln:20:23
     |vpiTypedef:
-    \_int_typespec: , line:20:11, endln:20:18
+    \_logic_typespec: , line:20:11, endln:20:18
       |vpiRange:
       \_range: , line:20:11, endln:20:18
         |vpiLeftRange:
@@ -30135,7 +30135,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_sp.addr), line:21:20, endln:21:24
     |vpiTypedef:
-    \_int_typespec: , line:21:11, endln:21:19
+    \_logic_typespec: , line:21:11, endln:21:19
       |vpiRange:
       \_range: , line:21:11, endln:21:19
         |vpiLeftRange:
@@ -30175,7 +30175,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_sp.din), line:22:20, endln:22:23
     |vpiTypedef:
-    \_int_typespec: , line:22:11, endln:22:18
+    \_logic_typespec: , line:22:11, endln:22:18
       |vpiRange:
       \_range: , line:22:11, endln:22:18
         |vpiLeftRange:
@@ -30215,7 +30215,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_sp.dout), line:23:20, endln:23:24
     |vpiTypedef:
-    \_int_typespec: , line:23:12, endln:23:19
+    \_logic_typespec: , line:23:12, endln:23:19
       |vpiRange:
       \_range: , line:23:12, endln:23:19
         |vpiLeftRange:
@@ -30279,7 +30279,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_sp.bist_wem), line:27:20, endln:27:28
     |vpiTypedef:
-    \_int_typespec: , line:27:11, endln:27:18
+    \_logic_typespec: , line:27:11, endln:27:18
       |vpiRange:
       \_range: , line:27:11, endln:27:18
         |vpiLeftRange:
@@ -30319,7 +30319,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_sp.bist_addr), line:28:20, endln:28:29
     |vpiTypedef:
-    \_int_typespec: , line:28:11, endln:28:19
+    \_logic_typespec: , line:28:11, endln:28:19
       |vpiRange:
       \_range: , line:28:11, endln:28:19
         |vpiLeftRange:
@@ -30359,7 +30359,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_sp.bist_din), line:29:20, endln:29:28
     |vpiTypedef:
-    \_int_typespec: , line:29:11, endln:29:18
+    \_logic_typespec: , line:29:11, endln:29:18
       |vpiRange:
       \_range: , line:29:11, endln:29:18
         |vpiLeftRange:
@@ -30447,7 +30447,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_sp.memconfig), line:35:20, endln:35:29
     |vpiTypedef:
-    \_int_typespec: , line:35:11, endln:35:16
+    \_logic_typespec: , line:35:11, endln:35:16
       |vpiRange:
       \_range: , line:35:11, endln:35:16
         |vpiLeftRange:
@@ -30477,7 +30477,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_memory_sp.memrepair), line:36:20, endln:36:29
     |vpiTypedef:
-    \_int_typespec: , line:36:11, endln:36:16
+    \_logic_typespec: , line:36:11, endln:36:16
       |vpiRange:
       \_range: , line:36:11, endln:36:16
         |vpiLeftRange:
@@ -30625,7 +30625,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mult.a), line:17:22, endln:17:23
     |vpiTypedef:
-    \_int_typespec: , line:17:11, endln:17:18
+    \_logic_typespec: , line:17:11, endln:17:18
       |vpiRange:
       \_range: , line:17:11, endln:17:18
         |vpiLeftRange:
@@ -30665,7 +30665,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mult.b), line:18:22, endln:18:23
     |vpiTypedef:
-    \_int_typespec: , line:18:11, endln:18:18
+    \_logic_typespec: , line:18:11, endln:18:18
       |vpiRange:
       \_range: , line:18:11, endln:18:18
         |vpiLeftRange:
@@ -30729,7 +30729,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mult.product), line:22:22, endln:22:29
     |vpiTypedef:
-    \_int_typespec: , line:22:12, endln:22:21
+    \_logic_typespec: , line:22:12, endln:22:21
       |vpiRange:
       \_range: , line:22:12, endln:22:21
         |vpiLeftRange:
@@ -30782,7 +30782,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mult.sum), line:23:22, endln:23:25
     |vpiTypedef:
-    \_int_typespec: , line:23:12, endln:23:21
+    \_logic_typespec: , line:23:12, endln:23:21
       |vpiRange:
       \_range: , line:23:12, endln:23:21
         |vpiLeftRange:
@@ -30835,7 +30835,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mult.carry), line:24:22, endln:24:27
     |vpiTypedef:
-    \_int_typespec: , line:24:12, endln:24:21
+    \_logic_typespec: , line:24:12, endln:24:21
       |vpiRange:
       \_range: , line:24:12, endln:24:21
         |vpiLeftRange:
@@ -31005,7 +31005,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux.sel), line:15:21, endln:15:24
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -31045,7 +31045,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux.in), line:16:21, endln:16:23
     |vpiTypedef:
-    \_int_typespec: , line:16:11, endln:16:20
+    \_logic_typespec: , line:16:11, endln:16:20
       |vpiRange:
       \_range: , line:16:11, endln:16:20
         |vpiLeftRange:
@@ -31095,7 +31095,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux.out), line:17:21, endln:17:24
     |vpiTypedef:
-    \_int_typespec: , line:17:12, endln:17:19
+    \_logic_typespec: , line:17:12, endln:17:19
       |vpiRange:
       \_range: , line:17:12, endln:17:19
         |vpiLeftRange:
@@ -31459,7 +31459,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux12.in11), line:23:20, endln:23:24
     |vpiTypedef:
-    \_int_typespec: , line:23:11, endln:23:18
+    \_logic_typespec: , line:23:11, endln:23:18
       |vpiRange:
       \_range: , line:23:11, endln:23:18
         |vpiLeftRange:
@@ -31499,7 +31499,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux12.in10), line:24:20, endln:24:24
     |vpiTypedef:
-    \_int_typespec: , line:24:11, endln:24:18
+    \_logic_typespec: , line:24:11, endln:24:18
       |vpiRange:
       \_range: , line:24:11, endln:24:18
         |vpiLeftRange:
@@ -31539,7 +31539,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux12.in9), line:25:20, endln:25:23
     |vpiTypedef:
-    \_int_typespec: , line:25:11, endln:25:18
+    \_logic_typespec: , line:25:11, endln:25:18
       |vpiRange:
       \_range: , line:25:11, endln:25:18
         |vpiLeftRange:
@@ -31579,7 +31579,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux12.in8), line:26:20, endln:26:23
     |vpiTypedef:
-    \_int_typespec: , line:26:11, endln:26:18
+    \_logic_typespec: , line:26:11, endln:26:18
       |vpiRange:
       \_range: , line:26:11, endln:26:18
         |vpiLeftRange:
@@ -31619,7 +31619,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux12.in7), line:27:20, endln:27:23
     |vpiTypedef:
-    \_int_typespec: , line:27:11, endln:27:18
+    \_logic_typespec: , line:27:11, endln:27:18
       |vpiRange:
       \_range: , line:27:11, endln:27:18
         |vpiLeftRange:
@@ -31659,7 +31659,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux12.in6), line:28:20, endln:28:23
     |vpiTypedef:
-    \_int_typespec: , line:28:11, endln:28:18
+    \_logic_typespec: , line:28:11, endln:28:18
       |vpiRange:
       \_range: , line:28:11, endln:28:18
         |vpiLeftRange:
@@ -31699,7 +31699,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux12.in5), line:29:20, endln:29:23
     |vpiTypedef:
-    \_int_typespec: , line:29:11, endln:29:18
+    \_logic_typespec: , line:29:11, endln:29:18
       |vpiRange:
       \_range: , line:29:11, endln:29:18
         |vpiLeftRange:
@@ -31739,7 +31739,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux12.in4), line:30:20, endln:30:23
     |vpiTypedef:
-    \_int_typespec: , line:30:11, endln:30:18
+    \_logic_typespec: , line:30:11, endln:30:18
       |vpiRange:
       \_range: , line:30:11, endln:30:18
         |vpiLeftRange:
@@ -31779,7 +31779,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux12.in3), line:31:20, endln:31:23
     |vpiTypedef:
-    \_int_typespec: , line:31:11, endln:31:18
+    \_logic_typespec: , line:31:11, endln:31:18
       |vpiRange:
       \_range: , line:31:11, endln:31:18
         |vpiLeftRange:
@@ -31819,7 +31819,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux12.in2), line:32:20, endln:32:23
     |vpiTypedef:
-    \_int_typespec: , line:32:11, endln:32:18
+    \_logic_typespec: , line:32:11, endln:32:18
       |vpiRange:
       \_range: , line:32:11, endln:32:18
         |vpiLeftRange:
@@ -31859,7 +31859,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux12.in1), line:33:20, endln:33:23
     |vpiTypedef:
-    \_int_typespec: , line:33:11, endln:33:18
+    \_logic_typespec: , line:33:11, endln:33:18
       |vpiRange:
       \_range: , line:33:11, endln:33:18
         |vpiLeftRange:
@@ -31899,7 +31899,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux12.in0), line:34:20, endln:34:23
     |vpiTypedef:
-    \_int_typespec: , line:34:11, endln:34:18
+    \_logic_typespec: , line:34:11, endln:34:18
       |vpiRange:
       \_range: , line:34:11, endln:34:18
         |vpiLeftRange:
@@ -31939,7 +31939,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux12.out), line:35:20, endln:35:23
     |vpiTypedef:
-    \_int_typespec: , line:35:12, endln:35:19
+    \_logic_typespec: , line:35:12, endln:35:19
       |vpiRange:
       \_range: , line:35:12, endln:35:19
         |vpiLeftRange:
@@ -32895,7 +32895,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux2.in1), line:12:20, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:18
+    \_logic_typespec: , line:12:11, endln:12:18
       |vpiRange:
       \_range: , line:12:11, endln:12:18
         |vpiLeftRange:
@@ -32935,7 +32935,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux2.in0), line:13:20, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:18
+    \_logic_typespec: , line:13:11, endln:13:18
       |vpiRange:
       \_range: , line:13:11, endln:13:18
         |vpiLeftRange:
@@ -32975,7 +32975,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux2.out), line:14:20, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:19
+    \_logic_typespec: , line:14:12, endln:14:19
       |vpiRange:
       \_range: , line:14:12, endln:14:19
         |vpiLeftRange:
@@ -33285,7 +33285,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux3.in2), line:13:20, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:18
+    \_logic_typespec: , line:13:11, endln:13:18
       |vpiRange:
       \_range: , line:13:11, endln:13:18
         |vpiLeftRange:
@@ -33325,7 +33325,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux3.in1), line:14:20, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:18
+    \_logic_typespec: , line:14:11, endln:14:18
       |vpiRange:
       \_range: , line:14:11, endln:14:18
         |vpiLeftRange:
@@ -33365,7 +33365,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux3.in0), line:15:20, endln:15:23
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -33405,7 +33405,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux3.out), line:16:20, endln:16:23
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:19
+    \_logic_typespec: , line:16:12, endln:16:19
       |vpiRange:
       \_range: , line:16:12, endln:16:19
         |vpiLeftRange:
@@ -33806,7 +33806,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux4.in3), line:14:20, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:18
+    \_logic_typespec: , line:14:11, endln:14:18
       |vpiRange:
       \_range: , line:14:11, endln:14:18
         |vpiLeftRange:
@@ -33846,7 +33846,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux4.in2), line:15:20, endln:15:23
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -33886,7 +33886,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux4.in1), line:16:20, endln:16:23
     |vpiTypedef:
-    \_int_typespec: , line:16:11, endln:16:18
+    \_logic_typespec: , line:16:11, endln:16:18
       |vpiRange:
       \_range: , line:16:11, endln:16:18
         |vpiLeftRange:
@@ -33926,7 +33926,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux4.in0), line:17:20, endln:17:23
     |vpiTypedef:
-    \_int_typespec: , line:17:11, endln:17:18
+    \_logic_typespec: , line:17:11, endln:17:18
       |vpiRange:
       \_range: , line:17:11, endln:17:18
         |vpiLeftRange:
@@ -33966,7 +33966,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux4.out), line:18:20, endln:18:23
     |vpiTypedef:
-    \_int_typespec: , line:18:12, endln:18:19
+    \_logic_typespec: , line:18:12, endln:18:19
       |vpiRange:
       \_range: , line:18:12, endln:18:19
         |vpiLeftRange:
@@ -34458,7 +34458,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux5.in4), line:15:20, endln:15:23
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -34498,7 +34498,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux5.in3), line:16:20, endln:16:23
     |vpiTypedef:
-    \_int_typespec: , line:16:11, endln:16:18
+    \_logic_typespec: , line:16:11, endln:16:18
       |vpiRange:
       \_range: , line:16:11, endln:16:18
         |vpiLeftRange:
@@ -34538,7 +34538,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux5.in2), line:17:20, endln:17:23
     |vpiTypedef:
-    \_int_typespec: , line:17:11, endln:17:18
+    \_logic_typespec: , line:17:11, endln:17:18
       |vpiRange:
       \_range: , line:17:11, endln:17:18
         |vpiLeftRange:
@@ -34578,7 +34578,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux5.in1), line:18:20, endln:18:23
     |vpiTypedef:
-    \_int_typespec: , line:18:11, endln:18:18
+    \_logic_typespec: , line:18:11, endln:18:18
       |vpiRange:
       \_range: , line:18:11, endln:18:18
         |vpiLeftRange:
@@ -34618,7 +34618,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux5.in0), line:19:20, endln:19:23
     |vpiTypedef:
-    \_int_typespec: , line:19:11, endln:19:18
+    \_logic_typespec: , line:19:11, endln:19:18
       |vpiRange:
       \_range: , line:19:11, endln:19:18
         |vpiLeftRange:
@@ -34658,7 +34658,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux5.out), line:20:20, endln:20:23
     |vpiTypedef:
-    \_int_typespec: , line:20:12, endln:20:19
+    \_logic_typespec: , line:20:12, endln:20:19
       |vpiRange:
       \_range: , line:20:12, endln:20:19
         |vpiLeftRange:
@@ -35241,7 +35241,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux6.in5), line:16:20, endln:16:23
     |vpiTypedef:
-    \_int_typespec: , line:16:11, endln:16:18
+    \_logic_typespec: , line:16:11, endln:16:18
       |vpiRange:
       \_range: , line:16:11, endln:16:18
         |vpiLeftRange:
@@ -35281,7 +35281,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux6.in4), line:17:20, endln:17:23
     |vpiTypedef:
-    \_int_typespec: , line:17:11, endln:17:18
+    \_logic_typespec: , line:17:11, endln:17:18
       |vpiRange:
       \_range: , line:17:11, endln:17:18
         |vpiLeftRange:
@@ -35321,7 +35321,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux6.in3), line:18:20, endln:18:23
     |vpiTypedef:
-    \_int_typespec: , line:18:11, endln:18:18
+    \_logic_typespec: , line:18:11, endln:18:18
       |vpiRange:
       \_range: , line:18:11, endln:18:18
         |vpiLeftRange:
@@ -35361,7 +35361,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux6.in2), line:19:20, endln:19:23
     |vpiTypedef:
-    \_int_typespec: , line:19:11, endln:19:18
+    \_logic_typespec: , line:19:11, endln:19:18
       |vpiRange:
       \_range: , line:19:11, endln:19:18
         |vpiLeftRange:
@@ -35401,7 +35401,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux6.in1), line:20:20, endln:20:23
     |vpiTypedef:
-    \_int_typespec: , line:20:11, endln:20:18
+    \_logic_typespec: , line:20:11, endln:20:18
       |vpiRange:
       \_range: , line:20:11, endln:20:18
         |vpiLeftRange:
@@ -35441,7 +35441,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux6.in0), line:21:20, endln:21:23
     |vpiTypedef:
-    \_int_typespec: , line:21:11, endln:21:18
+    \_logic_typespec: , line:21:11, endln:21:18
       |vpiRange:
       \_range: , line:21:11, endln:21:18
         |vpiLeftRange:
@@ -35481,7 +35481,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux6.out), line:22:20, endln:22:23
     |vpiTypedef:
-    \_int_typespec: , line:22:12, endln:22:19
+    \_logic_typespec: , line:22:12, endln:22:19
       |vpiRange:
       \_range: , line:22:12, endln:22:19
         |vpiLeftRange:
@@ -36155,7 +36155,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux7.in6), line:17:20, endln:17:23
     |vpiTypedef:
-    \_int_typespec: , line:17:11, endln:17:18
+    \_logic_typespec: , line:17:11, endln:17:18
       |vpiRange:
       \_range: , line:17:11, endln:17:18
         |vpiLeftRange:
@@ -36195,7 +36195,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux7.in5), line:18:20, endln:18:23
     |vpiTypedef:
-    \_int_typespec: , line:18:11, endln:18:18
+    \_logic_typespec: , line:18:11, endln:18:18
       |vpiRange:
       \_range: , line:18:11, endln:18:18
         |vpiLeftRange:
@@ -36235,7 +36235,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux7.in4), line:19:20, endln:19:23
     |vpiTypedef:
-    \_int_typespec: , line:19:11, endln:19:18
+    \_logic_typespec: , line:19:11, endln:19:18
       |vpiRange:
       \_range: , line:19:11, endln:19:18
         |vpiLeftRange:
@@ -36275,7 +36275,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux7.in3), line:20:20, endln:20:23
     |vpiTypedef:
-    \_int_typespec: , line:20:11, endln:20:18
+    \_logic_typespec: , line:20:11, endln:20:18
       |vpiRange:
       \_range: , line:20:11, endln:20:18
         |vpiLeftRange:
@@ -36315,7 +36315,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux7.in2), line:21:20, endln:21:23
     |vpiTypedef:
-    \_int_typespec: , line:21:11, endln:21:18
+    \_logic_typespec: , line:21:11, endln:21:18
       |vpiRange:
       \_range: , line:21:11, endln:21:18
         |vpiLeftRange:
@@ -36355,7 +36355,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux7.in1), line:22:20, endln:22:23
     |vpiTypedef:
-    \_int_typespec: , line:22:11, endln:22:18
+    \_logic_typespec: , line:22:11, endln:22:18
       |vpiRange:
       \_range: , line:22:11, endln:22:18
         |vpiLeftRange:
@@ -36395,7 +36395,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux7.in0), line:23:20, endln:23:23
     |vpiTypedef:
-    \_int_typespec: , line:23:11, endln:23:18
+    \_logic_typespec: , line:23:11, endln:23:18
       |vpiRange:
       \_range: , line:23:11, endln:23:18
         |vpiLeftRange:
@@ -36435,7 +36435,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux7.out), line:24:20, endln:24:23
     |vpiTypedef:
-    \_int_typespec: , line:24:12, endln:24:19
+    \_logic_typespec: , line:24:12, endln:24:19
       |vpiRange:
       \_range: , line:24:12, endln:24:19
         |vpiLeftRange:
@@ -37200,7 +37200,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux8.in7), line:18:20, endln:18:23
     |vpiTypedef:
-    \_int_typespec: , line:18:11, endln:18:18
+    \_logic_typespec: , line:18:11, endln:18:18
       |vpiRange:
       \_range: , line:18:11, endln:18:18
         |vpiLeftRange:
@@ -37240,7 +37240,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux8.in6), line:19:20, endln:19:23
     |vpiTypedef:
-    \_int_typespec: , line:19:11, endln:19:18
+    \_logic_typespec: , line:19:11, endln:19:18
       |vpiRange:
       \_range: , line:19:11, endln:19:18
         |vpiLeftRange:
@@ -37280,7 +37280,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux8.in5), line:20:20, endln:20:23
     |vpiTypedef:
-    \_int_typespec: , line:20:11, endln:20:18
+    \_logic_typespec: , line:20:11, endln:20:18
       |vpiRange:
       \_range: , line:20:11, endln:20:18
         |vpiLeftRange:
@@ -37320,7 +37320,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux8.in4), line:21:20, endln:21:23
     |vpiTypedef:
-    \_int_typespec: , line:21:11, endln:21:18
+    \_logic_typespec: , line:21:11, endln:21:18
       |vpiRange:
       \_range: , line:21:11, endln:21:18
         |vpiLeftRange:
@@ -37360,7 +37360,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux8.in3), line:22:20, endln:22:23
     |vpiTypedef:
-    \_int_typespec: , line:22:11, endln:22:18
+    \_logic_typespec: , line:22:11, endln:22:18
       |vpiRange:
       \_range: , line:22:11, endln:22:18
         |vpiLeftRange:
@@ -37400,7 +37400,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux8.in2), line:23:20, endln:23:23
     |vpiTypedef:
-    \_int_typespec: , line:23:11, endln:23:18
+    \_logic_typespec: , line:23:11, endln:23:18
       |vpiRange:
       \_range: , line:23:11, endln:23:18
         |vpiLeftRange:
@@ -37440,7 +37440,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux8.in1), line:24:20, endln:24:23
     |vpiTypedef:
-    \_int_typespec: , line:24:11, endln:24:18
+    \_logic_typespec: , line:24:11, endln:24:18
       |vpiRange:
       \_range: , line:24:11, endln:24:18
         |vpiLeftRange:
@@ -37480,7 +37480,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux8.in0), line:25:20, endln:25:23
     |vpiTypedef:
-    \_int_typespec: , line:25:11, endln:25:18
+    \_logic_typespec: , line:25:11, endln:25:18
       |vpiRange:
       \_range: , line:25:11, endln:25:18
         |vpiLeftRange:
@@ -37520,7 +37520,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux8.out), line:26:20, endln:26:23
     |vpiTypedef:
-    \_int_typespec: , line:26:12, endln:26:19
+    \_logic_typespec: , line:26:12, endln:26:19
       |vpiRange:
       \_range: , line:26:12, endln:26:19
         |vpiLeftRange:
@@ -38376,7 +38376,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux9.in8), line:19:20, endln:19:23
     |vpiTypedef:
-    \_int_typespec: , line:19:11, endln:19:18
+    \_logic_typespec: , line:19:11, endln:19:18
       |vpiRange:
       \_range: , line:19:11, endln:19:18
         |vpiLeftRange:
@@ -38416,7 +38416,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux9.in7), line:20:20, endln:20:23
     |vpiTypedef:
-    \_int_typespec: , line:20:11, endln:20:18
+    \_logic_typespec: , line:20:11, endln:20:18
       |vpiRange:
       \_range: , line:20:11, endln:20:18
         |vpiLeftRange:
@@ -38456,7 +38456,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux9.in6), line:21:20, endln:21:23
     |vpiTypedef:
-    \_int_typespec: , line:21:11, endln:21:18
+    \_logic_typespec: , line:21:11, endln:21:18
       |vpiRange:
       \_range: , line:21:11, endln:21:18
         |vpiLeftRange:
@@ -38496,7 +38496,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux9.in5), line:22:20, endln:22:23
     |vpiTypedef:
-    \_int_typespec: , line:22:11, endln:22:18
+    \_logic_typespec: , line:22:11, endln:22:18
       |vpiRange:
       \_range: , line:22:11, endln:22:18
         |vpiLeftRange:
@@ -38536,7 +38536,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux9.in4), line:23:20, endln:23:23
     |vpiTypedef:
-    \_int_typespec: , line:23:11, endln:23:18
+    \_logic_typespec: , line:23:11, endln:23:18
       |vpiRange:
       \_range: , line:23:11, endln:23:18
         |vpiLeftRange:
@@ -38576,7 +38576,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux9.in3), line:24:20, endln:24:23
     |vpiTypedef:
-    \_int_typespec: , line:24:11, endln:24:18
+    \_logic_typespec: , line:24:11, endln:24:18
       |vpiRange:
       \_range: , line:24:11, endln:24:18
         |vpiLeftRange:
@@ -38616,7 +38616,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux9.in2), line:25:20, endln:25:23
     |vpiTypedef:
-    \_int_typespec: , line:25:11, endln:25:18
+    \_logic_typespec: , line:25:11, endln:25:18
       |vpiRange:
       \_range: , line:25:11, endln:25:18
         |vpiLeftRange:
@@ -38656,7 +38656,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux9.in1), line:26:20, endln:26:23
     |vpiTypedef:
-    \_int_typespec: , line:26:11, endln:26:18
+    \_logic_typespec: , line:26:11, endln:26:18
       |vpiRange:
       \_range: , line:26:11, endln:26:18
         |vpiLeftRange:
@@ -38696,7 +38696,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux9.in0), line:27:20, endln:27:23
     |vpiTypedef:
-    \_int_typespec: , line:27:11, endln:27:18
+    \_logic_typespec: , line:27:11, endln:27:18
       |vpiRange:
       \_range: , line:27:11, endln:27:18
         |vpiLeftRange:
@@ -38736,7 +38736,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mux9.out), line:28:20, endln:28:23
     |vpiTypedef:
-    \_int_typespec: , line:28:12, endln:28:19
+    \_logic_typespec: , line:28:12, endln:28:19
       |vpiRange:
       \_range: , line:28:12, endln:28:19
         |vpiLeftRange:
@@ -39461,7 +39461,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx2.d0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -39501,7 +39501,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx2.d1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -39541,7 +39541,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx2.s), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -39581,7 +39581,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx2.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -39741,7 +39741,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx3.d0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -39781,7 +39781,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx3.d1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -39821,7 +39821,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx3.d2), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -39861,7 +39861,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx3.s0), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -39901,7 +39901,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx3.s1), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -39941,7 +39941,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx3.z), line:15:21, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:20
+    \_logic_typespec: , line:15:12, endln:15:20
       |vpiRange:
       \_range: , line:15:12, endln:15:20
         |vpiLeftRange:
@@ -40161,7 +40161,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx4.d0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -40201,7 +40201,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx4.d1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -40241,7 +40241,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx4.d2), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -40281,7 +40281,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx4.d3), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -40321,7 +40321,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx4.s0), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -40361,7 +40361,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx4.s1), line:15:21, endln:15:23
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:19
+    \_logic_typespec: , line:15:11, endln:15:19
       |vpiRange:
       \_range: , line:15:11, endln:15:19
         |vpiLeftRange:
@@ -40401,7 +40401,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mx4.z), line:16:21, endln:16:22
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:20
+    \_logic_typespec: , line:16:12, endln:16:20
       |vpiRange:
       \_range: , line:16:12, endln:16:20
         |vpiLeftRange:
@@ -40652,7 +40652,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi2.d0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -40692,7 +40692,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi2.d1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -40732,7 +40732,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi2.s), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -40772,7 +40772,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi2.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -40937,7 +40937,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi3.d0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -40977,7 +40977,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi3.d1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -41017,7 +41017,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi3.d2), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -41057,7 +41057,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi3.s0), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -41097,7 +41097,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi3.s1), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -41137,7 +41137,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi3.z), line:15:21, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:20
+    \_logic_typespec: , line:15:12, endln:15:20
       |vpiRange:
       \_range: , line:15:12, endln:15:20
         |vpiLeftRange:
@@ -41362,7 +41362,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi4.d0), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -41402,7 +41402,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi4.d1), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -41442,7 +41442,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi4.d2), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -41482,7 +41482,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi4.d3), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -41522,7 +41522,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi4.s0), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -41562,7 +41562,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi4.s1), line:15:21, endln:15:23
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:19
+    \_logic_typespec: , line:15:11, endln:15:19
       |vpiRange:
       \_range: , line:15:11, endln:15:19
         |vpiLeftRange:
@@ -41602,7 +41602,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_mxi4.z), line:16:21, endln:16:22
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:20
+    \_logic_typespec: , line:16:12, endln:16:20
       |vpiRange:
       \_range: , line:16:12, endln:16:20
         |vpiLeftRange:
@@ -41858,7 +41858,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nand3.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -41898,7 +41898,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nand3.b), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -41938,7 +41938,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nand3.c), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -41978,7 +41978,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nand3.z), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:12, endln:12:20
+    \_logic_typespec: , line:12:12, endln:12:20
       |vpiRange:
       \_range: , line:12:12, endln:12:20
         |vpiLeftRange:
@@ -42121,7 +42121,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nand4.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -42161,7 +42161,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nand4.b), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -42201,7 +42201,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nand4.c), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -42241,7 +42241,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nand4.d), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -42281,7 +42281,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nand4.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -42423,7 +42423,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nor2.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -42463,7 +42463,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nor2.b), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -42503,7 +42503,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nor2.z), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:12, endln:11:20
+    \_logic_typespec: , line:11:12, endln:11:20
       |vpiRange:
       \_range: , line:11:12, endln:11:20
         |vpiLeftRange:
@@ -42629,7 +42629,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nor3.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -42669,7 +42669,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nor3.b), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -42709,7 +42709,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nor3.c), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -42749,7 +42749,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nor3.z), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:12, endln:12:20
+    \_logic_typespec: , line:12:12, endln:12:20
       |vpiRange:
       \_range: , line:12:12, endln:12:20
         |vpiLeftRange:
@@ -42892,7 +42892,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nor4.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -42932,7 +42932,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nor4.b), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -42972,7 +42972,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nor4.c), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -43012,7 +43012,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nor4.d), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -43052,7 +43052,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_nor4.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -43200,7 +43200,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa21.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -43240,7 +43240,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa21.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -43280,7 +43280,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa21.b0), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -43320,7 +43320,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa21.z), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:12, endln:12:20
+    \_logic_typespec: , line:12:12, endln:12:20
       |vpiRange:
       \_range: , line:12:12, endln:12:20
         |vpiLeftRange:
@@ -43458,7 +43458,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa211.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -43498,7 +43498,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa211.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -43538,7 +43538,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa211.b0), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -43578,7 +43578,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa211.c0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -43618,7 +43618,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa211.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -43767,7 +43767,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa22.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -43807,7 +43807,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa22.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -43847,7 +43847,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa22.b0), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -43887,7 +43887,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa22.b1), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -43927,7 +43927,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa22.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -44082,7 +44082,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa221.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -44122,7 +44122,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa221.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -44162,7 +44162,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa221.b0), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -44202,7 +44202,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa221.b1), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -44242,7 +44242,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa221.c0), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -44282,7 +44282,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa221.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -44454,7 +44454,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa222.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -44494,7 +44494,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa222.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -44534,7 +44534,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa222.b0), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -44574,7 +44574,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa222.b1), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -44614,7 +44614,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa222.c0), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -44654,7 +44654,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa222.c1), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -44694,7 +44694,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa222.z), line:15:21, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:20
+    \_logic_typespec: , line:15:12, endln:15:20
       |vpiRange:
       \_range: , line:15:12, endln:15:20
         |vpiLeftRange:
@@ -44865,7 +44865,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa31.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -44905,7 +44905,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa31.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -44945,7 +44945,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa31.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -44985,7 +44985,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa31.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -45025,7 +45025,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa31.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -45180,7 +45180,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa311.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -45220,7 +45220,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa311.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -45260,7 +45260,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa311.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -45300,7 +45300,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa311.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -45340,7 +45340,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa311.c0), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -45380,7 +45380,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa311.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -45546,7 +45546,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa32.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -45586,7 +45586,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa32.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -45626,7 +45626,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa32.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -45666,7 +45666,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa32.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -45706,7 +45706,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa32.b1), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -45746,7 +45746,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa32.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -45918,7 +45918,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa33.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -45958,7 +45958,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa33.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -45998,7 +45998,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa33.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -46038,7 +46038,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa33.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -46078,7 +46078,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa33.b1), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -46118,7 +46118,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa33.b2), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -46158,7 +46158,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oa33.z), line:15:21, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:20
+    \_logic_typespec: , line:15:12, endln:15:20
       |vpiRange:
       \_range: , line:15:12, endln:15:20
         |vpiLeftRange:
@@ -46323,7 +46323,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai21.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -46363,7 +46363,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai21.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -46403,7 +46403,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai21.b0), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -46443,7 +46443,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai21.z), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:12, endln:12:20
+    \_logic_typespec: , line:12:12, endln:12:20
       |vpiRange:
       \_range: , line:12:12, endln:12:20
         |vpiLeftRange:
@@ -46586,7 +46586,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai22.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -46626,7 +46626,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai22.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -46666,7 +46666,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai22.b0), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -46706,7 +46706,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai22.b1), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -46746,7 +46746,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai22.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -46906,7 +46906,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai221.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -46946,7 +46946,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai221.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -46986,7 +46986,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai221.b0), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -47026,7 +47026,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai221.b1), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -47066,7 +47066,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai221.c0), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -47106,7 +47106,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai221.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -47283,7 +47283,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai222.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -47323,7 +47323,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai222.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -47363,7 +47363,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai222.b0), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -47403,7 +47403,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai222.b1), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -47443,7 +47443,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai222.c0), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -47483,7 +47483,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai222.c1), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -47523,7 +47523,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai222.z), line:15:21, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:20
+    \_logic_typespec: , line:15:12, endln:15:20
       |vpiRange:
       \_range: , line:15:12, endln:15:20
         |vpiLeftRange:
@@ -47699,7 +47699,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai31.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -47739,7 +47739,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai31.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -47779,7 +47779,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai31.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -47819,7 +47819,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai31.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -47859,7 +47859,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai31.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -48019,7 +48019,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai311.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -48059,7 +48059,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai311.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -48099,7 +48099,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai311.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -48139,7 +48139,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai311.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -48179,7 +48179,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai311.c0), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -48219,7 +48219,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai311.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -48390,7 +48390,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai32.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -48430,7 +48430,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai32.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -48470,7 +48470,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai32.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -48510,7 +48510,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai32.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -48550,7 +48550,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai32.b1), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -48590,7 +48590,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai32.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -48767,7 +48767,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai33.a0), line:9:21, endln:9:23
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -48807,7 +48807,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai33.a1), line:10:21, endln:10:23
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -48847,7 +48847,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai33.a2), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -48887,7 +48887,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai33.b0), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -48927,7 +48927,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai33.b1), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -48967,7 +48967,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai33.b2), line:14:21, endln:14:23
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -49007,7 +49007,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oai33.z), line:15:21, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:20
+    \_logic_typespec: , line:15:12, endln:15:20
       |vpiRange:
       \_range: , line:15:12, endln:15:20
         |vpiLeftRange:
@@ -49235,7 +49235,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oddr.in1), line:15:20, endln:15:23
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -49275,7 +49275,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oddr.in2), line:16:20, endln:16:23
     |vpiTypedef:
-    \_int_typespec: , line:16:11, endln:16:18
+    \_logic_typespec: , line:16:11, endln:16:18
       |vpiRange:
       \_range: , line:16:11, endln:16:18
         |vpiLeftRange:
@@ -49315,7 +49315,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_oddr.out), line:17:20, endln:17:23
     |vpiTypedef:
-    \_int_typespec: , line:17:12, endln:17:19
+    \_logic_typespec: , line:17:12, endln:17:19
       |vpiRange:
       \_range: , line:17:12, endln:17:19
         |vpiLeftRange:
@@ -49403,7 +49403,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_or2.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -49443,7 +49443,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_or2.b), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -49483,7 +49483,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_or2.z), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:12, endln:11:20
+    \_logic_typespec: , line:11:12, endln:11:20
       |vpiRange:
       \_range: , line:11:12, endln:11:20
         |vpiLeftRange:
@@ -49604,7 +49604,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_or3.a), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -49644,7 +49644,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_or3.b), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -49684,7 +49684,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_or3.c), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -49724,7 +49724,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_or3.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -49862,7 +49862,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_or4.a), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -49902,7 +49902,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_or4.b), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -49942,7 +49942,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_or4.c), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -49982,7 +49982,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_or4.d), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -50022,7 +50022,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_or4.z), line:14:21, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:20
+    \_logic_typespec: , line:14:12, endln:14:20
       |vpiRange:
       \_range: , line:14:12, endln:14:20
         |vpiLeftRange:
@@ -50318,7 +50318,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_par2ser.din), line:15:21, endln:15:24
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:19
+    \_logic_typespec: , line:15:11, endln:15:19
       |vpiRange:
       \_range: , line:15:11, endln:15:19
         |vpiLeftRange:
@@ -50358,7 +50358,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_par2ser.dout), line:16:21, endln:16:25
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:20
+    \_logic_typespec: , line:16:12, endln:16:20
       |vpiRange:
       \_range: , line:16:12, endln:16:20
         |vpiLeftRange:
@@ -50434,7 +50434,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_par2ser.datasize), line:20:21, endln:20:29
     |vpiTypedef:
-    \_int_typespec: , line:20:11, endln:20:16
+    \_logic_typespec: , line:20:11, endln:20:16
       |vpiRange:
       \_range: , line:20:11, endln:20:16
         |vpiLeftRange:
@@ -51527,7 +51527,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_parity.in), line:11:19, endln:11:21
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:18
+    \_logic_typespec: , line:11:11, endln:11:18
       |vpiRange:
       \_range: , line:11:11, endln:11:18
         |vpiLeftRange:
@@ -51758,7 +51758,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_pll.clkdiv), line:13:23, endln:13:29
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:21
+    \_logic_typespec: , line:13:12, endln:13:21
       |vpiRange:
       \_range: , line:13:12, endln:13:21
         |vpiLeftRange:
@@ -51811,7 +51811,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_pll.clkphase), line:14:23, endln:14:31
     |vpiTypedef:
-    \_int_typespec: , line:14:12, endln:14:22
+    \_logic_typespec: , line:14:12, endln:14:22
       |vpiRange:
       \_range: , line:14:12, endln:14:22
         |vpiLeftRange:
@@ -51864,7 +51864,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_pll.clkmult), line:15:23, endln:15:30
     |vpiTypedef:
-    \_int_typespec: , line:15:12, endln:15:17
+    \_logic_typespec: , line:15:12, endln:15:17
       |vpiRange:
       \_range: , line:15:12, endln:15:17
         |vpiLeftRange:
@@ -51894,7 +51894,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_pll.clkout), line:16:23, endln:16:29
     |vpiTypedef:
-    \_int_typespec: , line:16:13, endln:16:20
+    \_logic_typespec: , line:16:13, endln:16:20
       |vpiRange:
       \_range: , line:16:13, endln:16:20
         |vpiLeftRange:
@@ -52413,7 +52413,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_pwr_buf.in), line:12:18, endln:12:20
     |vpiTypedef:
-    \_int_typespec: , line:12:9, endln:12:16
+    \_logic_typespec: , line:12:9, endln:12:16
       |vpiRange:
       \_range: , line:12:9, endln:12:16
         |vpiLeftRange:
@@ -52453,7 +52453,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_pwr_buf.out), line:13:18, endln:13:21
     |vpiTypedef:
-    \_int_typespec: , line:13:10, endln:13:17
+    \_logic_typespec: , line:13:10, endln:13:17
       |vpiRange:
       \_range: , line:13:10, endln:13:17
         |vpiLeftRange:
@@ -52703,7 +52703,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_reg1.in), line:16:21, endln:16:23
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:19
+    \_logic_typespec: , line:16:12, endln:16:19
       |vpiRange:
       \_range: , line:16:12, endln:16:19
         |vpiLeftRange:
@@ -52743,7 +52743,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_reg1.out), line:17:21, endln:17:24
     |vpiTypedef:
-    \_int_typespec: , line:17:13, endln:17:20
+    \_logic_typespec: , line:17:13, endln:17:20
       |vpiRange:
       \_range: , line:17:13, endln:17:20
         |vpiLeftRange:
@@ -52977,7 +52977,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_regfile.wr_valid), line:18:24, endln:18:32
     |vpiTypedef:
-    \_int_typespec: , line:18:11, endln:18:19
+    \_logic_typespec: , line:18:11, endln:18:19
       |vpiRange:
       \_range: , line:18:11, endln:18:19
         |vpiLeftRange:
@@ -53017,7 +53017,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_regfile.wr_addr), line:19:24, endln:19:31
     |vpiTypedef:
-    \_int_typespec: , line:19:11, endln:19:23
+    \_logic_typespec: , line:19:11, endln:19:23
       |vpiRange:
       \_range: , line:19:11, endln:19:23
         |vpiLeftRange:
@@ -53067,7 +53067,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_regfile.wr_data), line:20:24, endln:20:31
     |vpiTypedef:
-    \_int_typespec: , line:20:11, endln:20:22
+    \_logic_typespec: , line:20:11, endln:20:22
       |vpiRange:
       \_range: , line:20:11, endln:20:22
         |vpiLeftRange:
@@ -53117,7 +53117,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_regfile.rd_valid), line:22:24, endln:22:32
     |vpiTypedef:
-    \_int_typespec: , line:22:11, endln:22:19
+    \_logic_typespec: , line:22:11, endln:22:19
       |vpiRange:
       \_range: , line:22:11, endln:22:19
         |vpiLeftRange:
@@ -53157,7 +53157,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_regfile.rd_addr), line:23:24, endln:23:31
     |vpiTypedef:
-    \_int_typespec: , line:23:11, endln:23:23
+    \_logic_typespec: , line:23:11, endln:23:23
       |vpiRange:
       \_range: , line:23:11, endln:23:23
         |vpiLeftRange:
@@ -53207,7 +53207,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_regfile.rd_data), line:24:24, endln:24:31
     |vpiTypedef:
-    \_int_typespec: , line:24:12, endln:24:23
+    \_logic_typespec: , line:24:12, endln:24:23
       |vpiRange:
       \_range: , line:24:12, endln:24:23
         |vpiLeftRange:
@@ -53342,7 +53342,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_rise2pulse.in), line:12:22, endln:12:24
     |vpiTypedef:
-    \_int_typespec: , line:12:13, endln:12:20
+    \_logic_typespec: , line:12:13, endln:12:20
       |vpiRange:
       \_range: , line:12:13, endln:12:20
         |vpiLeftRange:
@@ -53382,7 +53382,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_rise2pulse.out), line:13:22, endln:13:25
     |vpiTypedef:
-    \_int_typespec: , line:13:14, endln:13:21
+    \_logic_typespec: , line:13:14, endln:13:21
       |vpiRange:
       \_range: , line:13:14, endln:13:21
         |vpiLeftRange:
@@ -53890,7 +53890,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffq.d), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -53930,7 +53930,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffq.si), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -53970,7 +53970,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffq.se), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -54010,7 +54010,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffq.clk), line:13:21, endln:13:24
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -54205,7 +54205,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffqn.d), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -54245,7 +54245,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffqn.si), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -54285,7 +54285,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffqn.se), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -54325,7 +54325,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffqn.clk), line:13:21, endln:13:24
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -54536,7 +54536,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffrq.d), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -54576,7 +54576,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffrq.si), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -54616,7 +54616,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffrq.se), line:13:21, endln:13:23
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -54656,7 +54656,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffrq.clk), line:14:21, endln:14:24
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -54696,7 +54696,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffrq.nreset), line:15:21, endln:15:27
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:19
+    \_logic_typespec: , line:15:11, endln:15:19
       |vpiRange:
       \_range: , line:15:11, endln:15:19
         |vpiLeftRange:
@@ -54940,7 +54940,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffrqn.d), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -54980,7 +54980,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffrqn.si), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -55020,7 +55020,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffrqn.se), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -55060,7 +55060,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffrqn.clk), line:13:21, endln:13:24
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -55100,7 +55100,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffrqn.nreset), line:14:21, endln:14:27
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -55369,7 +55369,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffsq.d), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -55409,7 +55409,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffsq.si), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -55449,7 +55449,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffsq.se), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -55489,7 +55489,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffsq.clk), line:13:21, endln:13:24
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -55529,7 +55529,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffsq.nset), line:14:21, endln:14:25
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -55788,7 +55788,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffsqn.d), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -55828,7 +55828,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffsqn.si), line:11:21, endln:11:23
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -55868,7 +55868,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffsqn.se), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -55908,7 +55908,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffsqn.clk), line:13:21, endln:13:24
     |vpiTypedef:
-    \_int_typespec: , line:13:11, endln:13:19
+    \_logic_typespec: , line:13:11, endln:13:19
       |vpiRange:
       \_range: , line:13:11, endln:13:19
         |vpiLeftRange:
@@ -55948,7 +55948,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_sdffsqn.nset), line:14:21, endln:14:25
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -56275,7 +56275,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_ser2par.din), line:14:21, endln:14:24
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:19
+    \_logic_typespec: , line:14:11, endln:14:19
       |vpiRange:
       \_range: , line:14:11, endln:14:19
         |vpiLeftRange:
@@ -56762,7 +56762,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_shift.in), line:14:20, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:18
+    \_logic_typespec: , line:14:11, endln:14:18
       |vpiRange:
       \_range: , line:14:11, endln:14:18
         |vpiLeftRange:
@@ -56826,7 +56826,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_shift.shamt), line:17:21, endln:17:26
     |vpiTypedef:
-    \_int_typespec: , line:17:11, endln:17:18
+    \_logic_typespec: , line:17:11, endln:17:18
       |vpiRange:
       \_range: , line:17:11, endln:17:18
         |vpiLeftRange:
@@ -56866,7 +56866,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_shift.out), line:18:20, endln:18:23
     |vpiTypedef:
-    \_int_typespec: , line:18:12, endln:18:19
+    \_logic_typespec: , line:18:12, endln:18:19
       |vpiRange:
       \_range: , line:18:12, endln:18:19
         |vpiLeftRange:
@@ -57956,7 +57956,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_tristate.in), line:14:20, endln:14:22
     |vpiTypedef:
-    \_int_typespec: , line:14:11, endln:14:18
+    \_logic_typespec: , line:14:11, endln:14:18
       |vpiRange:
       \_range: , line:14:11, endln:14:18
         |vpiLeftRange:
@@ -57996,7 +57996,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_tristate.oe), line:15:20, endln:15:22
     |vpiTypedef:
-    \_int_typespec: , line:15:11, endln:15:18
+    \_logic_typespec: , line:15:11, endln:15:18
       |vpiRange:
       \_range: , line:15:11, endln:15:18
         |vpiLeftRange:
@@ -58036,7 +58036,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_tristate.out), line:16:20, endln:16:23
     |vpiTypedef:
-    \_int_typespec: , line:16:12, endln:16:19
+    \_logic_typespec: , line:16:12, endln:16:19
       |vpiRange:
       \_range: , line:16:12, endln:16:19
         |vpiLeftRange:
@@ -58124,7 +58124,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xnor2.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -58164,7 +58164,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xnor2.b), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -58204,7 +58204,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xnor2.z), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:12, endln:11:20
+    \_logic_typespec: , line:11:12, endln:11:20
       |vpiRange:
       \_range: , line:11:12, endln:11:20
         |vpiLeftRange:
@@ -58330,7 +58330,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xnor3.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -58370,7 +58370,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xnor3.b), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -58410,7 +58410,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xnor3.c), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -58450,7 +58450,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xnor3.z), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:12, endln:12:20
+    \_logic_typespec: , line:12:12, endln:12:20
       |vpiRange:
       \_range: , line:12:12, endln:12:20
         |vpiLeftRange:
@@ -58593,7 +58593,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xnor4.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -58633,7 +58633,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xnor4.b), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -58673,7 +58673,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xnor4.c), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -58713,7 +58713,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xnor4.d), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -58753,7 +58753,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xnor4.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -58895,7 +58895,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xor2.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -58935,7 +58935,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xor2.b), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -58975,7 +58975,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xor2.z), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:12, endln:11:20
+    \_logic_typespec: , line:11:12, endln:11:20
       |vpiRange:
       \_range: , line:11:12, endln:11:20
         |vpiLeftRange:
@@ -59096,7 +59096,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xor3.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -59136,7 +59136,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xor3.b), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -59176,7 +59176,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xor3.c), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -59216,7 +59216,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xor3.z), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:12, endln:12:20
+    \_logic_typespec: , line:12:12, endln:12:20
       |vpiRange:
       \_range: , line:12:12, endln:12:20
         |vpiLeftRange:
@@ -59354,7 +59354,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xor4.a), line:9:21, endln:9:22
     |vpiTypedef:
-    \_int_typespec: , line:9:11, endln:9:19
+    \_logic_typespec: , line:9:11, endln:9:19
       |vpiRange:
       \_range: , line:9:11, endln:9:19
         |vpiLeftRange:
@@ -59394,7 +59394,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xor4.b), line:10:21, endln:10:22
     |vpiTypedef:
-    \_int_typespec: , line:10:11, endln:10:19
+    \_logic_typespec: , line:10:11, endln:10:19
       |vpiRange:
       \_range: , line:10:11, endln:10:19
         |vpiLeftRange:
@@ -59434,7 +59434,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xor4.c), line:11:21, endln:11:22
     |vpiTypedef:
-    \_int_typespec: , line:11:11, endln:11:19
+    \_logic_typespec: , line:11:11, endln:11:19
       |vpiRange:
       \_range: , line:11:11, endln:11:19
         |vpiLeftRange:
@@ -59474,7 +59474,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xor4.d), line:12:21, endln:12:22
     |vpiTypedef:
-    \_int_typespec: , line:12:11, endln:12:19
+    \_logic_typespec: , line:12:11, endln:12:19
       |vpiRange:
       \_range: , line:12:11, endln:12:19
         |vpiLeftRange:
@@ -59514,7 +59514,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@oh_xor4.z), line:13:21, endln:13:22
     |vpiTypedef:
-    \_int_typespec: , line:13:12, endln:13:20
+    \_logic_typespec: , line:13:12, endln:13:20
       |vpiRange:
       \_range: , line:13:12, endln:13:20
         |vpiLeftRange:
@@ -59688,7 +59688,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@ohr_reg0.in), line:12:21, endln:12:23
     |vpiTypedef:
-    \_int_typespec: , line:12:12, endln:12:19
+    \_logic_typespec: , line:12:12, endln:12:19
       |vpiRange:
       \_range: , line:12:12, endln:12:19
         |vpiLeftRange:
@@ -59728,7 +59728,7 @@ design: (work@oh_fifo_async)
       |vpiActual:
       \_logic_net: (work@ohr_reg0.out), line:13:21, endln:13:24
     |vpiTypedef:
-    \_int_typespec: , line:13:13, endln:13:20
+    \_logic_typespec: , line:13:13, endln:13:20
       |vpiRange:
       \_range: , line:13:13, endln:13:20
         |vpiLeftRange:


### PR DESCRIPTION
Follow up to previous change to populate port/typespec information.

There was a bug introduced in parsing where ports weren't considered variables and so were being parsed as int_typespec instead of logic_typespec. This caused ambiguity between non-elab and elab models.