### PR TITLE
Issue #3239: Remove erroneous error reporting

### DIFF
--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -677,18 +677,23 @@ void FileContent::populateCoreMembers(NodeId startIndex, NodeId endIndex,
   }
 
   PathId fileId;
-  if (startIndex && endIndex) {
-    const VObject& startObject = m_objects[startIndex];
-    const VObject& endObject = m_objects[endIndex];
-    if (startObject.m_fileId == endObject.m_fileId) {
-      fileId = startObject.m_fileId;
-    } else {
-      Location loc(m_fileId);
-      Error err(ErrorDefinition::COMP_INTERNAL_ERROR_OUT_OF_BOUND, loc);
-      m_errors->addError(err);
-      std::cerr << "\nFILE INDEX MISMATCH\n\n";
-    }
-  } else if (startIndex) {
+  // Issue #3239: Apparently, it's possible that startIndex.m_fileId
+  // & endIndex.m_fileId are differently (for example, including a file
+  // in the middle of a module declaration).
+  //
+  // if (startIndex && endIndex) {
+  //   const VObject& startObject = m_objects[startIndex];
+  //   const VObject& endObject = m_objects[endIndex];
+  //   if (startObject.m_fileId == endObject.m_fileId) {
+  //     fileId = startObject.m_fileId;
+  //   } else {
+  //     Location loc(m_fileId);
+  //     Error err(ErrorDefinition::COMP_INTERNAL_ERROR_OUT_OF_BOUND, loc);
+  //     m_errors->addError(err);
+  //     std::cerr << "\nFILE INDEX MISMATCH\n\n";
+  //   }
+  // } else
+  if (startIndex) {
     const VObject& object = m_objects[startIndex];
     fileId = object.m_fileId;
   } else if (endIndex) {


### PR DESCRIPTION
Issue #3239: Remove erroneous error reporting

Apparently, it's possible that the start and end file of a VObject token are different. One such case is when a include file is in the middle of a module declaration.

Known Issue: VObject still needs to track the end file but there's only one PathId member which is tracking the start file. Something to follow up on.