### PR TITLE
Code maintenance

### DIFF
--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -83,7 +83,7 @@ PathId ParseCache::getCacheFileName_(PathId svFileNameId) {
   }
   fs::path cacheDirName = fileSystem->toPath(cacheDirId);
   Library* lib = m_parse->getLibrary();
-  std::string libName = lib->getName();
+  const std::string& libName = lib->getName();
   if (cacheFileName.empty()) {
     cacheFileName = cacheDirName / libName / (svFileName.string() + ".slpa");
   }

--- a/src/Cache/PythonAPICache.cpp
+++ b/src/Cache/PythonAPICache.cpp
@@ -65,7 +65,7 @@ PathId PythonAPICache::getCacheFileId_(PathId svFileNameId) const {
   std::filesystem::path svFileName = fileSystem->toPath(svFileNameId);
   svFileName = FileUtils::basename(svFileName);
   Library* lib = m_listener->getCompileSourceFile()->getLibrary();
-  std::string libName = lib->getName();
+  const std::string& libName = lib->getName();
   fs::path cacheFileName =
       cacheDirName / libName / (svFileName.string() + ".slpy");
   return fileSystem->toPathId(

--- a/src/DesignCompile/Builtin.cpp
+++ b/src/DesignCompile/Builtin.cpp
@@ -356,7 +356,7 @@ void Builtin::addBuiltinClasses() {
                                   VObjectType::slAttr_spec);
     const std::string& libName = fC1->getLibrary()->getName();
     if (stId) {
-      std::string name = fC1->SymName(stId);
+      const std::string& name = fC1->SymName(stId);
       fC1->insertObjectLookup(name, classId,
                               m_compiler->getCompiler()->getErrorContainer());
       std::string fullName = libName + "@" + name;

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -345,7 +345,7 @@ bool CompileClass::compile_class_property_(const FileContent* fC, NodeId id) {
       while (variable_decl_assignment) {
         NodeId var = fC->Child(variable_decl_assignment);
         NodeId range = fC->Sibling(var);
-        std::string varName = fC->SymName(var);
+        const std::string& varName = fC->SymName(var);
 
         Property* previous = m_class->getProperty(varName);
         if (previous) {
@@ -619,7 +619,7 @@ bool CompileClass::compile_class_constraint_(const FileContent* fC,
                                              NodeId class_constraint) {
   NodeId constraint_prototype = fC->Child(class_constraint);
   NodeId constraint_name = fC->Child(constraint_prototype);
-  std::string constName = fC->SymName(constraint_name);
+  const std::string& constName = fC->SymName(constraint_name);
   Constraint* prevDef = m_class->getConstraint(constName);
   if (prevDef) {
     Location loc1(fC->getFileId(class_constraint), fC->Line(class_constraint),
@@ -644,7 +644,7 @@ bool CompileClass::compile_class_declaration_(const FileContent* fC,
   UHDM::Serializer& s = m_compileDesign->getSerializer();
   const bool virtualClass = fC->sl_collect(id, VObjectType::slVirtual);
   const NodeId class_name_id = fC->sl_collect(id, VObjectType::slStringConst);
-  std::string class_name = fC->SymName(class_name_id);
+  const std::string& class_name = fC->SymName(class_name_id);
   std::string full_class_name =
       m_class->m_uhdm_definition->VpiFullName() + "::" + class_name;
   ClassDefinition* prevDef = m_class->getClass(class_name);
@@ -689,7 +689,7 @@ bool CompileClass::compile_class_declaration_(const FileContent* fC,
 bool CompileClass::compile_covergroup_declaration_(const FileContent* fC,
                                                    NodeId id) {
   NodeId covergroup_name = fC->Child(id);
-  std::string covergroupName = fC->SymName(covergroup_name);
+  const std::string& covergroupName = fC->SymName(covergroup_name);
   CoverGroupDefinition* prevDef = m_class->getCoverGroup(covergroupName);
   if (prevDef) {
     Location loc1(fC->getFileId(covergroup_name), fC->Line(covergroup_name),
@@ -744,7 +744,7 @@ bool CompileClass::compile_local_parameter_declaration_(const FileContent* fC,
   NodeId param_assignment = fC->Child(list_of_param_assignments);
   while (param_assignment) {
     NodeId var = fC->Child(param_assignment);
-    std::string name = fC->SymName(var);
+    const std::string& name = fC->SymName(var);
     const std::pair<FileCNodeId, DesignComponent*>* prevDef =
         m_class->getNamedObject(name);
     if (prevDef) {
@@ -788,7 +788,7 @@ bool CompileClass::compile_parameter_declaration_(const FileContent* fC,
   NodeId param_assignment = fC->Child(list_of_param_assignments);
   while (param_assignment) {
     NodeId var = fC->Child(param_assignment);
-    std::string name = fC->SymName(var);
+    const std::string& name = fC->SymName(var);
     const std::pair<FileCNodeId, DesignComponent*>* prevDef =
         m_class->getNamedObject(name);
     if (prevDef) {

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -434,8 +434,7 @@ constant *compileConst(const FileContent *fC, NodeId child, Serializer &s) {
           }
         }
         bool isSigned = false;
-        if ((value.find_first_of('s') != std::string::npos) ||
-            (value.find_first_of('S') != std::string::npos)) {
+        if (value.find_first_of("sS") != std::string::npos) {
           isSigned = true;
           v = value.substr(i + 3);
         } else {
@@ -731,7 +730,7 @@ any *CompileHelper::decodeHierPath(hier_path *path, bool &invalidValue,
       // std::string fileContent = FileUtils::getFileContent(fileName);
       // std::string_view lineText =
       //     StringUtils::getLineInString(fileContent, lineNumber);
-      std::string_view lineText = path->VpiFullName();
+      const std::string &lineText = path->VpiFullName();
       Location loc(fileId, lineNumber, 0, symbols->registerSymbol(lineText));
       Error err(ErrorDefinition::UHDM_UNRESOLVED_HIER_PATH, loc);
       errors->addError(err);
@@ -4610,8 +4609,8 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
       }
     }
 
-    std::string packagename = fC->SymName(Class_type_name);
-    std::string functionname = fC->SymName(Class_scope_name);
+    const std::string &packagename = fC->SymName(Class_type_name);
+    const std::string &functionname = fC->SymName(Class_scope_name);
     std::string basename = packagename + "::" + functionname;
     tf_call *call = nullptr;
     std::pair<task_func *, DesignComponent *> ret =
@@ -4950,7 +4949,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
             dotedName = fC->Sibling(dotedName);
           } else {
             fcall = s.MakeMethod_func_call();
-            std::string methodName = fC->SymName(dotedName);
+            const std::string &methodName = fC->SymName(dotedName);
             fcall->VpiName(methodName);
             fC->populateCoreMembers(dotedName, dotedName, fcall);
             VectorOfany *arguments = compileTfCallArguments(
@@ -5132,7 +5131,7 @@ bool CompileHelper::parseConstant(const UHDM::constant &constant,
       break;
     }
     default: {
-      if (v.find("UINT:") != std::string::npos) {
+      if (v.find("UINT:") == 0) {
         *value = std::strtoull(v.c_str() + std::string_view("UINT:").length(),
                                &endptr, 10);
       } else {

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -109,7 +109,7 @@ bool CompileHelper::importPackage(DesignComponent* scope, Design* design,
   scope->addObject(VObjectType::slPackage_import_item, fnid);
 
   NodeId nameId = fC->Child(id);
-  std::string pack_name = fC->SymName(nameId);
+  const std::string& pack_name = fC->SymName(nameId);
   std::string object_name;
   if (NodeId objId = fC->Sibling(nameId)) {
     if (fC->Type(objId) == slStringConst) {
@@ -125,7 +125,7 @@ bool CompileHelper::importPackage(DesignComponent* scope, Design* design,
     for (const auto& cls : classSet) {
       const FileContent* packageFile = cls.fC;
       NodeId classDef = packageFile->Sibling(cls.nodeId);
-      std::string name = packageFile->SymName(classDef);
+      const std::string& name = packageFile->SymName(classDef);
       if (!object_name.empty()) {
         if (name != object_name) continue;
       }
@@ -454,7 +454,7 @@ bool CompileHelper::compileTfPortList(Procedure* parent, const FileContent* fC,
       } else {
         typeName = VObject::getTypeName(the_type);
       }
-      std::string name = fC->SymName(tf_param_name);
+      const std::string& name = fC->SymName(tf_param_name);
       NodeId expression = fC->Sibling(tf_param_name);
       DataType* dtype = new DataType(fC, type, typeName, fC->Type(type));
 
@@ -529,7 +529,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
       dtype == VObjectType::slInterface_class_keyword ||
       dtype == VObjectType::slEnum_keyword) {
     type_name = fC->Sibling(data_type);
-    std::string name = fC->SymName(type_name);
+    const std::string& name = fC->SymName(type_name);
     const TypeDef* prevDef = scope->getTypeDef(name);
     if (prevDef) return prevDef;
     if (fC->Type(type_name) == VObjectType::slStringConst) {
@@ -732,7 +732,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
     }
     while (enum_name_declaration) {
       NodeId enumNameId = fC->Child(enum_name_declaration);
-      std::string enumName = fC->SymName(enumNameId);
+      const std::string& enumName = fC->SymName(enumNameId);
       NodeId enumValueId = fC->Sibling(enumNameId);
       Value* value = nullptr;
       if (enumValueId) {
@@ -1038,7 +1038,7 @@ bool CompileHelper::compileSubroutine_call(Scope* parent, Statement* parentStmt,
 
     next_name = fC->Sibling(next_name);
   }
-  std::string funcName = fC->SymName(var_chain[var_chain.size() - 1]);
+  const std::string& funcName = fC->SymName(var_chain[var_chain.size() - 1]);
   var_chain.pop_back();
 
   NodeId list_of_arguments = next_name;
@@ -1255,7 +1255,7 @@ bool CompileHelper::compileScopeVariable(Scope* parent, const FileContent* fC,
         if (varType == VObjectType::slList_of_arguments) {
           // new ()
         } else {
-          std::string varName = fC->SymName(var);
+          const std::string& varName = fC->SymName(var);
 
           Variable* previous = parent->getVariable(varName);
           if (previous) {
@@ -1557,7 +1557,6 @@ bool CompileHelper::compilePortDeclaration(DesignComponent* component,
           */
           NodeId type_identifier = fC->Child(subNode);
           NodeId interfIdName = fC->Child(type_identifier);
-          std::string interfName = fC->SymName(interfIdName);
 
           NodeId list_of_interface_identifiers = fC->Sibling(type_identifier);
           NodeId interface_identifier =
@@ -1948,7 +1947,7 @@ void CompileHelper::compileImportDeclaration(DesignComponent* component,
     m_exprBuilder.deleteValue(item_name);
     import_stmt->Item(imported_item);
 
-    const std::string& package_name(fC->SymName(package_name_id));
+    const std::string& package_name = fC->SymName(package_name_id);
     import_stmt->VpiName(package_name);
 
     package_import_item_id = fC->Sibling(package_import_item_id);
@@ -2260,8 +2259,8 @@ void CompileHelper::compileInstantiation(ModuleDefinition* mod,
   auto subModuleArray = mod->getModuleArrays();
 
   NodeId moduleName = fC->sl_collect(id, VObjectType::slStringConst);
-  std::string libName = fC->getLibrary()->getName();
-  std::string mname = fC->SymName(moduleName);
+  const std::string& libName = fC->getLibrary()->getName();
+  const std::string& mname = fC->SymName(moduleName);
   std::string modName = libName + "@" + mname;
 
   Design* design = compileDesign->getCompiler()->getDesign();
@@ -2379,7 +2378,7 @@ UHDM::atomic_stmt* CompileHelper::compileProceduralTimingControlStmt(
                                    compileDesign, pstmt, instance);
   }
   NodeId IntConst = fC->Child(Delay_control);
-  std::string value = fC->SymName(IntConst);
+  const std::string& value = fC->SymName(IntConst);
   UHDM::delay_control* dc = s.MakeDelay_control();
   dc->VpiDelay(value);
   fC->populateCoreMembers(Delay_control, Delay_control, dc);
@@ -2434,7 +2433,7 @@ UHDM::atomic_stmt* CompileHelper::compileDelayControl(
                                    compileDesign, pexpr, instance);
   }
   NodeId IntConst = fC->Child(Delay_control);
-  std::string value = fC->SymName(IntConst);
+  const std::string& value = fC->SymName(IntConst);
   UHDM::delay_control* dc = s.MakeDelay_control();
   dc->VpiDelay(value);
   fC->populateCoreMembers(fC->Child(Delay_control), fC->Child(Delay_control),
@@ -4124,7 +4123,7 @@ void CompileHelper::compileLetDeclaration(DesignComponent* component,
                                           CompileDesign* compileDesign) {
   Serializer& s = compileDesign->getSerializer();
   NodeId nameId = fC->Child(Let_declaration);
-  const std::string name = fC->SymName(nameId);
+  const std::string& name = fC->SymName(nameId);
   NodeId Let_port_list = fC->Sibling(nameId);
   NodeId Expression;
   if (fC->Type(Let_port_list) == slLet_port_list) {

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -507,7 +507,6 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
 
   for (unsigned int i = 0; i < m_module->m_fileContents.size(); i++) {
     const FileContent* fC = m_module->m_fileContents[i];
-    std::string libName = fC->getLibrary()->getName();
     VObject current = fC->Object(m_module->m_nodeIds[i]);
     NodeId id = current.m_child;
 
@@ -883,7 +882,6 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
       VObjectType::slTask_body_declaration};
   for (unsigned int i = 0; i < m_module->m_fileContents.size(); i++) {
     const FileContent* fC = m_module->m_fileContents[i];
-    std::string libName = fC->getLibrary()->getName();
     VObject current = fC->Object(m_module->m_nodeIds[i]);
     NodeId id = current.m_child;
     if (!id) id = current.m_sibling;

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -109,7 +109,6 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
   m_helper.setDesign(m_compileDesign->getCompiler()->getDesign());
   for (unsigned int i = 0; i < m_package->m_fileContents.size(); i++) {
     const FileContent* fC = m_package->m_fileContents[i];
-    std::string libName = fC->getLibrary()->getName();
     VObject current = fC->Object(m_package->m_nodeIds[i]);
     NodeId id = current.m_child;
 
@@ -214,7 +213,7 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
           if (fC->Type(nameId) == slVirtual) {
             nameId = fC->Sibling(nameId);
           }
-          std::string name = fC->SymName(nameId);
+          const std::string& name = fC->SymName(nameId);
           FileCNodeId fnid(fC, nameId);
           m_package->addObject(type, fnid);
 

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -236,7 +236,7 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
         if (fC->Type(nameId) == slVirtual) {
           nameId = fC->Sibling(nameId);
         }
-        std::string name = fC->SymName(nameId);
+        const std::string& name = fC->SymName(nameId);
         FileCNodeId fnid(fC, nameId);
         m_program->addObject(type, fnid);
 

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -557,7 +557,7 @@ typespec* CompileHelper::compileDatastructureTypespec(
   if (component) {
     const DataType* dt = component->getDataType(typeName);
     if (dt == nullptr) {
-      std::string libName = fC->getLibrary()->getName();
+      const std::string& libName = fC->getLibrary()->getName();
       dt = compileDesign->getCompiler()->getDesign()->getClassDefinition(
           libName + "@" + typeName);
       if (dt == nullptr) {
@@ -637,7 +637,7 @@ typespec* CompileHelper::compileDatastructureTypespec(
                   Location loc1(fC->getFileId(), fC->Line(suffixNode),
                                 fC->Column(suffixNode),
                                 symbols->registerSymbol(suffixname));
-                  std::string libName = fC->getLibrary()->getName();
+                  const std::string& libName = fC->getLibrary()->getName();
                   Design* design = compileDesign->getCompiler()->getDesign();
                   ModuleDefinition* def =
                       design->getModuleDefinition(libName + "@" + typeName2);
@@ -811,7 +811,7 @@ typespec* CompileHelper::compileDatastructureTypespec(
     }
 
     if (result == nullptr) {
-      std::string libName = fC->getLibrary()->getName();
+      const std::string& libName = fC->getLibrary()->getName();
       Design* design = compileDesign->getCompiler()->getDesign();
       ModuleDefinition* def =
           design->getModuleDefinition(libName + "@" + typeName);
@@ -1117,7 +1117,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
       int val = 0;
       while (enum_name_declaration) {
         NodeId enumNameId = fC->Child(enum_name_declaration);
-        std::string enumName = fC->SymName(enumNameId);
+        const std::string& enumName = fC->SymName(enumNameId);
         NodeId enumValueId = fC->Sibling(enumNameId);
         Value* value = nullptr;
         if (enumValueId) {

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -532,7 +532,7 @@ bool DesignElaboration::elaborateModule_(const std::string& moduleName,
                                          const FileContent* fC,
                                          bool onlyTopLevel) {
   const FileContent::NameIdMap& nameIds = fC->getObjectLookup();
-  std::string libName = fC->getLibrary()->getName();
+  const std::string& libName = fC->getLibrary()->getName();
   Config* config = getInstConfig(moduleName);
   if (config == nullptr) config = getCellConfig(moduleName);
   Design* design = m_compileDesign->getCompiler()->getDesign();
@@ -977,7 +977,7 @@ void DesignElaboration::elaborateInstance_(
           Value* initValue = m_exprBuilder.getValueFactory().newLValue();
           initValue->set(initVal);
 
-          std::string name = fC->SymName(varId);
+          const std::string& name = fC->SymName(varId);
           parent->setValue(name, initValue, m_exprBuilder, fC->Line(varId));
 
           // End-loop test
@@ -1302,7 +1302,6 @@ void DesignElaboration::elaborateInstance_(
       }
       // Named blocks
       else if (type == slSeq_block || type == slPar_block) {
-        std::string libName = fC->getLibrary()->getName();
         std::string fullName = parent->getModuleName() + "." + instName;
 
         def = design->getComponentDefinition(fullName);
@@ -1329,7 +1328,6 @@ void DesignElaboration::elaborateInstance_(
           instName = fC->SymName(nameId);
         }
 
-        std::string libName = fC->getLibrary()->getName();
         std::string fullName;
         if (instName.empty())
           fullName = parent->getModuleName() + "." + genBlkBaseName +
@@ -1368,7 +1366,7 @@ void DesignElaboration::elaborateInstance_(
         // Regular module binding
         NodeId moduleName =
             fC->sl_collect(subInstanceId, VObjectType::slStringConst);
-        std::string libName = fC->getLibrary()->getName();
+        const std::string& libName = fC->getLibrary()->getName();
         mname = fC->SymName(moduleName);
 
         std::vector<std::string> libs;
@@ -1699,7 +1697,7 @@ void DesignElaboration::collectParams_(std::vector<std::string>& params,
   }
   for (const auto& pack_import : pack_imports) {
     NodeId pack_id = pack_import.fC->Child(pack_import.nodeId);
-    std::string pack_name = pack_import.fC->SymName(pack_id);
+    const std::string& pack_name = pack_import.fC->SymName(pack_id);
     Package* def = design->getPackage(pack_name);
     if (def) {
       auto& paramSet = def->getObjects(VObjectType::slParam_assignment);
@@ -1736,7 +1734,7 @@ void DesignElaboration::collectParams_(std::vector<std::string>& params,
     for (FileCNodeId param :
          module->getObjects(VObjectType::slParam_assignment)) {
       NodeId ident = param.fC->Child(param.nodeId);
-      std::string name = param.fC->SymName(ident);
+      const std::string& name = param.fC->SymName(ident);
       params.push_back(name);
       moduleParams.push_back(name);
     }
@@ -1778,7 +1776,7 @@ void DesignElaboration::collectParams_(std::vector<std::string>& params,
       }
       if (parentFile->Type(child) == VObjectType::slStringConst) {
         // Named param
-        std::string name = parentFile->SymName(child);
+        const std::string& name = parentFile->SymName(child);
         overridenParams.insert(name);
         NodeId expr = parentFile->Sibling(child);
         if (!expr) {
@@ -2099,7 +2097,7 @@ void DesignElaboration::collectParams_(std::vector<std::string>& params,
     for (FileCNodeId param :
          module->getObjects(VObjectType::slParam_assignment)) {
       NodeId ident = param.fC->Child(param.nodeId);
-      std::string name = param.fC->SymName(ident);
+      const std::string& name = param.fC->SymName(ident);
       if (overridenParams.find(name) == overridenParams.end()) {
         NodeId exprId = param.fC->Sibling(ident);
         while (param.fC->Type(exprId) == slUnpacked_dimension) {

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -992,7 +992,7 @@ bool ElaborationStep::bindPortType_(Signal* signal, const FileContent* fC,
   ErrorContainer* errors = compiler->getErrorContainer();
   SymbolTable* symbols = compiler->getSymbolTable();
   Design* design = compiler->getDesign();
-  std::string libName = fC->getLibrary()->getName();
+  const std::string& libName = fC->getLibrary()->getName();
   VObjectType type = fC->Type(id);
   switch (type) {
     case VObjectType::slPort:
@@ -1057,7 +1057,7 @@ bool ElaborationStep::bindPortType_(Signal* signal, const FileContent* fC,
         case VObjectType::slInterface_port_declaration: {
           NodeId interface_identifier = fC->Child(subNode);
           NodeId interfIdName = fC->Child(interface_identifier);
-          std::string interfName = fC->SymName(interfIdName);
+          const std::string& interfName = fC->SymName(interfIdName);
 
           DesignComponent* def = nullptr;
           const DataType* type = nullptr;

--- a/src/DesignCompile/ResolveSymbols.cpp
+++ b/src/DesignCompile/ResolveSymbols.cpp
@@ -60,7 +60,7 @@ std::string ResolveSymbols::SymName(NodeId index) const {
 void ResolveSymbols::createFastLookup() {
   UHDM::Serializer& s = m_compileDesign->getSerializer();
   Library* lib = m_fileData->getLibrary();
-  std::string libName = lib->getName();
+  const std::string& libName = lib->getName();
 
   // std::string fileName =  "FILE: " + m_fileData->getFileName() + " " +
   // m_fileData->getChunkFileName () + "\n"; std::cout << fileName;

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -353,7 +353,7 @@ bool TestbenchElaboration::bindFunctionReturnTypesAndParamaters_() {
   for (const auto& [className, classDefinition] : classes) {
     for (auto& func : classDefinition->getFunctionMap()) {
       DataType* dtype = func.second->getReturnType();
-      std::string dataTypeName = dtype->getName();
+      const std::string& dataTypeName = dtype->getName();
       if (dtype->getDefinition()) continue;
       if (dtype->getFileContent() == nullptr) continue;
       if (dtype->getType() == VObjectType::slStringConst) {
@@ -364,7 +364,7 @@ bool TestbenchElaboration::bindFunctionReturnTypesAndParamaters_() {
       }
       for (auto& param : func.second->getParams()) {
         const DataType* dtype = param->getDataType();
-        std::string dataTypeName = dtype->getName();
+        const std::string& dataTypeName = dtype->getName();
         if (dtype->getDefinition()) continue;
         if (dtype->getFileContent() == nullptr) continue;
         if (dtype->getType() == VObjectType::slStringConst) {
@@ -586,7 +586,7 @@ bool TestbenchElaboration::bindForeachLoop_(ClassDefinition* classDefinition,
     }
     VObjectType rangeType = sfC->Type(rangeTypeId);
     if (rangeType == VObjectType::slStringConst) {
-      std::string dataTypeName = sfC->SymName(rangeTypeId);
+      const std::string& dataTypeName = sfC->SymName(rangeTypeId);
       itrDataType =
           bindDataType_(dataTypeName, sfC, rangeTypeId, classDefinition,
                         ErrorDefinition::COMP_UNDEFINED_TYPE);
@@ -669,7 +669,7 @@ bool TestbenchElaboration::bindTasks_() {
     for (auto& func : classDefinition->getTaskMap()) {
       for (auto param : func.second->getParams()) {
         const DataType* dtype = param->getDataType();
-        std::string dataTypeName = dtype->getName();
+        const std::string& dataTypeName = dtype->getName();
         if (dtype->getDefinition()) continue;
         if (dtype->getFileContent() == nullptr) continue;
         if (dtype->getType() == VObjectType::slStringConst) {

--- a/src/SourceCompile/CompileSourceFile.cpp
+++ b/src/SourceCompile/CompileSourceFile.cpp
@@ -274,7 +274,7 @@ bool CompileSourceFile::postPreprocess_() {
 
   const fs::path writePpOutputFileName =
       fileSystem->toPath(m_commandLineParser->writePpOutputFileId());
-  std::string libName = m_library->getName();
+  const std::string& libName = m_library->getName();
   fs::path ppFileName = m_commandLineParser->writePpOutput()
                             ? directory / libName / fileName
                             : writePpOutputFileName;


### PR DESCRIPTION
Code maintenance

* Use string reference wherever possible instead of cloning
* When parsing constants, look for prefixes not substring. i.e. use std::string::find == 0 instead of std::string::find == std::string::npos
* When looking for sign-ness allow both lower and upper case symbol consistently.

P.S. These are selected changes from other larger change and may not cover the specific case in its entirety.