### PR TITLE
Avoid accidental duplicate library registration

### DIFF
--- a/include/Surelog/Library/Library.h
+++ b/include/Surelog/Library/Library.h
@@ -28,8 +28,10 @@
 #include <Surelog/Common/PathId.h>
 
 #include <map>
+#include <ostream>
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace SURELOG {
@@ -39,31 +41,35 @@ class SymbolTable;
 
 class Library final {
  public:
-  Library(std::string_view name, SymbolTable* symbols)
-      : m_name(name), m_symbols(symbols) {}
+  typedef std::map<SymbolId, ModuleDefinition*, SymbolIdLessThanComparer>
+      ModuleDefinitionByNameMap;
+
+ public:
+  Library(std::string_view name, SymbolTable* symbols);
 
   void addFileId(PathId fid) {
     m_fileIds.push_back(fid);
     m_fileIdsSet.insert(fid);
   }
 
-  const std::string& getName() const { return m_name; }
+  const std::string& getName() const;
+  SymbolId getNameId() const { return m_nameId; }
   const PathIdVector& getFiles() const { return m_fileIds; }
   bool isMember(PathId fid) const {
     return m_fileIdsSet.find(fid) != m_fileIdsSet.end();
   }
-  std::string report(SymbolTable* symbols) const;
+  std::ostream& report(std::ostream& out) const;
   void addModuleDefinition(ModuleDefinition* def);
-  std::map<std::string, ModuleDefinition*>& getModules() { return m_modules; }
+  ModuleDefinitionByNameMap& getModules() { return m_modules; }
   ModuleDefinition* getModule(const std::string& name) const;
-  SymbolTable* getSymbols() const { return m_symbols; }
+  SymbolTable* getSymbols() { return m_symbols; }
 
  private:
-  std::string m_name;
+  SymbolId m_nameId;
+  SymbolTable* const m_symbols;
   PathIdVector m_fileIds;
   PathIdSet m_fileIdsSet;
-  std::map<std::string, ModuleDefinition*> m_modules;
-  SymbolTable* const m_symbols;
+  ModuleDefinitionByNameMap m_modules;
 };
 
 }  // namespace SURELOG

--- a/include/Surelog/Library/LibrarySet.h
+++ b/include/Surelog/Library/LibrarySet.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/Common/SymbolId.h>
 
+#include <ostream>
 #include <string_view>
 #include <vector>
 
@@ -40,12 +41,12 @@ class LibrarySet final {
  public:
   LibrarySet() = default;
 
-  void addLibrary(const Library& lib);
+  Library* addLibrary(std::string_view name, SymbolTable* symbolTable);
   std::vector<Library>& getLibraries() { return m_libraries; }
   Library* getLibrary(std::string_view libName);
   Library* getLibrary(PathId fileId);
   void checkErrors(SymbolTable* symbols, ErrorContainer* errors) const;
-  std::string report(SymbolTable* symbols) const;
+  std::ostream& report(std::ostream& out) const;
 
  private:
   LibrarySet(const LibrarySet& orig) = default;

--- a/src/Library/Library.cpp
+++ b/src/Library/Library.cpp
@@ -28,28 +28,28 @@
 
 namespace SURELOG {
 
+Library::Library(std::string_view name, SymbolTable* symbols)
+    : m_nameId(symbols->registerSymbol(name)), m_symbols(symbols) {}
+
+const std::string& Library::getName() const {
+  return m_symbols->getSymbol(m_nameId);
+}
+
 void Library::addModuleDefinition(ModuleDefinition* def) {
-  m_modules.insert(std::make_pair(def->getName(), def));
+  m_modules.emplace(m_symbols->registerSymbol(def->getName()), def);
 }
 
 ModuleDefinition* Library::getModule(const std::string& name) const {
-  std::map<std::string, ModuleDefinition*>::const_iterator itr =
-      m_modules.find(name);
-  if (itr == m_modules.end()) {
-    return nullptr;
-  } else {
-    return (*itr).second;
-  }
+  auto itr = m_modules.find(m_symbols->registerSymbol(name));
+  return (itr == m_modules.end()) ? nullptr : itr->second;
 }
 
-std::string Library::report(SymbolTable* symbols) const {
-  FileSystem* const fileSystem = FileSystem::getInstance();
-  std::string report;
-  report = "LIB: " + m_name + "\n";
-  for (auto id : m_fileIds) {
-    report += "     " + fileSystem->toPath(id).string() + "\n";
+std::ostream& Library::report(std::ostream& out) const {
+  out << "LIB: " << m_symbols->getSymbol(m_nameId) << std::endl;
+  for (const auto& id : m_fileIds) {
+    out << "     " << PathIdPP(id) << std::endl;
   }
-  return report;
+  return out;
 }
 
 }  // namespace SURELOG

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -65,11 +65,8 @@ bool ParseLibraryDef::parseLibrariesDefinition() {
   }
 
   // If "work" library is not yet declared from command line, create it
-  std::string workN = "work";
-  if (m_librarySet->getLibrary(workN) == nullptr) {
-    Library work(workN, m_symbolTable);
-    m_librarySet->addLibrary(work);
-  }
+  constexpr std::string_view workN = "work";
+  m_librarySet->addLibrary(workN, m_symbolTable);
 
   // Config files are parsed using the library top rule
   const PathIdVector& cfgFiles = m_commandLineParser->getConfigFiles();
@@ -93,7 +90,7 @@ bool ParseLibraryDef::parseLibrariesDefinition() {
   m_librarySet->checkErrors(m_symbolTable, m_errors);
 
   if (m_commandLineParser->getDebugLibraryDef()) {
-    std::cout << m_librarySet->report(m_symbolTable) << std::endl;
+    m_librarySet->report(std::cout) << std::endl;
   }
   return true;
 }

--- a/src/Library/SVLibShapeListener.cpp
+++ b/src/Library/SVLibShapeListener.cpp
@@ -62,13 +62,7 @@ void SVLibShapeListener::enterLibrary_declaration(
   FileSystem *const fileSystem = FileSystem::getInstance();
   std::string name = ctx->identifier()->getText();
   LibrarySet *librarySet = m_parser->getLibrarySet();
-  Library *lib = librarySet->getLibrary(name);
-  if (lib == nullptr) {
-    Library lib(name, m_parser->getSymbolTable());
-    librarySet->addLibrary(lib);
-  }
-  lib = librarySet->getLibrary(name);
-
+  Library *lib = librarySet->addLibrary(name, m_parser->getSymbolTable());
   SymbolTable *symbolTable = m_parser->getSymbolTable();
   PathId baseDirId = fileSystem->getParent(m_parser->getFileId(), symbolTable);
   for (auto pathSpec : ctx->file_path_spec()) {


### PR DESCRIPTION
Avoid accidental duplicate library registration

Minor improvements to the library management API to avoid silently registering duplicate libraries. LibrarySet::addLibrary checks and return the existing instance. Also, use emplace over push_back/insert and use stringstream over string concatenations.