### PR TITLE
Remove duplicate elements in instance_array/Instances

### DIFF
--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -2050,20 +2050,10 @@ bool NetlistElaboration::elab_ports_nets_(
                   }
                 }
                 instance->addSubInstance(interfaceInstance);
-                modport* mp = elab_modport_(
-                    instance, interfaceInstance, sigName,
-                    orig_interf->getName(), orig_interf,
-                    instance->getFileName(), instance->getLineNb(),
-                    orig_modport->getName(), array_int);
-
-                array_int->Instances()->push_back((interface*)mp->Interface());
-
-                auto interfs = netlist->interfaces();
-                if (interfs == nullptr) {
-                  netlist->interfaces(s.MakeInterfaceVec());
-                  interfs = netlist->interfaces();
-                }
-                interfs->push_back((interface*)mp->Interface());
+                elab_modport_(instance, interfaceInstance, sigName,
+                              orig_interf->getName(), orig_interf,
+                              instance->getFileName(), instance->getLineNb(),
+                              orig_modport->getName(), array_int);
               }
             } else {
               const std::string& sigName = sig->getName();
@@ -2088,13 +2078,6 @@ bool NetlistElaboration::elab_ports_nets_(
                   orig_modport->getName(), array_int);
               instance->addSubInstance(interfaceInstance);
               ref->Actual_group(mp);
-
-              auto interfs = netlist->interfaces();
-              if (interfs == nullptr) {
-                netlist->interfaces(s.MakeInterfaceVec());
-                interfs = netlist->interfaces();
-              }
-              interfs->push_back((interface*)mp->Interface());
             }
 
           } else {

--- a/tests/InterfBinding/InterfBinding.log
+++ b/tests/InterfBinding/InterfBinding.log
@@ -418,8 +418,6 @@ design: (work@BypassNetwork)
           |vpiName:backEnd
       |vpiInterface:
       \_interface: work@ControllerIF (work@BypassNetwork.ctrl), file:dut.sv, line:29:0
-  |vpiInterface:
-  \_interface: work@ControllerIF (work@BypassNetwork.ctrl), file:dut.sv, line:29:0
   |vpiContAssign:
   \_cont_assign: , line:33:9, endln:33:25
     |vpiParent:

--- a/tests/InterfaceElab/InterfaceElab.log
+++ b/tests/InterfaceElab/InterfaceElab.log
@@ -591,8 +591,6 @@ design: (work@testharness)
                   |vpiConstType:9
           |vpiInterface:
           \_interface: work@REG_BUS (work@testharness.i_peripherals.i_apb_to_reg.reg_o), file:dut.sv, line:27:0
-      |vpiInterface:
-      \_interface: work@REG_BUS (work@testharness.i_peripherals.i_apb_to_reg.reg_o), file:dut.sv, line:27:0
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/InterfaceModPort/InterfaceModPort.log
+++ b/tests/InterfaceModPort/InterfaceModPort.log
@@ -3328,8 +3328,6 @@ design: (work@interface_modports)
                 |vpiConstType:9
         |vpiInterface:
         \_interface: work@mem_if (work@interface_modports.U_ctrl.sif), file:top.v, line:120:0
-    |vpiInterface:
-    \_interface: work@mem_if (work@interface_modports.U_ctrl.sif), file:top.v, line:120:0
   |vpiModule:
   \_module: work@memory_model (work@interface_modports.U_model), file:top.v, line:121:1, endln:121:28
     |vpiParent:
@@ -3629,8 +3627,6 @@ design: (work@interface_modports)
                 |vpiConstType:9
         |vpiInterface:
         \_interface: work@mem_if (work@interface_modports.U_model.mif), file:top.v, line:121:0
-    |vpiInterface:
-    \_interface: work@mem_if (work@interface_modports.U_model.mif), file:top.v, line:121:0
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ModPortArrayBind/ModPortArrayBind.log
+++ b/tests/ModPortArrayBind/ModPortArrayBind.log
@@ -437,8 +437,6 @@ design: (work@r5p_bus_dec)
       |vpiInterface:
       \_interface: work@r5p_bus_if (work@r5p_bus_dec.m[0]), file:dut.sv, line:12:0
   |vpiInterface:
-  \_interface: work@r5p_bus_if (work@r5p_bus_dec.m[0]), file:dut.sv, line:12:0
-  |vpiInterface:
   \_interface: work@r5p_bus_if (work@r5p_bus_dec.m[1]), file:dut.sv, line:12:0
     |vpiParent:
     \_module: work@r5p_bus_dec (work@r5p_bus_dec), file:dut.sv, line:12:1, endln:29:10
@@ -462,8 +460,6 @@ design: (work@r5p_bus_dec)
           |vpiVisibility:1
       |vpiInterface:
       \_interface: work@r5p_bus_if (work@r5p_bus_dec.m[1]), file:dut.sv, line:12:0
-  |vpiInterface:
-  \_interface: work@r5p_bus_if (work@r5p_bus_dec.m[1]), file:dut.sv, line:12:0
   |vpiInterfaceArray:
   \_interface_array: (work@r5p_bus_dec.m)
     |vpiParent:
@@ -491,10 +487,6 @@ design: (work@r5p_bus_dec)
         |vpiConstType:9
     |vpiInstance:
     \_interface: work@r5p_bus_if (work@r5p_bus_dec.m[0]), file:dut.sv, line:12:0
-    |vpiInstance:
-    \_interface: work@r5p_bus_if (work@r5p_bus_dec.m[0]), file:dut.sv, line:12:0
-    |vpiInstance:
-    \_interface: work@r5p_bus_if (work@r5p_bus_dec.m[1]), file:dut.sv, line:12:0
     |vpiInstance:
     \_interface: work@r5p_bus_if (work@r5p_bus_dec.m[1]), file:dut.sv, line:12:0
   |vpiGenScopeArray:

--- a/tests/ModPortParam/ModPortParam.log
+++ b/tests/ModPortParam/ModPortParam.log
@@ -277,8 +277,6 @@ design: (work@Core)
             \_interface: work@PerformanceCounterIF (work@Core.csrUnit.perfCounter), file:dut.sv, line:16:0
         |vpiInterface:
         \_interface: work@PerformanceCounterIF (work@Core.csrUnit.perfCounter), file:dut.sv, line:16:0
-    |vpiInterface:
-    \_interface: work@PerformanceCounterIF (work@Core.csrUnit.perfCounter), file:dut.sv, line:16:0
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ModPortRange/ModPortRange.log
+++ b/tests/ModPortRange/ModPortRange.log
@@ -615,8 +615,6 @@ design: (work@range_itf_port)
       |vpiInterface:
       \_interface: work@MyInterface (work@range_itf_port.my_port1[0]), file:dut.sv, line:9:0
   |vpiInterface:
-  \_interface: work@MyInterface (work@range_itf_port.my_port1[0]), file:dut.sv, line:9:0
-  |vpiInterface:
   \_interface: work@MyInterface (work@range_itf_port.my_port1[1]), file:dut.sv, line:9:0
     |vpiParent:
     \_module: work@range_itf_port (work@range_itf_port), file:dut.sv, line:9:1, endln:13:10
@@ -640,8 +638,6 @@ design: (work@range_itf_port)
           |vpiVisibility:1
       |vpiInterface:
       \_interface: work@MyInterface (work@range_itf_port.my_port1[1]), file:dut.sv, line:9:0
-  |vpiInterface:
-  \_interface: work@MyInterface (work@range_itf_port.my_port1[1]), file:dut.sv, line:9:0
   |vpiInterfaceArray:
   \_interface_array: (work@range_itf_port.my_port1)
     |vpiParent:
@@ -669,10 +665,6 @@ design: (work@range_itf_port)
         |vpiConstType:9
     |vpiInstance:
     \_interface: work@MyInterface (work@range_itf_port.my_port1[0]), file:dut.sv, line:9:0
-    |vpiInstance:
-    \_interface: work@MyInterface (work@range_itf_port.my_port1[0]), file:dut.sv, line:9:0
-    |vpiInstance:
-    \_interface: work@MyInterface (work@range_itf_port.my_port1[1]), file:dut.sv, line:9:0
     |vpiInstance:
     \_interface: work@MyInterface (work@range_itf_port.my_port1[1]), file:dut.sv, line:9:0
 |uhdmtopModules:
@@ -783,8 +775,6 @@ design: (work@range_itf_port)
           |vpiNetType:1
       |vpiInterface:
       \_interface: work@mem_if (work@memory_ctrl1.sif2), file:dut.sv, line:25:0
-  |vpiInterface:
-  \_interface: work@mem_if (work@memory_ctrl1.sif2), file:dut.sv, line:25:0
 |uhdmtopModules:
 \_module: work@middle (work@middle), file:dut.sv, line:35:1, endln:36:10
   |vpiName:work@middle
@@ -952,8 +942,6 @@ design: (work@range_itf_port)
       |vpiInterface:
       \_interface: work@MyInterface (work@range_itf_port2.my_port1), file:dut.sv, line:39:0
   |vpiInterface:
-  \_interface: work@MyInterface (work@range_itf_port2.my_port1), file:dut.sv, line:39:0
-  |vpiInterface:
   \_interface: work@MyInterface (work@range_itf_port2.my_port2[0]), file:dut.sv, line:39:0
     |vpiParent:
     \_module: work@range_itf_port2 (work@range_itf_port2), file:dut.sv, line:39:1, endln:46:10
@@ -978,8 +966,6 @@ design: (work@range_itf_port)
       |vpiInterface:
       \_interface: work@MyInterface (work@range_itf_port2.my_port2[0]), file:dut.sv, line:39:0
   |vpiInterface:
-  \_interface: work@MyInterface (work@range_itf_port2.my_port2[0]), file:dut.sv, line:39:0
-  |vpiInterface:
   \_interface: work@MyInterface (work@range_itf_port2.my_port2[1]), file:dut.sv, line:39:0
     |vpiParent:
     \_module: work@range_itf_port2 (work@range_itf_port2), file:dut.sv, line:39:1, endln:46:10
@@ -1003,8 +989,6 @@ design: (work@range_itf_port)
           |vpiVisibility:1
       |vpiInterface:
       \_interface: work@MyInterface (work@range_itf_port2.my_port2[1]), file:dut.sv, line:39:0
-  |vpiInterface:
-  \_interface: work@MyInterface (work@range_itf_port2.my_port2[1]), file:dut.sv, line:39:0
   |vpiInterface:
   \_interface: work@MyInterface (work@range_itf_port2.my_port3), file:dut.sv, line:39:0
     |vpiParent:
@@ -1082,10 +1066,6 @@ design: (work@range_itf_port)
         |vpiConstType:9
     |vpiInstance:
     \_interface: work@MyInterface (work@range_itf_port2.my_port2[0]), file:dut.sv, line:39:0
-    |vpiInstance:
-    \_interface: work@MyInterface (work@range_itf_port2.my_port2[0]), file:dut.sv, line:39:0
-    |vpiInstance:
-    \_interface: work@MyInterface (work@range_itf_port2.my_port2[1]), file:dut.sv, line:39:0
     |vpiInstance:
     \_interface: work@MyInterface (work@range_itf_port2.my_port2[1]), file:dut.sv, line:39:0
   |vpiInterfaceArray:

--- a/tests/ModPortTest/ModPortTest.log
+++ b/tests/ModPortTest/ModPortTest.log
@@ -822,8 +822,6 @@ design: (work@dff0_test)
           |vpiNetType:1
       |vpiInterface:
       \_interface: work@mem_if (work@memory_ctrl2.sif), file:top.v, line:45:0
-  |vpiInterface:
-  \_interface: work@mem_if (work@memory_ctrl2.sif), file:top.v, line:45:0
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/NameCollisionBind/NameCollisionBind.log
+++ b/tests/NameCollisionBind/NameCollisionBind.log
@@ -329,8 +329,6 @@ design: (work@CSR_Unit)
           |vpiVisibility:1
       |vpiInterface:
       \_interface: work@PerformanceCounterIF (work@CSR_Unit.perfCounter), file:dut.sv, line:20:0
-  |vpiInterface:
-  \_interface: work@PerformanceCounterIF (work@CSR_Unit.perfCounter), file:dut.sv, line:20:0
   |vpiContAssign:
   \_cont_assign: , line:25:9, endln:25:53
     |vpiParent:

--- a/tests/OneNetModPort/OneNetModPort.log
+++ b/tests/OneNetModPort/OneNetModPort.log
@@ -940,8 +940,6 @@ design: (work@TOP)
               |vpiVisibility:1
           |vpiInterface:
           \_interface: work@ConnectTB (work@TOP.dut1.middle1.intf), file:dut.v, line:6:0
-      |vpiInterface:
-      \_interface: work@ConnectTB (work@TOP.dut1.middle1.intf), file:dut.v, line:6:0
       |vpiModule:
       \_module: work@SUB (work@TOP.dut1.middle1.sub1), file:dut.v, line:23:3, endln:23:50
         |vpiParent:

--- a/tests/UnitTest/UnitTest.log
+++ b/tests/UnitTest/UnitTest.log
@@ -1793,8 +1793,6 @@ design: (work@tb_operators)
           |vpiNetType:1
       |vpiInterface:
       \_interface: work@mem_if (work@memory_ctrl1.sif2), file:top.v, line:57:0
-  |vpiInterface:
-  \_interface: work@mem_if (work@memory_ctrl1.sif2), file:top.v, line:57:0
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0


### PR DESCRIPTION
Remove duplicate elements in instance_array/Instances

The interfaces in the instance_array/Instances collection were being
duplicated.
