### PR TITLE
Fix cache/source filestamp dependency

### DIFF
--- a/include/Surelog/Cache/Cache.h
+++ b/include/Surelog/Cache/Cache.h
@@ -69,11 +69,10 @@ class Cache {
 
   bool checkIfCacheIsValid(const SURELOG::CACHE::Header* header,
                            std::string_view schemaVersion, PathId cacheFileId,
-                           SymbolTable* symbolTable) const;
+                           PathId sourceFileId, SymbolTable* symbolTable) const;
 
   flatbuffers::Offset<SURELOG::CACHE::Header> createHeader(
-      flatbuffers::FlatBufferBuilder& builder, std::string_view schemaVersion,
-      PathId origFileId);
+      flatbuffers::FlatBufferBuilder& builder, std::string_view schemaVersion);
 
   // Store errors in cache. Canonicalize strings and store in "cacheSymbols".
   flatbuffers::Offset<VectorOffsetError> cacheErrors(

--- a/src/Cache/PythonAPICache.cpp
+++ b/src/Cache/PythonAPICache.cpp
@@ -120,6 +120,7 @@ bool PythonAPICache::checkCacheIsValid_(
   }
 
   if (!checkIfCacheIsValid(header, FlbSchemaVersion, cacheFileId,
+                           m_listener->getParseFile()->getFileId(LINE1),
                            symbolTable)) {
     return false;
   }
@@ -164,8 +165,7 @@ bool PythonAPICache::save() {
 
   flatbuffers::FlatBufferBuilder builder(1024);
   /* Create header section */
-  auto header =
-      createHeader(builder, FlbSchemaVersion, parseFile->getPpFileId());
+  auto header = createHeader(builder, FlbSchemaVersion);
 
   std::string pythonScriptFile = PythonAPI::getListenerScript();
   auto scriptFile = builder.CreateString(pythonScriptFile);

--- a/src/Cache/header.fbs
+++ b/src/Cache/header.fbs
@@ -28,11 +28,7 @@ table Header {
 
   // No file-timestamp as this would violate hermetic build assumptions:
   // running the same tool on the same file must always yield the same cache.
-
-  // Arguably, the filename should also not be recorded here, as this is
-  // strictly derived from the original filename when reading the cache. It
-  // makes it hard to create hermetic builds in different directories.
-  file_deprecated:string;
+  // Same is true for source filename as well.
 }
 
 table Error {

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -62,7 +62,7 @@ static std::unordered_map<std::string, std::string>
 //         Or when the cache schema changes
 //        This will render the cache invalid
 std::string_view CommandLineParser::getVersionNumber() {
-  static constexpr std::string_view kVersionNumber("1.41");
+  static constexpr std::string_view kVersionNumber("1.42");
   return kVersionNumber;
 }
 


### PR DESCRIPTION
Fix cache/source filestamp dependency

Cache stored the source filepath and used its timestamp to compare against its own. This violates hermetic build fundamentals. Removing the stored filepath and passing the necessary information into the call for checking validity.