### PR TITLE
Fixing a race condition during regression

### DIFF
--- a/third_party/tests/BuildOVMPkg/BuildOVMPkg.sl
+++ b/third_party/tests/BuildOVMPkg/BuildOVMPkg.sl
@@ -1,1 +1,1 @@
-   -createcache +incdir+../../../UVM/ovm-2.1.2/src/ +incdir+../../../UVM/vmm-1.1.1a/sv ../../../UVM/ovm-2.1.2/src/ovm_pkg.sv  -writepp -verbose  -mt 0 -parse -nocache
++incdir+../../../UVM/ovm-2.1.2/src/ +incdir+../../../UVM/vmm-1.1.1a/sv ../../../UVM/ovm-2.1.2/src/ovm_pkg.sv  -writepp -verbose  -mt 0 -parse

--- a/third_party/tests/BuildUVMPkg/BuildUVMPkg.sl
+++ b/third_party/tests/BuildUVMPkg/BuildUVMPkg.sl
@@ -1,1 +1,1 @@
-  ../../../UVM/1800.2-2017-1.0/pp_output/uvm_pkg.sv -verbose -parse -d coveruhdm -nocache -createcache
+../../../UVM/1800.2-2017-1.0/pp_output/uvm_pkg.sv -verbose -parse -d coveruhdm


### PR DESCRIPTION
Fixing a race condition during regression

BuildOVMPkg & BuildUVMPkg tests had the -createcache option which would mean the Surelog binary writes its cache output to the precompiled folder. This creates a race condition because as some other test could be reading the same file. Removing the flag and letting the tests write to its own designated folder.