### PR TITLE
Remove symlink files from repo

### DIFF
--- a/third_party/tests/ariane/src/fpga-support/behav/BramDwc/.gitignore
+++ b/third_party/tests/ariane/src/fpga-support/behav/BramDwc/.gitignore
@@ -1,1 +1,0 @@
-../common/gitignore

--- a/third_party/tests/ariane/src/fpga-support/synth/BramDwc/.gitignore
+++ b/third_party/tests/ariane/src/fpga-support/synth/BramDwc/.gitignore
@@ -1,1 +1,0 @@
-../common/gitignore


### PR DESCRIPTION
Remove symlink files from repo

These files don't work across platforms and report errors with git.

warning: unable to access 'third_party/tests/ariane/src/fpga-support/behav/BramDwc/.gitignore': Unknown error
warning: unable to access 'third_party/tests/ariane/src/fpga-support/synth/BramDwc/.gitignore': Unknown error