### PR TITLE
Upgrade more action versions to fix warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -295,7 +295,7 @@ jobs:
         mklink /D %GITHUB_WORKSPACE% C:\Surelog
 
     - name: Configure Pagefile
-      uses: al-cheb/configure-pagefile-action@v1.2
+      uses: al-cheb/configure-pagefile-action@v1.3
       with:
         minimum-size: 8GB
         maximum-size: 16GB
@@ -442,7 +442,7 @@ jobs:
         mklink /D %GITHUB_WORKSPACE% C:\Surelog
 
     - name: Configure Pagefile
-      uses: al-cheb/configure-pagefile-action@v1.2
+      uses: al-cheb/configure-pagefile-action@v1.3
       with:
         minimum-size: 8GB
         maximum-size: 16GB


### PR DESCRIPTION
Upgrade more action versions to fix warnings

Should be the last of the required one (because of Node 12 deprecation).