### PR TITLE
Handle carriage return and newlines across platform boundaries

### DIFF
--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -104,7 +104,11 @@ void AnalyzeFile::analyze() {
     std::string line;
     std::stringstream ss(m_text);
     while (std::getline(ss, line)) {
-      allLines.push_back(line);
+      while (!line.empty() &&
+             ((line.back() == '\r') || (line.back() == '\n'))) {
+        line.pop_back();
+      }
+      allLines.emplace_back(line);
     }
   }
   if (allLines.empty()) return;


### PR DESCRIPTION
Handle carriage return and newlines across platform boundaries

When a repository is sync-ed on Windows, the default line-ending used by Git is \r\n. But when building under WSL, the line-ending the code expects is \n. This difference causes the generated chunk files to be different across the platform making identifying differences harder.

Small edit in code to remove any carriage returns at the end of the line for content used to generate chunk files.