### PR TITLE
Fix incremental builds with cache version change

### DIFF
--- a/include/Surelog/Cache/Cache.h
+++ b/include/Surelog/Cache/Cache.h
@@ -69,7 +69,7 @@ class Cache {
 
   bool checkIfCacheIsValid(const SURELOG::CACHE::Header* header,
                            std::string_view schemaVersion, PathId cacheFileId,
-                           PathId sourceFileId, SymbolTable* symbolTable) const;
+                           PathId sourceFileId) const;
 
   flatbuffers::Offset<SURELOG::CACHE::Header> createHeader(
       flatbuffers::FlatBufferBuilder& builder, std::string_view schemaVersion);

--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -51,8 +51,7 @@ bool Cache::openFlatBuffers(PathId cacheFileId,
 
 bool Cache::checkIfCacheIsValid(const SURELOG::CACHE::Header* header,
                                 std::string_view schemaVersion,
-                                PathId cacheFileId, PathId sourceFileId,
-                                SymbolTable* symbolTable) const {
+                                PathId cacheFileId, PathId sourceFileId) const {
   /* Schema version */
   if (schemaVersion != header->flb_version()->string_view()) {
     return false;
@@ -70,7 +69,7 @@ bool Cache::checkIfCacheIsValid(const SURELOG::CACHE::Header* header,
   }
 
   /* Timestamp Cache vs Orig File */
-  if (cacheFileId) {
+  if (cacheFileId && sourceFileId) {
     FileSystem* const fileSystem = FileSystem::getInstance();
     std::filesystem::file_time_type ct = fileSystem->modtime(cacheFileId);
     std::filesystem::file_time_type ft = fileSystem->modtime(sourceFileId);

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -144,14 +144,15 @@ bool ParseCache::checkCacheIsValid_(PathId cacheFileId,
   const PARSECACHE::ParseCache* ppcache =
       PARSECACHE::GetParseCache(content.data());
   auto header = ppcache->header();
-  if (!m_isPrecompiled &&
-      !checkIfCacheIsValid(header, FlbSchemaVersion, cacheFileId,
-                           m_parse->getPpFileId(),
-                           m_parse->getCompileSourceFile()->getSymbolTable())) {
-    return false;
-  }
 
-  return true;
+  if (m_isPrecompiled) {
+    // For precompiled, check only the signature & version (so using
+    // BadPathId instead of the actual arguments)
+    return checkIfCacheIsValid(header, FlbSchemaVersion, BadPathId, BadPathId);
+  } else {
+    return checkIfCacheIsValid(header, FlbSchemaVersion, cacheFileId,
+                               m_parse->getPpFileId());
+  }
 }
 
 bool ParseCache::isValid() {

--- a/src/Cache/PythonAPICache.cpp
+++ b/src/Cache/PythonAPICache.cpp
@@ -114,13 +114,8 @@ bool PythonAPICache::checkCacheIsValid_(
     return false;
   }
 
-  if (!checkIfCacheIsValid(header, FlbSchemaVersion, cacheFileId,
-                           m_listener->getParseFile()->getFileId(LINE1),
-                           symbolTable)) {
-    return false;
-  }
-
-  return true;
+  return checkIfCacheIsValid(header, FlbSchemaVersion, cacheFileId,
+                             m_listener->getParseFile()->getFileId(LINE1));
 }
 
 bool PythonAPICache::checkCacheIsValid_(PathId cacheFileId) const {


### PR DESCRIPTION
Fix incremental builds with cache version change

Precompiled cache was not respecting version change since the check was completely being ignored. Ensure that the signature & version check is enabled for precompiled cache (both pp & parse cache).