### PR TITLE
Add namespace and use class scope for VObjectType enum

### DIFF
--- a/include/Surelog/Design/DesignElement.h
+++ b/include/Surelog/Design/DesignElement.h
@@ -68,7 +68,7 @@ class DesignElement final {
 
   TimeInfo m_timeInfo;
   NodeId m_node;
-  VObjectType m_defaultNetType = slNetType_Wire;
+  VObjectType m_defaultNetType = VObjectType::slNetType_Wire;
   void* m_context;  // Not persisted field, only used to build the DesignElement
                     // -> VNode relation
 };

--- a/include/Surelog/Design/TimeInfo.h
+++ b/include/Surelog/Design/TimeInfo.h
@@ -58,7 +58,7 @@ class TimeInfo final {
 
 class NetTypeInfo final {
  public:
-  VObjectType m_type = slNoType;
+  VObjectType m_type = VObjectType::slNoType;
   PathId m_fileId;
   unsigned int m_line = 0;
 };

--- a/scripts/generate_parser_listener.py
+++ b/scripts/generate_parser_listener.py
@@ -452,7 +452,8 @@ def _generate_VObjectTypes_h(filepath):
     '#include <set>',
     '#include <unordered_set>',
     '',
-    'enum /* class */ VObjectType : uint16_t {  // TODO: convert to enum class',
+    'namespace SURELOG {',
+    'enum class VObjectType : uint16_t {',
   ]
 
   index = 1
@@ -466,6 +467,7 @@ def _generate_VObjectTypes_h(filepath):
     'typedef std::set<VObjectType> VObjectTypeSet;',
     'typedef std::unordered_set<VObjectType> VObjectTypeUnorderedSet;',
     '',
+    '} // namespace SURELOG',
     '#endif // SURELOG_VOBJECTTYPES_H',
     ''
   ])

--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -299,7 +299,7 @@ std::string SLgetFile(FileContent* fC, RawNodeId id) {
 
 unsigned int SLgetType(FileContent* fC, RawNodeId id) {
   if (!fC) return 0;
-  return fC->Type(NodeId(id));
+  return static_cast<unsigned int>(fC->Type(NodeId(id)));
 }
 
 RawNodeId SLgetChild(FileContent* fC, RawNodeId index) {

--- a/src/API/slapi_scripts.i
+++ b/src/API/slapi_scripts.i
@@ -7,6 +7,9 @@
 %{
 #include <Surelog/Common/SymbolId.h>
 using SURELOG::RawNodeId;
+
+#include <Surelog/SourceCompile/VObjectTypes.h>
+using SURELOG::VObjectType;
 %}
 
 %template (UIntVector) std::vector<unsigned int>;

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -250,7 +250,7 @@ bool ParseCache::save() {
           elem->m_type, (RawNodeId)elem->m_uniqueId, elem->m_line,
           elem->m_column, elem->m_endLine, elem->m_endColumn, timeInfo,
           (RawNodeId)elem->m_parent, (RawNodeId)elem->m_node,
-          elem->m_defaultNetType));
+          static_cast<unsigned int>(elem->m_defaultNetType)));
     }
   auto elementList = builder.CreateVector(element_vec);
 

--- a/src/Design/DataType.cpp
+++ b/src/Design/DataType.cpp
@@ -41,53 +41,72 @@ bool DataType::isInteger_type(VObjectType type) {
 }
 
 bool DataType::isInteger_atom_type(VObjectType type) {
-  return (
-      type == slIntegerAtomType_Byte || type == slIntegerAtomType_Shortint ||
-      type == slIntegerAtomType_Integer || type == slIntegerAtomType_LongInt ||
-      type == slIntegerAtomType_Int || type == slIntegerAtomType_Time);
+  return (type == VObjectType::slIntegerAtomType_Byte ||
+          type == VObjectType::slIntegerAtomType_Shortint ||
+          type == VObjectType::slIntegerAtomType_Integer ||
+          type == VObjectType::slIntegerAtomType_LongInt ||
+          type == VObjectType::slIntegerAtomType_Int ||
+          type == VObjectType::slIntegerAtomType_Time);
 }
 
 bool DataType::isInteger_vector_type(VObjectType type) {
-  return (type == slIntVec_TypeBit || type == slIntVec_TypeLogic ||
-          type == slIntVec_TypeReg);
+  return (type == VObjectType::slIntVec_TypeBit ||
+          type == VObjectType::slIntVec_TypeLogic ||
+          type == VObjectType::slIntVec_TypeReg);
 }
 
 bool DataType::isNon_integer_type(VObjectType type) {
-  return (type == slNonIntType_ShortReal || type == slNonIntType_Real ||
-          type == slNonIntType_RealTime);
+  return (type == VObjectType::slNonIntType_ShortReal ||
+          type == VObjectType::slNonIntType_Real ||
+          type == VObjectType::slNonIntType_RealTime);
 }
 
 bool DataType::isNet_type(VObjectType type) {
-  return (type == slNetType_Supply0 || type == slNetType_Supply1 ||
-          type == slNetType_Tri || type == slNetType_TriAnd ||
-          type == slNetType_TriOr || type == slNetType_TriReg ||
-          type == slNetType_Tri0 || type == slNetType_Tri1 ||
-          type == slNetType_Uwire || type == slNetType_Wire ||
-          type == slNetType_Wand || type == slNetType_Wor);
+  return (type == VObjectType::slNetType_Supply0 ||
+          type == VObjectType::slNetType_Supply1 ||
+          type == VObjectType::slNetType_Tri ||
+          type == VObjectType::slNetType_TriAnd ||
+          type == VObjectType::slNetType_TriOr ||
+          type == VObjectType::slNetType_TriReg ||
+          type == VObjectType::slNetType_Tri0 ||
+          type == VObjectType::slNetType_Tri1 ||
+          type == VObjectType::slNetType_Uwire ||
+          type == VObjectType::slNetType_Wire ||
+          type == VObjectType::slNetType_Wand ||
+          type == VObjectType::slNetType_Wor);
 }
 
 bool DataType::isData_type(VObjectType type) {
   return (isInteger_vector_type(type) || isInteger_atom_type(type) ||
-          isNon_integer_type(type) || type == slString_type ||
-          type == slChandle_type || type == slEvent_type ||
-          type == slType_reference);
+          isNon_integer_type(type) || type == VObjectType::slString_type ||
+          type == VObjectType::slChandle_type ||
+          type == VObjectType::slEvent_type ||
+          type == VObjectType::slType_reference);
 }
 
 bool DataType::isString_type(VObjectType type) {
-  return (type == slString_type || type == slStringConst ||
-          type == slStringLiteral);
+  return (type == VObjectType::slString_type ||
+          type == VObjectType::slStringConst ||
+          type == VObjectType::slStringLiteral);
 }
 
 bool DataType::isNumber(VObjectType type) {
   return (type == VObjectType::slRealConst ||
-          type == VObjectType::slInteger_type || type == slNumber_1Tickb0 ||
-          type == slNumber_1Tickb1 || type == slNumber_1TickB0 ||
-          type == slNumber_1TickB1 || type == slNumber_Tickb0 ||
-          type == slNumber_Tickb1 || type == slNumber_TickB0 ||
-          type == slNumber_TickB1 || type == slNumber_Tick0 ||
-          type == slNumber_Tick1 || type == slNumber_1Tickbx ||
-          type == slNumber_1TickbX || type == slNumber_1TickBx ||
-          type == slNumber_1TickBX);
+          type == VObjectType::slInteger_type ||
+          type == VObjectType::slNumber_1Tickb0 ||
+          type == VObjectType::slNumber_1Tickb1 ||
+          type == VObjectType::slNumber_1TickB0 ||
+          type == VObjectType::slNumber_1TickB1 ||
+          type == VObjectType::slNumber_Tickb0 ||
+          type == VObjectType::slNumber_Tickb1 ||
+          type == VObjectType::slNumber_TickB0 ||
+          type == VObjectType::slNumber_TickB1 ||
+          type == VObjectType::slNumber_Tick0 ||
+          type == VObjectType::slNumber_Tick1 ||
+          type == VObjectType::slNumber_1Tickbx ||
+          type == VObjectType::slNumber_1TickbX ||
+          type == VObjectType::slNumber_1TickBx ||
+          type == VObjectType::slNumber_1TickBX);
 }
 
 bool DataType::isCompatible(const Value* value) const {

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -122,7 +122,7 @@ std::string Design::reportInstanceTree() const {
     std::string type_s;
     Location loc(tmp->getFileId(), tmp->getLineNb(), tmp->getColumnNb(),
                  tmp->getFullPathId(symbols));
-    if (type == slUdp_instantiation) {
+    if (type == VObjectType::slUdp_instantiation) {
       type_s = "[UDP]";
       Error err(ErrorDefinition::ELAB_INSTANCE_PATH, loc);
       m_errors->addError(err);
@@ -141,15 +141,15 @@ std::string Design::reportInstanceTree() const {
       type_s = "[GAT]";
       Error err(ErrorDefinition::ELAB_INSTANCE_PATH, loc);
       m_errors->addError(err);
-    } else if (type == slInterface_instantiation) {
+    } else if (type == VObjectType::slInterface_instantiation) {
       type_s = "[I/F]";
       Error err(ErrorDefinition::ELAB_INTERFACE_INSTANCE_PATH, loc);
       m_errors->addError(err);
-    } else if (type == slProgram_instantiation) {
+    } else if (type == VObjectType::slProgram_instantiation) {
       type_s = "[PRG]";
       Error err(ErrorDefinition::ELAB_PROGRAM_INSTANCE_PATH, loc);
       m_errors->addError(err);
-    } else if (type == slModule_declaration) {
+    } else if (type == VObjectType::slModule_declaration) {
       type_s = "[TOP]";
       Error err(ErrorDefinition::ELAB_INSTANCE_PATH, loc);
       m_errors->addError(err);

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -41,8 +41,8 @@ FileContent::FileContent(PathId fileId, Library* library,
       m_library(library),
       m_symbolTable(symbolTable),
       m_parentFile(parent) {
-  addObject(BadSymbolId, BadPathId, sl_INVALID_, 0, 0, 0, 0, InvalidNodeId,
-            InvalidNodeId, InvalidNodeId, InvalidNodeId);
+  addObject(BadSymbolId, BadPathId, VObjectType::sl_INVALID_, 0, 0, 0, 0,
+            InvalidNodeId, InvalidNodeId, InvalidNodeId, InvalidNodeId);
 }
 
 std::string FileContent::getName() const {
@@ -317,7 +317,7 @@ VObjectType FileContent::Type(NodeId index) const {
     Error err(ErrorDefinition::COMP_INTERNAL_ERROR_OUT_OF_BOUND, loc);
     m_errors->addError(err);
     std::cerr << "\nINTERNAL OUT OF BOUND ERROR\n\n";
-    return sl_INVALID_;
+    return VObjectType::sl_INVALID_;
   }
   return (VObjectType)m_objects[index].m_type;
 }

--- a/src/Design/ModuleInstance.cpp
+++ b/src/Design/ModuleInstance.cpp
@@ -81,7 +81,7 @@ UHDM::expr* ModuleInstance::getComplexValue(std::string_view name) const {
       }
     }
 
-    if (instance->getType() != slModule_instantiation)
+    if (instance->getType() != VObjectType::slModule_instantiation)
       instance = instance->getParent();
     else
       instance = nullptr;
@@ -120,7 +120,7 @@ Value* ModuleInstance::getValue(std::string_view name,
       }
     }
 
-    if (instance->getType() != slModule_instantiation)
+    if (instance->getType() != VObjectType::slModule_instantiation)
       instance = instance->getParent();
     else
       instance = nullptr;

--- a/src/Design/Signal.cpp
+++ b/src/Design/Signal.cpp
@@ -95,7 +95,8 @@ Signal::Signal(const FileContent* fileContent, NodeId nodeId, VObjectType type,
 
 std::string Signal::getInterfaceTypeName() const {
   std::string type_name;
-  if (m_fileContent->Type(m_interfaceTypeNameId) == slClass_scope) {
+  if (m_fileContent->Type(m_interfaceTypeNameId) ==
+      VObjectType::slClass_scope) {
     NodeId Class_type = m_fileContent->Child(m_interfaceTypeNameId);
     NodeId Pack_name = m_fileContent->Child(Class_type);
     type_name = m_fileContent->SymName(Pack_name) + "::";
@@ -105,11 +106,11 @@ std::string Signal::getInterfaceTypeName() const {
     type_name = m_fileContent->SymName(m_interfaceTypeNameId);
     NodeId constant_select = m_fileContent->Sibling(m_interfaceTypeNameId);
     if (constant_select) {
-      if (m_fileContent->Type(constant_select) == slStringConst) {
+      if (m_fileContent->Type(constant_select) == VObjectType::slStringConst) {
         type_name += "." + m_fileContent->SymName(constant_select);
       } else {
         NodeId selector = m_fileContent->Child(constant_select);
-        if (m_fileContent->Type(selector) == slStringConst)
+        if (m_fileContent->Type(selector) == VObjectType::slStringConst)
           type_name += "." + m_fileContent->SymName(selector);
       }
     }

--- a/src/Design/ValuedComponentI.cpp
+++ b/src/Design/ValuedComponentI.cpp
@@ -39,7 +39,7 @@ Value* ValuedComponentI::getValue(std::string_view name) const {
     if (m_parentScope) {
       if (const ModuleInstance* inst =
               valuedcomponenti_cast<ModuleInstance*>(this)) {
-        if (inst->getType() != slModule_instantiation) {
+        if (inst->getType() != VObjectType::slModule_instantiation) {
           return m_parentScope->getValue(name);
         }
       } else {

--- a/src/DesignCompile/Builtin.cpp
+++ b/src/DesignCompile/Builtin.cpp
@@ -354,7 +354,7 @@ void Builtin::addBuiltinClasses() {
       m_compiler->getCompiler(), fileId);
 
   std::vector<NodeId> classes =
-      fC1->sl_collect_all(fC1->getRootNode(), slClass_declaration);
+      fC1->sl_collect_all(fC1->getRootNode(), VObjectType::slClass_declaration);
   m_compiler->getCompiler()->getDesign()->addFileContent(fC1->getFileId(), fC1);
   for (const auto& classId : classes) {
     NodeId stId = fC1->sl_collect(classId, VObjectType::slStringConst,

--- a/src/DesignCompile/CompileAssertion.cpp
+++ b/src/DesignCompile/CompileAssertion.cpp
@@ -39,7 +39,7 @@ bool CompileHelper::compileAssertionItem(DesignComponent* component,
                                          CompileDesign* compileDesign) {
   UHDM::Serializer& s = compileDesign->getSerializer();
   NodeId item = fC->Child(nodeId);
-  if (fC->Type(item) == slConcurrent_assertion_item) {
+  if (fC->Type(item) == VObjectType::slConcurrent_assertion_item) {
     NodeId Concurrent_assertion_statement = fC->Child(item);
     UHDM::VectorOfany* stmts = compileStmt(
         component, fC, Concurrent_assertion_statement, compileDesign, nullptr);
@@ -96,10 +96,10 @@ UHDM::any* CompileHelper::compileConcurrentAssertion(
   NodeId Action_block = fC->Sibling(Property_spec);
   UHDM::any* if_stmt = nullptr;
   UHDM::any* else_stmt = nullptr;
-  if (fC->Type(Action_block) == slAction_block) {
+  if (fC->Type(Action_block) == VObjectType::slAction_block) {
     NodeId if_stmt_id = fC->Child(Action_block);
     NodeId else_stmt_id;
-    if (fC->Type(if_stmt_id) == slElse) {
+    if (fC->Type(if_stmt_id) == VObjectType::slElse) {
       else_stmt_id = fC->Sibling(if_stmt_id);
       if_stmt_id = InvalidNodeId;
     } else {
@@ -137,7 +137,7 @@ UHDM::any* CompileHelper::compileConcurrentAssertion(
     case VObjectType::slAssume_property_statement: {
       NodeId Property_expr = fC->Child(Property_spec);
       UHDM::expr* clocking_event = nullptr;
-      if (fC->Type(Property_expr) == slClocking_event) {
+      if (fC->Type(Property_expr) == VObjectType::slClocking_event) {
         clocking_event = (UHDM::expr*)compileExpression(
             component, fC, Property_expr, compileDesign, pstmt, instance,
             false);
@@ -218,7 +218,7 @@ UHDM::any* CompileHelper::compileSimpleImmediateAssertion(
   NodeId Action_block = fC->Sibling(Expression);
   NodeId if_stmt_id = fC->Child(Action_block);
   NodeId else_stmt_id;
-  if (fC->Type(if_stmt_id) == slElse) {
+  if (fC->Type(if_stmt_id) == VObjectType::slElse) {
     else_stmt_id = fC->Sibling(if_stmt_id);
     if_stmt_id = InvalidNodeId;
   } else {
@@ -301,12 +301,12 @@ UHDM::any* CompileHelper::compileDeferredImmediateAssertion(
     SURELOG::ValuedComponentI* instance) {
   UHDM::Serializer& s = compileDesign->getSerializer();
   NodeId the_stmt_child = fC->Child(the_stmt);
-  int isFinal = fC->Type(the_stmt_child) == slPound_delay ? 0 : 1;
+  int isFinal = fC->Type(the_stmt_child) == VObjectType::slPound_delay ? 0 : 1;
   NodeId Expression = isFinal ? the_stmt_child : fC->Sibling(the_stmt_child);
   NodeId Action_block = fC->Sibling(Expression);
   NodeId if_stmt_id = fC->Child(Action_block);
   NodeId else_stmt_id;
-  if (fC->Type(if_stmt_id) == slElse) {
+  if (fC->Type(if_stmt_id) == VObjectType::slElse) {
     else_stmt_id = fC->Sibling(if_stmt_id);
     if_stmt_id = InvalidNodeId;
   } else {

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -222,7 +222,8 @@ bool CompileClass::compile() {
       case VObjectType::slStringConst: {
         NodeId sibling = fC->Sibling(id);
         if (!sibling) {
-          if (fC->Type(fC->Parent(id)) != slClass_declaration) break;
+          if (fC->Type(fC->Parent(id)) != VObjectType::slClass_declaration)
+            break;
           const std::string& endLabel = fC->SymName(id);
           std::string moduleName = m_class->getName();
           moduleName = StringUtils::ltrim(moduleName, '@');
@@ -477,7 +478,7 @@ bool CompileClass::compile_class_method_(const FileContent* fC, NodeId id) {
     NodeId task_decl =
         m_helper.setFuncTaskQualifiers(fC, fC->Child(id), nullptr);
     NodeId Task_body_declaration;
-    if (fC->Type(task_decl) == slTask_body_declaration)
+    if (fC->Type(task_decl) == VObjectType::slTask_body_declaration)
       Task_body_declaration = task_decl;
     else
       Task_body_declaration = fC->Child(task_decl);
@@ -510,7 +511,7 @@ bool CompileClass::compile_class_method_(const FileContent* fC, NodeId id) {
       NodeId task_decl =
           m_helper.setFuncTaskQualifiers(fC, fC->Child(id), nullptr);
       NodeId Task_body_declaration;
-      if (fC->Type(task_decl) == slTask_body_declaration)
+      if (fC->Type(task_decl) == VObjectType::slTask_body_declaration)
         Task_body_declaration = task_decl;
       else
         Task_body_declaration = fC->Child(task_decl);
@@ -723,8 +724,9 @@ bool CompileClass::compile_local_parameter_declaration_(const FileContent* fC,
    n<> u<20> t<Local_parameter_declaration> p<21> c<10> l<3>
   */
   NodeId list_of_type_assignments = fC->Child(id);
-  if (fC->Type(list_of_type_assignments) == slList_of_type_assignments ||
-      fC->Type(list_of_type_assignments) == slType) {
+  if (fC->Type(list_of_type_assignments) ==
+          VObjectType::slList_of_type_assignments ||
+      fC->Type(list_of_type_assignments) == VObjectType::slType) {
     // Type param
     m_helper.compileParameterDeclaration(m_class, fC, list_of_type_assignments,
                                          m_compileDesign, true, nullptr, false,
@@ -766,8 +768,9 @@ bool CompileClass::compile_local_parameter_declaration_(const FileContent* fC,
 bool CompileClass::compile_parameter_declaration_(const FileContent* fC,
                                                   NodeId id) {
   NodeId list_of_type_assignments = fC->Child(id);
-  if (fC->Type(list_of_type_assignments) == slList_of_type_assignments ||
-      fC->Type(list_of_type_assignments) == slType) {
+  if (fC->Type(list_of_type_assignments) ==
+          VObjectType::slList_of_type_assignments ||
+      fC->Type(list_of_type_assignments) == VObjectType::slType) {
     // Type param
     m_helper.compileParameterDeclaration(m_class, fC, list_of_type_assignments,
                                          m_compileDesign, false, nullptr, false,
@@ -869,13 +872,14 @@ bool CompileClass::compile_class_parameters_(const FileContent* fC, NodeId id) {
     while (parameter_port_declaration) {
       NodeId list_of_type_assignments = fC->Child(parameter_port_declaration);
       NodeId type = fC->Child(list_of_type_assignments);
-      if (fC->Type(list_of_type_assignments) == slList_of_type_assignments ||
-          fC->Type(list_of_type_assignments) == slType) {
+      if (fC->Type(list_of_type_assignments) ==
+              VObjectType::slList_of_type_assignments ||
+          fC->Type(list_of_type_assignments) == VObjectType::slType) {
         // Type param
         m_helper.compileParameterDeclaration(
             m_class, fC, list_of_type_assignments, m_compileDesign, false,
             nullptr, false, false, false);
-      } else if (fC->Type(type) == slType) {
+      } else if (fC->Type(type) == VObjectType::slType) {
         // Handled in compile_parameter_declaration_
       } else {
         // Regular param

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -1091,11 +1091,12 @@ UHDM::any *CompileHelper::compileSelectExpression(
     ValuedComponentI *instance, bool reduce, bool muteErrors) {
   UHDM::Serializer &s = compileDesign->getSerializer();
   UHDM::any *result = nullptr;
-  if ((fC->Type(Bit_select) == slConstant_bit_select) &&
+  if ((fC->Type(Bit_select) == VObjectType::slConstant_bit_select) &&
       (!fC->Sibling(Bit_select))) {
     Bit_select = fC->Child(Bit_select);
   }
-  if ((fC->Type(Bit_select) == slBit_select) && (!fC->Sibling(Bit_select))) {
+  if ((fC->Type(Bit_select) == VObjectType::slBit_select) &&
+      (!fC->Sibling(Bit_select))) {
     Bit_select = fC->Child(Bit_select);
   }
   if (fC->Child(Bit_select) && fC->Sibling(Bit_select)) {
@@ -1125,8 +1126,8 @@ UHDM::any *CompileHelper::compileSelectExpression(
       }
       if (bitexp) {
         while (bitexp) {
-          if ((fC->Type(bitexp) != slConstant_expression) &&
-              (fC->Type(bitexp) != slExpression)) {
+          if ((fC->Type(bitexp) != VObjectType::slConstant_expression) &&
+              (fC->Type(bitexp) != VObjectType::slExpression)) {
             break;
           }
           expr *sel =
@@ -1207,15 +1208,15 @@ UHDM::any *CompileHelper::compileSelectExpression(
         } else if ((fC->Type(Bit_select) == VObjectType::slSelect)) {
           ref_obj *r = s.MakeRef_obj();
           NodeId nameId = fC->Child(Bit_select);
-          if (nameId && (fC->Type(nameId) == slStringConst)) {
+          if (nameId && (fC->Type(nameId) == VObjectType::slStringConst)) {
             r->VpiName(fC->SymName(nameId));
             elems->push_back(r);
             hname += "." + fC->SymName(nameId);
           }
         } else if (fC->Type(Bit_select) == VObjectType::slStringConst) {
           NodeId tmp = fC->Sibling(Bit_select);
-          if (((fC->Type(tmp) == slConstant_bit_select) ||
-               (fC->Type(tmp) == slBit_select)) &&
+          if (((fC->Type(tmp) == VObjectType::slConstant_bit_select) ||
+               (fC->Type(tmp) == VObjectType::slBit_select)) &&
               fC->Child(tmp)) {
             any *sel =
                 compileExpression(component, fC, Bit_select, compileDesign,
@@ -1309,12 +1310,12 @@ UHDM::any *CompileHelper::compileExpression(
   UHDM::VectorOfattribute *attributes = nullptr;
   if (parentType == VObjectType::slAttribute_instance) {
     attributes = compileAttributes(component, fC, parent, compileDesign);
-    while (fC->Type(parent) == slAttribute_instance)
+    while (fC->Type(parent) == VObjectType::slAttribute_instance)
       parent = fC->Sibling(parent);
   }
   parentType = fC->Type(parent);
   NodeId child = fC->Child(parent);
-  VObjectType childType = sl_INVALID_;
+  VObjectType childType = VObjectType::sl_INVALID_;
   if (child) {
     childType = fC->Type(child);
   }
@@ -1466,7 +1467,7 @@ UHDM::any *CompileHelper::compileExpression(
     }
     case VObjectType::slExpression: {
       NodeId Iff = fC->Sibling(parent);
-      if (fC->Type(Iff) == slIff) {
+      if (fC->Type(Iff) == VObjectType::slIff) {
         operation *op = s.MakeOperation();
         op->VpiOpType(vpiIffOp);
         op->VpiParent(pexpr);
@@ -1516,7 +1517,7 @@ UHDM::any *CompileHelper::compileExpression(
         NodeId Name = fC->Child(Port_reference);
         NodeId Constant_select = fC->Sibling(Name);
 
-        if (fC->Type(Constant_select) == slConstant_select) {
+        if (fC->Type(Constant_select) == VObjectType::slConstant_select) {
           Constant_select = fC->Child(Constant_select);
         }
         if (fC->Child(Constant_select) || fC->Sibling(Constant_select)) {
@@ -1573,7 +1574,7 @@ UHDM::any *CompileHelper::compileExpression(
     NodeId Expression = child;
     while (Expression) {
       NodeId n = fC->Child(Expression);
-      if (fC->Type(n) == slVariable_lvalue) {
+      if (fC->Type(n) == VObjectType::slVariable_lvalue) {
         n = Expression;
       }
       UHDM::any *exp = compileExpression(component, fC, n, compileDesign, pexpr,
@@ -1680,7 +1681,7 @@ UHDM::any *CompileHelper::compileExpression(
             op->Attributes(attributes);
             UHDM::VectorOfany *operands = s.MakeAnyVec();
             NodeId var = fC->Sibling(child);
-            if (fC->Type(var) == slVariable_lvalue) {
+            if (fC->Type(var) == VObjectType::slVariable_lvalue) {
               var = fC->Child(var);
             }
             if (UHDM::any *operand =
@@ -1767,7 +1768,7 @@ UHDM::any *CompileHelper::compileExpression(
             op->Operands(operands);
             operands->push_back(result);
             VObjectType distType = fC->Type(dist);
-            if (distType == slBoolean_abbrev) {
+            if (distType == VObjectType::slBoolean_abbrev) {
               NodeId repetition = fC->Child(dist);
               VObjectType repetType = fC->Type(repetition);
               op->VpiOpType(UhdmWriter::getVpiOpType(repetType));
@@ -1776,8 +1777,9 @@ UHDM::any *CompileHelper::compileExpression(
                                     pexpr, instance, reduce, muteErrors);
               operands->push_back(rep);
               result = op;
-            } else if (distType == slThroughout || distType == slWithin ||
-                       distType == slIntersect) {
+            } else if (distType == VObjectType::slThroughout ||
+                       distType == VObjectType::slWithin ||
+                       distType == VObjectType::slIntersect) {
               NodeId repetition = fC->Sibling(dist);
               op->VpiOpType(UhdmWriter::getVpiOpType(distType));
               any *rep =
@@ -1811,7 +1813,8 @@ UHDM::any *CompileHelper::compileExpression(
             NodeId Constant_primary = fC->Child(Expression);
             NodeId Constant_expression = fC->Child(Constant_primary);
             NodeId TmpSibling = fC->Sibling(Constant_expression);
-            if (TmpSibling && (fC->Type(TmpSibling) == slConstant_expression)) {
+            if (TmpSibling &&
+                (fC->Type(TmpSibling) == VObjectType::slConstant_expression)) {
               Sibling = TmpSibling;
               Expression = Constant_primary;
             }
@@ -1934,7 +1937,7 @@ UHDM::any *CompileHelper::compileExpression(
               compileExpression(component, fC, child, compileDesign, pexpr,
                                 instance, reduce, muteErrors);
           NodeId op = fC->Sibling(child);
-          if ((!op) || (fC->Type(op) == slConstant_expression)) {
+          if ((!op) || (fC->Type(op) == VObjectType::slConstant_expression)) {
             result = opL;
             break;
           }
@@ -1960,7 +1963,7 @@ UHDM::any *CompileHelper::compileExpression(
           if (fC->Type(rval) == VObjectType::slAttribute_instance) {
             UHDM::VectorOfattribute *attributes =
                 compileAttributes(component, fC, rval, compileDesign);
-            while (fC->Type(rval) == slAttribute_instance)
+            while (fC->Type(rval) == VObjectType::slAttribute_instance)
               rval = fC->Sibling(rval);
             operation->Attributes(attributes);
           }
@@ -2110,12 +2113,12 @@ UHDM::any *CompileHelper::compileExpression(
               if (fC->Type(rval) == VObjectType::slAttribute_instance) {
                 UHDM::VectorOfattribute *attributes =
                     compileAttributes(component, fC, rval, compileDesign);
-                while (fC->Type(rval) == slAttribute_instance)
+                while (fC->Type(rval) == VObjectType::slAttribute_instance)
                   rval = fC->Sibling(rval);
                 operation->Attributes(attributes);
               }
 
-            } else if (opType == slExpression) {
+            } else if (opType == VObjectType::slExpression) {
               // Assignment
               UHDM::operation *operation = s.MakeOperation();
               UHDM::VectorOfany *operands = s.MakeAnyVec();
@@ -2131,7 +2134,7 @@ UHDM::any *CompileHelper::compileExpression(
               if (fC->Type(rval) == VObjectType::slAttribute_instance) {
                 UHDM::VectorOfattribute *attributes =
                     compileAttributes(component, fC, rval, compileDesign);
-                while (fC->Type(rval) == slAttribute_instance)
+                while (fC->Type(rval) == VObjectType::slAttribute_instance)
                   rval = fC->Sibling(rval);
                 operation->Attributes(attributes);
               }
@@ -2166,7 +2169,7 @@ UHDM::any *CompileHelper::compileExpression(
           seqinst->Named_event_sequence_expr_groups(args);
           while (Sequence_actual_arg) {
             NodeId arg = Sequence_actual_arg;
-            if (fC->Type(Sequence_actual_arg) == slSequence_arg) {
+            if (fC->Type(Sequence_actual_arg) == VObjectType::slSequence_arg) {
               arg = fC->Child(Sequence_actual_arg);
             }
             if (arg) {
@@ -2204,13 +2207,14 @@ UHDM::any *CompileHelper::compileExpression(
             int operationType = UhdmWriter::getVpiOpType(type);
             if (NodeId subOp1 = fC->Child(oper)) {
               VObjectType subOp1type = fC->Type(subOp1);
-              if (subOp1type == slPound_Pound_delay) {
+              if (subOp1type == VObjectType::slPound_Pound_delay) {
                 if (NodeId subOp2 = fC->Sibling(subOp1)) {
                   VObjectType subOp2type = fC->Type(subOp2);
-                  if (subOp2type == slAssociative_dimension) {
+                  if (subOp2type == VObjectType::slAssociative_dimension) {
                     operationType = vpiConsecutiveRepeatOp;
                   } else if (subOp2type ==
-                             slCycle_delay_const_range_expression) {
+                             VObjectType::
+                                 slCycle_delay_const_range_expression) {
                     range *r = s.MakeRange();
                     NodeId lhs = fC->Child(subOp2);
                     NodeId rhs = fC->Sibling(lhs);
@@ -2255,10 +2259,10 @@ UHDM::any *CompileHelper::compileExpression(
                 compileExpression(component, fC, Expression, compileDesign,
                                   nullptr, instance, reduce, muteErrors);
           }
-          if ((fC->Type(Simple_type) == slSigning_Unsigned) ||
-              (fC->Type(Simple_type) == slSigning_Signed)) {
+          if ((fC->Type(Simple_type) == VObjectType::slSigning_Unsigned) ||
+              (fC->Type(Simple_type) == VObjectType::slSigning_Signed)) {
             UHDM::sys_func_call *sys = s.MakeSys_func_call();
-            if (fC->Type(Simple_type) == slSigning_Unsigned)
+            if (fC->Type(Simple_type) == VObjectType::slSigning_Unsigned)
               sys->VpiName("$unsigned");
             else
               sys->VpiName("$signed");
@@ -2330,7 +2334,7 @@ UHDM::any *CompileHelper::compileExpression(
                   }
                 }
                 if (result && selectId) {
-                  if (fC->Type(selectId) == slConstant_select) {
+                  if (fC->Type(selectId) == VObjectType::slConstant_select) {
                     selectId = fC->Child(selectId);
                   }
                   if (fC->Child(selectId) || fC->Sibling(selectId))
@@ -2398,7 +2402,7 @@ UHDM::any *CompileHelper::compileExpression(
             NodeId rhsbackup = rhs;
             while ((rhs = fC->Sibling(rhs))) {
               if (fC->Type(rhs) == VObjectType::slStringConst) {
-                if (fC->Type(rhsbackup) == slPackage_scope) {
+                if (fC->Type(rhsbackup) == VObjectType::slPackage_scope) {
                   name += "::" + fC->SymName(rhs);
                 } else {
                   name += "." + fC->SymName(rhs);
@@ -2600,9 +2604,9 @@ UHDM::any *CompileHelper::compileExpression(
           NodeId Slice_size = fC->Sibling(Stream_operator);
           UHDM::any *exp_slice = nullptr;
           NodeId Stream_concatenation;
-          if (fC->Type(Slice_size) == slSlice_size) {
+          if (fC->Type(Slice_size) == VObjectType::slSlice_size) {
             NodeId Constant_expression = fC->Child(Slice_size);
-            if (fC->Type(Constant_expression) == slSimple_type) {
+            if (fC->Type(Constant_expression) == VObjectType::slSimple_type) {
               NodeId Integer_type = fC->Child(Constant_expression);
               NodeId Type = fC->Child(Integer_type);
               exp_slice = compileBits(component, fC, Type, compileDesign, pexpr,
@@ -2709,7 +2713,7 @@ UHDM::any *CompileHelper::compileExpression(
         case VObjectType::slSubroutine_call: {
           NodeId Dollar_keyword = fC->Child(child);
           NodeId nameId;
-          if (fC->Type(Dollar_keyword) == slStringConst) {
+          if (fC->Type(Dollar_keyword) == VObjectType::slStringConst) {
             nameId = Dollar_keyword;
           } else {
             nameId = fC->Sibling(Dollar_keyword);
@@ -2736,9 +2740,9 @@ UHDM::any *CompileHelper::compileExpression(
           } else if (name == "typename") {
             result = compileTypename(component, fC, List_of_arguments,
                                      compileDesign, pexpr, instance, reduce);
-          } else if (fC->Type(Dollar_keyword) == slStringConst ||
-                     fC->Type(Dollar_keyword) == slClass_scope) {
-            if (fC->Type(Dollar_keyword) == slClass_scope) {
+          } else if (fC->Type(Dollar_keyword) == VObjectType::slStringConst ||
+                     fC->Type(Dollar_keyword) == VObjectType::slClass_scope) {
+            if (fC->Type(Dollar_keyword) == VObjectType::slClass_scope) {
               NodeId Class_type = fC->Child(Dollar_keyword);
               NodeId Class_type_name = fC->Child(Class_type);
               NodeId Class_scope_name = fC->Sibling(Dollar_keyword);
@@ -2746,8 +2750,8 @@ UHDM::any *CompileHelper::compileExpression(
                      "::" + fC->SymName(Class_scope_name);
             }
             NodeId Select = fC->Sibling(Dollar_keyword);
-            if (fC->Type(Select) == slConstant_bit_select ||
-                fC->Type(Select) == slBit_select) {
+            if (fC->Type(Select) == VObjectType::slConstant_bit_select ||
+                fC->Type(Select) == VObjectType::slBit_select) {
               result = compileExpression(component, fC, Dollar_keyword,
                                          compileDesign, pexpr, instance, reduce,
                                          muteErrors);
@@ -2811,13 +2815,14 @@ UHDM::any *CompileHelper::compileExpression(
           int operationType = UhdmWriter::getVpiOpType(type);
           if (NodeId subOp1 = fC->Child(child)) {
             VObjectType subOp1type = fC->Type(subOp1);
-            if (subOp1type == slPound_Pound_delay) {
+            if (subOp1type == VObjectType::slPound_Pound_delay) {
               operationType = vpiUnaryCycleDelayOp;
               if (NodeId subOp2 = fC->Sibling(subOp1)) {
                 VObjectType subOp2type = fC->Type(subOp2);
-                if (subOp2type == slAssociative_dimension) {
+                if (subOp2type == VObjectType::slAssociative_dimension) {
                   operationType = vpiConsecutiveRepeatOp;
-                } else if (subOp2type == slCycle_delay_const_range_expression) {
+                } else if (subOp2type ==
+                           VObjectType::slCycle_delay_const_range_expression) {
                   range *r = s.MakeRange();
                   NodeId lhs = fC->Child(subOp2);
                   NodeId rhs = fC->Sibling(lhs);
@@ -2857,12 +2862,12 @@ UHDM::any *CompileHelper::compileExpression(
           if (NodeId sib = fC->Sibling(child)) {
             VObjectType type = fC->Type(sib);
             switch (type) {
-              case slOR:
-              case slAND:
-              case slUNTIL:
-              case slS_UNTIL:
-              case slUNTIL_WITH:
-              case slS_UNTIL_WITH: {
+              case VObjectType::slOR:
+              case VObjectType::slAND:
+              case VObjectType::slUNTIL:
+              case VObjectType::slS_UNTIL:
+              case VObjectType::slUNTIL_WITH:
+              case VObjectType::slS_UNTIL_WITH: {
                 int optype = UhdmWriter::getVpiOpType(type);
                 operation *oper = s.MakeOperation();
                 oper->VpiOpType(optype);
@@ -3125,7 +3130,8 @@ UHDM::any *CompileHelper::compileAssignmentPattern(
       fC->Type(Structure_pattern_key) == VObjectType::slConstant_expression) {
     with_key = false;
   }
-  if (!with_key && fC->Type(Structure_pattern_key) == slConstant_expression) {
+  if (!with_key &&
+      fC->Type(Structure_pattern_key) == VObjectType::slConstant_expression) {
     // '{2{1}}
     NodeId Expression = Structure_pattern_key;
     if (any *exp = compileExpression(component, fC, Expression, compileDesign,
@@ -3216,7 +3222,7 @@ UHDM::any *CompileHelper::compileAssignmentPattern(
           NodeId Constant_primary = fC->Child(Constant_expression);
           if (!Constant_primary) {
             UHDM::string_typespec *tps = s.MakeString_typespec();
-            if (fC->Type(Constant_expression) == slStringConst) {
+            if (fC->Type(Constant_expression) == VObjectType::slStringConst) {
               tps->VpiName(fC->SymName(Constant_expression));
             } else {
               tps->VpiName("default");
@@ -3226,7 +3232,7 @@ UHDM::any *CompileHelper::compileAssignmentPattern(
             pattern->Typespec(tps);
           } else {
             NodeId Primary_literal = Constant_primary;
-            if (fC->Type(Primary_literal) != slPrimary_literal)
+            if (fC->Type(Primary_literal) != VObjectType::slPrimary_literal)
               Primary_literal = fC->Child(Constant_primary);
             pattern->Typespec(compileTypespec(component, fC, Primary_literal,
                                               compileDesign, nullptr, instance,
@@ -3862,34 +3868,34 @@ const typespec *CompileHelper::getTypespec(DesignComponent *component,
   std::string basename;
   std::vector<std::string> suffixnames;
   switch (fC->Type(id)) {
-    case slIntegerAtomType_Byte: {
+    case VObjectType::slIntegerAtomType_Byte: {
       result = s.MakeByte_typespec();
       break;
     }
-    case slIntegerAtomType_Int: {
+    case VObjectType::slIntegerAtomType_Int: {
       result = s.MakeInt_typespec();
       break;
     }
-    case slIntegerAtomType_Integer: {
+    case VObjectType::slIntegerAtomType_Integer: {
       result = s.MakeInteger_typespec();
       break;
     }
-    case slIntegerAtomType_LongInt: {
+    case VObjectType::slIntegerAtomType_LongInt: {
       result = s.MakeLong_int_typespec();
       break;
     }
-    case slIntegerAtomType_Shortint: {
+    case VObjectType::slIntegerAtomType_Shortint: {
       result = s.MakeShort_int_typespec();
       break;
     }
-    case slIntegerAtomType_Time: {
+    case VObjectType::slIntegerAtomType_Time: {
       result = s.MakeTime_typespec();
       break;
     }
     case VObjectType::slStringConst: {
       basename = fC->SymName(id);
       NodeId suffix = fC->Sibling(id);
-      while (suffix && (fC->Type(suffix) == slStringConst)) {
+      while (suffix && (fC->Type(suffix) == VObjectType::slStringConst)) {
         suffixnames.push_back(fC->SymName(suffix));
         suffix = fC->Sibling(suffix);
       }
@@ -4115,9 +4121,9 @@ UHDM::any *CompileHelper::compileBits(
   UHDM::Serializer &s = compileDesign->getSerializer();
   UHDM::any *result = nullptr;
   NodeId Expression = List_of_arguments;
-  if (fC->Type(Expression) == slList_of_arguments) {
+  if (fC->Type(Expression) == VObjectType::slList_of_arguments) {
     Expression = fC->Child(Expression);
-  } else if (fC->Type(Expression) == slData_type) {
+  } else if (fC->Type(Expression) == VObjectType::slData_type) {
     Expression = fC->Child(Expression);
   }
   NodeId typeSpecId;
@@ -4126,21 +4132,21 @@ UHDM::any *CompileHelper::compileBits(
   const typespec *tps = nullptr;
   const any *exp = nullptr;
   switch (fC->Type(Expression)) {
-    case slIntegerAtomType_Byte:
-    case slIntegerAtomType_Int:
-    case slIntegerAtomType_Integer:
-    case slIntegerAtomType_LongInt:
-    case slIntegerAtomType_Shortint:
-    case slIntegerAtomType_Time:
-    case slIntVec_TypeLogic:
-    case slIntVec_TypeBit:
-    case slIntVec_TypeReg:
+    case VObjectType::slIntegerAtomType_Byte:
+    case VObjectType::slIntegerAtomType_Int:
+    case VObjectType::slIntegerAtomType_Integer:
+    case VObjectType::slIntegerAtomType_LongInt:
+    case VObjectType::slIntegerAtomType_Shortint:
+    case VObjectType::slIntegerAtomType_Time:
+    case VObjectType::slIntVec_TypeLogic:
+    case VObjectType::slIntVec_TypeBit:
+    case VObjectType::slIntVec_TypeReg:
       typeSpecId = Expression;
       break;
     default: {
       NodeId Primary = fC->Child(Expression);
       NodeId Primary_literal = fC->Child(Primary);
-      if (fC->Type(Primary_literal) == slConcatenation) {
+      if (fC->Type(Primary_literal) == VObjectType::slConcatenation) {
         NodeId ConcatExpression = fC->Child(Primary_literal);
         while (ConcatExpression) {
           NodeId Primary = fC->Child(ConcatExpression);
@@ -4161,7 +4167,8 @@ UHDM::any *CompileHelper::compileBits(
                          reduce, sizeMode);
           ConcatExpression = fC->Sibling(ConcatExpression);
         }
-      } else if (fC->Type(Primary_literal) == slComplex_func_call) {
+      } else if (fC->Type(Primary_literal) ==
+                 VObjectType::slComplex_func_call) {
         typeSpecId = Primary_literal;
       } else {
         NodeId StringConst = fC->Child(Primary_literal);
@@ -4237,76 +4244,77 @@ UHDM::any *CompileHelper::compileTypename(
   UHDM::Serializer &s = compileDesign->getSerializer();
   UHDM::any *result = nullptr;
   UHDM::constant *c = s.MakeConstant();
-  if (fC->Type(Expression) == slData_type) Expression = fC->Child(Expression);
+  if (fC->Type(Expression) == VObjectType::slData_type)
+    Expression = fC->Child(Expression);
   VObjectType type = fC->Type(Expression);
   switch (type) {
-    case slIntVec_TypeLogic:
+    case VObjectType::slIntVec_TypeLogic:
       c->VpiValue("STRING:logic");
       c->VpiDecompile("logic");
       c->VpiConstType(vpiStringConst);
       result = c;
       break;
-    case slIntVec_TypeBit:
+    case VObjectType::slIntVec_TypeBit:
       c->VpiValue("STRING:bit");
       c->VpiDecompile("bit");
       c->VpiConstType(vpiStringConst);
       result = c;
       break;
-    case slIntVec_TypeReg:
+    case VObjectType::slIntVec_TypeReg:
       c->VpiValue("STRING:reg");
       c->VpiDecompile("reg");
       c->VpiConstType(vpiStringConst);
       result = c;
       break;
-    case slIntegerAtomType_Byte:
+    case VObjectType::slIntegerAtomType_Byte:
       c->VpiValue("STRING:byte");
       c->VpiDecompile("byte");
       c->VpiConstType(vpiStringConst);
       result = c;
       break;
-    case slIntegerAtomType_Shortint:
+    case VObjectType::slIntegerAtomType_Shortint:
       c->VpiValue("STRING:shortint");
       c->VpiDecompile("shortint");
       c->VpiConstType(vpiStringConst);
       result = c;
       break;
-    case slIntegerAtomType_Int:
+    case VObjectType::slIntegerAtomType_Int:
       c->VpiValue("STRING:int");
       c->VpiDecompile("int");
       c->VpiConstType(vpiStringConst);
       result = c;
       break;
-    case slIntegerAtomType_Integer:
+    case VObjectType::slIntegerAtomType_Integer:
       c->VpiValue("STRING:integer");
       c->VpiDecompile("integer");
       c->VpiConstType(vpiStringConst);
       result = c;
       break;
-    case slIntegerAtomType_LongInt:
+    case VObjectType::slIntegerAtomType_LongInt:
       c->VpiValue("STRING:longint");
       c->VpiDecompile("longint");
       c->VpiConstType(vpiStringConst);
       result = c;
       break;
-    case slIntegerAtomType_Time:
+    case VObjectType::slIntegerAtomType_Time:
       c->VpiValue("STRING:time");
       c->VpiDecompile("time");
       c->VpiConstType(vpiStringConst);
       result = c;
       break;
-    case slNonIntType_ShortReal:
+    case VObjectType::slNonIntType_ShortReal:
       c->VpiValue("STRING:shortreal");
       c->VpiDecompile("shortreal");
       c->VpiConstType(vpiStringConst);
       result = c;
       break;
-    case slNonIntType_Real:
+    case VObjectType::slNonIntType_Real:
       c->VpiValue("STRING:real");
       c->VpiDecompile("real");
       c->VpiConstType(vpiStringConst);
       result = c;
       break;
-    case slNonIntType_RealTime:
+    case VObjectType::slNonIntType_RealTime:
       c->VpiValue("STRING:realtime");
       c->VpiDecompile("realtime");
       c->VpiConstType(vpiStringConst);
@@ -4333,7 +4341,7 @@ UHDM::any *CompileHelper::compileBound(
   UHDM::Serializer &s = compileDesign->getSerializer();
   UHDM::any *result = nullptr;
   NodeId Expression = List_of_arguments;
-  if (fC->Type(Expression) == slList_of_arguments) {
+  if (fC->Type(Expression) == VObjectType::slList_of_arguments) {
     Expression = fC->Child(Expression);
   }
   expr *operand =
@@ -4421,7 +4429,7 @@ UHDM::any *CompileHelper::compileClog2(
   UHDM::Serializer &s = compileDesign->getSerializer();
   UHDM::any *result = nullptr;
   NodeId Expression = List_of_arguments;
-  if (fC->Type(Expression) == slList_of_arguments) {
+  if (fC->Type(Expression) == VObjectType::slList_of_arguments) {
     Expression = fC->Child(Expression);
   }
   expr *operand =
@@ -4472,10 +4480,11 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
   NodeId tmp = dotedName;
   NodeId List_of_arguments;
   while (tmp) {
-    if (fC->Type(tmp) == slStringConst || fC->Type(tmp) == slMethod_call_body ||
-        fC->Type(tmp) == slSubroutine_call) {
+    if (fC->Type(tmp) == VObjectType::slStringConst ||
+        fC->Type(tmp) == VObjectType::slMethod_call_body ||
+        fC->Type(tmp) == VObjectType::slSubroutine_call) {
       hierPath = true;
-    } else if (fC->Type(tmp) == slList_of_arguments) {
+    } else if (fC->Type(tmp) == VObjectType::slList_of_arguments) {
       List_of_arguments = tmp;
     }
     tmp = fC->Sibling(tmp);
@@ -4498,13 +4507,13 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
     ref->VpiFullName(fC->SymName(nameId));
     nameId = fC->Sibling(nameId);
     while (nameId) {
-      if (fC->Type(nameId) == slStringConst) {
+      if (fC->Type(nameId) == VObjectType::slStringConst) {
         name += "." + fC->SymName(nameId);
         ref = s.MakeRef_obj();
         elems->push_back(ref);
         ref->VpiName(fC->SymName(nameId));
         ref->VpiFullName(fC->SymName(nameId));
-      } else if (fC->Type(nameId) == slConstant_expression) {
+      } else if (fC->Type(nameId) == VObjectType::slConstant_expression) {
         NodeId Constant_expresion = fC->Child(nameId);
         if (Constant_expresion) {
           name += "[";
@@ -4563,15 +4572,15 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
                                instance, reduce, muteErrors);
     }
     std::string rootName = fC->SymName(Method);
-    if (fC->Type(Handle) == slThis_keyword) {
+    if (fC->Type(Handle) == VObjectType::slThis_keyword) {
       rootName = "this";
-    } else if (fC->Type(Handle) == slSuper_keyword) {
+    } else if (fC->Type(Handle) == VObjectType::slSuper_keyword) {
       rootName = "super";
-    } else if (fC->Type(Handle) == slThis_dot_super) {
+    } else if (fC->Type(Handle) == VObjectType::slThis_dot_super) {
       rootName = "super";
     }
     NodeId List_of_arguments = fC->Sibling(Method);
-    if (fC->Type(List_of_arguments) == slList_of_arguments) {
+    if (fC->Type(List_of_arguments) == VObjectType::slList_of_arguments) {
       method_func_call *fcall = s.MakeMethod_func_call();
       expr *object =
           (expr *)compileExpression(component, fC, Handle, compileDesign, pexpr,
@@ -4585,12 +4594,13 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
           reduce, muteErrors);
       fcall->Tf_call_args(arguments);
       result = fcall;
-    } else if (fC->Type(List_of_arguments) == slConstant_expression ||
-               fC->Type(List_of_arguments) == slSelect ||
-               fC->Type(List_of_arguments) == slConstant_select) {
+    } else if (fC->Type(List_of_arguments) ==
+                   VObjectType::slConstant_expression ||
+               fC->Type(List_of_arguments) == VObjectType::slSelect ||
+               fC->Type(List_of_arguments) == VObjectType::slConstant_select) {
       // TODO: prefix the var_select with "this" class var
       // (this.fields[idx-1].get...)
-      if (fC->Type(List_of_arguments) == slSelect)
+      if (fC->Type(List_of_arguments) == VObjectType::slSelect)
         List_of_arguments = fC->Child(List_of_arguments);
       result = compileSelectExpression(component, fC, Method, rootName,
                                        compileDesign, pexpr, instance, reduce,
@@ -4608,21 +4618,23 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
         while (Method) {
           ref_obj *r = s.MakeRef_obj();
           NodeId nameId = Method;
-          if (fC->Type(nameId) == slPs_or_hierarchical_identifier) {
+          if (fC->Type(nameId) ==
+              VObjectType::slPs_or_hierarchical_identifier) {
             nameId = fC->Child(Method);
           }
           r->VpiName(fC->SymName(nameId));
           fullName += "." + fC->SymName(nameId);
           elems->push_back(r);
           Method = fC->Sibling(Method);
-          if (fC->Type(Method) != slStringConst) {
+          if (fC->Type(Method) != VObjectType::slStringConst) {
             break;
           }
         }
         path->VpiName(fullName);
         result = path;
       }
-    } else if (fC->Type(List_of_arguments) == slConstant_bit_select) {
+    } else if (fC->Type(List_of_arguments) ==
+               VObjectType::slConstant_bit_select) {
       // TODO: Fill this
       method_func_call *fcall = s.MakeMethod_func_call();
       expr *object =
@@ -4637,7 +4649,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
       fC->populateCoreMembers(Method, Method, fcall);
       fcall->Tf_call_args(arguments);
       result = fcall;
-    } else if (fC->Type(List_of_arguments) == slStringConst) {
+    } else if (fC->Type(List_of_arguments) == VObjectType::slStringConst) {
       // TODO: this is a mockup
       constant *cvar = s.MakeConstant();
       cvar->VpiDecompile("this");
@@ -4650,7 +4662,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
     NodeId List_of_arguments = fC->Sibling(Class_scope_name);
     NodeId Bit_Select;
     if (List_of_arguments) {
-      if (fC->Type(List_of_arguments) == slSelect) {
+      if (fC->Type(List_of_arguments) == VObjectType::slSelect) {
         Bit_Select = fC->Child(List_of_arguments);
         if (!fC->Child(Bit_Select)) {
           List_of_arguments = InvalidNodeId;
@@ -4684,7 +4696,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
         Value *val = pack->getValue(functionname);
         if (val && val->isValid()) {
           if (Bit_Select) {
-            if (fC->Type(Bit_Select) == slConstant_select) {
+            if (fC->Type(Bit_Select) == VObjectType::slConstant_select) {
               Bit_Select = fC->Child(Bit_Select);
             }
             any *tmpResult = compileSelectExpression(
@@ -4706,7 +4718,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
       if (pack && pack->getParameters()) {
         for (UHDM::any *param : *pack->getParameters()) {
           if (param->VpiName() == functionname) {
-            if ((fC->Type(List_of_arguments) == slSelect) &&
+            if ((fC->Type(List_of_arguments) == VObjectType::slSelect) &&
                 (fC->Child(List_of_arguments))) {
               result = compileSelectExpression(
                   component, fC, fC->Child(List_of_arguments), "",
@@ -4874,7 +4886,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
               Expression = dotedName;
             }
 
-            if (fC->Type(BitSelect) == slPart_select_range) {
+            if (fC->Type(BitSelect) == VObjectType::slPart_select_range) {
               expr *select = (expr *)compilePartSelectRange(
                   component, fC, Expression, "CREATE_UNNAMED_PARENT",
                   compileDesign, nullptr, instance, reduce, muteErrors);
@@ -4888,7 +4900,8 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
               elems->push_back(select);
               the_name += decompileHelper(select);
             } else if (Expression &&
-                       (fC->Type(Expression) == slPart_select_range) &&
+                       (fC->Type(Expression) ==
+                        VObjectType::slPart_select_range) &&
                        fC->Child(Expression)) {
               expr *select = (expr *)compilePartSelectRange(
                   component, fC, fC->Child(Expression), "CREATE_UNNAMED_PARENT",
@@ -4934,11 +4947,11 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
 
         NodeId lookAhead = fC->Sibling(dotedName);
 
-        if ((fC->Type(dotedName) == slMethod_call_body) ||
-            (fC->Type(lookAhead) == slList_of_arguments)) {
+        if ((fC->Type(dotedName) == VObjectType::slMethod_call_body) ||
+            (fC->Type(lookAhead) == VObjectType::slList_of_arguments)) {
           NodeId method_child = fC->Child(dotedName);
           method_func_call *fcall = nullptr;
-          if (fC->Type(method_child) == slBuilt_in_method_call) {
+          if (fC->Type(method_child) == VObjectType::slBuilt_in_method_call) {
             // vpiName: method name (Array_method_name above)
             NodeId method_name_node = fC->Child(method_child);
             if (method_name_node)
@@ -4950,20 +4963,20 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
             if (method_name_node) {
               method_name = fC->SymName(method_name_node);
               VObjectType calltype = fC->Type(method_name_node);
-              if (calltype == slAnd_call) {
+              if (calltype == VObjectType::slAnd_call) {
                 method_name = "and";
-              } else if (calltype == slOr_call) {
+              } else if (calltype == VObjectType::slOr_call) {
                 method_name = "or";
-              } else if (calltype == slXor_call) {
+              } else if (calltype == VObjectType::slXor_call) {
                 method_name = "xor";
-              } else if (calltype == slUnique_call) {
+              } else if (calltype == VObjectType::slUnique_call) {
                 method_name = "unique";
               }
             }
 
             NodeId randomize_call = fC->Child(method_child);
 
-            if (fC->Type(randomize_call) == slRandomize_call) {
+            if (fC->Type(randomize_call) == VObjectType::slRandomize_call) {
               fcall =
                   compileRandomizeCall(component, fC, fC->Child(randomize_call),
                                        compileDesign, pexpr);
@@ -4975,7 +4988,8 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
               NodeId list_of_arguments =
                   fC->Sibling(fC->Child(fC->Child(method_child)));
               NodeId with_conditions_node;
-              if (fC->Type(list_of_arguments) == slList_of_arguments) {
+              if (fC->Type(list_of_arguments) ==
+                  VObjectType::slList_of_arguments) {
                 VectorOfany *arguments = compileTfCallArguments(
                     component, fC, list_of_arguments, compileDesign, fcall,
                     instance, reduce, muteErrors);
@@ -5106,7 +5120,7 @@ UHDM::any *CompileHelper::compileComplexFuncCall(
       }
       result = ref;
     }
-  } else if (fC->Type(dotedName) == slList_of_arguments) {
+  } else if (fC->Type(dotedName) == VObjectType::slList_of_arguments) {
     result = compileTfCall(component, fC, fC->Parent(name), compileDesign);
   } else if (fC->Type(name) == VObjectType::slStringConst) {
     const std::string &n = fC->SymName(name);

--- a/src/DesignCompile/CompileExpression_test.cpp
+++ b/src/DesignCompile/CompileExpression_test.cpp
@@ -50,7 +50,8 @@ TEST(CompileExpression, ExprFromParseTree1) {
       "parameter p7 = (1'b0) ? 15 : 16;"
       "endmodule");
   NodeId root = fC->getRootNode();
-  std::vector<NodeId> assigns = fC->sl_collect_all(root, slParam_assignment);
+  std::vector<NodeId> assigns =
+      fC->sl_collect_all(root, VObjectType::slParam_assignment);
   EXPECT_EQ(assigns.size(), 7);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
@@ -79,7 +80,8 @@ TEST(CompileExpression, ExprFromParseTree2) {
       "parameter p4 = ~1'b0;"
       "endmodule");
   NodeId root = fC->getRootNode();
-  std::vector<NodeId> assigns = fC->sl_collect_all(root, slParam_assignment);
+  std::vector<NodeId> assigns =
+      fC->sl_collect_all(root, VObjectType::slParam_assignment);
   EXPECT_EQ(assigns.size(), 4);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
@@ -106,7 +108,8 @@ TEST(CompileExpression, ExprFromParseTree3) {
       "parameter p2 = '{1'b1, 2'b10}"
       "endmodule");
   NodeId root = fC->getRootNode();
-  std::vector<NodeId> assigns = fC->sl_collect_all(root, slParam_assignment);
+  std::vector<NodeId> assigns =
+      fC->sl_collect_all(root, VObjectType::slParam_assignment);
   EXPECT_EQ(assigns.size(), 2);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
@@ -146,7 +149,8 @@ TEST(CompileExpression, ExprFromPpTree) {
   // elaboration performed here!
   auto fC = pharness.parse(text);
   NodeId root = fC->getRootNode();
-  std::vector<NodeId> assigns = fC->sl_collect_all(root, slParam_assignment);
+  std::vector<NodeId> assigns =
+      fC->sl_collect_all(root, VObjectType::slParam_assignment);
   EXPECT_EQ(assigns.size(), 2);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);

--- a/src/DesignCompile/CompileFileContent.cpp
+++ b/src/DesignCompile/CompileFileContent.cpp
@@ -97,8 +97,9 @@ bool CompileFileContent::collectObjects_() {
       }
       case VObjectType::slParameter_declaration: {
         NodeId list_of_type_assignments = fC->Child(id);
-        if (fC->Type(list_of_type_assignments) == slList_of_type_assignments ||
-            fC->Type(list_of_type_assignments) == slType) {
+        if (fC->Type(list_of_type_assignments) ==
+                VObjectType::slList_of_type_assignments ||
+            fC->Type(list_of_type_assignments) == VObjectType::slType) {
           // Type param
           m_helper.compileParameterDeclaration(
               m_fileContent, fC, list_of_type_assignments, m_compileDesign,
@@ -117,8 +118,9 @@ bool CompileFileContent::collectObjects_() {
       }
       case VObjectType::slLocal_parameter_declaration: {
         NodeId list_of_type_assignments = fC->Child(id);
-        if (fC->Type(list_of_type_assignments) == slList_of_type_assignments ||
-            fC->Type(list_of_type_assignments) == slType) {
+        if (fC->Type(list_of_type_assignments) ==
+                VObjectType::slList_of_type_assignments ||
+            fC->Type(list_of_type_assignments) == VObjectType::slType) {
           // Type param
           m_helper.compileParameterDeclaration(
               m_fileContent, fC, list_of_type_assignments, m_compileDesign,

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -112,7 +112,7 @@ bool CompileHelper::importPackage(DesignComponent* scope, Design* design,
   const std::string& pack_name = fC->SymName(nameId);
   std::string object_name;
   if (NodeId objId = fC->Sibling(nameId)) {
-    if (fC->Type(objId) == slStringConst) {
+    if (fC->Type(objId) == VObjectType::slStringConst) {
       object_name = fC->SymName(objId);
     }
   }
@@ -541,7 +541,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
   } else if (dtype == VObjectType::slStringConst) {
     NodeId btype = data_type;
     NodeId Select = fC->Sibling(btype);
-    if (fC->Type(Select) == slConstant_bit_select) {
+    if (fC->Type(Select) == VObjectType::slConstant_bit_select) {
       NodeId subType = fC->Sibling(Select);
       NodeId nameId = fC->Sibling(subType);
       if (nameId) {
@@ -600,7 +600,8 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
   bool enumType = false;
   bool structType = false;
   NodeId Packed_dimension = fC->Sibling(enum_base_type);
-  if (Packed_dimension && (fC->Type(Packed_dimension) == slPacked_dimension)) {
+  if (Packed_dimension &&
+      (fC->Type(Packed_dimension) == VObjectType::slPacked_dimension)) {
     packed_array_tps = s.MakePacked_array_typespec();
     int size;
     VectorOfrange* ranges =
@@ -783,7 +784,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
   } else {
     bool forwardDeclaration = false;
     NodeId stype = fC->Child(data_type);
-    if (!stype && (fC->Type(data_type) == slStringConst)) {
+    if (!stype && (fC->Type(data_type) == VObjectType::slStringConst)) {
       stype = data_type;
       if (!fC->Sibling(stype)) {
         name = fC->SymName(stype);
@@ -1393,13 +1394,13 @@ void setDirectionAndType(DesignComponent* component, const FileContent* fC,
                          UHDM::VectorOfattribute* attributes) {
   ModuleDefinition* module =
       valuedcomponenti_cast<ModuleDefinition*>(component);
-  VObjectType dir_type = slNoType;
+  VObjectType dir_type = VObjectType::slNoType;
   if (type == VObjectType::slInput_declaration)
-    dir_type = slPortDir_Inp;
+    dir_type = VObjectType::slPortDir_Inp;
   else if (type == VObjectType::slOutput_declaration)
-    dir_type = slPortDir_Out;
+    dir_type = VObjectType::slPortDir_Out;
   else if (type == VObjectType::slInout_declaration)
-    dir_type = slPortDir_Inout;
+    dir_type = VObjectType::slPortDir_Inout;
 
   if (module) {
     while (signal) {
@@ -1409,10 +1410,12 @@ void setDirectionAndType(DesignComponent* component, const FileContent* fC,
           found = true;
           port->setStatic();
           NodeId unpacked_dimension = fC->Sibling(signal);
-          if (fC->Type(unpacked_dimension) == slUnpacked_dimension) {
+          if (fC->Type(unpacked_dimension) ==
+              VObjectType::slUnpacked_dimension) {
             port->setUnpackedDimension(unpacked_dimension);
           }
-          if (fC->Type(unpacked_dimension) == slConstant_expression) {
+          if (fC->Type(unpacked_dimension) ==
+              VObjectType::slConstant_expression) {
             port->setDefaultValue(unpacked_dimension);
           }
           if (attributes) port->attributes(attributes);
@@ -1448,7 +1451,7 @@ void setDirectionAndType(DesignComponent* component, const FileContent* fC,
         signal = fC->Sibling(signal);
       }
 
-      if (fC->Type(signal) == slUnpacked_dimension) {
+      if (fC->Type(signal) == VObjectType::slUnpacked_dimension) {
         break;
       }
     }
@@ -1500,8 +1503,9 @@ bool CompileHelper::compilePortDeclaration(DesignComponent* component,
           NodeId if_name = fC->Sibling(if_type);
           if (if_name) {
             NodeId if_name_s = fC->Child(if_name);
-            Signal* signal = new Signal(fC, if_name_s, if_type_name_s, slNoType,
-                                        InvalidNodeId, false);
+            Signal* signal =
+                new Signal(fC, if_name_s, if_type_name_s, VObjectType::slNoType,
+                           InvalidNodeId, false);
             signal->setStatic();
             component->getPorts().push_back(signal);
           } else {
@@ -1537,9 +1541,9 @@ bool CompileHelper::compilePortDeclaration(DesignComponent* component,
       NodeId subNode = fC->Child(id);
       VObjectType subType = fC->Type(subNode);
       UHDM::VectorOfattribute* attributes = nullptr;
-      if (subType == slAttribute_instance) {
+      if (subType == VObjectType::slAttribute_instance) {
         attributes = compileAttributes(component, fC, subNode, compileDesign);
-        while (fC->Type(subNode) == slAttribute_instance) {
+        while (fC->Type(subNode) == VObjectType::slAttribute_instance) {
           subNode = fC->Sibling(subNode);
           subType = fC->Type(subNode);
         }
@@ -1570,8 +1574,9 @@ bool CompileHelper::compilePortDeclaration(DesignComponent* component,
               interface_identifier = fC->Sibling(interface_identifier);
               unpackedDimension = Unpacked_dimension;
             }
-            Signal* signal = new Signal(fC, identifier, interfIdName, slNoType,
-                                        unpackedDimension, false);
+            Signal* signal =
+                new Signal(fC, identifier, interfIdName, VObjectType::slNoType,
+                           unpackedDimension, false);
             signal->setStatic();
             component->getSignals().push_back(signal);
             interface_identifier = fC->Sibling(interface_identifier);
@@ -1674,7 +1679,7 @@ bool CompileHelper::compileAnsiPortDeclaration(DesignComponent* component,
 
     NodeId packedDimension = fC->Sibling(NetType);
     if (fC->Type(packedDimension) ==
-        slStringConst) {  // net type is class_scope
+        VObjectType::slStringConst) {  // net type is class_scope
       packedDimension = fC->Sibling(packedDimension);
     }
     NodeId specParamId;
@@ -1705,10 +1710,10 @@ bool CompileHelper::compileAnsiPortDeclaration(DesignComponent* component,
     NodeId unpackedDimension;
     NodeId defaultValue;
     NodeId tmp = fC->Sibling(identifier);
-    if (fC->Type(tmp) == slUnpacked_dimension) {
+    if (fC->Type(tmp) == VObjectType::slUnpacked_dimension) {
       unpackedDimension = tmp;
     }
-    if (fC->Type(tmp) == slConstant_expression) {
+    if (fC->Type(tmp) == VObjectType::slConstant_expression) {
       defaultValue = tmp;
       if (dir_type == VObjectType::slPortDir_Ref) {
         Location loc(fC->getFileId(tmp), fC->Line(tmp), fC->Column(tmp),
@@ -1747,7 +1752,7 @@ bool CompileHelper::compileAnsiPortDeclaration(DesignComponent* component,
     n<sif2> u<14> t<StringConst> p<15> l<11>
     n<> u<15> t<Ansi_port_declaration> p<16> c<13> l<11>
     */
-    Signal* s = new Signal(fC, port_name, interface_name, slNoType,
+    Signal* s = new Signal(fC, port_name, interface_name, VObjectType::slNoType,
                            unpacked_dimension, false);
     s->setStatic();
     s->setTypespecId(interface_name);
@@ -1758,7 +1763,7 @@ bool CompileHelper::compileAnsiPortDeclaration(DesignComponent* component,
     if (data_type) {
       NodeId if_type_name_s = fC->Child(data_type);
       NodeId unpackedDimension = fC->Sibling(identifier);
-      if (fC->Type(unpackedDimension) != slUnpacked_dimension)
+      if (fC->Type(unpackedDimension) != VObjectType::slUnpacked_dimension)
         unpackedDimension = InvalidNodeId;
       if (fC->Type(if_type_name_s) == VObjectType::slIntVec_TypeReg ||
           fC->Type(if_type_name_s) == VObjectType::slIntVec_TypeLogic) {
@@ -1805,19 +1810,19 @@ bool CompileHelper::compileAnsiPortDeclaration(DesignComponent* component,
         signal->setStatic();
         component->getSignals().push_back(signal);
       } else {
-        if (fC->Type(net_port_header) == slInterface_port_header) {
-          dataType = slInterface_port_header;
+        if (fC->Type(net_port_header) == VObjectType::slInterface_port_header) {
+          dataType = VObjectType::slInterface_port_header;
         }
         Signal* signal = new Signal(fC, identifier, dataType, port_direction,
                                     packed, is_signed);
-        if (fC->Type(net_port_header) == slInterface_port_header) {
+        if (fC->Type(net_port_header) == VObjectType::slInterface_port_header) {
           signal->setTypespecId(identifier);
         }
         signal->setStatic();
         component->getPorts().push_back(signal);
         signal = new Signal(fC, identifier, dataType, port_direction, packed,
                             is_signed);
-        if (fC->Type(net_port_header) == slInterface_port_header) {
+        if (fC->Type(net_port_header) == VObjectType::slInterface_port_header) {
           signal->setTypespecId(identifier);
         }
         signal->setStatic();
@@ -1863,7 +1868,7 @@ bool CompileHelper::compileNetDeclaration(DesignComponent* component,
   } else {
     nettype = fC->Type(NetType);
     NodeId net = fC->Sibling(NetTypeOrTrireg_Net);
-    if (fC->Type(net) == slPacked_dimension) {
+    if (fC->Type(net) == VObjectType::slPacked_dimension) {
       List_of_net_decl_assignments = fC->Sibling(net);
     } else {
       List_of_net_decl_assignments = net;
@@ -1871,8 +1876,8 @@ bool CompileHelper::compileNetDeclaration(DesignComponent* component,
   }
 
   NodeId delay;
-  if (fC->Type(List_of_net_decl_assignments) == slDelay3 ||
-      fC->Type(List_of_net_decl_assignments) == slDelay_control) {
+  if (fC->Type(List_of_net_decl_assignments) == VObjectType::slDelay3 ||
+      fC->Type(List_of_net_decl_assignments) == VObjectType::slDelay_control) {
     delay = List_of_net_decl_assignments;
     List_of_net_decl_assignments = fC->Sibling(List_of_net_decl_assignments);
   }
@@ -1889,19 +1894,20 @@ bool CompileHelper::compileNetDeclaration(DesignComponent* component,
     }
     NodeId Unpacked_dimension;
     NodeId tmp = fC->Sibling(signal);
-    if (fC->Type(tmp) == slUnpacked_dimension) {
+    if (fC->Type(tmp) == VObjectType::slUnpacked_dimension) {
       Unpacked_dimension = tmp;
     }
 
-    if (fC->Type(Packed_dimension) == slData_type) {
+    if (fC->Type(Packed_dimension) == VObjectType::slData_type) {
       NetType = fC->Child(Packed_dimension);
-      if (fC->Type(NetType) != slIntVec_TypeLogic) {  //"wire logic" is "wire"
+      if (fC->Type(NetType) !=
+          VObjectType::slIntVec_TypeLogic) {  //"wire logic" is "wire"
         subnettype = nettype;
         nettype = fC->Type(NetType);
       }
     }
 
-    if (nettype == slStringConst) {
+    if (nettype == VObjectType::slStringConst) {
       Signal* sig = new Signal(fC, signal, InvalidNodeId, subnettype,
                                Unpacked_dimension, false);
       if (portRef) portRef->setLowConn(sig);
@@ -1910,8 +1916,9 @@ bool CompileHelper::compileNetDeclaration(DesignComponent* component,
       sig->setTypespecId(NetType);
       component->getSignals().push_back(sig);
     } else {
-      Signal* sig = new Signal(fC, signal, nettype, Packed_dimension, slNoType,
-                               NetType, Unpacked_dimension, false);
+      Signal* sig =
+          new Signal(fC, signal, nettype, Packed_dimension,
+                     VObjectType::slNoType, NetType, Unpacked_dimension, false);
       if (portRef) portRef->setLowConn(sig);
       sig->setDelay(delay);
       sig->setStatic();
@@ -2052,17 +2059,18 @@ bool CompileHelper::compileDataDeclaration(
       NodeId data_type = fC->Child(variable_declaration);
       NodeId intVec_TypeReg = fC->Child(data_type);
       NodeId packedDimension = fC->Sibling(intVec_TypeReg);
-      if (fC->Type(packedDimension) == slStringConst) {
+      if (fC->Type(packedDimension) == VObjectType::slStringConst) {
         // class or package name;
-        if (fC->Type(fC->Sibling(packedDimension)) == slPacked_dimension) {
+        if (fC->Type(fC->Sibling(packedDimension)) ==
+            VObjectType::slPacked_dimension) {
           packedDimension = fC->Sibling(packedDimension);
         } else {
           packedDimension = InvalidNodeId;
         }
-      } else if (fC->Type(packedDimension) == slSigning_Signed) {
+      } else if (fC->Type(packedDimension) == VObjectType::slSigning_Signed) {
         is_signed = true;
         packedDimension = fC->Sibling(packedDimension);
-      } else if (fC->Type(packedDimension) == slSigning_Unsigned) {
+      } else if (fC->Type(packedDimension) == VObjectType::slSigning_Unsigned) {
         packedDimension = fC->Sibling(packedDimension);
       }
       NodeId unpackedDimension;
@@ -2149,19 +2157,20 @@ n<> u<17> t<Continuous_assign> p<18> c<16> l<4>
   while (Net_assignment) {
     NodeId Net_lvalue = fC->Child(Net_assignment);
     NodeId Expression = fC->Sibling(Net_lvalue);
-    if (Expression && (fC->Type(Expression) != slUnpacked_dimension)) {
+    if (Expression &&
+        (fC->Type(Expression) != VObjectType::slUnpacked_dimension)) {
       // LHS
       NodeId Ps_or_hierarchical_identifier = fC->Child(Net_lvalue);
       NodeId Hierarchical_identifier = Ps_or_hierarchical_identifier;
       if (fC->Type(fC->Child(Ps_or_hierarchical_identifier)) ==
-          slHierarchical_identifier) {
+          VObjectType::slHierarchical_identifier) {
         Hierarchical_identifier = fC->Child(fC->Child(Hierarchical_identifier));
       }
       UHDM::any* lhs_exp =
           compileExpression(component, fC, Hierarchical_identifier,
                             compileDesign, nullptr, instance);
       NodeId Constant_select = fC->Sibling(Ps_or_hierarchical_identifier);
-      if ((fC->Type(Constant_select) == slConstant_select) &&
+      if ((fC->Type(Constant_select) == VObjectType::slConstant_select) &&
           (Ps_or_hierarchical_identifier != Hierarchical_identifier)) {
         UHDM::any* sel = compileSelectExpression(
             component, fC, fC->Child(Constant_select), "", compileDesign,
@@ -2182,8 +2191,9 @@ n<> u<17> t<Continuous_assign> p<18> c<16> l<4>
       UHDM::cont_assign* cassign = s.MakeCont_assign();
       if (Strength0) {
         VObjectType st0 = fC->Type(Strength0);
-        if (st0 == slSupply0 || st0 == slStrong0 || st0 == slPull0 ||
-            st0 == slWeak0 || st0 == slHighZ0) {
+        if (st0 == VObjectType::slSupply0 || st0 == VObjectType::slStrong0 ||
+            st0 == VObjectType::slPull0 || st0 == VObjectType::slWeak0 ||
+            st0 == VObjectType::slHighZ0) {
           cassign->VpiStrength0(
               UhdmWriter::getStrengthType(fC->Type(Strength0)));
         } else {
@@ -2193,8 +2203,9 @@ n<> u<17> t<Continuous_assign> p<18> c<16> l<4>
       }
       if (Strength1) {
         VObjectType st1 = fC->Type(Strength1);
-        if (st1 == slSupply0 || st1 == slStrong0 || st1 == slPull0 ||
-            st1 == slWeak0 || st1 == slHighZ0) {
+        if (st1 == VObjectType::slSupply0 || st1 == VObjectType::slStrong0 ||
+            st1 == VObjectType::slPull0 || st1 == VObjectType::slWeak0 ||
+            st1 == VObjectType::slHighZ0) {
           cassign->VpiStrength0(
               UhdmWriter::getStrengthType(fC->Type(Strength1)));
         } else {
@@ -2279,9 +2290,9 @@ void CompileHelper::compileInstantiation(ModuleDefinition* mod,
   if (def == nullptr) return;
 
   NodeId typespecId = fC->Child(id);
-  NodeId hierInstId = fC->sl_collect(id, slHierarchical_instance);
+  NodeId hierInstId = fC->sl_collect(id, VObjectType::slHierarchical_instance);
   while (hierInstId) {
-    NodeId instId = fC->sl_collect(hierInstId, slName_of_instance);
+    NodeId instId = fC->sl_collect(hierInstId, VObjectType::slName_of_instance);
     NodeId identifierId;
     std::string instName;
     if (instId) {
@@ -2485,7 +2496,7 @@ bool CompileHelper::compileAlwaysBlock(DesignComponent* component,
   NodeId Statement = fC->Sibling(always_keyword);
   NodeId Statement_item = fC->Child(Statement);
   VectorOfany* stmts = nullptr;
-  if (fC->Type(Statement_item) == slStringConst) {
+  if (fC->Type(Statement_item) == VObjectType::slStringConst) {
     stmts = compileStmt(component, fC, Statement_item, compileDesign, always,
                         instance);
   } else {
@@ -2590,7 +2601,7 @@ bool CompileHelper::compileParameterDeclaration(
     component->setParam_assigns(s.MakeParam_assignVec());
     param_assigns = component->getParam_assigns();
   }
-  if (fC->Type(nodeId) == slList_of_type_assignments) {
+  if (fC->Type(nodeId) == VObjectType::slList_of_type_assignments) {
     // Type param
     NodeId typeNameId = fC->Child(nodeId);
     while (typeNameId) {
@@ -2622,7 +2633,7 @@ bool CompileHelper::compileParameterDeclaration(
       if (skip) typeNameId = fC->Sibling(typeNameId);
     }
 
-  } else if (fC->Type(nodeId) == slType) {
+  } else if (fC->Type(nodeId) == VObjectType::slType) {
     // Type param
     NodeId list_of_param_assignments = fC->Sibling(nodeId);
     NodeId Param_assignment = fC->Child(list_of_param_assignments);
@@ -2652,7 +2663,7 @@ bool CompileHelper::compileParameterDeclaration(
     // Regular param
     NodeId Data_type_or_implicit;
     NodeId List_of_param_assignments;
-    if (fC->Type(nodeId) == slList_of_param_assignments) {
+    if (fC->Type(nodeId) == VObjectType::slList_of_param_assignments) {
       List_of_param_assignments = nodeId;
     } else {
       Data_type_or_implicit = fC->Child(nodeId);
@@ -2673,14 +2684,16 @@ bool CompileHelper::compileParameterDeclaration(
         Data_type = fC->Child(Data_type);
         NodeId Signage = fC->Sibling(Data_type);
         VObjectType type = fC->Type(Data_type);
-        if (type == slIntegerAtomType_Byte || type == slIntegerAtomType_Int ||
-            type == slIntegerAtomType_Integer ||
-            type == slIntegerAtomType_LongInt ||
-            type == slIntegerAtomType_Shortint) {
+        if (type == VObjectType::slIntegerAtomType_Byte ||
+            type == VObjectType::slIntegerAtomType_Int ||
+            type == VObjectType::slIntegerAtomType_Integer ||
+            type == VObjectType::slIntegerAtomType_LongInt ||
+            type == VObjectType::slIntegerAtomType_Shortint) {
           isSigned = true;
         }
-        if (fC->Type(Signage) == slSigning_Signed) isSigned = true;
-        if (fC->Type(Signage) == slSigning_Unsigned) isSigned = false;
+        if (fC->Type(Signage) == VObjectType::slSigning_Signed) isSigned = true;
+        if (fC->Type(Signage) == VObjectType::slSigning_Unsigned)
+          isSigned = false;
       }
 
       bool isMultiDimension = isMultidimensional(ts, component);
@@ -3016,7 +3029,7 @@ UHDM::any* CompileHelper::compileTfCall(DesignComponent* component,
   NodeId tfNameNode;
   UHDM::tf_call* call = nullptr;
   std::string name;
-  if (leaf_type == slDollar_keyword) {
+  if (leaf_type == VObjectType::slDollar_keyword) {
     // System call, AST is:
     // n<> u<28> t<Subroutine_call> p<29> c<17> l<3>
     //     n<> u<17> t<Dollar_keyword> p<28> s<18> l<3>
@@ -3030,17 +3043,17 @@ UHDM::any* CompileHelper::compileTfCall(DesignComponent* component,
     return compileComplexFuncCall(component, fC, fC->Child(Tf_call_stmt),
                                   compileDesign, nullptr, nullptr, false,
                                   false);
-  } else if (leaf_type == slDollar_root_keyword) {
+  } else if (leaf_type == VObjectType::slDollar_root_keyword) {
     NodeId Dollar_root_keyword = dollar_or_string;
     NodeId nameId = fC->Sibling(Dollar_root_keyword);
     name = "$root." + fC->SymName(nameId);
     nameId = fC->Sibling(nameId);
     tfNameNode = nameId;
     while (nameId) {
-      if (fC->Type(nameId) == slStringConst) {
+      if (fC->Type(nameId) == VObjectType::slStringConst) {
         name += "." + fC->SymName(nameId);
         tfNameNode = nameId;
-      } else if (fC->Type(nameId) == slConstant_bit_select) {
+      } else if (fC->Type(nameId) == VObjectType::slConstant_bit_select) {
         NodeId Constant_expresion = fC->Child(nameId);
         if (Constant_expresion) {
           name += "[";
@@ -3058,25 +3071,25 @@ UHDM::any* CompileHelper::compileTfCall(DesignComponent* component,
     func_call* fcall = s.MakeFunc_call();
     fcall->VpiName(name);
     call = fcall;
-  } else if (leaf_type == slSystem_task_names) {
+  } else if (leaf_type == VObjectType::slSystem_task_names) {
     tfNameNode = dollar_or_string;
     call = s.MakeSys_func_call();
     name = fC->SymName(fC->Child(dollar_or_string));
-  } else if (leaf_type == slImplicit_class_handle) {
+  } else if (leaf_type == VObjectType::slImplicit_class_handle) {
     NodeId handle = fC->Child(dollar_or_string);
-    if (fC->Type(handle) == slSuper_keyword ||
-        fC->Type(handle) == slThis_keyword ||
-        fC->Type(handle) == slThis_dot_super) {
+    if (fC->Type(handle) == VObjectType::slSuper_keyword ||
+        fC->Type(handle) == VObjectType::slThis_keyword ||
+        fC->Type(handle) == VObjectType::slThis_dot_super) {
       return (tf_call*)compileComplexFuncCall(
           component, fC, fC->Child(Tf_call_stmt), compileDesign, nullptr,
           nullptr, false, false);
-    } else if (fC->Type(handle) == slDollar_root_keyword) {
+    } else if (fC->Type(handle) == VObjectType::slDollar_root_keyword) {
       name = "$root.";
       tfNameNode = fC->Sibling(dollar_or_string);
       call = s.MakeSys_func_call();
       name += fC->SymName(tfNameNode);
     }
-  } else if (leaf_type == slClass_scope) {
+  } else if (leaf_type == VObjectType::slClass_scope) {
     return (tf_call*)compileComplexFuncCall(
         component, fC, fC->Child(Tf_call_stmt), compileDesign, nullptr, nullptr,
         false, false);
@@ -3089,7 +3102,7 @@ UHDM::any* CompileHelper::compileTfCall(DesignComponent* component,
     tfNameNode = dollar_or_string;
     name = fC->SymName(tfNameNode);
     NodeId Constant_bit_select = fC->Sibling(tfNameNode);
-    if (fC->Type(Constant_bit_select) == slConstant_bit_select) {
+    if (fC->Type(Constant_bit_select) == VObjectType::slConstant_bit_select) {
       tfNameNode = fC->Sibling(Constant_bit_select);
       method_func_call* fcall = s.MakeMethod_func_call();
       const std::string& mname = fC->SymName(tfNameNode);
@@ -3183,7 +3196,7 @@ UHDM::any* CompileHelper::compileTfCall(DesignComponent* component,
     fC->populateCoreMembers(Tf_call_stmt, Tf_call_stmt, call);
   }
   NodeId argListNode = fC->Sibling(tfNameNode);
-  if (fC->Type(argListNode) == slAttribute_instance) {
+  if (fC->Type(argListNode) == VObjectType::slAttribute_instance) {
     /* UHDM::VectorOfattribute* attributes = */ compileAttributes(
         component, fC, argListNode, compileDesign);
   } else {
@@ -3219,13 +3232,13 @@ VectorOfany* CompileHelper::compileTfCallArguments(
   std::vector<any*> argOrder;
   while (argumentNode) {
     NodeId argument = argumentNode;
-    if (fC->Type(argument) == slArgument) {
+    if (fC->Type(argument) == VObjectType::slArgument) {
       argument = fC->Child(argument);
     }
     NodeId sibling = fC->Sibling(argument);
     NodeId Expression;
-    if ((fC->Type(argument) == slStringConst) &&
-        (fC->Type(sibling) == slExpression)) {
+    if ((fC->Type(argument) == VObjectType::slStringConst) &&
+        (fC->Type(sibling) == VObjectType::slExpression)) {
       // arg by name
       Expression = sibling;
       UHDM::any* exp =
@@ -3237,9 +3250,9 @@ VectorOfany* CompileHelper::compileTfCallArguments(
         argOrder.push_back(exp);
       }
       argumentNode = fC->Sibling(argumentNode);
-    } else if (((fC->Type(argument) == slUnary_Tilda) ||
-                (fC->Type(argument) == slUnary_Not)) &&
-               (fC->Type(sibling) == slExpression)) {
+    } else if (((fC->Type(argument) == VObjectType::slUnary_Tilda) ||
+                (fC->Type(argument) == VObjectType::slUnary_Not)) &&
+               (fC->Type(sibling) == VObjectType::slExpression)) {
       // arg by position
       Expression = argument;
       UHDM::any* exp =
@@ -3274,7 +3287,7 @@ VectorOfany* CompileHelper::compileTfCallArguments(
     argumentNode = fC->Sibling(argumentNode);
   }
   if (NodeId clocking = fC->Sibling(Arg_list_node)) {
-    if (fC->Type(clocking) == slClocking_event) {
+    if (fC->Type(clocking) == VObjectType::slClocking_event) {
       UHDM::any* exp = compileExpression(component, fC, clocking, compileDesign,
                                          call, instance, reduce, muteErrors);
       if (exp) {
@@ -3316,9 +3329,9 @@ UHDM::assignment* CompileHelper::compileBlockingAssignment(
     UHDM::any* pstmt, ValuedComponentI* instance) {
   UHDM::Serializer& s = compileDesign->getSerializer();
   NodeId Variable_lvalue;
-  if (fC->Type(Operator_assignment) == slVariable_lvalue) {
+  if (fC->Type(Operator_assignment) == VObjectType::slVariable_lvalue) {
     Variable_lvalue = Operator_assignment;
-  } else if (fC->Type(Operator_assignment) == slStringConst) {
+  } else if (fC->Type(Operator_assignment) == VObjectType::slStringConst) {
     Variable_lvalue = Operator_assignment;
   } else {
     Variable_lvalue = fC->Child(Operator_assignment);
@@ -3327,15 +3340,15 @@ UHDM::assignment* CompileHelper::compileBlockingAssignment(
   UHDM::any* rhs_rf = nullptr;
   NodeId Delay_or_event_control;
   NodeId AssignOp_Assign;
-  if (fC->Type(Variable_lvalue) == slHierarchical_identifier ||
-      fC->Type(Variable_lvalue) == slStringConst) {
+  if (fC->Type(Variable_lvalue) == VObjectType::slHierarchical_identifier ||
+      fC->Type(Variable_lvalue) == VObjectType::slStringConst) {
     NodeId Variable_lvalue = Operator_assignment;
     Delay_or_event_control = fC->Sibling(Variable_lvalue);
     NodeId Expression = fC->Sibling(Delay_or_event_control);
     lhs_rf = any_cast<expr*>(compileExpression(component, fC, Variable_lvalue,
                                                compileDesign, pstmt, instance));
     AssignOp_Assign = InvalidNodeId;
-    if (fC->Type(Delay_or_event_control) == slDynamic_array_new) {
+    if (fC->Type(Delay_or_event_control) == VObjectType::slDynamic_array_new) {
       method_func_call* fcall = s.MakeMethod_func_call();
       fC->populateCoreMembers(Delay_or_event_control, Delay_or_event_control,
                               fcall);
@@ -3353,15 +3366,15 @@ UHDM::assignment* CompileHelper::compileBlockingAssignment(
       rhs_rf = compileExpression(component, fC, Expression, compileDesign,
                                  pstmt, instance);
     }
-  } else if (fC->Type(Variable_lvalue) == slVariable_lvalue) {
+  } else if (fC->Type(Variable_lvalue) == VObjectType::slVariable_lvalue) {
     AssignOp_Assign = fC->Sibling(Variable_lvalue);
     NodeId Hierarchical_identifier = fC->Child(Variable_lvalue);
     if (fC->Type(fC->Child(Hierarchical_identifier)) ==
-        slHierarchical_identifier) {
+        VObjectType::slHierarchical_identifier) {
       Hierarchical_identifier = fC->Child(Hierarchical_identifier);
       Hierarchical_identifier = fC->Child(Hierarchical_identifier);
     } else if (fC->Type(Hierarchical_identifier) !=
-               slPs_or_hierarchical_identifier) {
+               VObjectType::slPs_or_hierarchical_identifier) {
       Hierarchical_identifier = Variable_lvalue;
     }
 
@@ -3382,7 +3395,8 @@ UHDM::assignment* CompileHelper::compileBlockingAssignment(
     }
     rhs_rf = compileExpression(component, fC, Expression, compileDesign, pstmt,
                                instance, false);
-  } else if (fC->Type(Operator_assignment) == slHierarchical_identifier) {
+  } else if (fC->Type(Operator_assignment) ==
+             VObjectType::slHierarchical_identifier) {
     //  = new ...
     NodeId Hierarchical_identifier = Operator_assignment;
     NodeId Select = fC->Sibling(Hierarchical_identifier);
@@ -3408,7 +3422,7 @@ UHDM::assignment* CompileHelper::compileBlockingAssignment(
   assignment* assign = s.MakeAssignment();
   UHDM::delay_control* delay_control = nullptr;
   if (Delay_or_event_control &&
-      (fC->Type(Delay_or_event_control) != slSelect)) {
+      (fC->Type(Delay_or_event_control) != VObjectType::slSelect)) {
     delay_control = s.MakeDelay_control();
     assign->Delay_control(delay_control);
     delay_control->VpiParent(assign);
@@ -3461,9 +3475,9 @@ std::vector<UHDM::attribute*>* CompileHelper::compileAttributes(
     CompileDesign* compileDesign) {
   UHDM::Serializer& s = compileDesign->getSerializer();
   std::vector<UHDM::attribute*>* results = nullptr;
-  if (fC->Type(nodeId) == slAttribute_instance) {
+  if (fC->Type(nodeId) == VObjectType::slAttribute_instance) {
     results = s.MakeAttributeVec();
-    while (fC->Type(nodeId) == slAttribute_instance) {
+    while (fC->Type(nodeId) == VObjectType::slAttribute_instance) {
       UHDM::attribute* attribute = s.MakeAttribute();
       NodeId Attr_spec = fC->Child(nodeId);
       NodeId Attr_name = fC->Child(Attr_spec);
@@ -3493,13 +3507,13 @@ UHDM::clocking_block* CompileHelper::compileClockingBlock(
   NodeId clocking_block_type = fC->Child(nodeId);
   NodeId clocking_block_name;
   std::string name;
-  if (fC->Type(clocking_block_type) == slDefault) {
-  } else if (fC->Type(clocking_block_type) == slGlobal) {
-  } else if (fC->Type(clocking_block_type) == slStringConst) {
+  if (fC->Type(clocking_block_type) == VObjectType::slDefault) {
+  } else if (fC->Type(clocking_block_type) == VObjectType::slGlobal) {
+  } else if (fC->Type(clocking_block_type) == VObjectType::slStringConst) {
     clocking_block_name = clocking_block_type;
   }
   NodeId clocking_event = fC->Sibling(clocking_block_type);
-  if (fC->Type(clocking_event) == slStringConst) {
+  if (fC->Type(clocking_event) == VObjectType::slStringConst) {
     clocking_block_name = clocking_event;
     clocking_event = fC->Sibling(clocking_block_name);
   }
@@ -3514,25 +3528,25 @@ UHDM::clocking_block* CompileHelper::compileClockingBlock(
   cblock->Clocking_event(ctrl);
   NodeId clocking_item = fC->Sibling(clocking_event);
   while (clocking_item) {
-    if (fC->Type(clocking_item) == slClocking_item) {
+    if (fC->Type(clocking_item) == VObjectType::slClocking_item) {
       NodeId item = fC->Child(clocking_item);
       VObjectType direction = fC->Type(item);
       UHDM::delay_control* dcInp = nullptr;
       UHDM::delay_control* dcOut = nullptr;
       int inputEdge = 0;
       int outputEdge = 0;
-      if (direction == slDefaultSkew_IntputOutput) {
+      if (direction == VObjectType::slDefaultSkew_IntputOutput) {
         NodeId Clocking_skew = fC->Child(item);
         if (Clocking_skew) {
           NodeId Edge = fC->Child(Clocking_skew);
           NodeId Skew = Clocking_skew;
-          if (fC->Type(Edge) == slEdge_Negedge) {
+          if (fC->Type(Edge) == VObjectType::slEdge_Negedge) {
             cblock->VpiInputEdge(vpiNegedge);
             Skew = fC->Sibling(Edge);
-          } else if (fC->Type(Edge) == slEdge_Posedge) {
+          } else if (fC->Type(Edge) == VObjectType::slEdge_Posedge) {
             cblock->VpiInputEdge(vpiPosedge);
             Skew = fC->Sibling(Edge);
-          } else if (fC->Type(Edge) == slEdge_Edge) {
+          } else if (fC->Type(Edge) == VObjectType::slEdge_Edge) {
             cblock->VpiInputEdge(vpiAnyEdge);
             Skew = fC->Sibling(Edge);
           }
@@ -3545,13 +3559,13 @@ UHDM::clocking_block* CompileHelper::compileClockingBlock(
           if (Clocking_skew) {
             NodeId Edge = fC->Child(Clocking_skew);
             NodeId Skew = Clocking_skew;
-            if (fC->Type(Edge) == slEdge_Negedge) {
+            if (fC->Type(Edge) == VObjectType::slEdge_Negedge) {
               cblock->VpiOutputEdge(vpiNegedge);
               Skew = fC->Sibling(Edge);
-            } else if (fC->Type(Edge) == slEdge_Posedge) {
+            } else if (fC->Type(Edge) == VObjectType::slEdge_Posedge) {
               cblock->VpiOutputEdge(vpiPosedge);
               Skew = fC->Sibling(Edge);
-            } else if (fC->Type(Edge) == slEdge_Edge) {
+            } else if (fC->Type(Edge) == VObjectType::slEdge_Edge) {
               cblock->VpiOutputEdge(vpiAnyEdge);
               Skew = fC->Sibling(Edge);
             }
@@ -3564,18 +3578,18 @@ UHDM::clocking_block* CompileHelper::compileClockingBlock(
           }
         }
       }
-      if (direction == slDefaultSkew_Intput) {
+      if (direction == VObjectType::slDefaultSkew_Intput) {
         NodeId Clocking_skew = fC->Child(item);
         if (Clocking_skew) {
           NodeId Edge = fC->Child(Clocking_skew);
           NodeId Skew = Clocking_skew;
-          if (fC->Type(Edge) == slEdge_Negedge) {
+          if (fC->Type(Edge) == VObjectType::slEdge_Negedge) {
             cblock->VpiInputEdge(vpiNegedge);
             Skew = fC->Sibling(Edge);
-          } else if (fC->Type(Edge) == slEdge_Posedge) {
+          } else if (fC->Type(Edge) == VObjectType::slEdge_Posedge) {
             cblock->VpiInputEdge(vpiPosedge);
             Skew = fC->Sibling(Edge);
-          } else if (fC->Type(Edge) == slEdge_Edge) {
+          } else if (fC->Type(Edge) == VObjectType::slEdge_Edge) {
             cblock->VpiInputEdge(vpiAnyEdge);
             Skew = fC->Sibling(Edge);
           }
@@ -3586,18 +3600,18 @@ UHDM::clocking_block* CompileHelper::compileClockingBlock(
           }
         }
       }
-      if (direction == slDefaultSkew_Output) {
+      if (direction == VObjectType::slDefaultSkew_Output) {
         NodeId Clocking_skew = fC->Child(item);
         if (Clocking_skew) {
           NodeId Edge = fC->Child(Clocking_skew);
           NodeId Skew = Clocking_skew;
-          if (fC->Type(Edge) == slEdge_Negedge) {
+          if (fC->Type(Edge) == VObjectType::slEdge_Negedge) {
             cblock->VpiOutputEdge(vpiNegedge);
             Skew = fC->Sibling(Edge);
-          } else if (fC->Type(Edge) == slEdge_Posedge) {
+          } else if (fC->Type(Edge) == VObjectType::slEdge_Posedge) {
             cblock->VpiOutputEdge(vpiPosedge);
             Skew = fC->Sibling(Edge);
-          } else if (fC->Type(Edge) == slEdge_Edge) {
+          } else if (fC->Type(Edge) == VObjectType::slEdge_Edge) {
             cblock->VpiOutputEdge(vpiAnyEdge);
             Skew = fC->Sibling(Edge);
           }
@@ -3607,18 +3621,18 @@ UHDM::clocking_block* CompileHelper::compileClockingBlock(
             cblock->Output_skew(dc);
           }
         }
-      } else if (direction == slClockingDir_Input) {
+      } else if (direction == VObjectType::slClockingDir_Input) {
         NodeId Clocking_skew = fC->Child(item);
         if (Clocking_skew) {
           NodeId Edge = fC->Child(Clocking_skew);
           NodeId Skew = Clocking_skew;
-          if (fC->Type(Edge) == slEdge_Negedge) {
+          if (fC->Type(Edge) == VObjectType::slEdge_Negedge) {
             inputEdge = vpiNegedge;
             Skew = fC->Sibling(Edge);
-          } else if (fC->Type(Edge) == slEdge_Posedge) {
+          } else if (fC->Type(Edge) == VObjectType::slEdge_Posedge) {
             inputEdge = vpiPosedge;
             Skew = fC->Sibling(Edge);
-          } else if (fC->Type(Edge) == slEdge_Edge) {
+          } else if (fC->Type(Edge) == VObjectType::slEdge_Edge) {
             inputEdge = vpiAnyEdge;
             Skew = fC->Sibling(Edge);
           }
@@ -3627,18 +3641,18 @@ UHDM::clocking_block* CompileHelper::compileClockingBlock(
                 component, fC, Skew, compileDesign, cblock, instance);
           }
         }
-      } else if (direction == slClockingDir_Output) {
+      } else if (direction == VObjectType::slClockingDir_Output) {
         NodeId Clocking_skew = fC->Child(item);
         if (Clocking_skew) {
           NodeId Edge = fC->Child(Clocking_skew);
           NodeId Skew = Clocking_skew;
-          if (fC->Type(Edge) == slEdge_Negedge) {
+          if (fC->Type(Edge) == VObjectType::slEdge_Negedge) {
             outputEdge = vpiNegedge;
             Skew = fC->Sibling(Edge);
-          } else if (fC->Type(Edge) == slEdge_Posedge) {
+          } else if (fC->Type(Edge) == VObjectType::slEdge_Posedge) {
             outputEdge = vpiPosedge;
             Skew = fC->Sibling(Edge);
-          } else if (fC->Type(Edge) == slEdge_Edge) {
+          } else if (fC->Type(Edge) == VObjectType::slEdge_Edge) {
             outputEdge = vpiAnyEdge;
             Skew = fC->Sibling(Edge);
           }
@@ -3647,18 +3661,18 @@ UHDM::clocking_block* CompileHelper::compileClockingBlock(
                 component, fC, Skew, compileDesign, cblock, instance);
           }
         }
-      } else if (direction == slClockingDir_InputOutput) {
+      } else if (direction == VObjectType::slClockingDir_InputOutput) {
         NodeId Clocking_skew = fC->Child(item);
         if (Clocking_skew) {
           NodeId Edge = fC->Child(Clocking_skew);
           NodeId Skew = Clocking_skew;
-          if (fC->Type(Edge) == slEdge_Negedge) {
+          if (fC->Type(Edge) == VObjectType::slEdge_Negedge) {
             inputEdge = vpiNegedge;
             Skew = fC->Sibling(Edge);
-          } else if (fC->Type(Edge) == slEdge_Posedge) {
+          } else if (fC->Type(Edge) == VObjectType::slEdge_Posedge) {
             inputEdge = vpiPosedge;
             Skew = fC->Sibling(Edge);
-          } else if (fC->Type(Edge) == slEdge_Edge) {
+          } else if (fC->Type(Edge) == VObjectType::slEdge_Edge) {
             inputEdge = vpiAnyEdge;
             Skew = fC->Sibling(Edge);
           }
@@ -3671,13 +3685,13 @@ UHDM::clocking_block* CompileHelper::compileClockingBlock(
           if (Clocking_skew) {
             NodeId Edge = fC->Child(Clocking_skew);
             NodeId Skew = Clocking_skew;
-            if (fC->Type(Edge) == slEdge_Negedge) {
+            if (fC->Type(Edge) == VObjectType::slEdge_Negedge) {
               outputEdge = vpiNegedge;
               Skew = fC->Sibling(Edge);
-            } else if (fC->Type(Edge) == slEdge_Posedge) {
+            } else if (fC->Type(Edge) == VObjectType::slEdge_Posedge) {
               outputEdge = vpiPosedge;
               Skew = fC->Sibling(Edge);
-            } else if (fC->Type(Edge) == slEdge_Edge) {
+            } else if (fC->Type(Edge) == VObjectType::slEdge_Edge) {
               outputEdge = vpiAnyEdge;
               Skew = fC->Sibling(Edge);
             }
@@ -3687,7 +3701,7 @@ UHDM::clocking_block* CompileHelper::compileClockingBlock(
             }
           }
         }
-      } else if (direction == slClockingDir_Inout) {
+      } else if (direction == VObjectType::slClockingDir_Inout) {
         // No skew value
       }
 
@@ -3717,17 +3731,17 @@ UHDM::clocking_block* CompileHelper::compileClockingBlock(
           ios->push_back(io);
           const std::string& sigName = fC->SymName(Identifier);
           io->VpiName(sigName);
-          if (direction == slClockingDir_Input) {
+          if (direction == VObjectType::slClockingDir_Input) {
             io->Input_skew(dcInp);
             io->VpiDirection(vpiInput);
-          } else if (direction == slClockingDir_Output) {
+          } else if (direction == VObjectType::slClockingDir_Output) {
             io->Output_skew(dcOut);
             io->VpiDirection(vpiOutput);
-          } else if (direction == slClockingDir_InputOutput) {
+          } else if (direction == VObjectType::slClockingDir_InputOutput) {
             io->Input_skew(dcInp);
             io->Output_skew(dcOut);
             io->VpiDirection(vpiOutput);
-          } else if (direction == slClockingDir_Inout) {
+          } else if (direction == VObjectType::slClockingDir_Inout) {
             io->VpiDirection(vpiInout);
           }
           Clocking_decl_assign = fC->Sibling(Clocking_decl_assign);
@@ -4136,7 +4150,7 @@ void CompileHelper::compileLetDeclaration(DesignComponent* component,
   const std::string& name = fC->SymName(nameId);
   NodeId Let_port_list = fC->Sibling(nameId);
   NodeId Expression;
-  if (fC->Type(Let_port_list) == slLet_port_list) {
+  if (fC->Type(Let_port_list) == VObjectType::slLet_port_list) {
     Expression = fC->Sibling(Let_port_list);
   } else {
     Expression = Let_port_list;

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -221,9 +221,9 @@ bool CompileModule::collectUdpObjects_() {
     current = fC->Object(id);
     VObjectType type = fC->Type(id);
     switch (type) {
-      case slUdp_declaration:
-      case slUdp_nonansi_declaration:
-      case slUdp_ansi_declaration: {
+      case VObjectType::slUdp_declaration:
+      case VObjectType::slUdp_nonansi_declaration:
+      case VObjectType::slUdp_ansi_declaration: {
         UHDM::VectorOfattribute* attributes = nullptr;
         NodeId Attributes = fC->Child(id);
         if (fC->Type(Attributes) == VObjectType::slAttribute_instance) {
@@ -233,7 +233,7 @@ bool CompileModule::collectUdpObjects_() {
         }
         break;
       }
-      case slUdp_port_list: {
+      case VObjectType::slUdp_port_list: {
         std::vector<UHDM::io_decl*>* ios = defn->Io_decls();
         if (ios == nullptr) {
           defn->Io_decls(s.MakeIo_declVec());
@@ -251,8 +251,8 @@ bool CompileModule::collectUdpObjects_() {
         }
         break;
       }
-      case slUdp_output_declaration:
-      case slUdp_reg_declaration: {
+      case VObjectType::slUdp_output_declaration:
+      case VObjectType::slUdp_reg_declaration: {
         NodeId Output = fC->Child(id);
         UHDM::VectorOfattribute* attributes = nullptr;
         if (fC->Type(Output) == VObjectType::slAttribute_instance) {
@@ -281,7 +281,7 @@ bool CompileModule::collectUdpObjects_() {
         }
         break;
       }
-      case slUdp_input_declaration: {
+      case VObjectType::slUdp_input_declaration: {
         NodeId Indentifier_list = fC->Child(id);
         UHDM::VectorOfattribute* attributes = nullptr;
         if (fC->Type(Indentifier_list) == VObjectType::slAttribute_instance) {
@@ -313,7 +313,7 @@ bool CompileModule::collectUdpObjects_() {
         }
         break;
       }
-      case slCombinational_entry: {
+      case VObjectType::slCombinational_entry: {
         NodeId Level_input_list = fC->Child(id);
         NodeId Output_symbol = fC->Sibling(Level_input_list);
         NodeId Level_symbol = fC->Child(Level_input_list);
@@ -322,10 +322,10 @@ bool CompileModule::collectUdpObjects_() {
         while (Level_symbol) {
           NodeId Symbol = fC->Child(Level_symbol);
           unsigned int nbSymb = 0;
-          if (fC->Type(Symbol) == slQmark) {
+          if (fC->Type(Symbol) == VObjectType::slQmark) {
             ventry += "? ";
             nbSymb = 1;
-          } else if (fC->Type(Symbol) == slBinOp_Mult) {
+          } else if (fC->Type(Symbol) == VObjectType::slBinOp_Mult) {
             ventry += "* ";
             nbSymb = 1;
           } else {
@@ -357,7 +357,7 @@ bool CompileModule::collectUdpObjects_() {
         entries->push_back(entry);
         break;
       }
-      case slSequential_entry: {
+      case VObjectType::slSequential_entry: {
         NodeId Seq_input_list = fC->Child(id);
         NodeId Level_input_list = fC->Child(Seq_input_list);
         NodeId Current_state = fC->Sibling(Seq_input_list);
@@ -366,13 +366,13 @@ bool CompileModule::collectUdpObjects_() {
         unsigned int nb = 0;
         NodeId Level_symbol = fC->Child(Level_input_list);
         while (Level_symbol) {
-          if (fC->Type(Level_symbol) == slEdge_indicator) {
+          if (fC->Type(Level_symbol) == VObjectType::slEdge_indicator) {
             NodeId Level_Symbol = fC->Child(Level_symbol);
             while (Level_Symbol) {
               NodeId Symbol = fC->Child(Level_Symbol);
-              if (fC->Type(Symbol) == slQmark) {
+              if (fC->Type(Symbol) == VObjectType::slQmark) {
                 ventry += "?";
-              } else if (fC->Type(Symbol) == slBinOp_Mult) {
+              } else if (fC->Type(Symbol) == VObjectType::slBinOp_Mult) {
                 ventry += "* ";
               } else {
                 const std::string& symb = fC->SymName(Symbol);
@@ -386,10 +386,10 @@ bool CompileModule::collectUdpObjects_() {
             NodeId Symbol = fC->Child(Level_symbol);
 
             unsigned int nbSymb = 0;
-            if (fC->Type(Symbol) == slQmark) {
+            if (fC->Type(Symbol) == VObjectType::slQmark) {
               ventry += "? ";
               nbSymb = 1;
-            } else if (fC->Type(Symbol) == slBinOp_Mult) {
+            } else if (fC->Type(Symbol) == VObjectType::slBinOp_Mult) {
               ventry += "* ";
               nbSymb = 1;
             } else {
@@ -409,9 +409,9 @@ bool CompileModule::collectUdpObjects_() {
         ventry += ": ";
         NodeId Symbol = fC->Child(Current_state);
 
-        if (fC->Type(Symbol) == slQmark) {
+        if (fC->Type(Symbol) == VObjectType::slQmark) {
           ventry += "? ";
-        } else if (fC->Type(Symbol) == slBinOp_Mult) {
+        } else if (fC->Type(Symbol) == VObjectType::slBinOp_Mult) {
           ventry += "* ";
         } else {
           const std::string& symb = fC->SymName(Symbol);
@@ -427,7 +427,7 @@ bool CompileModule::collectUdpObjects_() {
         ventry += ": ";
         Symbol = fC->Child(Next_state);
 
-        if (fC->Type(Symbol) == slOutput_symbol) {
+        if (fC->Type(Symbol) == VObjectType::slOutput_symbol) {
           Symbol = fC->Child(Symbol);
           const std::string& symb = fC->SymName(Symbol);
           unsigned int nbSymb = symb.size();
@@ -454,7 +454,7 @@ bool CompileModule::collectUdpObjects_() {
         entries->push_back(entry);
         break;
       }
-      case slUdp_initial_statement: {
+      case VObjectType::slUdp_initial_statement: {
         NodeId Identifier = fC->Child(id);
         NodeId Value = fC->Sibling(Identifier);
         UHDM::initial* init = s.MakeInitial();
@@ -655,8 +655,8 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
 
           NodeId list_of_type_assignments = fC->Child(id);
           if (fC->Type(list_of_type_assignments) ==
-                  slList_of_type_assignments ||
-              fC->Type(list_of_type_assignments) == slType) {
+                  VObjectType::slList_of_type_assignments ||
+              fC->Type(list_of_type_assignments) == VObjectType::slType) {
             // Type param
             m_helper.compileParameterDeclaration(
                 m_module, fC, list_of_type_assignments, m_compileDesign, false,
@@ -673,8 +673,8 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
           if (collectType != CollectType::DEFINITION) break;
           NodeId list_of_type_assignments = fC->Child(id);
           if (fC->Type(list_of_type_assignments) ==
-                  slList_of_type_assignments ||
-              fC->Type(list_of_type_assignments) == slType) {
+                  VObjectType::slList_of_type_assignments ||
+              fC->Type(list_of_type_assignments) == VObjectType::slType) {
             // Type param
             m_helper.compileParameterDeclaration(
                 m_module, fC, list_of_type_assignments, m_compileDesign, true,
@@ -706,11 +706,11 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
           NodeId StringLiteral = fC->Sibling(Import);
           NodeId Context_keyword = fC->Sibling(StringLiteral);
           NodeId Task_prototype;
-          if (fC->Type(Context_keyword) == slContext_keyword)
+          if (fC->Type(Context_keyword) == VObjectType::slContext_keyword)
             Task_prototype = fC->Sibling(Context_keyword);
           else
             Task_prototype = Context_keyword;
-          if (fC->Type(Task_prototype) == slTask_prototype) {
+          if (fC->Type(Task_prototype) == VObjectType::slTask_prototype) {
             Task* task = m_helper.compileTaskPrototype(m_module, fC, id,
                                                        m_compileDesign);
             m_module->insertTask(task);
@@ -729,7 +729,7 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
         case VObjectType::slClass_declaration: {
           if (collectType != CollectType::OTHER) break;
           NodeId nameId = fC->Child(id);
-          if (fC->Type(nameId) == slVirtual) {
+          if (fC->Type(nameId) == VObjectType::slVirtual) {
             nameId = fC->Sibling(nameId);
           }
           std::string name = fC->SymName(nameId);
@@ -801,7 +801,8 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
           if (collectType != CollectType::DEFINITION) break;
           NodeId sibling = fC->Sibling(id);
           if (!sibling) {
-            if (fC->Type(fC->Parent(id)) != slModule_declaration) break;
+            if (fC->Type(fC->Parent(id)) != VObjectType::slModule_declaration)
+              break;
             const std::string& endLabel = fC->SymName(id);
             std::string moduleName = m_module->getName();
             moduleName = StringUtils::ltrim(moduleName, '@');
@@ -1116,8 +1117,8 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
 
           NodeId list_of_type_assignments = fC->Child(id);
           if (fC->Type(list_of_type_assignments) ==
-                  slList_of_type_assignments ||
-              fC->Type(list_of_type_assignments) == slType) {
+                  VObjectType::slList_of_type_assignments ||
+              fC->Type(list_of_type_assignments) == VObjectType::slType) {
             // Type param
             m_helper.compileParameterDeclaration(
                 m_module, fC, list_of_type_assignments, m_compileDesign, false,
@@ -1134,8 +1135,8 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
           if (collectType != CollectType::DEFINITION) break;
           NodeId list_of_type_assignments = fC->Child(id);
           if (fC->Type(list_of_type_assignments) ==
-                  slList_of_type_assignments ||
-              fC->Type(list_of_type_assignments) == slType) {
+                  VObjectType::slList_of_type_assignments ||
+              fC->Type(list_of_type_assignments) == VObjectType::slType) {
             // Type param
             m_helper.compileParameterDeclaration(
                 m_module, fC, list_of_type_assignments, m_compileDesign, true,
@@ -1248,9 +1249,9 @@ bool CompileModule::checkModule_() {
     if (port->isInterface()) continue;
     const FileContent* fC = port->getFileContent();
     NodeId portId = port->getNodeId();
-    if (fC->Type(portId) == slPort) {
+    if (fC->Type(portId) == VObjectType::slPort) {
       NodeId expName = fC->Child(portId);
-      if (fC->Type(expName) == slStringConst) {
+      if (fC->Type(expName) == VObjectType::slStringConst) {
         // Port expression
         continue;
       }
@@ -1369,14 +1370,14 @@ void CompileModule::compileClockingBlock_(const FileContent* fC, NodeId id) {
   NodeId clocking_block_name;
   SymbolId clocking_block_symbol;
   ClockingBlock::Type type = ClockingBlock::Regular;
-  if (fC->Type(clocking_block_type) == slDefault)
+  if (fC->Type(clocking_block_type) == VObjectType::slDefault)
     type = ClockingBlock::Default;
-  else if (fC->Type(clocking_block_type) == slGlobal)
+  else if (fC->Type(clocking_block_type) == VObjectType::slGlobal)
     type = ClockingBlock::Global;
-  else if (fC->Type(clocking_block_type) == slStringConst)
+  else if (fC->Type(clocking_block_type) == VObjectType::slStringConst)
     clocking_block_name = clocking_block_type;
   NodeId clocking_event = fC->Sibling(clocking_block_type);
-  if (fC->Type(clocking_event) == slStringConst) {
+  if (fC->Type(clocking_event) == VObjectType::slStringConst) {
     clocking_block_name = clocking_event;
     clocking_event = fC->Sibling(clocking_block_name);
   }

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -150,8 +150,8 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
           if (collectType != CollectType::DEFINITION) break;
           NodeId list_of_type_assignments = fC->Child(id);
           if (fC->Type(list_of_type_assignments) ==
-                  slList_of_type_assignments ||
-              fC->Type(list_of_type_assignments) == slType) {
+                  VObjectType::slList_of_type_assignments ||
+              fC->Type(list_of_type_assignments) == VObjectType::slType) {
             // Type param
             m_helper.compileParameterDeclaration(
                 m_package, fC, list_of_type_assignments, m_compileDesign, false,
@@ -168,8 +168,8 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
           if (collectType != CollectType::DEFINITION) break;
           NodeId list_of_type_assignments = fC->Child(id);
           if (fC->Type(list_of_type_assignments) ==
-                  slList_of_type_assignments ||
-              fC->Type(list_of_type_assignments) == slType) {
+                  VObjectType::slList_of_type_assignments ||
+              fC->Type(list_of_type_assignments) == VObjectType::slType) {
             // Type param
             m_helper.compileParameterDeclaration(
                 m_package, fC, list_of_type_assignments, m_compileDesign, true,
@@ -210,7 +210,7 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
         case VObjectType::slClass_declaration: {
           if (collectType != CollectType::OTHER) break;
           NodeId nameId = fC->Child(id);
-          if (fC->Type(nameId) == slVirtual) {
+          if (fC->Type(nameId) == VObjectType::slVirtual) {
             nameId = fC->Sibling(nameId);
           }
           const std::string& name = fC->SymName(nameId);
@@ -256,11 +256,11 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
           NodeId StringLiteral = fC->Sibling(Import);
           NodeId Context_keyword = fC->Sibling(StringLiteral);
           NodeId Task_prototype;
-          if (fC->Type(Context_keyword) == slContext_keyword)
+          if (fC->Type(Context_keyword) == VObjectType::slContext_keyword)
             Task_prototype = fC->Sibling(Context_keyword);
           else
             Task_prototype = Context_keyword;
-          if (fC->Type(Task_prototype) == slTask_prototype) {
+          if (fC->Type(Task_prototype) == VObjectType::slTask_prototype) {
             Task* task = m_helper.compileTaskPrototype(m_package, fC, id,
                                                        m_compileDesign);
             m_package->insertTask(task);
@@ -275,7 +275,8 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
           if (collectType != CollectType::DEFINITION) break;
           NodeId sibling = fC->Sibling(id);
           if (!sibling) {
-            if (fC->Type(fC->Parent(id)) != slPackage_declaration) break;
+            if (fC->Type(fC->Parent(id)) != VObjectType::slPackage_declaration)
+              break;
             const std::string& endLabel = fC->SymName(id);
             std::string moduleName = m_package->getName();
             moduleName = StringUtils::ltrim(moduleName, '@');

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -199,8 +199,9 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
       case VObjectType::slParameter_declaration: {
         if (collectType != CollectType::DEFINITION) break;
         NodeId list_of_type_assignments = fC->Child(id);
-        if (fC->Type(list_of_type_assignments) == slList_of_type_assignments ||
-            fC->Type(list_of_type_assignments) == slType) {
+        if (fC->Type(list_of_type_assignments) ==
+                VObjectType::slList_of_type_assignments ||
+            fC->Type(list_of_type_assignments) == VObjectType::slType) {
           // Type param
           m_helper.compileParameterDeclaration(
               m_program, fC, list_of_type_assignments, m_compileDesign, false,
@@ -216,8 +217,9 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
       case VObjectType::slLocal_parameter_declaration: {
         if (collectType != CollectType::DEFINITION) break;
         NodeId list_of_type_assignments = fC->Child(id);
-        if (fC->Type(list_of_type_assignments) == slList_of_type_assignments ||
-            fC->Type(list_of_type_assignments) == slType) {
+        if (fC->Type(list_of_type_assignments) ==
+                VObjectType::slList_of_type_assignments ||
+            fC->Type(list_of_type_assignments) == VObjectType::slType) {
           // Type param
           m_helper.compileParameterDeclaration(
               m_program, fC, list_of_type_assignments, m_compileDesign, true,
@@ -233,7 +235,7 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
       case VObjectType::slClass_declaration: {
         if (collectType != CollectType::OTHER) break;
         NodeId nameId = fC->Child(id);
-        if (fC->Type(nameId) == slVirtual) {
+        if (fC->Type(nameId) == VObjectType::slVirtual) {
           nameId = fC->Sibling(nameId);
         }
         const std::string& name = fC->SymName(nameId);
@@ -288,11 +290,11 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
         NodeId StringLiteral = fC->Sibling(Import);
         NodeId Context_keyword = fC->Sibling(StringLiteral);
         NodeId Task_prototype;
-        if (fC->Type(Context_keyword) == slContext_keyword)
+        if (fC->Type(Context_keyword) == VObjectType::slContext_keyword)
           Task_prototype = fC->Sibling(Context_keyword);
         else
           Task_prototype = Context_keyword;
-        if (fC->Type(Task_prototype) == slTask_prototype) {
+        if (fC->Type(Task_prototype) == VObjectType::slTask_prototype) {
           Task* task =
               m_helper.compileTaskPrototype(m_program, fC, id, m_compileDesign);
           m_program->insertTask(task);
@@ -307,7 +309,8 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
         if (collectType != CollectType::DEFINITION) break;
         NodeId sibling = fC->Sibling(id);
         if (!sibling) {
-          if (fC->Type(fC->Parent(id)) != slProgram_declaration) break;
+          if (fC->Type(fC->Parent(id)) != VObjectType::slProgram_declaration)
+            break;
           const std::string& endLabel = fC->SymName(id);
           std::string moduleName = m_program->getName();
           moduleName = StringUtils::ltrim(moduleName, '@');

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -111,7 +111,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
   UHDM::VectorOfattribute* attributes = nullptr;
   if (type == VObjectType::slAttribute_instance) {
     attributes = compileAttributes(component, fC, the_stmt, compileDesign);
-    while (fC->Type(the_stmt) == slAttribute_instance)
+    while (fC->Type(the_stmt) == VObjectType::slAttribute_instance)
       the_stmt = fC->Sibling(the_stmt);
   }
   type = fC->Type(the_stmt);
@@ -219,7 +219,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
         NodeId Statement = fC->Parent(Statement_item);
         NodeId Label = fC->Child(Statement);
         if (fC->Sibling(Label) == Statement_item) {
-          if (fC->Type(Label) == slStringConst) labelId = Label;
+          if (fC->Type(Label) == VObjectType::slStringConst) labelId = Label;
         }
       }
 
@@ -303,7 +303,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
         NodeId Statement = fC->Parent(Statement_item);
         NodeId Label = fC->Child(Statement);
         if (fC->Sibling(Label) == Statement_item) {
-          if (fC->Type(Label) == slStringConst) labelId = Label;
+          if (fC->Type(Label) == VObjectType::slStringConst) labelId = Label;
         }
       }
       if (labelId) {
@@ -425,12 +425,12 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
       NodeId loopVarId = fC->Child(Loop_variables);
       NodeId Statement = Loop_variables;
       VectorOfany* loop_vars = s.MakeAnyVec();
-      while (fC->Type(Statement) == slStringConst ||
-             fC->Type(Statement) == slLoop_variables ||
-             fC->Type(Statement) == slComma) {
-        if (fC->Type(Statement) == slStringConst)
+      while (fC->Type(Statement) == VObjectType::slStringConst ||
+             fC->Type(Statement) == VObjectType::slLoop_variables ||
+             fC->Type(Statement) == VObjectType::slComma) {
+        if (fC->Type(Statement) == VObjectType::slStringConst)
           loopVarId = Statement;
-        else if (fC->Type(Statement) == slComma) {
+        else if (fC->Type(Statement) == VObjectType::slComma) {
           operation* op = s.MakeOperation();
           fC->populateCoreMembers(Statement, Statement, op);
           op->VpiOpType(vpiNullOp);
@@ -450,9 +450,9 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
           loop_vars->push_back(ref);
           ref->VpiParent(for_each);
           loopVarId = fC->Sibling(loopVarId);
-          while (fC->Type(loopVarId) == slComma) {
+          while (fC->Type(loopVarId) == VObjectType::slComma) {
             NodeId lookahead = fC->Sibling(loopVarId);
-            if (fC->Type(lookahead) == slComma) {
+            if (fC->Type(lookahead) == VObjectType::slComma) {
               operation* op = s.MakeOperation();
               fC->populateCoreMembers(loopVarId, loopVarId, op);
               op->VpiOpType(vpiNullOp);
@@ -463,11 +463,11 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
               break;
             }
           }
-          if ((fC->Type(loopVarId) != slStringConst) &&
-              ((fC->Type(loopVarId) != slComma))) {
+          if ((fC->Type(loopVarId) != VObjectType::slStringConst) &&
+              ((fC->Type(loopVarId) != VObjectType::slComma))) {
             break;
           }
-          if (fC->Type(loopVarId) == slComma) {
+          if (fC->Type(loopVarId) == VObjectType::slComma) {
             loopVarId = fC->Sibling(loopVarId);
           }
         }
@@ -601,7 +601,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
         // wait fork
         UHDM::wait_fork* waitst = s.MakeWait_fork();
         stmt = waitst;
-      } else if (fC->Type(Expression) == slExpression) {
+      } else if (fC->Type(Expression) == VObjectType::slExpression) {
         // wait
         NodeId Statement_or_null = fC->Sibling(Expression);
         UHDM::wait_stmt* waitst = s.MakeWait_stmt();
@@ -627,8 +627,9 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
         VectorOfany* conditions = s.MakeAnyVec();
         waitst->VpiConditions(conditions);
         NodeId Hierarchical_identifier = Expression;
-        while (Hierarchical_identifier && (fC->Type(Hierarchical_identifier) ==
-                                           slHierarchical_identifier)) {
+        while (Hierarchical_identifier &&
+               (fC->Type(Hierarchical_identifier) ==
+                VObjectType::slHierarchical_identifier)) {
           UHDM::any* cond_exp = compileExpression(
               component, fC, Hierarchical_identifier, compileDesign);
           conditions->push_back(cond_exp);
@@ -636,7 +637,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
         }
         NodeId Action_block = Hierarchical_identifier;
         NodeId Stmt = fC->Child(Action_block);
-        if (fC->Type(Stmt) == slStatement_or_null) {
+        if (fC->Type(Stmt) == VObjectType::slStatement_or_null) {
           // If only
           VectorOfany* if_stmts =
               compileStmt(component, fC, Stmt, compileDesign, waitst, instance);
@@ -645,7 +646,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
             waitst->VpiStmt(stmt);
             stmt->VpiParent(waitst);
           }
-        } else if (fC->Type(Stmt) == slElse) {
+        } else if (fC->Type(Stmt) == VObjectType::slElse) {
           // Else Only
           Stmt = fC->Sibling(Stmt);
           VectorOfany* if_stmts =
@@ -680,7 +681,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
     case VObjectType::slEvent_trigger: {
       UHDM::event_stmt* estmt = s.MakeEvent_stmt();
       NodeId Trigger_type = fC->Child(the_stmt);
-      if (fC->Type(Trigger_type) != slNonBlockingTriggerEvent) {
+      if (fC->Type(Trigger_type) != VObjectType::slNonBlockingTriggerEvent) {
         estmt->VpiBlocking(true);
       }
       stmt = estmt;
@@ -798,16 +799,16 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
       results = stmts;
       break;
     }
-    case slExpect_property_statement: {
+    case VObjectType::slExpect_property_statement: {
       expect_stmt* expect = s.MakeExpect_stmt();
       NodeId Property_expr = fC->Child(the_stmt);
       NodeId If_block = fC->Sibling(Property_expr);
       UHDM::any* if_stmt = nullptr;
       UHDM::any* else_stmt = nullptr;
-      if (fC->Type(If_block) == slAction_block) {
+      if (fC->Type(If_block) == VObjectType::slAction_block) {
         NodeId if_stmt_id = fC->Child(If_block);
         NodeId else_stmt_id;
-        if (fC->Type(if_stmt_id) == slElse) {
+        if (fC->Type(if_stmt_id) == VObjectType::slElse) {
           else_stmt_id = fC->Sibling(if_stmt_id);
           if_stmt_id = InvalidNodeId;
         } else {
@@ -829,7 +830,7 @@ VectorOfany* CompileHelper::compileStmt(DesignComponent* component,
       NodeId Clocking_event = fC->Child(Property_expr);
 
       UHDM::expr* clocking_event = nullptr;
-      if (fC->Type(Clocking_event) == slClocking_event) {
+      if (fC->Type(Clocking_event) == VObjectType::slClocking_event) {
         clocking_event = (UHDM::expr*)compileExpression(
             component, fC, Clocking_event, compileDesign, pstmt, instance,
             false);
@@ -909,17 +910,17 @@ VectorOfany* CompileHelper::compileDataDeclaration(
   VObjectType type = fC->Type(nodeId);
   bool automatic_status = false;
   bool const_status = false;
-  if (type == slLifetime_Automatic) {
+  if (type == VObjectType::slLifetime_Automatic) {
     nodeId = fC->Sibling(nodeId);
     automatic_status = true;
     type = fC->Type(nodeId);
   }
-  if (type == slLifetime_Static) {
+  if (type == VObjectType::slLifetime_Static) {
     nodeId = fC->Sibling(nodeId);
     automatic_status = false;
     type = fC->Type(nodeId);
   }
-  if (type == slConst_type) {
+  if (type == VObjectType::slConst_type) {
     nodeId = fC->Sibling(nodeId);
     const_status = true;
     type = fC->Type(nodeId);
@@ -941,13 +942,13 @@ VectorOfany* CompileHelper::compileDataDeclaration(
         NodeId Var = fC->Child(Variable_decl_assignment);
         NodeId tmp = fC->Sibling(Var);
         std::vector<UHDM::range*>* unpackedDimensions = nullptr;
-        if (fC->Type(tmp) != slExpression) {
+        if (fC->Type(tmp) != VObjectType::slExpression) {
           int unpackedSize;
           unpackedDimensions =
               compileRanges(component, fC, tmp, compileDesign, nullptr,
                             instance, reduce, unpackedSize, false);
         }
-        while (tmp && (fC->Type(tmp) != slExpression)) {
+        while (tmp && (fC->Type(tmp) != VObjectType::slExpression)) {
           tmp = fC->Sibling(tmp);
         }
         NodeId Expression = tmp;
@@ -1057,13 +1058,13 @@ UHDM::atomic_stmt* CompileHelper::compileConditionalStmt(
     ValuedComponentI* instance) {
   UHDM::Serializer& s = compileDesign->getSerializer();
   int qualifier = 0;
-  if (fC->Type(Cond_predicate) == slUnique_priority) {
+  if (fC->Type(Cond_predicate) == VObjectType::slUnique_priority) {
     NodeId Qualifier = fC->Child(Cond_predicate);
-    if (fC->Type(Qualifier) == slUnique) {
+    if (fC->Type(Qualifier) == VObjectType::slUnique) {
       qualifier = vpiUniqueQualifier;
-    } else if (fC->Type(Qualifier) == slPriority) {
+    } else if (fC->Type(Qualifier) == VObjectType::slPriority) {
       qualifier = vpiPriorityQualifier;
-    } else if (fC->Type(Qualifier) == slUnique0) {
+    } else if (fC->Type(Qualifier) == VObjectType::slUnique0) {
       qualifier = vpiUniqueQualifier;
     }
     Cond_predicate = fC->Sibling(Cond_predicate);
@@ -1173,7 +1174,7 @@ UHDM::atomic_stmt* CompileHelper::compileRandcaseStmt(
       case_item->Stmt(stmt);
     }
     RandCase = fC->Sibling(RandCase);
-    if (fC->Type(RandCase) == slEndcase) {
+    if (fC->Type(RandCase) == VObjectType::slEndcase) {
       break;
     }
   }
@@ -1360,16 +1361,16 @@ n<> u<142> t<Tf_item_declaration> p<386> c<141> s<384> l<28>
   while (tf_item_decl) {
     if (fC->Type(tf_item_decl) == VObjectType::slTf_item_declaration) {
       NodeId Tf_port_declaration = fC->Child(tf_item_decl);
-      if (fC->Type(Tf_port_declaration) == slTf_port_declaration) {
+      if (fC->Type(Tf_port_declaration) == VObjectType::slTf_port_declaration) {
         NodeId TfPortDir = fC->Child(Tf_port_declaration);
         VObjectType tf_port_direction_type = fC->Type(TfPortDir);
         NodeId Data_type_or_implicit = fC->Sibling(TfPortDir);
         NodeId Data_type = fC->Child(Data_type_or_implicit);
         typespec* ts = nullptr;
-        if (fC->Type(Data_type) == slData_type) {
+        if (fC->Type(Data_type) == VObjectType::slData_type) {
           ts = compileTypespec(component, fC, Data_type, compileDesign, parent,
                                nullptr, true);
-        } else if (fC->Type(Data_type) == slPacked_dimension) {
+        } else if (fC->Type(Data_type) == VObjectType::slPacked_dimension) {
           // Implicit type
           int size;
           VectorOfrange* ranges =
@@ -1387,7 +1388,8 @@ n<> u<142> t<Tf_item_declaration> p<386> c<141> s<384> l<28>
         while (nameId) {
           VectorOfrange* ranges = nullptr;
           NodeId Variable_dimension = fC->Sibling(nameId);
-          if (fC->Type(Variable_dimension) == slVariable_dimension) {
+          if (fC->Type(Variable_dimension) ==
+              VObjectType::slVariable_dimension) {
             int size;
             ranges =
                 compileRanges(component, fC, Variable_dimension, compileDesign,
@@ -1404,19 +1406,23 @@ n<> u<142> t<Tf_item_declaration> p<386> c<141> s<384> l<28>
           fC->populateCoreMembers(nameId, nameId, decl);
           decl->Typespec(ts);
           decl->Ranges(ranges);
-          if (fC->Type(Variable_dimension) == slVariable_dimension) {
+          if (fC->Type(Variable_dimension) ==
+              VObjectType::slVariable_dimension) {
             nameId = fC->Sibling(nameId);
           }
           nameId = fC->Sibling(nameId);
         }
-      } else if (fC->Type(Tf_port_declaration) == slBlock_item_declaration) {
+      } else if (fC->Type(Tf_port_declaration) ==
+                 VObjectType::slBlock_item_declaration) {
         NodeId Data_declaration = fC->Child(Tf_port_declaration);
-        if (fC->Type(Data_declaration) == slData_declaration) {
+        if (fC->Type(Data_declaration) == VObjectType::slData_declaration) {
           NodeId Variable_declaration = fC->Child(Data_declaration);
           bool is_static = false;
-          if (fC->Type(Variable_declaration) == slLifetime_Automatic) {
+          if (fC->Type(Variable_declaration) ==
+              VObjectType::slLifetime_Automatic) {
             Variable_declaration = fC->Sibling(Variable_declaration);
-          } else if (fC->Type(Variable_declaration) == slLifetime_Static) {
+          } else if (fC->Type(Variable_declaration) ==
+                     VObjectType::slLifetime_Static) {
             is_static = true;
             Variable_declaration = fC->Sibling(Variable_declaration);
           }
@@ -1507,7 +1513,7 @@ std::vector<io_decl*>* CompileHelper::compileTfPortList(
     NodeId tf_data_type_or_implicit = fC->Child(tf_port_item);
     NodeId tf_data_type = fC->Child(tf_data_type_or_implicit);
     VObjectType tf_port_direction_type = fC->Type(tf_data_type_or_implicit);
-    if (tf_port_direction_type != slData_type_or_implicit)
+    if (tf_port_direction_type != VObjectType::slData_type_or_implicit)
       previousDirection = UhdmWriter::getVpiDirection(tf_port_direction_type);
     decl->VpiDirection(previousDirection);
     NodeId tf_param_name = fC->Sibling(tf_data_type_or_implicit);
@@ -1525,7 +1531,7 @@ std::vector<io_decl*>* CompileHelper::compileTfPortList(
     NodeId unpackedDimension =
         fC->Sibling(fC->Sibling(fC->Child(tf_port_item)));
     if (unpackedDimension &&
-        (fC->Type(unpackedDimension) != slVariable_dimension))
+        (fC->Type(unpackedDimension) != VObjectType::slVariable_dimension))
       unpackedDimension = fC->Sibling(unpackedDimension);
     int size;
     std::vector<UHDM::range*>* unpackedDimensions =
@@ -1564,11 +1570,11 @@ NodeId CompileHelper::setFuncTaskQualifiers(const FileContent* fC,
   NodeId func_decl = nodeId;
   VObjectType func_type = fC->Type(nodeId);
 
-  if (func_type == slFunction_declaration) {
+  if (func_type == VObjectType::slFunction_declaration) {
     func_decl = fC->Child(nodeId);
     func_type = fC->Type(func_decl);
   }
-  if (func_type == slTask_declaration) {
+  if (func_type == VObjectType::slTask_declaration) {
     func_decl = fC->Child(nodeId);
     func_type = fC->Type(func_decl);
   }
@@ -1691,7 +1697,7 @@ bool CompileHelper::compileTask(DesignComponent* component,
   std::string name;
   NodeId task_decl = setFuncTaskQualifiers(fC, nodeId, nullptr);
   NodeId Task_body_declaration;
-  if (fC->Type(task_decl) == slTask_body_declaration)
+  if (fC->Type(task_decl) == VObjectType::slTask_body_declaration)
     Task_body_declaration = task_decl;
   else
     Task_body_declaration = fC->Child(task_decl);
@@ -1726,20 +1732,23 @@ bool CompileHelper::compileTask(DesignComponent* component,
   fC->populateCoreMembers(nodeId, task_decl, task);
   NodeId Tf_port_list = fC->Sibling(task_name);
   NodeId Statement_or_null;
-  if (fC->Type(Tf_port_list) == slTf_port_list) {
+  if (fC->Type(Tf_port_list) == VObjectType::slTf_port_list) {
     Statement_or_null = fC->Sibling(Tf_port_list);
     task->Io_decls(
         compileTfPortList(component, task, fC, Tf_port_list, compileDesign));
   } else if (fC->Type(Tf_port_list) == VObjectType::slTf_item_declaration) {
     NodeId Block_item_declaration = fC->Child(Tf_port_list);
-    if (fC->Type(Block_item_declaration) != slBlock_item_declaration) {
+    if (fC->Type(Block_item_declaration) !=
+        VObjectType::slBlock_item_declaration) {
       compileTfPortDecl(component, task, fC, Tf_port_list, compileDesign);
       while (fC->Type(Tf_port_list) == VObjectType::slTf_item_declaration) {
         NodeId Tf_port_declaration = fC->Child(Tf_port_list);
-        if (fC->Type(Tf_port_declaration) == slTf_port_declaration) {
-        } else if (fC->Type(Tf_port_declaration) == slBlock_item_declaration) {
+        if (fC->Type(Tf_port_declaration) ==
+            VObjectType::slTf_port_declaration) {
+        } else if (fC->Type(Tf_port_declaration) ==
+                   VObjectType::slBlock_item_declaration) {
           NodeId ItemNode = fC->Child(Tf_port_declaration);
-          if (fC->Type(ItemNode) != slData_declaration) break;
+          if (fC->Type(ItemNode) != VObjectType::slData_declaration) break;
         } else {
           break;
         }
@@ -1750,7 +1759,7 @@ bool CompileHelper::compileTask(DesignComponent* component,
   } else if (fC->Type(Tf_port_list) == VObjectType::slBlock_item_declaration) {
     Statement_or_null = Tf_port_list;
   } else {
-    if (fC->Type(Tf_port_list) == slStatement_or_null)
+    if (fC->Type(Tf_port_list) == VObjectType::slStatement_or_null)
       Statement_or_null = Tf_port_list;
   }
 
@@ -1767,19 +1776,22 @@ bool CompileHelper::compileTask(DesignComponent* component,
     VectorOfany* stmts = s.MakeAnyVec();
     begin->Stmts(stmts);
     while (Statement_or_null) {
-      if (Statement_or_null && (fC->Type(Statement_or_null) == slEndtask))
+      if (Statement_or_null &&
+          (fC->Type(Statement_or_null) == VObjectType::slEndtask))
         break;
-      if (fC->Type(fC->Child(Statement_or_null)) == slTf_port_declaration) {
+      if (fC->Type(fC->Child(Statement_or_null)) ==
+          VObjectType::slTf_port_declaration) {
         compileTfPortDecl(component, task, fC, Statement_or_null,
                           compileDesign);
         while (fC->Type(Statement_or_null) ==
                VObjectType::slTf_item_declaration) {
           NodeId Tf_port_declaration = fC->Child(Statement_or_null);
-          if (fC->Type(Tf_port_declaration) == slTf_port_declaration) {
+          if (fC->Type(Tf_port_declaration) ==
+              VObjectType::slTf_port_declaration) {
           } else if (fC->Type(Tf_port_declaration) ==
-                     slBlock_item_declaration) {
+                     VObjectType::slBlock_item_declaration) {
             NodeId ItemNode = fC->Child(Tf_port_declaration);
-            if (fC->Type(ItemNode) != slData_declaration) break;
+            if (fC->Type(ItemNode) != VObjectType::slData_declaration) break;
           } else {
             break;
           }
@@ -1827,7 +1839,8 @@ bool CompileHelper::compileTask(DesignComponent* component,
     }
   } else {
     // Page 983, 2017 Standard: 0 or 1 Stmt
-    if (Statement_or_null && (fC->Type(Statement_or_null) != slEndtask)) {
+    if (Statement_or_null &&
+        (fC->Type(Statement_or_null) != VObjectType::slEndtask)) {
       VectorOfany* stmts = compileStmt(component, fC, Statement_or_null,
                                        compileDesign, task, instance, reduce);
       if (stmts) {
@@ -1886,7 +1899,7 @@ bool CompileHelper::compileClassConstructorDeclaration(
   std::string className;
   NodeId Tf_port_list;
   Tf_port_list = fC->Child(nodeId);
-  if (fC->Type(Tf_port_list) == slClass_scope) {
+  if (fC->Type(Tf_port_list) == VObjectType::slClass_scope) {
     NodeId Class_scope = Tf_port_list;
     NodeId Class_type = fC->Child(Class_scope);
     NodeId Class_name = fC->Child(Class_type);
@@ -1921,7 +1934,7 @@ bool CompileHelper::compileClassConstructorDeclaration(
       compileTfPortList(component, func, fC, Tf_port_list, compileDesign));
 
   NodeId Stmt;
-  if (fC->Type(Tf_port_list) == slFunction_statement_or_null) {
+  if (fC->Type(Tf_port_list) == VObjectType::slFunction_statement_or_null) {
     Stmt = Tf_port_list;
   } else {
     Stmt = fC->Sibling(Tf_port_list);
@@ -1929,27 +1942,27 @@ bool CompileHelper::compileClassConstructorDeclaration(
   int nbStmts = 0;
   NodeId StmtTmp = Stmt;
   while (StmtTmp) {
-    if (fC->Type(StmtTmp) == slBlock_item_declaration) {
+    if (fC->Type(StmtTmp) == VObjectType::slBlock_item_declaration) {
       nbStmts++;
-    } else if (fC->Type(StmtTmp) == slSuper_dot_new) {
+    } else if (fC->Type(StmtTmp) == VObjectType::slSuper_dot_new) {
       nbStmts++;
       NodeId lookAhead = fC->Sibling(StmtTmp);
-      if (fC->Type(lookAhead) == slList_of_arguments) {
+      if (fC->Type(lookAhead) == VObjectType::slList_of_arguments) {
         StmtTmp = fC->Sibling(StmtTmp);
       }
-    } else if (fC->Type(StmtTmp) == slFunction_statement_or_null) {
+    } else if (fC->Type(StmtTmp) == VObjectType::slFunction_statement_or_null) {
       nbStmts++;
     }
     StmtTmp = fC->Sibling(StmtTmp);
   }
 
   if (nbStmts == 1) {
-    if (fC->Type(Stmt) == slSuper_dot_new) {
+    if (fC->Type(Stmt) == VObjectType::slSuper_dot_new) {
       UHDM::method_func_call* mcall = s.MakeMethod_func_call();
       mcall->VpiParent(func);
       mcall->VpiName("super.new");
       NodeId Args = fC->Sibling(Stmt);
-      if (fC->Type(Args) == slList_of_arguments) {
+      if (fC->Type(Args) == VObjectType::slList_of_arguments) {
         VectorOfany* arguments = compileTfCallArguments(
             component, fC, Args, compileDesign, mcall, nullptr, false, false);
         mcall->Tf_call_args(arguments);
@@ -1976,12 +1989,12 @@ bool CompileHelper::compileClassConstructorDeclaration(
     begin->Stmts(stmts);
     Stmt = fC->Sibling(Tf_port_list);
     while (Stmt) {
-      if (fC->Type(Stmt) == slSuper_dot_new) {
+      if (fC->Type(Stmt) == VObjectType::slSuper_dot_new) {
         UHDM::method_func_call* mcall = s.MakeMethod_func_call();
         mcall->VpiParent(func);
         mcall->VpiName("super.new");
         NodeId Args = fC->Sibling(Stmt);
-        if (fC->Type(Args) == slList_of_arguments) {
+        if (fC->Type(Args) == VObjectType::slList_of_arguments) {
           VectorOfany* arguments = compileTfCallArguments(
               component, fC, Args, compileDesign, mcall, nullptr, false, false);
           mcall->Tf_call_args(arguments);
@@ -2023,8 +2036,8 @@ bool CompileHelper::compileFunction(DesignComponent* component,
   NodeId func_decl = setFuncTaskQualifiers(fC, nodeId, nullptr);
   VObjectType func_decl_type = fC->Type(func_decl);
   bool constructor = false;
-  if (func_decl_type == slClass_constructor_declaration ||
-      func_decl_type == slClass_constructor_prototype) {
+  if (func_decl_type == VObjectType::slClass_constructor_declaration ||
+      func_decl_type == VObjectType::slClass_constructor_prototype) {
     constructor = true;
   }
   NodeId Tf_port_list;
@@ -2033,7 +2046,7 @@ bool CompileHelper::compileFunction(DesignComponent* component,
     name = "new";
   } else {
     NodeId Function_body_declaration;
-    if (fC->Type(func_decl) == slFunction_body_declaration)
+    if (fC->Type(func_decl) == VObjectType::slFunction_body_declaration)
       Function_body_declaration = func_decl;
     else
       Function_body_declaration = fC->Child(func_decl);
@@ -2079,7 +2092,7 @@ bool CompileHelper::compileFunction(DesignComponent* component,
     tps->VpiName(cdef->getUhdmDefinition()->VpiFullName());
   } else {
     NodeId Function_body_declaration;
-    if (fC->Type(func_decl) == slFunction_body_declaration)
+    if (fC->Type(func_decl) == VObjectType::slFunction_body_declaration)
       Function_body_declaration = func_decl;
     else
       Function_body_declaration = fC->Child(func_decl);
@@ -2087,11 +2100,11 @@ bool CompileHelper::compileFunction(DesignComponent* component,
         fC->Child(Function_body_declaration);
     NodeId Function_data_type = fC->Child(Function_data_type_or_implicit);
     NodeId Return_data_type = fC->Child(Function_data_type);
-    if (fC->Type(Function_data_type) == slPacked_dimension) {
+    if (fC->Type(Function_data_type) == VObjectType::slPacked_dimension) {
       Return_data_type = Function_data_type;
     }
     if ((!Return_data_type) &&
-        (fC->Type(Function_data_type) == slSigning_Unsigned)) {
+        (fC->Type(Function_data_type) == VObjectType::slSigning_Unsigned)) {
       Return_data_type = Function_data_type;
     }
     variables* var = nullptr;
@@ -2125,13 +2138,16 @@ bool CompileHelper::compileFunction(DesignComponent* component,
     while (fC->Type(Tf_port_list) == VObjectType::slTf_item_declaration) {
       NodeId Block_item_declaration = fC->Child(Tf_port_list);
       NodeId Parameter_declaration = fC->Child(Block_item_declaration);
-      if ((fC->Type(Parameter_declaration) == slParameter_declaration) ||
-          (fC->Type(Parameter_declaration) == slLocal_parameter_declaration)) {
+      if ((fC->Type(Parameter_declaration) ==
+           VObjectType::slParameter_declaration) ||
+          (fC->Type(Parameter_declaration) ==
+           VObjectType::slLocal_parameter_declaration)) {
         DesignComponent* tmp =
             new ModuleDefinition(nullptr, InvalidNodeId, "fake");
         compileParameterDeclaration(
             tmp, fC, Parameter_declaration, compileDesign,
-            (fC->Type(Parameter_declaration) == slLocal_parameter_declaration),
+            (fC->Type(Parameter_declaration) ==
+             VObjectType::slLocal_parameter_declaration),
             nullptr, false, false, false);
         if (tmp->getParameters()) {
           VectorOfany* params = func->Parameters();
@@ -2410,10 +2426,10 @@ UHDM::any* CompileHelper::compileProceduralContinuousAssign(
       NodeId Variable_lvalue = fC->Child(Variable_assignment);
       NodeId Hierarchical_identifier = fC->Child(Variable_lvalue);
       if (fC->Type(fC->Child(Hierarchical_identifier)) ==
-          slHierarchical_identifier) {
+          VObjectType::slHierarchical_identifier) {
         Hierarchical_identifier = fC->Child(fC->Child(Hierarchical_identifier));
       } else if (fC->Type(Hierarchical_identifier) !=
-                 slPs_or_hierarchical_identifier) {
+                 VObjectType::slPs_or_hierarchical_identifier) {
         Hierarchical_identifier = Variable_lvalue;
       }
       NodeId Expression = fC->Sibling(Variable_lvalue);
@@ -2434,10 +2450,10 @@ UHDM::any* CompileHelper::compileProceduralContinuousAssign(
       NodeId Variable_lvalue = fC->Child(Variable_assignment);
       NodeId Hierarchical_identifier = fC->Child(Variable_lvalue);
       if (fC->Type(fC->Child(Hierarchical_identifier)) ==
-          slHierarchical_identifier) {
+          VObjectType::slHierarchical_identifier) {
         Hierarchical_identifier = fC->Child(fC->Child(Hierarchical_identifier));
       } else if (fC->Type(Hierarchical_identifier) !=
-                 slPs_or_hierarchical_identifier) {
+                 VObjectType::slPs_or_hierarchical_identifier) {
         Hierarchical_identifier = Variable_lvalue;
       }
       NodeId Expression = fC->Sibling(Variable_lvalue);
@@ -2458,10 +2474,10 @@ UHDM::any* CompileHelper::compileProceduralContinuousAssign(
       NodeId Variable_lvalue = fC->Child(Variable_assignment);
       NodeId Hierarchical_identifier = fC->Child(Variable_lvalue);
       if (fC->Type(fC->Child(Hierarchical_identifier)) ==
-          slHierarchical_identifier) {
+          VObjectType::slHierarchical_identifier) {
         Hierarchical_identifier = fC->Child(fC->Child(Hierarchical_identifier));
       } else if (fC->Type(Hierarchical_identifier) !=
-                 slPs_or_hierarchical_identifier) {
+                 VObjectType::slPs_or_hierarchical_identifier) {
         Hierarchical_identifier = Variable_lvalue;
       }
       expr* lhs = (expr*)compileExpression(
@@ -2477,10 +2493,10 @@ UHDM::any* CompileHelper::compileProceduralContinuousAssign(
       NodeId Variable_lvalue = fC->Child(Variable_assignment);
       NodeId Hierarchical_identifier = fC->Child(Variable_lvalue);
       if (fC->Type(fC->Child(Hierarchical_identifier)) ==
-          slHierarchical_identifier) {
+          VObjectType::slHierarchical_identifier) {
         Hierarchical_identifier = fC->Child(fC->Child(Hierarchical_identifier));
       } else if (fC->Type(Hierarchical_identifier) !=
-                 slPs_or_hierarchical_identifier) {
+                 VObjectType::slPs_or_hierarchical_identifier) {
         Hierarchical_identifier = Variable_lvalue;
       }
       expr* lhs = (expr*)compileExpression(
@@ -2507,13 +2523,13 @@ UHDM::any* CompileHelper::compileForLoop(DesignComponent* component,
   NodeId Statement_or_null;
   NodeId tmp = fC->Sibling(nodeId);
   while (tmp) {
-    if (fC->Type(tmp) == slFor_initialization) {
+    if (fC->Type(tmp) == VObjectType::slFor_initialization) {
       For_initialization = tmp;
-    } else if (fC->Type(tmp) == slExpression) {
+    } else if (fC->Type(tmp) == VObjectType::slExpression) {
       Condition = tmp;
-    } else if (fC->Type(tmp) == slFor_step) {
+    } else if (fC->Type(tmp) == VObjectType::slFor_step) {
       For_step = tmp;
-    } else if (fC->Type(tmp) == slStatement_or_null) {
+    } else if (fC->Type(tmp) == VObjectType::slStatement_or_null) {
       Statement_or_null = tmp;
     }
     tmp = fC->Sibling(tmp);
@@ -2522,7 +2538,8 @@ UHDM::any* CompileHelper::compileForLoop(DesignComponent* component,
   // Init
   if (For_initialization) {
     NodeId For_variable_declaration = fC->Child(For_initialization);
-    if (fC->Type(For_variable_declaration) == slFor_variable_declaration) {
+    if (fC->Type(For_variable_declaration) ==
+        VObjectType::slFor_variable_declaration) {
       while (For_variable_declaration) {
         VectorOfany* stmts = for_stmt->VpiForInitStmts();
         if (stmts == nullptr) {
@@ -2559,18 +2576,18 @@ UHDM::any* CompileHelper::compileForLoop(DesignComponent* component,
         For_variable_declaration = fC->Sibling(For_variable_declaration);
       }
     } else if (fC->Type(For_variable_declaration) ==
-               slList_of_variable_assignments) {
+               VObjectType::slList_of_variable_assignments) {
       NodeId List_of_variable_assignments = For_variable_declaration;
       NodeId Variable_assignment = fC->Child(List_of_variable_assignments);
       while (Variable_assignment) {
         NodeId Variable_lvalue = fC->Child(Variable_assignment);
         NodeId Hierarchical_identifier = fC->Child(Variable_lvalue);
         if (fC->Type(fC->Child(Hierarchical_identifier)) ==
-            slHierarchical_identifier) {
+            VObjectType::slHierarchical_identifier) {
           Hierarchical_identifier =
               fC->Child(fC->Child(Hierarchical_identifier));
         } else if (fC->Type(Hierarchical_identifier) !=
-                   slPs_or_hierarchical_identifier) {
+                   VObjectType::slPs_or_hierarchical_identifier) {
           Hierarchical_identifier = Variable_lvalue;
         }
         NodeId Expression = fC->Sibling(Variable_lvalue);
@@ -2625,7 +2642,7 @@ UHDM::any* CompileHelper::compileForLoop(DesignComponent* component,
       }
 
       NodeId Expression = fC->Child(For_step_assignment);
-      if (fC->Type(Expression) == slOperator_assignment) {
+      if (fC->Type(Expression) == VObjectType::slOperator_assignment) {
         std::vector<UHDM::any*>* incstmts =
             compileStmt(component, fC, Expression, compileDesign, for_stmt);
         if (incstmts) {
@@ -2834,13 +2851,13 @@ UHDM::method_func_call* CompileHelper::compileRandomizeCall(
   method_func_call* result = func_call;
   func_call->VpiName("randomize");
   NodeId With;
-  if (fC->Type(Identifier_list) == slIdentifier_list) {
+  if (fC->Type(Identifier_list) == VObjectType::slIdentifier_list) {
     With = fC->Sibling(Identifier_list);
-  } else if (fC->Type(Identifier_list) == slWith) {
+  } else if (fC->Type(Identifier_list) == VObjectType::slWith) {
     With = Identifier_list;
   }
   NodeId Constraint_block = fC->Sibling(With);
-  if (fC->Type(Identifier_list) == slIdentifier_list) {
+  if (fC->Type(Identifier_list) == VObjectType::slIdentifier_list) {
     VectorOfany* arguments =
         compileTfCallArguments(component, fC, Identifier_list, compileDesign,
                                func_call, nullptr, false, false);
@@ -2902,7 +2919,7 @@ void CompileHelper::compileBindStmt(DesignComponent* component,
   const std::string& targetName = fC->SymName(Target_scope);
   NodeId Bind_instantiation = fC->Sibling(Target_scope);
   NodeId Instance_target;
-  if (fC->Type(Bind_instantiation) == slStringConst) {
+  if (fC->Type(Bind_instantiation) == VObjectType::slStringConst) {
     Instance_target = Bind_instantiation;
     NodeId Constant_bit_select = fC->Sibling(Bind_instantiation);
     Bind_instantiation = fC->Sibling(Constant_bit_select);
@@ -2910,7 +2927,7 @@ void CompileHelper::compileBindStmt(DesignComponent* component,
   NodeId Module_instantiation = fC->Child(Bind_instantiation);
   NodeId Source_scope = fC->Child(Module_instantiation);
   NodeId tmp = fC->Sibling(Source_scope);
-  if (fC->Type(tmp) == slParameter_value_assignment) {
+  if (fC->Type(tmp) == VObjectType::slParameter_value_assignment) {
     tmp = fC->Sibling(tmp);
   }
   NodeId Instance_name = tmp;

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -204,9 +204,9 @@ UHDM::any* CompileHelper::compileVariable(
       the_type == VObjectType::slPs_or_hierarchical_identifier) {
     variable = fC->Child(variable);
     the_type = fC->Type(variable);
-  } else if (the_type == slImplicit_class_handle) {
+  } else if (the_type == VObjectType::slImplicit_class_handle) {
     NodeId Handle = fC->Child(variable);
-    if (fC->Type(Handle) == slThis_keyword) {
+    if (fC->Type(Handle) == VObjectType::slThis_keyword) {
       variable = fC->Sibling(variable);
       the_type = fC->Type(variable);
     }
@@ -221,13 +221,13 @@ UHDM::any* CompileHelper::compileVariable(
   if (!Packed_dimension) {
     // Implicit return value:
     // function [1:0] fct();
-    if (fC->Type(variable) == slConstant_range) {
+    if (fC->Type(variable) == VObjectType::slConstant_range) {
       Packed_dimension = variable;
     }
   }
 
-  if (fC->Type(variable) == slStringConst &&
-      fC->Type(Packed_dimension) == slStringConst) {
+  if (fC->Type(variable) == VObjectType::slStringConst &&
+      fC->Type(Packed_dimension) == VObjectType::slStringConst) {
     UHDM::hier_path* path = s.MakeHier_path();
     VectorOfany* elems = s.MakeAnyVec();
     path->Path_elems(elems);
@@ -235,7 +235,7 @@ UHDM::any* CompileHelper::compileVariable(
     ref_obj* obj = s.MakeRef_obj();
     obj->VpiName(fullName);
     elems->push_back(obj);
-    while (fC->Type(Packed_dimension) == slStringConst) {
+    while (fC->Type(Packed_dimension) == VObjectType::slStringConst) {
       ref_obj* obj = s.MakeRef_obj();
       const std::string& name = fC->SymName(Packed_dimension);
       fullName += "." + name;
@@ -253,14 +253,14 @@ UHDM::any* CompileHelper::compileVariable(
                     instance, reduce, size, muteErrors);
   typespec* ts = nullptr;
   VObjectType decl_type = fC->Type(declarationId);
-  if (decl_type != slPs_or_hierarchical_identifier &&
-      decl_type != slImplicit_class_handle) {
+  if (decl_type != VObjectType::slPs_or_hierarchical_identifier &&
+      decl_type != VObjectType::slImplicit_class_handle) {
     ts = compileTypespec(component, fC, declarationId, compileDesign, pstmt,
                          instance, reduce, true);
   }
   bool isSigned = true;
   const NodeId signId = fC->Sibling(variable);
-  if (signId && (fC->Type(signId) == slSigning_Unsigned)) {
+  if (signId && (fC->Type(signId) == VObjectType::slSigning_Unsigned)) {
     isSigned = false;
   }
   switch (the_type) {
@@ -303,7 +303,7 @@ UHDM::any* CompileHelper::compileVariable(
         }
       }
       if (result == nullptr) {
-        if (the_type == slStringConst) {
+        if (the_type == VObjectType::slStringConst) {
           if (ts) {
             if (ts->UhdmType() == uhdmclass_typespec) {
               class_var* var = s.MakeClass_var();
@@ -315,7 +315,7 @@ UHDM::any* CompileHelper::compileVariable(
         }
       }
       if (result == nullptr) {
-        if (the_type == slChandle_type) {
+        if (the_type == VObjectType::slChandle_type) {
           chandle_var* var = s.MakeChandle_var();
           var->Typespec(ts);
           result = var;
@@ -608,16 +608,18 @@ typespec* CompileHelper::compileDatastructureTypespec(
           if ((sig->getName() == typeName) && sig->getInterfaceTypeNameId()) {
             std::string suffixname;
             std::string typeName2 = typeName;
-            if (fC->Type(sig->getInterfaceTypeNameId()) == slStringConst) {
+            if (fC->Type(sig->getInterfaceTypeNameId()) ==
+                VObjectType::slStringConst) {
               typeName2 = fC->SymName(sig->getInterfaceTypeNameId());
             }
             NodeId suffixNode;
             if ((suffixNode = fC->Sibling(type))) {
-              if (fC->Type(suffixNode) == slStringConst) {
+              if (fC->Type(suffixNode) == VObjectType::slStringConst) {
                 suffixname = fC->SymName(suffixNode);
-              } else if (fC->Type(suffixNode) == slConstant_bit_select) {
+              } else if (fC->Type(suffixNode) ==
+                         VObjectType::slConstant_bit_select) {
                 suffixNode = fC->Sibling(suffixNode);
-                if (fC->Type(suffixNode) == slStringConst) {
+                if (fC->Type(suffixNode) == VObjectType::slStringConst) {
                   suffixname = fC->SymName(suffixNode);
                 }
               }
@@ -726,8 +728,8 @@ typespec* CompileHelper::compileDatastructureTypespec(
           NodeId n = parent_tpd->getDefinitionNode();
           param = actualFC->Sibling(n);
         }
-        if (param &&
-            (actualFC->Type(param) != slList_of_net_decl_assignments)) {
+        if (param && (actualFC->Type(param) !=
+                      VObjectType::slList_of_net_decl_assignments)) {
           VectorOfany* params = s.MakeAnyVec();
           ref->Parameters(params);
           VectorOfparam_assign* assigns = s.MakeParam_assignVec();
@@ -740,7 +742,7 @@ typespec* CompileHelper::compileDatastructureTypespec(
               actualFC->Child(List_of_parameter_assignments);
           if (Ordered_parameter_assignment &&
               (actualFC->Type(Ordered_parameter_assignment) ==
-               slOrdered_parameter_assignment)) {
+               VObjectType::slOrdered_parameter_assignment)) {
             while (Ordered_parameter_assignment) {
               NodeId Param_expression =
                   actualFC->Child(Ordered_parameter_assignment);
@@ -754,7 +756,7 @@ typespec* CompileHelper::compileDatastructureTypespec(
                 fName = p->getName();
                 fparam = p->getUhdmParam();
 
-                if (actualFC->Type(Data_type) == slData_type) {
+                if (actualFC->Type(Data_type) == VObjectType::slData_type) {
                   typespec* tps =
                       compileTypespec(component, actualFC, Data_type,
                                       compileDesign, result, instance, reduce);
@@ -814,7 +816,7 @@ typespec* CompileHelper::compileDatastructureTypespec(
       ModuleDefinition* def =
           design->getModuleDefinition(libName + "@" + typeName);
       if (def) {
-        if (def->getType() == slInterface_declaration) {
+        if (def->getType() == VObjectType::slInterface_declaration) {
           interface_typespec* tps = s.MakeInterface_typespec();
           tps->VpiName(typeName);
           fC->populateCoreMembers(type, type, tps);
@@ -932,7 +934,7 @@ UHDM::typespec* CompileHelper::compileBuiltinTypespec(
   typespec* result = nullptr;
   NodeId sign = fC->Sibling(type);
   bool isSigned = true;
-  if (sign && (fC->Type(sign) == slSigning_Unsigned)) {
+  if (sign && (fC->Type(sign) == VObjectType::slSigning_Unsigned)) {
     isSigned = false;
   }
   switch (the_type) {
@@ -1043,25 +1045,25 @@ UHDM::typespec* CompileHelper::compileTypespec(
   } else if (the_type == VObjectType::slStringConst) {
     // Class parameter or struct reference
     Packed_dimension = fC->Sibling(type);
-    if (fC->Type(Packed_dimension) != slPacked_dimension)
+    if (fC->Type(Packed_dimension) != VObjectType::slPacked_dimension)
       Packed_dimension = InvalidNodeId;
   } else {
     Packed_dimension = fC->Sibling(type);
-    if (fC->Type(Packed_dimension) == slData_type_or_implicit) {
+    if (fC->Type(Packed_dimension) == VObjectType::slData_type_or_implicit) {
       Packed_dimension = fC->Child(Packed_dimension);
     }
   }
   bool isPacked = false;
-  if (fC->Type(Packed_dimension) == slPacked_keyword) {
+  if (fC->Type(Packed_dimension) == VObjectType::slPacked_keyword) {
     Packed_dimension = fC->Sibling(Packed_dimension);
     isPacked = true;
   }
-  if (fC->Type(Packed_dimension) == slStruct_union_member) {
+  if (fC->Type(Packed_dimension) == VObjectType::slStruct_union_member) {
     Packed_dimension = fC->Sibling(Packed_dimension);
   }
 
-  if (fC->Type(Packed_dimension) == slSigning_Signed ||
-      fC->Type(Packed_dimension) == slSigning_Unsigned) {
+  if (fC->Type(Packed_dimension) == VObjectType::slSigning_Signed ||
+      fC->Type(Packed_dimension) == VObjectType::slSigning_Unsigned) {
     Packed_dimension = fC->Sibling(Packed_dimension);
   }
   int size;
@@ -1097,7 +1099,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
     case VObjectType::slEnum_name_declaration: {
       typespec* baseType = nullptr;
       uint64_t baseSize = 64;
-      if (the_type == slEnum_base_type) {
+      if (the_type == VObjectType::slEnum_base_type) {
         baseType =
             compileTypespec(component, fC, fC->Child(type), compileDesign,
                             pstmt, instance, reduce, isVariable);
@@ -1222,7 +1224,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
     }
     case VObjectType::slPrimary_literal: {
       NodeId literal = fC->Child(type);
-      if (fC->Type(literal) == slStringConst) {
+      if (fC->Type(literal) == VObjectType::slStringConst) {
         const std::string& typeName = fC->SymName(literal);
         result = compileDatastructureTypespec(
             component, fC, type, compileDesign, instance, reduce, "", typeName);
@@ -1277,7 +1279,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
       std::string typeName;
       NodeId class_type = fC->Child(type);
       NodeId class_name;
-      if (the_type == slClass_scope)
+      if (the_type == VObjectType::slClass_scope)
         class_name = fC->Child(class_type);
       else
         class_name = class_type;
@@ -1429,7 +1431,8 @@ UHDM::typespec* CompileHelper::compileTypespec(
             m->Typespec(member_ts);
             member_ts->VpiParent(m);
           }
-          if (Expression && (fC->Type(Expression) != slVariable_dimension)) {
+          if (Expression &&
+              (fC->Type(Expression) != VObjectType::slVariable_dimension)) {
             any* ex =
                 compileExpression(component, fC, Expression, compileDesign,
                                   nullptr, instance, reduce, false);
@@ -1694,7 +1697,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
     }
     case VObjectType::slType_reference: {
       NodeId child = fC->Child(type);
-      if (fC->Type(child) == slExpression) {
+      if (fC->Type(child) == VObjectType::slExpression) {
         expr* exp =
             (expr*)compileExpression(component, fC, child, compileDesign,
                                      nullptr, instance, reduce, reduce);
@@ -1744,7 +1747,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
       }
       break;
     }
-    case slData_type_or_implicit: {
+    case VObjectType::slData_type_or_implicit: {
       logic_typespec* tps = s.MakeLogic_typespec();
       fC->populateCoreMembers(type, type, tps);
       VectorOfrange* ranges =

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -643,7 +643,8 @@ ModuleInstance* DesignElaboration::createBindInstance_(
     std::vector<ModuleInstance*> parentSubInstances;
     instance->setInstanceBinding(parent);
     NodeId parameterOverloading = fC->Sibling(bindNodeId);
-    if (fC->Type(parameterOverloading) == slHierarchical_instance) {
+    if (fC->Type(parameterOverloading) ==
+        VObjectType::slHierarchical_instance) {
       parameterOverloading = InvalidNodeId;
     }
     elaborateInstance_(targetDef->getFileContents()[0],
@@ -812,9 +813,9 @@ void DesignElaboration::elaborateInstance_(
     VObjectType type = fC->Type(subInstanceId);
     std::vector<NodeId> subSubInstances;
     std::string instName;
-    if (type == slGenerate_region) {
+    if (type == VObjectType::slGenerate_region) {
       NodeId Generate_block = fC->Child(subInstanceId);
-      if (fC->Type(Generate_block) != slGenerate_block) {
+      if (fC->Type(Generate_block) != VObjectType::slGenerate_block) {
         continue;
       }
       NodeId nameId = fC->Child(Generate_block);
@@ -841,7 +842,8 @@ void DesignElaboration::elaborateInstance_(
             }
           }
           Generate_block = fC->Sibling(Generate_block);
-          if (Generate_block && (fC->Type(Generate_block) == slEndgenerate)) {
+          if (Generate_block &&
+              (fC->Type(Generate_block) == VObjectType::slEndgenerate)) {
             break;
           }
         }
@@ -863,13 +865,14 @@ void DesignElaboration::elaborateInstance_(
       Config* subConfig = config;
       VObjectType type = fC->Type(subInstanceId);
 
-      if (type == slSeq_block || type == slPar_block) {
+      if (type == VObjectType::slSeq_block ||
+          type == VObjectType::slPar_block) {
         NodeId identifierId = fC->Child(subInstanceId);
         if (fC->Name(identifierId))
           instName = fC->SymName(identifierId);
         else
           instName = "UNNAMED";
-      } else if (type == slConditional_generate_construct) {
+      } else if (type == VObjectType::slConditional_generate_construct) {
         NodeId constructId = fC->Child(subInstanceId);
         NodeId condId = fC->Child(constructId);
         NodeId blockId = fC->Sibling(condId);
@@ -879,7 +882,8 @@ void DesignElaboration::elaborateInstance_(
         else
           instName = "UNNAMED";
       } else {
-        NodeId instId = fC->sl_collect(subInstanceId, slName_of_instance);
+        NodeId instId =
+            fC->sl_collect(subInstanceId, VObjectType::slName_of_instance);
         NodeId identifierId;
         if (instId) {
           identifierId = fC->Child(instId);
@@ -894,7 +898,8 @@ void DesignElaboration::elaborateInstance_(
         def = design->getComponentDefinition(modName);
         NodeId instanceId = fC->Sibling(fC->Child(subInstanceId));
         while (instanceId) {
-          NodeId instId = fC->sl_collect(instanceId, slName_of_instance);
+          NodeId instId =
+              fC->sl_collect(instanceId, VObjectType::slName_of_instance);
           NodeId identifierId;
           if (instId) {
             identifierId = fC->Child(instId);
@@ -952,7 +957,7 @@ void DesignElaboration::elaborateInstance_(
         }
 
         NodeId conditionId = fC->Child(subInstanceId);
-        if (fC->Type(conditionId) == slIf_generate_construct) {
+        if (fC->Type(conditionId) == VObjectType::slIf_generate_construct) {
           NodeId IF = fC->Child(conditionId);
           conditionId = fC->Sibling(IF);
         }
@@ -988,7 +993,7 @@ void DesignElaboration::elaborateInstance_(
           if (!expr) {  // Unary operator like i++
             expr = var;
           } else if (fC->Type(assignOp) !=
-                     slAssignOp_Assign) {  // Operators like +=
+                     VObjectType::slAssignOp_Assign) {  // Operators like +=
             expr = var;
           }
           // Generate block
@@ -1122,7 +1127,7 @@ void DesignElaboration::elaborateInstance_(
                   NodeId Generate_block = tmp;
                   NodeId Generate_item = fC->Child(Generate_block);
                   NodeId Cond;
-                  if (fC->Type(Generate_item) == slGenerate_item) {
+                  if (fC->Type(Generate_item) == VObjectType::slGenerate_item) {
                     NodeId Module_or_generate_item = fC->Child(Generate_item);
                     NodeId Module_common_item =
                         fC->Child(Module_or_generate_item);
@@ -1146,7 +1151,8 @@ void DesignElaboration::elaborateInstance_(
                       condVal = true;
                     }
                   } else if (fC->Type(Generate_item) ==
-                             slGenerate_module_conditional_statement) {
+                             VObjectType::
+                                 slGenerate_module_conditional_statement) {
                     Cond = fC->Child(Generate_item);
                     if (fC->Type(Cond) == VObjectType::slIF) {
                       Cond = fC->Sibling(Cond);
@@ -1199,8 +1205,8 @@ void DesignElaboration::elaborateInstance_(
                   NodeId If_generate_construct =
                       fC->Child(Conditional_generate_construct);
                   if (fC->Type(If_generate_construct) ==
-                      slIf_generate_construct) {
-                    if (fC->Type(childId) == slGenerate_block)
+                      VObjectType::slIf_generate_construct) {
+                    if (fC->Type(childId) == VObjectType::slGenerate_block)
                       childId = fC->Child(childId);
                     blockIds = fC->sl_collect_all(childId, btypes, true);
                     if (!blockIds.empty()) {
@@ -1277,28 +1283,30 @@ void DesignElaboration::elaborateInstance_(
           elaborateInstance_(def->getFileContents()[0], childId, paramOverride,
                              factory, child, config, allSubInstances);
           childId = fC->Sibling(childId);
-          if (fC->Type(childId) == slGenerate_block) {
+          if (fC->Type(childId) == VObjectType::slGenerate_block) {
             NodeId subChild = fC->Child(childId);
-            if (fC->Type(subChild) == slGenerate_block) {
+            if (fC->Type(subChild) == VObjectType::slGenerate_block) {
               break;
             }
           }
-          if (fC->Type(childId) == slGenerate_module_item) {
+          if (fC->Type(childId) == VObjectType::slGenerate_module_item) {
             NodeId node = fC->Child(childId);
-            if (fC->Type(node) == slGenerate_module_conditional_statement) {
+            if (fC->Type(node) ==
+                VObjectType::slGenerate_module_conditional_statement) {
               break;
             }
-            if (fC->Type(node) == slGenerate_module_block) {
+            if (fC->Type(node) == VObjectType::slGenerate_module_block) {
               break;
             }
           }
-          if (fC->Type(childId) == slElse) break;
-          if (fC->Type(childId) == slEnd) break;
+          if (fC->Type(childId) == VObjectType::slElse) break;
+          if (fC->Type(childId) == VObjectType::slEnd) break;
         }
         parent->addSubInstance(child);
       }
       // Named blocks
-      else if (type == slSeq_block || type == slPar_block) {
+      else if (type == VObjectType::slSeq_block ||
+               type == VObjectType::slPar_block) {
         std::string fullName = parent->getModuleName() + "." + instName;
 
         def = design->getComponentDefinition(fullName);
@@ -1315,9 +1323,9 @@ void DesignElaboration::elaborateInstance_(
                            allSubInstances);
         parent->addSubInstance(child);
 
-      } else if (type == slGenerate_region) {
+      } else if (type == VObjectType::slGenerate_region) {
         NodeId Generate_block = fC->Child(subInstanceId);
-        if (fC->Type(Generate_block) != slGenerate_block) {
+        if (fC->Type(Generate_block) != VObjectType::slGenerate_block) {
           continue;
         }
         NodeId nameId = fC->Child(Generate_block);
@@ -1421,7 +1429,7 @@ void DesignElaboration::elaborateInstance_(
         NodeId tmpId = fC->Sibling(moduleName);
         VObjectType tmpType = fC->Type(tmpId);
         if (tmpType == VObjectType::slParameter_value_assignment ||
-            tmpType == slDelay2) {
+            tmpType == VObjectType::slDelay2) {
           paramOverride = tmpId;
         }
 
@@ -1440,7 +1448,8 @@ void DesignElaboration::elaborateInstance_(
         if (!hierInstId) continue;
 
         while (hierInstId) {
-          NodeId instId = fC->sl_collect(hierInstId, slName_of_instance);
+          NodeId instId =
+              fC->sl_collect(hierInstId, VObjectType::slName_of_instance);
           NodeId identifierId;
           if (instId) {
             identifierId = fC->Child(instId);
@@ -1513,7 +1522,8 @@ void DesignElaboration::elaborateInstance_(
 
             // Vector instances
             while (unpackedDimId) {
-              if (fC->Type(unpackedDimId) == slUnpacked_dimension) {
+              if (fC->Type(unpackedDimId) ==
+                  VObjectType::slUnpacked_dimension) {
                 NodeId constantRangeId = fC->Child(unpackedDimId);
                 NodeId leftNode = fC->Child(constantRangeId);
                 NodeId rightNode = fC->Sibling(leftNode);
@@ -1524,8 +1534,8 @@ void DesignElaboration::elaborateInstance_(
                                                  nullptr, parent, true, false);
                 m_helper.checkForLoops(false);
                 int64_t right = 0;
-                if (rightNode &&
-                    (fC->Type(rightNode) == slConstant_expression)) {
+                if (rightNode && (fC->Type(rightNode) ==
+                                  VObjectType::slConstant_expression)) {
                   m_helper.checkForLoops(true);
                   right = m_helper.getValue(validValue, parentDef, fC,
                                             rightNode, m_compileDesign, nullptr,
@@ -1754,9 +1764,9 @@ void DesignElaboration::collectParams_(std::vector<std::string>& params,
         VObjectType::slNamed_parameter_assignment};
     std::vector<NodeId> overrideParams =
         parentFile->sl_collect_all(parentParamOverride, types);
-    if (parentFile->Type(parentParamOverride) == slDelay2) {
+    if (parentFile->Type(parentParamOverride) == VObjectType::slDelay2) {
       NodeId tmp = parentFile->Child(parentParamOverride);
-      if (parentFile->Type(tmp) == slMintypmax_expression) {
+      if (parentFile->Type(tmp) == VObjectType::slMintypmax_expression) {
         while (tmp) {
           overrideParams.push_back(tmp);
           tmp = parentFile->Sibling(tmp);
@@ -1768,7 +1778,7 @@ void DesignElaboration::collectParams_(std::vector<std::string>& params,
     unsigned int index = 0;
     for (auto paramAssign : overrideParams) {
       NodeId child = parentFile->Child(paramAssign);
-      if (parentFile->Type(paramAssign) == slDelay2) {
+      if (parentFile->Type(paramAssign) == VObjectType::slDelay2) {
         child = paramAssign;
       }
       if (parentFile->Type(child) == VObjectType::slStringConst) {
@@ -1960,7 +1970,7 @@ void DesignElaboration::collectParams_(std::vector<std::string>& params,
           name = moduleParams[index];
           overridenParams.insert(name);
         } else {
-          if (parentFile->Type(expr) != slDelay2) {
+          if (parentFile->Type(expr) != VObjectType::slDelay2) {
             Location loc(parentFile->getFileId(paramAssign),
                          parentFile->Line(paramAssign),
                          parentFile->Column(paramAssign),
@@ -2044,7 +2054,7 @@ void DesignElaboration::collectParams_(std::vector<std::string>& params,
     NodeId hIdent = fC->Child(defParam);
     NodeId var;
     fC->Child(hIdent);
-    if (fC->Type(hIdent) == slHierarchical_identifier)
+    if (fC->Type(hIdent) == VObjectType::slHierarchical_identifier)
       var = fC->Child(hIdent);
     else
       var = hIdent;
@@ -2052,9 +2062,9 @@ void DesignElaboration::collectParams_(std::vector<std::string>& params,
     std::string fullPath;
     std::string path;
     while (var) {
-      if (fC->Type(var) == slStringConst) {
+      if (fC->Type(var) == VObjectType::slStringConst) {
         fullPath += fC->SymName(var);
-      } else if (fC->Type(var) == slConstant_expression) {
+      } else if (fC->Type(var) == VObjectType::slConstant_expression) {
         NodeId Constant_primary = fC->Child(var);
         NodeId Primary_literal = fC->Child(Constant_primary);
         NodeId IntConst = fC->Child(Primary_literal);
@@ -2063,7 +2073,7 @@ void DesignElaboration::collectParams_(std::vector<std::string>& params,
       }
       var = fC->Sibling(var);
       bool isString = false;
-      if (fC->Type(var) == slStringConst) {
+      if (fC->Type(var) == VObjectType::slStringConst) {
         isString = true;
       }
       if (var && isString) {
@@ -2103,11 +2113,11 @@ void DesignElaboration::collectParams_(std::vector<std::string>& params,
       const std::string& name = param.fC->SymName(ident);
       if (overridenParams.find(name) == overridenParams.end()) {
         NodeId exprId = param.fC->Sibling(ident);
-        while (param.fC->Type(exprId) == slUnpacked_dimension) {
+        while (param.fC->Type(exprId) == VObjectType::slUnpacked_dimension) {
           exprId = param.fC->Sibling(exprId);
         }
         NodeId Data_type = param.fC->Child(exprId);
-        if (param.fC->Type(Data_type) != slData_type) {
+        if (param.fC->Type(Data_type) != VObjectType::slData_type) {
           // Regular params
           Parameter* p = module->getParameter(name);
           bool isMultidimension = false;

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -163,7 +163,7 @@ bool ElaborationStep::bindTypedefs_() {
           NodeId Packed_dimension = fC->Sibling(id);
           typespec* tpclone = nullptr;
           if (Packed_dimension &&
-              fC->Type(Packed_dimension) == slPacked_dimension) {
+              fC->Type(Packed_dimension) == VObjectType::slPacked_dimension) {
             tpclone = m_helper.compileTypespec(
                 defTuple.second, typd->getFileContent(),
                 typd->getDefinitionNode(), m_compileDesign, nullptr, nullptr,
@@ -201,7 +201,7 @@ bool ElaborationStep::bindTypedefs_() {
         if (ts) {
           ts->VpiName(typd->getName());
           std::string name;
-          if (typeF->Type(typeId) == slStringConst) {
+          if (typeF->Type(typeId) == VObjectType::slStringConst) {
             name = typeF->SymName(typeId);
           } else {
             name = typd->getName();
@@ -964,7 +964,7 @@ bool bindStructInPackage(Design* design, Signal* signal,
       if (actual->getCategory() == DataType::Category::STRUCT) {
         Struct* st = (Struct*)actual;
         if (st->isNet()) {
-          signal->setType(slNetType_Wire);
+          signal->setType(VObjectType::slNetType_Wire);
         }
       }
       return true;
@@ -1090,13 +1090,13 @@ bool ElaborationStep::bindPortType_(Signal* signal, const FileContent* fC,
       }
       break;
     }
-    case slStringConst: {
+    case VObjectType::slStringConst: {
       std::string interfName;
       if (signal->getInterfaceTypeNameId()) {
         interfName = signal->getInterfaceTypeName();
       } else {
         if (NodeId typespecId = signal->getTypeSpecId()) {
-          if (fC->Type(typespecId) == slClass_scope) {
+          if (fC->Type(typespecId) == VObjectType::slClass_scope) {
             NodeId Class_type = fC->Child(typespecId);
             NodeId Class_type_name = fC->Child(Class_type);
             NodeId Class_scope_name = fC->Sibling(typespecId);
@@ -1104,7 +1104,7 @@ bool ElaborationStep::bindPortType_(Signal* signal, const FileContent* fC,
                                     fC->SymName(Class_type_name),
                                     fC->SymName(Class_scope_name)))
               return true;
-          } else if (fC->Type(typespecId) == slStringConst) {
+          } else if (fC->Type(typespecId) == VObjectType::slStringConst) {
             interfName = fC->SymName(typespecId);
           }
         }
@@ -1204,13 +1204,13 @@ bool ElaborationStep::bindPortType_(Signal* signal, const FileContent* fC,
           DataType::Category cat = def->getCategory();
           if (cat == DataType::Category::SIMPLE_TYPEDEF) {
             VObjectType t = def->getType();
-            if (t == slIntVec_TypeLogic) {  // Make "net types" explicit (vs
-                                            // variable types) for elab.
-              signal->setType(slIntVec_TypeLogic);
-            } else if (t == slIntVec_TypeReg) {
-              signal->setType(slIntVec_TypeReg);
-            } else if (t == slNetType_Wire) {
-              signal->setType(slNetType_Wire);
+            if (t == VObjectType::slIntVec_TypeLogic) {
+              // Make "net types" explicit (vs variable types) for elab.
+              signal->setType(VObjectType::slIntVec_TypeLogic);
+            } else if (t == VObjectType::slIntVec_TypeReg) {
+              signal->setType(VObjectType::slIntVec_TypeReg);
+            } else if (t == VObjectType::slNetType_Wire) {
+              signal->setType(VObjectType::slNetType_Wire);
             }
           } else if (cat == DataType::Category::REF) {
             // Should not arrive here, there should always be an actual
@@ -1233,7 +1233,7 @@ bool ElaborationStep::bindPortType_(Signal* signal, const FileContent* fC,
           }
         }
       }
-      if (signal->getType() != slNoType) {
+      if (signal->getType() != VObjectType::slNoType) {
         return true;
       }
       if (def == nullptr) {
@@ -1281,28 +1281,28 @@ UHDM::expr* ElaborationStep::exprFromAssign_(DesignComponent* component,
   // Assignment section
   NodeId assignment;
   NodeId Assign = fC->Sibling(id);
-  if (Assign && (fC->Type(Assign) == slExpression)) {
+  if (Assign && (fC->Type(Assign) == VObjectType::slExpression)) {
     assignment = Assign;
   }
   if (unpackedDimension) {
     NodeId tmp = unpackedDimension;
-    while ((fC->Type(tmp) == slUnpacked_dimension) ||
-           (fC->Type(tmp) == slVariable_dimension)) {
+    while ((fC->Type(tmp) == VObjectType::slUnpacked_dimension) ||
+           (fC->Type(tmp) == VObjectType::slVariable_dimension)) {
       tmp = fC->Sibling(tmp);
     }
-    if (tmp && (fC->Type(tmp) != slUnpacked_dimension) &&
-        (fC->Type(tmp) != slVariable_dimension)) {
+    if (tmp && (fC->Type(tmp) != VObjectType::slUnpacked_dimension) &&
+        (fC->Type(tmp) != VObjectType::slVariable_dimension)) {
       assignment = tmp;
     }
   }
 
   NodeId expression;
   if (assignment) {
-    if (fC->Type(assignment) == slClass_new) {
+    if (fC->Type(assignment) == VObjectType::slClass_new) {
       expression = assignment;
     } else {
       NodeId Primary = fC->Child(assignment);
-      if (fC->Type(assignment) == slExpression) {
+      if (fC->Type(assignment) == VObjectType::slExpression) {
         Primary = assignment;
       }
       expression = Primary;
@@ -1608,30 +1608,30 @@ any* ElaborationStep::makeVar_(DesignComponent* component, Signal* sig,
 
   if (obj == nullptr) {
     variables* var = nullptr;
-    if (subnettype == slIntegerAtomType_Shortint) {
+    if (subnettype == VObjectType::slIntegerAtomType_Shortint) {
       UHDM::short_int_var* int_var = s.MakeShort_int_var();
       var = int_var;
       tps = s.MakeShort_int_typespec();
       int_var->Typespec(tps);
-    } else if (subnettype == slIntegerAtomType_Int) {
+    } else if (subnettype == VObjectType::slIntegerAtomType_Int) {
       UHDM::int_var* int_var = s.MakeInt_var();
       var = int_var;
       tps = s.MakeInt_typespec();
       int_var->Typespec(tps);
-    } else if (subnettype == slIntegerAtomType_Integer) {
+    } else if (subnettype == VObjectType::slIntegerAtomType_Integer) {
       UHDM::integer_var* int_var = s.MakeInteger_var();
       var = int_var;
       tps = s.MakeInteger_typespec();
       int_var->Typespec(tps);
-    } else if (subnettype == slIntegerAtomType_LongInt) {
+    } else if (subnettype == VObjectType::slIntegerAtomType_LongInt) {
       UHDM::long_int_var* int_var = s.MakeLong_int_var();
       var = int_var;
       tps = s.MakeLong_int_typespec();
       int_var->Typespec(tps);
-    } else if (subnettype == slIntegerAtomType_Time) {
+    } else if (subnettype == VObjectType::slIntegerAtomType_Time) {
       UHDM::time_var* int_var = s.MakeTime_var();
       var = int_var;
-    } else if (subnettype == slIntVec_TypeBit) {
+    } else if (subnettype == VObjectType::slIntVec_TypeBit) {
       UHDM::bit_var* int_var = s.MakeBit_var();
       bit_typespec* btps = s.MakeBit_typespec();
       btps->Ranges(packedDimensions);
@@ -1639,28 +1639,28 @@ any* ElaborationStep::makeVar_(DesignComponent* component, Signal* sig,
       int_var->Typespec(tps);
       int_var->Ranges(packedDimensions);
       var = int_var;
-    } else if (subnettype == slIntegerAtomType_Byte) {
+    } else if (subnettype == VObjectType::slIntegerAtomType_Byte) {
       UHDM::byte_var* int_var = s.MakeByte_var();
       byte_typespec* btps = s.MakeByte_typespec();
       tps = btps;
       int_var->Typespec(tps);
       var = int_var;
-    } else if (subnettype == slNonIntType_ShortReal) {
+    } else if (subnettype == VObjectType::slNonIntType_ShortReal) {
       UHDM::short_real_var* int_var = s.MakeShort_real_var();
       var = int_var;
-    } else if (subnettype == slNonIntType_Real) {
+    } else if (subnettype == VObjectType::slNonIntType_Real) {
       UHDM::real_var* int_var = s.MakeReal_var();
       var = int_var;
-    } else if (subnettype == slNonIntType_RealTime) {
+    } else if (subnettype == VObjectType::slNonIntType_RealTime) {
       UHDM::time_var* int_var = s.MakeTime_var();
       var = int_var;
-    } else if (subnettype == slString_type) {
+    } else if (subnettype == VObjectType::slString_type) {
       UHDM::string_var* int_var = s.MakeString_var();
       var = int_var;
-    } else if (subnettype == slChandle_type) {
+    } else if (subnettype == VObjectType::slChandle_type) {
       UHDM::chandle_var* chandle_var = s.MakeChandle_var();
       var = chandle_var;
-    } else if (subnettype == slIntVec_TypeLogic) {
+    } else if (subnettype == VObjectType::slIntVec_TypeLogic) {
       logic_var* logicv = s.MakeLogic_var();
       logicv->Ranges(packedDimensions);
       logic_typespec* ltps = s.MakeLogic_typespec();
@@ -1674,7 +1674,7 @@ any* ElaborationStep::makeVar_(DesignComponent* component, Signal* sig,
       tps = ltps;
       logicv->Typespec(tps);
       var = logicv;
-    } else if (subnettype == slEvent_type) {
+    } else if (subnettype == VObjectType::slEvent_type) {
       named_event* event = s.MakeNamed_event();
       event->VpiName(signame);
       if (instance) {

--- a/src/DesignCompile/Elaboration_test.cpp
+++ b/src/DesignCompile/Elaboration_test.cpp
@@ -74,7 +74,8 @@ TEST(Elaboration, ExprFromPpTree) {
   NodeId root = fC->getRootNode();
   EXPECT_NE(top, nullptr);
 
-  std::vector<NodeId> assigns = fC->sl_collect_all(root, slParam_assignment);
+  std::vector<NodeId> assigns =
+      fC->sl_collect_all(root, VObjectType::slParam_assignment);
   EXPECT_EQ(assigns.size(), 2);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
@@ -121,7 +122,8 @@ TEST(Elaboration, ExprFromText) {
   NodeId root = fC->getRootNode();
   EXPECT_NE(top, nullptr);
 
-  std::vector<NodeId> assigns = fC->sl_collect_all(root, slParam_assignment);
+  std::vector<NodeId> assigns =
+      fC->sl_collect_all(root, VObjectType::slParam_assignment);
   EXPECT_EQ(assigns.size(), 3);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
@@ -165,11 +167,11 @@ TEST(Elaboration, ExprUsePackage) {
   }
   EXPECT_NE(top, nullptr);
   NodeId root = fC->getRootNode();
-  NodeId moduleRoot = fC->sl_collect(root, slModule_declaration);
+  NodeId moduleRoot = fC->sl_collect(root, VObjectType::slModule_declaration);
   EXPECT_TRUE(moduleRoot);
 
   std::vector<NodeId> assigns =
-      fC->sl_collect_all(moduleRoot, slParam_assignment);
+      fC->sl_collect_all(moduleRoot, VObjectType::slParam_assignment);
   EXPECT_EQ(assigns.size(), 3);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -570,7 +570,7 @@ ModuleInstance* NetlistElaboration::getInterfaceInstance_(
     }
     NodeId Net_lvalue;
     if (const NodeId Name_of_instance = fC->Child(Udp_instance);
-        fC->Type(Name_of_instance) == slName_of_instance) {
+        fC->Type(Name_of_instance) == VObjectType::slName_of_instance) {
       Net_lvalue = fC->Sibling(Name_of_instance);
     } else {
       Net_lvalue = Name_of_instance;
@@ -583,15 +583,15 @@ ModuleInstance* NetlistElaboration::getInterfaceInstance_(
         if (fC->Type(Net_lvalue) == VObjectType::slNet_lvalue) {
           NodeId Hierarchical_identifier = fC->Child(Net_lvalue);
           if (fC->Type(fC->Child(Hierarchical_identifier)) ==
-              slHierarchical_identifier) {
+              VObjectType::slHierarchical_identifier) {
             Hierarchical_identifier =
                 fC->Child(fC->Child(Hierarchical_identifier));
           } else if (fC->Type(Hierarchical_identifier) !=
-                     slPs_or_hierarchical_identifier) {
+                     VObjectType::slPs_or_hierarchical_identifier) {
             Hierarchical_identifier = Net_lvalue;
           }
           sigId = Hierarchical_identifier;
-          if (fC->Type(fC->Child(sigId)) == slStringConst) {
+          if (fC->Type(fC->Child(sigId)) == VObjectType::slStringConst) {
             sigId = fC->Child(sigId);
           }
           sigName = fC->SymName(sigId);
@@ -644,22 +644,23 @@ ModuleInstance* NetlistElaboration::getInterfaceInstance_(
           formalName = fC->SymName(formalNameId);
         } else {
           NodeId tmp = Expression;
-          if (fC->Type(tmp) == slOpenParens) {
+          if (fC->Type(tmp) == VObjectType::slOpenParens) {
             tmp = fC->Sibling(tmp);
-            if (fC->Type(tmp) == slCloseParens) {  // .p()  explicit disconnect
+            if (fC->Type(tmp) ==
+                VObjectType::slCloseParens) {  // .p()  explicit disconnect
               Named_port_connection = fC->Sibling(Named_port_connection);
               index++;
               continue;
             } else if (fC->Type(tmp) ==
-                       slExpression) {  // .p(s) connection by name
+                       VObjectType::slExpression) {  // .p(s) connection by name
               formalId = tmp;
               Expression = tmp;
             }
           }  // else .p implicit connection
         }
         NodeId sigId = formalId;
-        if (fC->Type(Expression) == slAttribute_instance) {
-          while (fC->Type(Expression) == slAttribute_instance)
+        if (fC->Type(Expression) == VObjectType::slAttribute_instance) {
+          while (fC->Type(Expression) == VObjectType::slAttribute_instance)
             Expression = fC->Sibling(Expression);
         }
         if (Expression) {
@@ -804,7 +805,7 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
     }
     NodeId Net_lvalue;
     if (const NodeId Name_of_instance = fC->Child(Udp_instance);
-        fC->Type(Name_of_instance) == slName_of_instance) {
+        fC->Type(Name_of_instance) == VObjectType::slName_of_instance) {
       Net_lvalue = fC->Sibling(Name_of_instance);
       NodeId Name = fC->Child(Name_of_instance);
       NodeId Unpacked_dimension = fC->Sibling(Name);
@@ -829,24 +830,24 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
         if (fC->Type(Net_lvalue) == VObjectType::slNet_lvalue) {
           NodeId Hierarchical_identifier = fC->Child(Net_lvalue);
           if (fC->Type(fC->Child(Hierarchical_identifier)) ==
-              slHierarchical_identifier) {
+              VObjectType::slHierarchical_identifier) {
             Hierarchical_identifier =
                 fC->Child(fC->Child(Hierarchical_identifier));
           } else if (fC->Type(Hierarchical_identifier) !=
-                     slPs_or_hierarchical_identifier) {
+                     VObjectType::slPs_or_hierarchical_identifier) {
             Hierarchical_identifier = Net_lvalue;
           }
           if (m_helper.isSelected(fC, Hierarchical_identifier))
             bit_or_part_select = true;
           sigId = Hierarchical_identifier;
-          if (fC->Type(fC->Child(sigId)) == slStringConst) {
+          if (fC->Type(fC->Child(sigId)) == VObjectType::slStringConst) {
             sigId = fC->Child(sigId);
           }
           sigName = fC->SymName(sigId);
         } else if (fC->Type(Net_lvalue) == VObjectType::slExpression) {
           NodeId Primary = fC->Child(Net_lvalue);
           NodeId Primary_literal = fC->Child(Primary);
-          if (fC->Type(Primary_literal) == slComplex_func_call)
+          if (fC->Type(Primary_literal) == VObjectType::slComplex_func_call)
             bit_or_part_select = true;
           sigId = fC->Child(Primary_literal);
           sigName = fC->SymName(sigId);
@@ -855,7 +856,8 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
           if (index < ports->size()) {
             port* p = (*ports)[index];
 
-            if ((!bit_or_part_select) && (fC->Type(sigId) == slStringConst)) {
+            if ((!bit_or_part_select) &&
+                (fC->Type(sigId) == VObjectType::slStringConst)) {
               bool bitBlast = false;
               any* net = nullptr;
               if (parent) {
@@ -909,11 +911,11 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
               if (fC->Type(Net_lvalue) == VObjectType::slNet_lvalue) {
                 NodeId Hierarchical_identifier = fC->Child(Net_lvalue);
                 if (fC->Type(fC->Child(Hierarchical_identifier)) ==
-                    slHierarchical_identifier) {
+                    VObjectType::slHierarchical_identifier) {
                   Hierarchical_identifier =
                       fC->Child(fC->Child(Hierarchical_identifier));
                 } else if (fC->Type(Hierarchical_identifier) !=
-                           slPs_or_hierarchical_identifier) {
+                           VObjectType::slPs_or_hierarchical_identifier) {
                   Hierarchical_identifier = Net_lvalue;
                 }
                 m_helper.checkForLoops(true);
@@ -946,7 +948,8 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
             netlist->ports(ports);
           }
           fC->populateCoreMembers(Net_lvalue, Net_lvalue, p);
-          if ((fC->Type(sigId) == slStringConst) && (!bit_or_part_select)) {
+          if ((fC->Type(sigId) == VObjectType::slStringConst) &&
+              (!bit_or_part_select)) {
             ref_obj* ref = s.MakeRef_obj();
             fC->populateCoreMembers(sigId, sigId, ref);
             p->High_conn(ref);
@@ -960,11 +963,11 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
           } else {
             NodeId Hierarchical_identifier = fC->Child(Net_lvalue);
             if (fC->Type(fC->Child(Hierarchical_identifier)) ==
-                slHierarchical_identifier) {
+                VObjectType::slHierarchical_identifier) {
               Hierarchical_identifier =
                   fC->Child(fC->Child(Hierarchical_identifier));
             } else if (fC->Type(Hierarchical_identifier) !=
-                       slPs_or_hierarchical_identifier) {
+                       VObjectType::slPs_or_hierarchical_identifier) {
               Hierarchical_identifier = Net_lvalue;
             }
             m_helper.checkForLoops(true);
@@ -1044,7 +1047,7 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
         if (fC->Type(formalId) == VObjectType::slAttribute_instance) {
           attributes = m_helper.compileAttributes(parent_comp, fC, formalId,
                                                   m_compileDesign);
-          while (fC->Type(formalId) == slAttribute_instance) {
+          while (fC->Type(formalId) == VObjectType::slAttribute_instance) {
             formalId = fC->Sibling(formalId);
           }
         }
@@ -1065,9 +1068,10 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
           formalName = fC->SymName(formalNameId);
         } else {
           NodeId tmp = Expression;
-          if (fC->Type(tmp) == slOpenParens) {
+          if (fC->Type(tmp) == VObjectType::slOpenParens) {
             tmp = fC->Sibling(tmp);
-            if (fC->Type(tmp) == slCloseParens) {  // .p()  explicit disconnect
+            if (fC->Type(tmp) ==
+                VObjectType::slCloseParens) {  // .p()  explicit disconnect
               Named_port_connection = fC->Sibling(Named_port_connection);
               port* p = nullptr;
               if (ports) {
@@ -1104,17 +1108,17 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
               index++;
               continue;
             } else if (fC->Type(tmp) ==
-                       slExpression) {  // .p(s) connection by name
+                       VObjectType::slExpression) {  // .p(s) connection by name
               sigId = tmp;
               Expression = tmp;
             }
           }  // else .p implicit connection
         }
         expr* hexpr = nullptr;
-        if (fC->Type(Expression) == slAttribute_instance) {
+        if (fC->Type(Expression) == VObjectType::slAttribute_instance) {
           attributes =
               m_helper.compileAttributes(comp, fC, Expression, m_compileDesign);
-          while (fC->Type(Expression) == slAttribute_instance)
+          while (fC->Type(Expression) == VObjectType::slAttribute_instance)
             Expression = fC->Sibling(Expression);
         }
         if (Expression) {
@@ -1128,7 +1132,8 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
           sigId = fC->Child(Primary_literal);
         }
         std::string sigName;
-        if (fC->Type(sigId) == slStringConst) sigName = fC->SymName(sigId);
+        if (fC->Type(sigId) == VObjectType::slStringConst)
+          sigName = fC->SymName(sigId);
         std::string baseName = sigName;
         std::string selectName;
         if (NodeId subId = fC->Sibling(sigId)) {
@@ -1604,25 +1609,30 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
   UHDM::typespec* tps = nullptr;
   // Determine if the "signal" is a net or a var
   bool isNet = true;
-  if ((dtype && (subnettype == slNoType)) || sig->isConst() || sig->isVar() ||
-      (!sig->isStatic()) || (subnettype == slClass_scope) ||
-      (subnettype == slStringConst) || (subnettype == slIntegerAtomType_Int) ||
-      (subnettype == slIntegerAtomType_Integer) ||
-      (subnettype == slIntegerAtomType_Byte) ||
-      (subnettype == slIntegerAtomType_LongInt) ||
-      (subnettype == slIntegerAtomType_Shortint) ||
-      (subnettype == slString_type) || (subnettype == slNonIntType_Real) ||
-      (subnettype == slNonIntType_RealTime) ||
-      (subnettype == slNonIntType_ShortReal) || (subnettype == slEvent_type) ||
-      (subnettype == slChandle_type) || (subnettype == slIntVec_TypeBit) ||
-      (subnettype == slEnum_base_type) ||
-      ((!sig->isVar()) && (subnettype == slIntVec_TypeLogic))) {
+  if ((dtype && (subnettype == VObjectType::slNoType)) || sig->isConst() ||
+      sig->isVar() || (!sig->isStatic()) ||
+      (subnettype == VObjectType::slClass_scope) ||
+      (subnettype == VObjectType::slStringConst) ||
+      (subnettype == VObjectType::slIntegerAtomType_Int) ||
+      (subnettype == VObjectType::slIntegerAtomType_Integer) ||
+      (subnettype == VObjectType::slIntegerAtomType_Byte) ||
+      (subnettype == VObjectType::slIntegerAtomType_LongInt) ||
+      (subnettype == VObjectType::slIntegerAtomType_Shortint) ||
+      (subnettype == VObjectType::slString_type) ||
+      (subnettype == VObjectType::slNonIntType_Real) ||
+      (subnettype == VObjectType::slNonIntType_RealTime) ||
+      (subnettype == VObjectType::slNonIntType_ShortReal) ||
+      (subnettype == VObjectType::slEvent_type) ||
+      (subnettype == VObjectType::slChandle_type) ||
+      (subnettype == VObjectType::slIntVec_TypeBit) ||
+      (subnettype == VObjectType::slEnum_base_type) ||
+      ((!sig->isVar()) && (subnettype == VObjectType::slIntVec_TypeLogic))) {
     isNet = false;
   }
-  if (sig->getDirection() == slPortDir_Out ||
-      sig->getDirection() == slPortDir_Inp ||
-      sig->getDirection() == slPortDir_Inout) {
-    if ((!sig->isVar()) && (subnettype == slIntVec_TypeLogic)) {
+  if (sig->getDirection() == VObjectType::slPortDir_Out ||
+      sig->getDirection() == VObjectType::slPortDir_Inp ||
+      sig->getDirection() == VObjectType::slPortDir_Inout) {
+    if ((!sig->isVar()) && (subnettype == VObjectType::slIntVec_TypeLogic)) {
       isNet = true;
     }
   }
@@ -1962,7 +1972,7 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
         }
         nets->push_back((net*)obj);
       }
-    } else if (subnettype == slStruct_union) {
+    } else if (subnettype == VObjectType::slStruct_union) {
       // Implicit type
       struct_net* stv = s.MakeStruct_net();
       stv->VpiName(signame);
@@ -2147,21 +2157,21 @@ bool NetlistElaboration::elab_ports_nets_(
         if (!do_ports) continue;
         // Ports pass
         port* dest_port = s.MakePort();
-        if (sig->getDirection() != slNoType) {
+        if (sig->getDirection() != VObjectType::slNoType) {
           lastPortDirection = UhdmWriter::getVpiDirection(sig->getDirection());
         }
         dest_port->VpiDirection(lastPortDirection);
         std::string signame;
         VObjectType nodeIdType = fC->Type(sig->getNodeId());
-        if (nodeIdType == slStringConst) {
+        if (nodeIdType == VObjectType::slStringConst) {
           signame = sig->getName();
           dest_port->VpiName(signame);
-        } else if (nodeIdType == slPort) {
+        } else if (nodeIdType == VObjectType::slPort) {
           NodeId PortName = fC->Child(sig->getNodeId());
           signame = fC->SymName(PortName);
           dest_port->VpiName(signame);
           NodeId Port_expr = fC->Sibling(PortName);
-          if (fC->Type(Port_expr) == slPort_expression) {
+          if (fC->Type(Port_expr) == VObjectType::slPort_expression) {
             any* exp =
                 m_helper.compileExpression(comp, fC, Port_expr, m_compileDesign,
                                            nullptr, child, true, false);
@@ -2341,7 +2351,7 @@ bool NetlistElaboration::elab_ports_nets_(
       } else if (pass == 1) {
         // Nets pass
         if (do_ports) continue;
-        if (fC->Type(sig->getNodeId()) == slStringConst) {
+        if (fC->Type(sig->getNodeId()) == VObjectType::slStringConst) {
           const std::string& signame = sig->getName();
           if (portInterf.find(signame) == portInterf.end()) {
             bool sigIsPort = false;
@@ -2361,7 +2371,7 @@ bool NetlistElaboration::elab_ports_nets_(
         // Port low conn pass
         if (do_ports) continue;
         std::string signame;
-        if (fC->Type(sig->getNodeId()) == slStringConst) {
+        if (fC->Type(sig->getNodeId()) == VObjectType::slStringConst) {
           signame = sig->getName();
         } else {
           portIndex++;
@@ -2468,8 +2478,8 @@ UHDM::any* NetlistElaboration::bind_net_(const FileContent* origfC, NodeId id,
         VObjectType implicitNetType =
             component->getDesignElement()
                 ? component->getDesignElement()->m_defaultNetType
-                : slNetType_Wire;
-        if (implicitNetType == slNoType) {
+                : VObjectType::slNetType_Wire;
+        if (implicitNetType == VObjectType::slNoType) {
           SymbolTable* symbols =
               m_compileDesign->getCompiler()->getSymbolTable();
           ErrorContainer* errors =

--- a/src/DesignCompile/ResolveSymbols.cpp
+++ b/src/DesignCompile/ResolveSymbols.cpp
@@ -290,7 +290,7 @@ bool ResolveSymbols::bindDefinition_(NodeId objIndex,
                                      const VObjectTypeUnorderedSet& bindTypes) {
   std::string modName =
       SymName(sl_collect(objIndex, VObjectType::slStringConst));
-  NodeId nameId = Child(sl_collect(objIndex, slName_of_instance));
+  NodeId nameId = Child(sl_collect(objIndex, VObjectType::slName_of_instance));
   std::string instName(BadRawSymbol);
   if (nameId) instName = SymName(nameId);
   Design::FileIdDesignContentMap& all_files =
@@ -358,9 +358,10 @@ bool ResolveSymbols::resolve() {
     }
     if (bind) {
       /*bool found = */
-      bindDefinition_(objIndex,
-                      {slUdp_declaration, slModule_declaration,
-                       slInterface_declaration, slProgram_declaration});
+      bindDefinition_(objIndex, {VObjectType::slUdp_declaration,
+                                 VObjectType::slModule_declaration,
+                                 VObjectType::slInterface_declaration,
+                                 VObjectType::slProgram_declaration});
       /*
        * This warning is now treated in the elaboration to give the library
       information if (!found)

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -712,7 +712,7 @@ bool TestbenchElaboration::bindProperties_() {
           classDefinition, fC, packedDimension, m_compileDesign, nullptr,
           nullptr, true, packedSize, false);
       std::vector<UHDM::range*>* unpackedDimensions = nullptr;
-      if (fC->Type(unpackedDimension) == slClass_new) {
+      if (fC->Type(unpackedDimension) == VObjectType::slClass_new) {
       } else {
         unpackedDimensions = m_helper.compileRanges(
             classDefinition, fC, unpackedDimension, m_compileDesign, nullptr,

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -137,24 +137,25 @@ bool UhdmChecker::registerFile(const FileContent* fC,
 
     if (((type == VObjectType::slStringConst) &&
          (fC->Type(current.m_parent) ==
-          slModule_declaration)) ||  // endmodule : name
+          VObjectType::slModule_declaration)) ||  // endmodule : name
         ((type == VObjectType::slStringConst) &&
          (fC->Type(current.m_parent) ==
-          slPackage_declaration)) ||  // endpackage : name
+          VObjectType::slPackage_declaration)) ||  // endpackage : name
         ((type == VObjectType::slStringConst) &&
          (fC->Type(current.m_parent) ==
-          slFunction_body_declaration)) ||  // endfunction  : name
+          VObjectType::slFunction_body_declaration)) ||  // endfunction  : name
         ((type == VObjectType::slStringConst) &&
          (fC->Type(current.m_parent) ==
-          slTask_declaration)) ||  // endtask : name
+          VObjectType::slTask_declaration)) ||  // endtask : name
         ((type == VObjectType::slStringConst) &&
          (fC->Type(current.m_parent) ==
-          slClass_declaration)) ||  // endclass : name
+          VObjectType::slClass_declaration)) ||  // endclass : name
         ((type == VObjectType::slStringConst) &&
          (fC->Type(current.m_parent) ==
-          slName_of_instance)) ||  // instance name
+          VObjectType::slName_of_instance)) ||  // instance name
         ((type == VObjectType::slStringConst) &&
-         (fC->Type(current.m_parent) == slType_declaration))  // struct name
+         (fC->Type(current.m_parent) ==
+          VObjectType::slType_declaration))  // struct name
     ) {
       RangesMap::iterator lineItr = uhdmCover.find(current.m_line);
       if (skipModule == false) {

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -609,9 +609,9 @@ void UhdmWriter::writePorts(std::vector<Signal*>& orig_ports, BaseClass* parent,
     signalBaseMap.insert(std::make_pair(orig_port, dest_port));
     signalMap.insert(std::make_pair(orig_port->getName(), orig_port));
     const FileContent* fC = orig_port->getFileContent();
-    if (fC->Type(orig_port->getNodeId()) == slStringConst)
+    if (fC->Type(orig_port->getNodeId()) == VObjectType::slStringConst)
       dest_port->VpiName(orig_port->getName());
-    if (orig_port->getDirection() != slNoType)
+    if (orig_port->getDirection() != VObjectType::slNoType)
       lastPortDirection =
           UhdmWriter::getVpiDirection(orig_port->getDirection());
     dest_port->VpiDirection(lastPortDirection);
@@ -737,7 +737,7 @@ void writeNets(std::vector<Signal*>& orig_nets, BaseClass* parent,
     }
     if (dest_net) {
       const FileContent* fC = orig_net->getFileContent();
-      if (fC->Type(orig_net->getNodeId()) == slStringConst) {
+      if (fC->Type(orig_net->getNodeId()) == VObjectType::slStringConst) {
         UhdmWriter::SignalMap::iterator portItr =
             portMap.find(orig_net->getName());
         if (portItr != portMap.end()) {
@@ -1237,7 +1237,7 @@ void UhdmWriter::writeModule(ModuleDefinition* mod, module* m, Serializer& s,
           const std::string typeName = sig->getInterfaceTypeName();
           interface_array* smarray = s.MakeInterface_array();
           smarray->Ranges(unpackedDimensions);
-          if (fC->Type(id) == slStringConst) {
+          if (fC->Type(id) == VObjectType::slStringConst) {
             smarray->VpiName(sig->getName());
           }
           smarray->VpiFullName(typeName);
@@ -2950,7 +2950,7 @@ void UhdmWriter::lateBinding(UHDM::Serializer& s, DesignComponent* mod,
     if (!ref->Actual_group()) {
       if (mod) {
         if (auto elem = mod->getDesignElement()) {
-          if (elem->m_defaultNetType == slNoType) {
+          if (elem->m_defaultNetType == VObjectType::slNoType) {
             Location loc(fileSystem->toPathId(
                              ref->VpiFile(),
                              m_compileDesign->getCompiler()->getSymbolTable()),

--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -669,7 +669,7 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
           NodeId Primary_literal = fC->Child(Constant_primary);
           NodeId ConstVal = fC->Child(Primary_literal);
           std::string token;
-          if (fC->Type(ConstVal) == slIntConst) {
+          if (fC->Type(ConstVal) == VObjectType::slIntConst) {
             token = fC->SymName(ConstVal);
           } else {
             Value* constVal =
@@ -860,7 +860,7 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
         }
         break;
       }
-      case slIncDec_PlusPlus: {
+      case VObjectType::slIncDec_PlusPlus: {
         const std::string& name = fC->SymName(fC->Sibling(parent));
         Value* sval = nullptr;
         if (instance) {
@@ -877,7 +877,7 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
         }
         break;
       }
-      case slIncDec_MinusMinus: {
+      case VObjectType::slIncDec_MinusMinus: {
         const std::string& name = fC->SymName(fC->Sibling(parent));
         Value* sval = nullptr;
         if (instance) {

--- a/src/Expression/ExprBuilder_test.cpp
+++ b/src/Expression/ExprBuilder_test.cpp
@@ -105,7 +105,8 @@ TEST(ExprBuilderTest, ExprFromParseTree1) {
       "parameter p3 = -2 * -5;"
       "endmodule");
   NodeId root = fC->getRootNode();
-  std::vector<NodeId> assigns = fC->sl_collect_all(root, slParam_assignment);
+  std::vector<NodeId> assigns =
+      fC->sl_collect_all(root, VObjectType::slParam_assignment);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
     NodeId rhs = fC->Sibling(param);
@@ -127,7 +128,8 @@ TEST(ExprBuilderTest, ExprFromParseTree2) {
       "parameter p4 = 32 - 16;"
       "endmodule");
   NodeId root = fC->getRootNode();
-  std::vector<NodeId> assigns = fC->sl_collect_all(root, slParam_assignment);
+  std::vector<NodeId> assigns =
+      fC->sl_collect_all(root, VObjectType::slParam_assignment);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
     NodeId rhs = fC->Sibling(param);

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -208,7 +208,7 @@ bool ParseLibraryDef::parseConfigDefinition() {
     for (auto inst : instances) {
       VObjectType type = fC->Type(inst);
       NodeId instName = fC->Child(inst);
-      if (type == slInst_clause) instName = fC->Child(instName);
+      if (type == VObjectType::slInst_clause) instName = fC->Child(instName);
       std::string instNameS;
       while (instName) {
         if (instNameS.empty())
@@ -227,7 +227,7 @@ bool ParseLibraryDef::parseConfigDefinition() {
         }
 
         UseClause usec(UseClause::UseLib, libs, fC, instClause);
-        if (type == slInst_clause)
+        if (type == VObjectType::slInst_clause)
           conf.addInstanceUseClause(instNameS, usec);
         else
           conf.addCellUseClause(instNameS, usec);
@@ -235,7 +235,7 @@ bool ParseLibraryDef::parseConfigDefinition() {
         NodeId use = fC->Child(instClause);
         std::string useName;
         VObjectType useType = fC->Type(use);
-        if (useType == slParameter_value_assignment) {
+        if (useType == VObjectType::slParameter_value_assignment) {
           UseClause usec(UseClause::UseParam, fC, use);
           conf.addInstanceUseClause(instNameS, usec);
         } else {
@@ -249,7 +249,7 @@ bool ParseLibraryDef::parseConfigDefinition() {
           }
           useName = StringUtils::replaceAll(useName, ".", "@");
           UseClause usec(UseClause::UseModule, useName, fC, mem);
-          if (type == slInst_clause)
+          if (type == VObjectType::slInst_clause)
             conf.addInstanceUseClause(instNameS, usec);
           else
             conf.addCellUseClause(instNameS, usec);
@@ -266,7 +266,7 @@ bool ParseLibraryDef::parseConfigDefinition() {
           use = fC->Sibling(use);
         }
         UseClause usec(UseClause::UseConfig, useName, fC, mem);
-        if (type == slInst_clause)
+        if (type == VObjectType::slInst_clause)
           conf.addInstanceUseClause(instNameS, usec);
         else
           conf.addCellUseClause(instNameS, usec);

--- a/src/SourceCompile/CompilationUnit.cpp
+++ b/src/SourceCompile/CompilationUnit.cpp
@@ -77,7 +77,7 @@ void CompilationUnit::recordDefaultNetType(NetTypeInfo& info) {
 VObjectType CompilationUnit::getDefaultNetType(PathId fileId,
                                                unsigned int line) {
   if (m_defaultNetTypes.empty()) {
-    return slNetType_Wire;
+    return VObjectType::slNetType_Wire;
   }
   for (int i = (int)m_defaultNetTypes.size() - 1; i >= 0; i--) {
     NetTypeInfo& info = m_defaultNetTypes[i];
@@ -87,7 +87,7 @@ VObjectType CompilationUnit::getDefaultNetType(PathId fileId,
       }
     }
   }
-  return slNetType_Wire;
+  return VObjectType::slNetType_Wire;
 }
 
 void CompilationUnit::setCurrentTimeInfo(PathId fileId) {

--- a/src/SourceCompile/ParseFile_test.cpp
+++ b/src/SourceCompile/ParseFile_test.cpp
@@ -30,13 +30,13 @@ TEST(ParserTest, BasicParse) {
   {
     auto fC = harness.parse("module top(); assign a = b; endmodule");
     NodeId root = fC->getRootNode();
-    NodeId assign = fC->sl_collect(root, slContinuous_assign);
+    NodeId assign = fC->sl_collect(root, VObjectType::slContinuous_assign);
     EXPECT_TRUE(assign);
   }
   {
     auto fC = harness.parse("module top(); assign a = !b; endmodule");
     NodeId root = fC->getRootNode();
-    NodeId assign = fC->sl_collect(root, slContinuous_assign);
+    NodeId assign = fC->sl_collect(root, VObjectType::slContinuous_assign);
     /*
     n<> u<10> t<Net_lvalue> p<17> c<7> s<16> l<1:22> el<1:23>
     n<b> u<11> t<StringConst> p<12> l<1:27> el<1:28>
@@ -54,7 +54,7 @@ TEST(ParserTest, BasicParse) {
     NodeId Net_lvalue = fC->Child(Net_assignment);
     NodeId Expression = fC->Sibling(Net_lvalue);
     NodeId Unary_Not = fC->Child(Expression);
-    EXPECT_EQ(fC->Type(Unary_Not), slUnary_Not);
+    EXPECT_EQ(fC->Type(Unary_Not), VObjectType::slUnary_Not);
   }
 }
 }  // namespace

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -2031,39 +2031,39 @@ void SV3_1aTreeShapeListener::exitTf_port_direction(
 void SV3_1aTreeShapeListener::exitDefault_nettype_directive(
     SV3_1aParser::Default_nettype_directiveContext *ctx) {
   NetTypeInfo info;
-  info.m_type = slNetType_Wire;
+  info.m_type = VObjectType::slNetType_Wire;
   info.m_fileId = m_pf->getFileId(0);
   std::pair<int, int> lineCol = ParseUtils::getLineColumn(m_tokens, ctx);
   info.m_line = lineCol.first;
   if (ctx->Simple_identifier()) {
     addVObject((antlr4::ParserRuleContext *)ctx->Simple_identifier(),
                ctx->Simple_identifier()->getText(), VObjectType::slStringConst);
-    info.m_type = slNoType;
+    info.m_type = VObjectType::slNoType;
   } else if (ctx->net_type()) {
     if (ctx->net_type()->SUPPLY0())
-      info.m_type = slSupply0;
+      info.m_type = VObjectType::slSupply0;
     else if (ctx->net_type()->SUPPLY1())
-      info.m_type = slSupply1;
+      info.m_type = VObjectType::slSupply1;
     else if (ctx->net_type()->WIRE())
-      info.m_type = slNetType_Wire;
+      info.m_type = VObjectType::slNetType_Wire;
     else if (ctx->net_type()->UWIRE())
-      info.m_type = slNetType_Uwire;
+      info.m_type = VObjectType::slNetType_Uwire;
     else if (ctx->net_type()->WAND())
-      info.m_type = slNetType_Wand;
+      info.m_type = VObjectType::slNetType_Wand;
     else if (ctx->net_type()->WOR())
-      info.m_type = slNetType_Wor;
+      info.m_type = VObjectType::slNetType_Wor;
     else if (ctx->net_type()->TRI())
-      info.m_type = slNetType_Tri;
+      info.m_type = VObjectType::slNetType_Tri;
     else if (ctx->net_type()->TRIREG())
-      info.m_type = slNetType_TriReg;
+      info.m_type = VObjectType::slNetType_TriReg;
     else if (ctx->net_type()->TRIOR())
-      info.m_type = slNetType_TriOr;
+      info.m_type = VObjectType::slNetType_TriOr;
     else if (ctx->net_type()->TRIAND())
-      info.m_type = slNetType_TriAnd;
+      info.m_type = VObjectType::slNetType_TriAnd;
     else if (ctx->net_type()->TRI0())
-      info.m_type = slNetType_Tri0;
+      info.m_type = VObjectType::slNetType_Tri0;
     else if (ctx->net_type()->TRI1())
-      info.m_type = slNetType_Tri1;
+      info.m_type = VObjectType::slNetType_Tri1;
   }
   addVObject(ctx, VObjectType::slDefault_nettype_directive);
   m_pf->getCompilationUnit()->recordDefaultNetType(info);


### PR DESCRIPTION
Add namespace and use class scope for VObjectType enum

VObjectType is now a public header and it was missing the namespace. Also, the lack of use of enum class generated tons of static analyzer warnings in client code.

Fixed both issues - use enum class and wrapped it in namespace.