### PR TITLE
Don't reduce when building non-elaborated tree

### DIFF
--- a/include/Surelog/DesignCompile/CompileHelper.h
+++ b/include/Surelog/DesignCompile/CompileHelper.h
@@ -314,7 +314,7 @@ class CompileHelper final {
                                       NodeId Assignment_pattern,
                                       CompileDesign* compileDesign,
                                       UHDM::any* pexpr,
-                                      ValuedComponentI* instance);
+                                      ValuedComponentI* instance, bool reduce);
 
   UHDM::array_var* compileArrayVar(DesignComponent* component,
                                    const FileContent* fC, NodeId varId,

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -2104,7 +2104,7 @@ UHDM::any *CompileHelper::compileExpression(
         }
         case VObjectType::slAssignment_pattern: {
           result = compileAssignmentPattern(component, fC, child, compileDesign,
-                                            pexpr, instance);
+                                            pexpr, instance, reduce);
           break;
         }
         case VObjectType::slSequence_instance: {
@@ -3048,12 +3048,10 @@ UHDM::any *CompileHelper::compileExpression(
   return result;
 }
 
-UHDM::any *CompileHelper::compileAssignmentPattern(DesignComponent *component,
-                                                   const FileContent *fC,
-                                                   NodeId Assignment_pattern,
-                                                   CompileDesign *compileDesign,
-                                                   UHDM::any *pexpr,
-                                                   ValuedComponentI *instance) {
+UHDM::any *CompileHelper::compileAssignmentPattern(
+    DesignComponent *component, const FileContent *fC,
+    NodeId Assignment_pattern, CompileDesign *compileDesign, UHDM::any *pexpr,
+    ValuedComponentI *instance, bool reduce) {
   FileSystem *const fileSystem = FileSystem::getInstance();
   UHDM::Serializer &s = compileDesign->getSerializer();
   UHDM::any *result = nullptr;
@@ -3063,10 +3061,7 @@ UHDM::any *CompileHelper::compileAssignmentPattern(DesignComponent *component,
   operation->VpiParent(pexpr);
   operation->VpiOpType(vpiAssignmentPatternOp);
   operation->Operands(operands);
-  bool reduce = false;
-  if (component && valuedcomponenti_cast<Package *>(component)) {
-    reduce = true;
-  }
+
   // Page 1035: For an operation of type vpiAssignmentPatternOp, the operand
   // iteration shall return the expressions as if the assignment pattern were
   // written with the positional notation. Nesting of assignment patterns shall
@@ -3130,34 +3125,39 @@ UHDM::any *CompileHelper::compileAssignmentPattern(DesignComponent *component,
         if (any *exp =
                 compileExpression(component, fC, Expression, compileDesign,
                                   operation, instance, reduce, false)) {
-          if (exp->UhdmType() == uhdmoperation) {
-            UHDM::operation *op = (UHDM::operation *)exp;
-            bool reduceMore = true;
-            int opType = op->VpiOpType();
-            if (opType == vpiConcatOp) {
-              if (op->Operands()->size() != 1) {
-                reduceMore = false;
+          if (reduce) {
+            if (exp->UhdmType() == uhdmoperation) {
+              UHDM::operation *op = (UHDM::operation *)exp;
+              bool reduceMore = true;
+              int opType = op->VpiOpType();
+              if (opType == vpiConcatOp) {
+                if (op->Operands()->size() != 1) {
+                  reduceMore = false;
+                }
+              }
+              if (reduceMore) {
+                bool invalidValue = false;
+                any *tmp = reduceExpr(
+                    exp, invalidValue, component, compileDesign, instance,
+                    fileSystem->toPathId(op->VpiFile(), fC->getSymbolTable()),
+                    op->VpiLineNo(), nullptr, true);
+                if (invalidValue == false) {
+                  exp = tmp;
+                }
               }
             }
-            if (reduceMore) {
-              bool invalidValue = false;
-              any *tmp = reduceExpr(
-                  exp, invalidValue, component, compileDesign, instance,
-                  fileSystem->toPathId(op->VpiFile(), fC->getSymbolTable()),
-                  op->VpiLineNo(), nullptr, true);
-              if (invalidValue == false) {
+            if (exp->UhdmType() == uhdmref_obj) {
+              ref_obj *ref = (ref_obj *)exp;
+              const std::string &name = ref->VpiName();
+              any *tmp = getValue(name, component, compileDesign, instance,
+                                  fC->getFileId(), fC->Line(Expression), pexpr,
+                                  true, true);
+              if (tmp) {
                 exp = tmp;
+                if (exp->VpiLineNo() == 0) {
+                  fC->populateCoreMembers(Expression, Expression, exp);
+                }
               }
-            }
-          }
-          if (exp->UhdmType() == uhdmref_obj) {
-            ref_obj *ref = (ref_obj *)exp;
-            const std::string &name = ref->VpiName();
-            any *tmp = getValue(name, component, compileDesign, instance,
-                                fC->getFileId(), fC->Line(Expression), pexpr,
-                                true, true);
-            if (tmp) {
-              exp = tmp;
             }
           }
           tagged_pattern *pattern = s.MakeTagged_pattern();

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -2531,6 +2531,9 @@ bool CompileHelper::isMultidimensional(UHDM::typespec* ts,
       bit_typespec* lts = (bit_typespec*)ts;
       if (lts->Ranges() && lts->Ranges()->size() > 1) isMultiDimension = true;
     } else if (ttps == uhdmstruct_typespec) {
+      // Intentionally treating struct as multi-dimensional to prevent
+      // reduction.
+      // https://github.com/chipsalliance/Surelog/pull/3264#discussion_r996568514
       isMultiDimension = true;
     }
   }


### PR DESCRIPTION
Don't reduce when building non-elaborated tree

When building non-elaborated tree some expressions in package where being reduced, which should happen only when building the elaborated tree.