### PR TITLE
Fix test for empty string.

### DIFF
--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -2250,7 +2250,7 @@ void UhdmWriter::lateTypedefBinding(UHDM::Serializer& s, DesignComponent* mod,
         }
       }
 
-      if ((name == "") && (found == false)) {
+      if ((name.empty()) && (found == false)) {
         // Port .op({\op[1] ,\op[0] })
         if (operation* op = any_cast<operation*>(var)) {
           const typespec* baseTypespec = nullptr;


### PR DESCRIPTION
Should always be str.empty() instead of str == "".

Signed-off-by: Henner Zeller <h.zeller@acm.org>