### PR TITLE
Few more cache consistency fixes

### DIFF
--- a/include/Surelog/Cache/PPCache.h
+++ b/include/Surelog/Cache/PPCache.h
@@ -42,15 +42,14 @@ class PPCache : Cache {
  private:
   PPCache(const PPCache& orig) = delete;
 
-  PathId getCacheFileId_(PathId sourceFileId);
-  bool restore_(PathId cacheFileId, bool errorsOnly, int recursionDepth);
+  PathId getCacheFileId_(PathId sourceFileId) const;
   bool restore_(PathId cacheFileId, const std::vector<char>& content,
                 bool errorsOnly, int recursionDepth);
-  bool checkCacheIsValid_(PathId cacheFileId);
-  bool checkCacheIsValid_(PathId cacheFileId, const std::vector<char>& content);
+  bool checkCacheIsValid_(PathId cacheFileId) const;
+  bool checkCacheIsValid_(PathId cacheFileId,
+                          const std::vector<char>& content) const;
 
-  PreprocessFile* m_pp;
-  bool m_isPrecompiled;
+  PreprocessFile* const m_pp = nullptr;
 };
 
 }  // namespace SURELOG

--- a/include/Surelog/Cache/ParseCache.h
+++ b/include/Surelog/Cache/ParseCache.h
@@ -42,13 +42,13 @@ class ParseCache : Cache {
  private:
   ParseCache(const ParseCache& orig) = delete;
 
-  PathId getCacheFileId_(PathId ppFileId);
+  PathId getCacheFileId_(PathId ppFileId) const;
   bool restore_(PathId cacheFileId, const std::vector<char>& content);
+  bool checkCacheIsValid_(PathId cacheFileId) const;
   bool checkCacheIsValid_(PathId cacheFileId,
                           const std::vector<char>& content) const;
 
-  ParseFile* m_parse;
-  bool m_isPrecompiled;
+  ParseFile* const m_parse = nullptr;
 };
 
 }  // namespace SURELOG


### PR DESCRIPTION
Few more cache consistency fixes

* Bookkeeping of PPCache::m_isPrecompiled was wrong. The said variable gets set/modified in PPCache::getCacheFileId_ which gets called recursively from PPCache::checkCacheIsValid_ to validate the includes. The resultant value of the variable is the from the last call to PPCache::getCacheFileId_ which doesn't necessarily match the expectation when PPCache::restore is called. Resolution: Compute the flag each time its required. For consistency, removed the same from ParseCache as well.

* Output path for both PPCache & ParseCache was wrong when parseOnly flag is set. With the flag set, PreprocessFile doesn't actually generate a preprocess output for the parser to use. The original source itself is used as input to the parser. The input to the FileSystem::getPpCacheFile is however the path to preprocess output wihich is expected to be in the output folder. The result is a wrong path that puts the cache file right next to the source. Fixed it by computing a "potential" path for the preprocessed output that gets used for computing the cache path. For consistency, similar update to ParseCache as well.

* With -nohash option enabled, basic signature & version checks were skipped. Fixed for both caches.

* Enforced consistent checks across public & private APIs in both caches.