### PR TITLE
Some cleanup after FileSystem transition

### DIFF
--- a/include/Surelog/Common/NodeId.h
+++ b/include/Surelog/Common/NodeId.h
@@ -1,3 +1,19 @@
+/*
+ Copyright 2019 Alain Dargelas
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
 #ifndef SURELOG_NODEID_H
 #define SURELOG_NODEID_H
 #pragma once

--- a/include/Surelog/Common/PathId.h
+++ b/include/Surelog/Common/PathId.h
@@ -21,7 +21,6 @@
 #include <Surelog/Common/SymbolId.h>
 
 #include <cstdint>
-#include <filesystem>
 #include <istream>
 #include <ostream>
 #include <set>

--- a/include/Surelog/Package/Precompiled.h
+++ b/include/Surelog/Package/Precompiled.h
@@ -32,6 +32,8 @@
 
 namespace SURELOG {
 class PathId;
+class SymbolTable;
+
 class Precompiled final {
  public:
   static Precompiled* getSingleton();

--- a/include/Surelog/surelog.h
+++ b/include/Surelog/surelog.h
@@ -21,6 +21,7 @@
 // Header file for Surelog library
 
 #include <Surelog/CommandLine/CommandLineParser.h>
+#include <Surelog/Common/FileSystem.h>
 #include <Surelog/ErrorReporting/Error.h>
 #include <Surelog/ErrorReporting/ErrorContainer.h>
 #include <Surelog/ErrorReporting/ErrorDefinition.h>

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -42,9 +42,6 @@
 #include <stack>
 
 namespace SURELOG {
-
-namespace fs = std::filesystem;
-
 int FunctorCompileClass::operator()() const {
   CompileClass* instance =
       new CompileClass(m_compileDesign, m_class, m_design, m_symbols, m_errors);
@@ -56,13 +53,9 @@ int FunctorCompileClass::operator()() const {
 bool CompileClass::compile() {
   if (m_class->m_fileContents.empty()) return true;
 
-  FileSystem* const fileSystem = FileSystem::getInstance();
   const FileContent* fC = m_class->m_fileContents[0];
   if (fC == nullptr) return true;
   NodeId nodeId = m_class->m_nodeIds[0];
-
-  fs::path fileName = fileSystem->toPath(fC->getFileId(nodeId));
-  std::string fullName;
 
   std::vector<std::string> names;
   ClassDefinition* parent = m_class;
@@ -72,6 +65,8 @@ bool CompileClass::compile() {
     names.push_back(parent->getName());
     parent = parent->m_parent;
   }
+
+  std::string fullName;
   if (tmp_container) {
     fullName = tmp_container->getName() + "::";
   }
@@ -87,8 +82,8 @@ bool CompileClass::compile() {
 
   if (m_class->m_uhdm_definition->VpiFullName().empty())
     m_class->m_uhdm_definition->VpiFullName(fullName);
-  Location loc(fileSystem->toPathId(fileName, m_symbols), fC->Line(nodeId),
-               fC->Column(nodeId), m_symbols->registerSymbol(fullName));
+  Location loc(fC->getFileId(nodeId), fC->Line(nodeId), fC->Column(nodeId),
+               m_symbols->registerSymbol(fullName));
 
   Error err1(ErrorDefinition::COMP_COMPILE_CLASS, loc);
   ErrorContainer* errors = new ErrorContainer(m_symbols);

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -62,9 +62,6 @@
 #endif
 
 namespace SURELOG {
-
-namespace fs = std::filesystem;
-
 CompileDesign::CompileDesign(Compiler* compiler) : m_compiler(compiler) {}
 CompileDesign::~CompileDesign() {
   // TODO: ownership not clear.
@@ -176,7 +173,6 @@ void CompileDesign::compileMT_(ObjectMapType& objects, int maxThreadCount) {
 
 void CompileDesign::collectObjects_(Design::FileIdDesignContentMap& all_files,
                                     Design* design, bool finalCollection) {
-  FileSystem* const fileSystem = FileSystem::getInstance();
   typedef std::map<std::string, std::vector<Package*>> FileNamePackageMap;
   FileNamePackageMap fileNamePackageMap;
   SymbolTable* symbols = m_compiler->getSymbolTable();
@@ -228,16 +224,13 @@ void CompileDesign::collectObjects_(Design::FileIdDesignContentMap& all_files,
             ((oldParentFile != newParentFile) ||
              ((oldParentFile == nullptr) && (newParentFile == nullptr)))) {
           NodeId oldNodeId = existing->getNodeIds()[0];
-          fs::path oldFileName = fileSystem->toPath(oldFC->getFileId());
           unsigned int oldLine = oldFC->Line(oldNodeId);
-          fs::path newFileName = fileSystem->toPath(newFC->getFileId());
           unsigned int newLine = newFC->Line(newNodeId);
-          if ((oldFileName != newFileName) || (oldLine != newLine)) {
-            Location loc1(fileSystem->toPathId(oldFileName, symbols), oldLine,
-                          oldFC->Column(oldNodeId),
+          if ((oldFC->getFileId() != newFC->getFileId()) ||
+              (oldLine != newLine)) {
+            Location loc1(oldFC->getFileId(), oldLine, oldFC->Column(oldNodeId),
                           symbols->registerSymbol(pack.first));
-            Location loc2(fileSystem->toPathId(newFileName, symbols), newLine,
-                          newFC->Column(newNodeId),
+            Location loc2(newFC->getFileId(), newLine, newFC->Column(newNodeId),
                           symbols->registerSymbol(pack.first));
             Error err(ErrorDefinition::COMP_MULTIPLY_DEFINED_PACKAGE, loc1,
                       loc2);

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -57,7 +57,6 @@
 namespace SURELOG {
 
 using namespace UHDM;  // NOLINT (using a bunch of them)
-namespace fs = std::filesystem;
 
 bool CompileHelper::substituteAssignedValue(const UHDM::any *oper,
                                             CompileDesign *compileDesign) {

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -59,7 +59,6 @@
 namespace SURELOG {
 
 using namespace UHDM;  // NOLINT (using a bunch of them)
-namespace fs = std::filesystem;
 
 variables* CompileHelper::getSimpleVarFromTypespec(
     UHDM::typespec* spec, std::vector<UHDM::range*>* packedDimensions,

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -54,9 +54,6 @@
 #include <unordered_set>
 
 namespace SURELOG {
-
-namespace fs = std::filesystem;
-
 DesignElaboration::DesignElaboration(CompileDesign* compileDesign)
     : TestbenchElaboration(compileDesign) {
   m_moduleDefFactory = nullptr;
@@ -2435,9 +2432,9 @@ void DesignElaboration::createFileList_() {
     }
   }
 
-  const fs::path directory = fileSystem->toPath(cmdLine->getFullCompileDirId());
-  fs::path fileList = directory / "file_elab.lst";
-  PathId fileId = fileSystem->toPathId(fileList, cmdLine->getSymbolTable());
+  PathId fileId =
+      fileSystem->getChild(cmdLine->getFullCompileDirId(), "file_elab.lst",
+                           cmdLine->getSymbolTable());
   std::ostream& ofs = fileSystem->openForWrite(fileId);
   if (ofs.good()) {
     const Compiler::PPFileMap& ppFileName =
@@ -2452,7 +2449,7 @@ void DesignElaboration::createFileList_() {
     }
     fileSystem->close(ofs);
   } else {
-    std::cerr << "Could not create filelist: " << fileList << std::endl;
+    std::cerr << "Could not create filelist: " << PathIdPP(fileId) << std::endl;
   }
 }
 }  // namespace SURELOG

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -59,7 +59,6 @@
 
 namespace SURELOG {
 
-namespace fs = std::filesystem;
 using namespace UHDM;  // NOLINT (using a bunch of these)
 
 ElaborationStep::ElaborationStep(CompileDesign* compileDesign)

--- a/src/DesignCompile/EvalFunc.cpp
+++ b/src/DesignCompile/EvalFunc.cpp
@@ -40,7 +40,6 @@
 
 namespace SURELOG {
 
-namespace fs = std::filesystem;
 using namespace UHDM;  // NOLINT (using a bunch of them)
 
 expr* CompileHelper::EvalFunc(UHDM::function* func, std::vector<any*>* args,

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -56,8 +56,6 @@
 
 namespace SURELOG {
 
-namespace fs = std::filesystem;
-
 using namespace UHDM;  // NOLINT (using a bunch of these)
 
 NetlistElaboration::NetlistElaboration(CompileDesign* compileDesign)

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -44,8 +44,6 @@
 
 namespace SURELOG {
 
-namespace fs = std::filesystem;
-
 bool checkValidFunction(const DataType* dtype, const std::string& function,
                         Statement* stmt, Design* design,
                         std::string& datatypeName) {

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -3623,7 +3623,6 @@ void UhdmWriter::writeInstance(ModuleDefinition* mod, ModuleInstance* instance,
 
 vpiHandle UhdmWriter::write(PathId uhdmFileId) {
   FileSystem* const fileSystem = FileSystem::getInstance();
-  const std::filesystem::path uhdmFile = fileSystem->toPath(uhdmFileId);
   ComponentMap componentMap;
   ModPortMap modPortMap;
   InstanceMap instanceMap;
@@ -3633,7 +3632,7 @@ vpiHandle UhdmWriter::write(PathId uhdmFileId) {
       m_compileDesign->getCompiler()->getErrorContainer(),
       m_compileDesign->getCompiler()->getSymbolTable());
 
-  Location loc((SymbolId)uhdmFileId);
+  Location loc(uhdmFileId);
   Error err(ErrorDefinition::UHDM_CREATING_MODEL, loc);
   m_compileDesign->getCompiler()->getErrorContainer()->addError(err);
   m_compileDesign->getCompiler()->getErrorContainer()->printMessages(
@@ -3957,6 +3956,7 @@ vpiHandle UhdmWriter::write(PathId uhdmFileId) {
     }
   }
 
+  const std::filesystem::path uhdmFile = fileSystem->toAbsPath(uhdmFileId);
   if (m_compileDesign->getCompiler()->getCommandLineParser()->writeUhdm()) {
     Error err(ErrorDefinition::UHDM_WRITE_DB, loc);
     m_compileDesign->getCompiler()->getErrorContainer()->addError(err);

--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -32,7 +32,6 @@
 #include <antlr4-runtime.h>
 #include <stdio.h>
 
-#include <filesystem>
 #include <iostream>
 #include <mutex>
 #if !(defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__))
@@ -40,9 +39,6 @@
 #endif
 
 namespace SURELOG {
-
-namespace fs = std::filesystem;
-
 ErrorContainer::ErrorContainer(SymbolTable* symbolTable,
                                LogListener* logListener /* = nullptr */)
     : m_clp(nullptr),
@@ -128,8 +124,8 @@ void ErrorContainer::appendErrors(ErrorContainer& rhs) {
         if (loc.m_fileId)
           loc.m_fileId = fileSystem->copy(loc.m_fileId, m_symbolTable);
         if (loc.m_object) {
-          loc.m_object = m_symbolTable->registerSymbol(
-              rhs.m_symbolTable->getSymbol(loc.m_object));
+          loc.m_object =
+              m_symbolTable->copyFrom(loc.m_object, rhs.m_symbolTable);
         }
       }
       addError(err);

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -37,12 +37,9 @@
 #include <parser/SV3_1aLexer.h>
 #include <parser/SV3_1aParser.h>
 
-#include <filesystem>
-
 namespace SURELOG {
 
 using namespace antlr4;
-namespace fs = std::filesystem;
 
 ParseLibraryDef::ParseLibraryDef(CommandLineParser* commandLineParser,
                                  ErrorContainer* errors,
@@ -104,7 +101,6 @@ bool ParseLibraryDef::parseLibrariesDefinition() {
 bool ParseLibraryDef::parseLibraryDefinition(PathId fileId, Library* lib) {
   FileSystem* const fileSystem = FileSystem::getInstance();
   m_fileId = fileId;
-  const fs::path fileName = fileSystem->toPath(fileId);
   std::istream& stream = fileSystem->openForRead(m_fileId);
 
   if (!stream.good()) {

--- a/src/Library/SVLibShapeListener.cpp
+++ b/src/Library/SVLibShapeListener.cpp
@@ -36,9 +36,6 @@
 #include <regex>
 
 namespace SURELOG {
-
-namespace fs = std::filesystem;
-
 SVLibShapeListener::SVLibShapeListener(ParseLibraryDef *parser,
                                        antlr4::CommonTokenStream *tokens)
     : SV3_1aTreeShapeHelper(

--- a/src/Package/Precompiled.cpp
+++ b/src/Package/Precompiled.cpp
@@ -54,7 +54,7 @@ bool Precompiled::isFilePrecompiled(std::string_view fileName) const {
 
 bool Precompiled::isFilePrecompiled(PathId fileId,
                                     SymbolTable* symbolTable) const {
-  std::filesystem::path fileName =
+  std::string_view fileName =
       std::get<1>(FileSystem::getInstance()->getLeaf(fileId, symbolTable));
   return (m_packageFileSet.find(fileName) != m_packageFileSet.end());
 }

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -379,7 +379,7 @@ void AnalyzeFile::analyze() {
   if (inComment || inString) {
     m_splitFiles.clear();
     m_lineOffsets.clear();
-    Location loc((SymbolId)m_fileId);
+    Location loc(m_fileId);
     Error err(ErrorDefinition::PA_CANNOT_SPLIT_FILE, loc);
     errors->addError(err);
     errors->printMessages();

--- a/src/SourceCompile/ParseFile.cpp
+++ b/src/SourceCompile/ParseFile.cpp
@@ -40,9 +40,6 @@
 #include <parser/SV3_1aParser.h>
 
 namespace SURELOG {
-
-namespace fs = std::filesystem;
-
 ParseFile::ParseFile(PathId fileId, SymbolTable* symbolTable,
                      ErrorContainer* errors)
     : m_fileId(fileId),
@@ -222,6 +219,7 @@ PathId ParseFile::getFileId(unsigned int line) {
         Location ppfile(fileId);
         Error err(ErrorDefinition::PA_INTERNAL_ERROR, ppfile);
         addError(err);
+        return m_fileId;
       }
       return fileInfoCache[line];
     }
@@ -231,6 +229,7 @@ PathId ParseFile::getFileId(unsigned int line) {
       Location ppfile(fileId);
       Error err(ErrorDefinition::PA_INTERNAL_ERROR, ppfile);
       addError(err);
+      return m_fileId;
     }
     return fileInfoCache[line];
   } else {
@@ -250,6 +249,7 @@ unsigned int ParseFile::getLineNb(unsigned int line) {
         Location ppfile(fileId);
         Error err(ErrorDefinition::PA_INTERNAL_ERROR, ppfile);
         addError(err);
+        return line;
       }
       return lineInfoCache[line];
     }
@@ -259,6 +259,7 @@ unsigned int ParseFile::getLineNb(unsigned int line) {
       Location ppfile(fileId);
       Error err(ErrorDefinition::PA_INTERNAL_ERROR, ppfile);
       addError(err);
+      return line;
     }
     return lineInfoCache[line];
   } else {

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -48,7 +48,6 @@
 namespace SURELOG {
 
 using namespace antlr4;
-namespace fs = std::filesystem;
 
 const char* const PreprocessFile::MacroNotDefined = "SURELOG_MACRO_NOT_DEFINED";
 const char* const PreprocessFile::PP__Line__Marking = "SURELOG__LINE__MARKING";


### PR DESCRIPTION
Some cleanup after FileSystem transition to make follow up PRs easier to review. Includes -

* Remove remanants of filesystem include
* Remove fs namespace from files where it's unused
* Avoid copying PathId to create errors
* Avoid the filesystem api use in favor of FileSystem (getChild, getSibling)
* Adding a few forward declarations where necessary in headers
* Adding copyright notices on a few files that were missing