### PR TITLE
FileContent::SymName now returns std::string_view instead of std::string

### DIFF
--- a/include/Surelog/Common/Containers.h
+++ b/include/Surelog/Common/Containers.h
@@ -33,7 +33,8 @@ typedef std::map<std::string, Program*, StringViewCompare>
 
 typedef std::multimap<std::string, ClassDefinition*, StringViewCompare>
     ClassNameClassDefinitionMultiMap;
-typedef std::map<std::string, ClassDefinition*> ClassNameClassDefinitionMap;
+typedef std::map<std::string, ClassDefinition*, std::less<>>
+    ClassNameClassDefinitionMap;
 
 typedef std::map<std::string, std::vector<MacroInfo*>, StringViewCompare>
     MacroStorage;

--- a/include/Surelog/Design/Design.h
+++ b/include/Surelog/Design/Design.h
@@ -152,7 +152,7 @@ class Design final {
 
   Program* getProgram(std::string_view name) const;
 
-  ClassDefinition* getClassDefinition(const std::string& name) const;
+  ClassDefinition* getClassDefinition(std::string_view name) const;
 
   ErrorContainer* getErrorContainer() { return m_errors; }
 
@@ -187,7 +187,7 @@ class Design final {
   void addDefParam(const std::string& name, const FileContent* fC,
                    NodeId nodeId, Value* value);
 
-  void addClassDefinition(const std::string& className,
+  void addClassDefinition(std::string_view className,
                           ClassDefinition* classDef);
 
   void addProgramDefinition(const std::string programName, Program* program) {

--- a/include/Surelog/Design/Enum.h
+++ b/include/Surelog/Design/Enum.h
@@ -47,7 +47,7 @@ class Enum : public DataType {
 
   typedef std::map<std::string, std::pair<unsigned int, Value*>> NameValueMap;
 
-  void addValue(const std::string& name, unsigned int lineNb, Value* value) {
+  void addValue(std::string_view name, unsigned int lineNb, Value* value) {
     m_values.emplace(name, std::make_pair(lineNb, value));
   }
   Value* getValue(const std::string& name) const;

--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -53,7 +53,7 @@ class FileContent : public DesignComponent {
 
   void setLibrary(Library* lib) { m_library = lib; }
 
-  typedef std::unordered_map<std::string, NodeId> NameIdMap;
+  typedef std::map<std::string, NodeId, std::less<>> NameIdMap;
 
   NodeId sl_get(NodeId parent,
                 VObjectType type) const;  // Get first child item of type
@@ -124,7 +124,7 @@ class FileContent : public DesignComponent {
   const std::vector<VObject>& getVObjects() const { return m_objects; }
   std::vector<VObject>* mutableVObjects() { return &m_objects; }
   const NameIdMap& getObjectLookup() const { return m_objectLookup; }
-  void insertObjectLookup(const std::string& name, NodeId id,
+  void insertObjectLookup(std::string_view name, NodeId id,
                           ErrorContainer* errors);
   std::unordered_set<std::string>& getReferencedObjects() {
     return m_referencedObjects;
@@ -158,7 +158,7 @@ class FileContent : public DesignComponent {
 
   unsigned short EndColumn(NodeId index) const;
 
-  const std::string& SymName(NodeId index) const;
+  std::string_view SymName(NodeId index) const;
 
   const ModuleNameModuleDefinitionMap& getModuleDefinitions() const {
     return m_moduleDefinitions;

--- a/include/Surelog/Design/ModuleDefinition.h
+++ b/include/Surelog/Design/ModuleDefinition.h
@@ -58,19 +58,19 @@ class ModuleDefinition : public DesignComponent, public ClockingBlockHolder {
   unsigned int getSize() const override;
 
   typedef std::map<std::string, ClockingBlock> ClockingBlockMap;
-  typedef std::map<std::string, ModPort> ModPortSignalMap;
-  typedef std::map<std::string, std::vector<ClockingBlock>>
+  typedef std::map<std::string, ModPort, std::less<>> ModPortSignalMap;
+  typedef std::map<std::string, std::vector<ClockingBlock>, std::less<>>
       ModPortClockingBlockMap;
 
   ModPortSignalMap& getModPortSignalMap() { return m_modportSignalMap; }
   ModPortClockingBlockMap& getModPortClockingBlockMap() {
     return m_modportClockingBlockMap;
   }
-  void insertModPort(const std::string& modport, const Signal& signal,
+  void insertModPort(std::string_view modport, const Signal& signal,
                      NodeId nodeId);
-  void insertModPort(const std::string& modport, ClockingBlock& block);
+  void insertModPort(std::string_view modport, ClockingBlock& block);
   const Signal* getModPortSignal(const std::string& modport, NodeId port) const;
-  ModPort* getModPort(const std::string& modport);
+  ModPort* getModPort(std::string_view modport);
 
   const ClockingBlock* getModPortClockingBlock(const std::string& modport,
                                                NodeId port) const;

--- a/include/Surelog/Design/Netlist.h
+++ b/include/Surelog/Design/Netlist.h
@@ -45,7 +45,7 @@ class Netlist {
   typedef std::map<std::string, std::pair<ModPort*, UHDM::modport*>> ModPortMap;
   typedef std::map<std::string, std::pair<ModuleInstance*, UHDM::BaseClass*>>
       InstanceMap;
-  typedef std::map<std::string, UHDM::BaseClass*> SymbolTable;
+  typedef std::map<std::string, UHDM::BaseClass*, std::less<>> SymbolTable;
 
   std::vector<UHDM::interface*>* interfaces() { return m_interfaces; }
   std::vector<UHDM::interface_array*>* interface_arrays() {

--- a/include/Surelog/Design/Parameter.h
+++ b/include/Surelog/Design/Parameter.h
@@ -40,7 +40,7 @@ class FileContent;
 class Parameter : public DataType {
   SURELOG_IMPLEMENT_RTTI(Parameter, DataType)
  public:
-  Parameter(const FileContent* fC, NodeId nodeId, const std::string& name,
+  Parameter(const FileContent* fC, NodeId nodeId, std::string_view name,
             NodeId node_type, bool port_param);
 
   ~Parameter() override;
@@ -51,7 +51,7 @@ class Parameter : public DataType {
   void setUhdmParam(UHDM::any* param) { m_param = param; }
   UHDM::any* getUhdmParam() const { return m_param; }
   bool isPortParam() const { return m_port_param; }
-  void setImportedPackage(const std::string& package) {
+  void setImportedPackage(std::string_view package) {
     m_importedPackage = package;
   }
   std::string importedPackage() { return m_importedPackage; }

--- a/include/Surelog/Design/Scope.h
+++ b/include/Surelog/Design/Scope.h
@@ -40,7 +40,7 @@ class Variable;
 class Scope : public RTTI {
   SURELOG_IMPLEMENT_RTTI(Scope, RTTI)
  public:
-  typedef std::map<std::string, Variable*> VariableMap;
+  typedef std::map<std::string, Variable*, std::less<>> VariableMap;
   typedef std::map<std::string, DataType*> DataTypeMap;
   typedef std::vector<Statement*> StmtVector;
   typedef std::vector<Scope*> ScopeVector;
@@ -55,7 +55,7 @@ class Scope : public RTTI {
   void addVariable(Variable* var);
 
   VariableMap& getVariables() { return m_variables; }
-  Variable* getVariable(const std::string& name);
+  Variable* getVariable(std::string_view name);
 
   DataTypeMap& getUsedDataTypeMap() { return m_usedDataTypes; }
   DataType* getUsedDataType(const std::string& name);

--- a/include/Surelog/Design/Signal.h
+++ b/include/Surelog/Design/Signal.h
@@ -55,7 +55,7 @@ class Signal final {
   VObjectType getDirection() const { return m_direction; }
   const FileContent* getFileContent() const { return m_fileContent; }
   NodeId getNodeId() const { return m_nodeId; }
-  const std::string& getName() const;
+  std::string_view getName() const;
   std::string getInterfaceTypeName() const;
 
   ModuleDefinition* getInterfaceDef() { return m_interfaceDef; }

--- a/include/Surelog/Design/Statement.h
+++ b/include/Surelog/Design/Statement.h
@@ -94,7 +94,7 @@ class SubRoutineCallStmt : public Statement {
   SubRoutineCallStmt(Scope* scope, Statement* parentStmt,
                      const FileContent* fileContent, NodeId node,
                      VObjectType type, std::vector<NodeId>& var_chain,
-                     std::string funcName, std::vector<SubRoutineArg*>& args,
+                     std::string_view funcName, std::vector<SubRoutineArg*>& args,
                      bool static_call, bool system_call)
       : Statement(scope, parentStmt, fileContent, node, type),
         m_var_chain(var_chain),

--- a/include/Surelog/Design/TfPortItem.h
+++ b/include/Surelog/Design/TfPortItem.h
@@ -36,7 +36,7 @@ class Value;
 class TfPortItem : public Variable {
  public:
   TfPortItem(Procedure* parent, const FileContent* fc, NodeId id, NodeId range,
-             const std::string& name, DataType* type, Value* default_value,
+             std::string_view name, DataType* type, Value* default_value,
              VObjectType direction)
       : Variable(type, fc, id, range, name),
         m_parent(parent),

--- a/include/Surelog/DesignCompile/CompileHelper.h
+++ b/include/Surelog/DesignCompile/CompileHelper.h
@@ -251,8 +251,8 @@ class CompileHelper final {
   UHDM::typespec* compileDatastructureTypespec(
       DesignComponent* component, const FileContent* fC, NodeId type,
       CompileDesign* compileDesign, SURELOG::ValuedComponentI* instance,
-      bool reduce, const std::string& suffixname = "",
-      const std::string& typeName = "");
+      bool reduce, std::string_view suffixname = "",
+      std::string_view typeName = "");
 
   UHDM::any* compileCheckerInstantiation(DesignComponent* component,
                                          const FileContent* fC, NodeId nodeId,
@@ -301,7 +301,7 @@ class CompileHelper final {
 
   UHDM::any* compilePartSelectRange(
       DesignComponent* component, const FileContent* fC, NodeId Constant_range,
-      const std::string& name, CompileDesign* compileDesign, UHDM::any* pexpr,
+      std::string_view name, CompileDesign* compileDesign, UHDM::any* pexpr,
       ValuedComponentI* instance, bool reduce, bool muteErrors);
 
   std::vector<UHDM::range*>* compileRanges(
@@ -337,7 +337,7 @@ class CompileHelper final {
 
   UHDM::any* compileSelectExpression(
       DesignComponent* component, const FileContent* fC, NodeId Bit_select,
-      const std::string& name, CompileDesign* compileDesign, UHDM::any* pexpr,
+      std::string_view name, CompileDesign* compileDesign, UHDM::any* pexpr,
       ValuedComponentI* instance, bool reduce, bool muteErrors);
 
   UHDM::any* compileBits(DesignComponent* component, const FileContent* fC,
@@ -354,7 +354,7 @@ class CompileHelper final {
                           NodeId Expression, CompileDesign* compileDesign,
                           UHDM::any* pexpr, ValuedComponentI* instance,
                           bool reduce, bool muteErrors,
-                          const std::string& name);
+                          std::string_view name);
 
   UHDM::any* compileTypename(DesignComponent* component, const FileContent* fC,
                              NodeId Expression, CompileDesign* compileDesign,
@@ -382,15 +382,15 @@ class CompileHelper final {
                                 CompileDesign* compileDesign);
 
   UHDM::any* bindVariable(DesignComponent* component, const UHDM::any* scope,
-                          const std::string& name,
+                          std::string_view name,
                           CompileDesign* compileDesign);
 
   UHDM::any* bindVariable(DesignComponent* component,
-                          ValuedComponentI* instance, const std::string& name,
+                          ValuedComponentI* instance, std::string_view name,
                           CompileDesign* compileDesign);
 
   UHDM::any* bindParameter(DesignComponent* component,
-                           ValuedComponentI* instance, const std::string& name,
+                           ValuedComponentI* instance, std::string_view name,
                            CompileDesign* compileDesign, bool crossHierarchy);
 
   UHDM::event_control* compileClocking_event(DesignComponent* component,
@@ -471,7 +471,7 @@ class CompileHelper final {
       CompileDesign* compileDesign);
 
   std::pair<UHDM::task_func*, DesignComponent*> getTaskFunc(
-      const std::string& name, DesignComponent* component,
+      std::string_view name, DesignComponent* component,
       CompileDesign* compileDesign, ValuedComponentI* instance,
       UHDM::any* pexpr);
 
@@ -487,7 +487,7 @@ class CompileHelper final {
   bool loopDetected(PathId fileId, int lineNumber, CompileDesign* compileDesign,
                     ValuedComponentI* instance);
 
-  UHDM::any* getValue(const std::string& name, DesignComponent* component,
+  UHDM::any* getValue(std::string_view name, DesignComponent* component,
                       CompileDesign* compileDesign, ValuedComponentI* instance,
                       PathId fileId, int lineNumber, UHDM::any* pexpr,
                       bool reduce, bool muteErrors = false);
@@ -509,7 +509,7 @@ class CompileHelper final {
   bool substituteAssignedValue(const UHDM::any* op,
                                CompileDesign* compileDesign);
 
-  UHDM::any* getObject(const std::string& name, DesignComponent* component,
+  UHDM::any* getObject(std::string_view name, DesignComponent* component,
                        CompileDesign* compileDesign, ValuedComponentI* instance,
                        const UHDM::any* pexpr);
 
@@ -524,7 +524,7 @@ class CompileHelper final {
                                CompileDesign* compileDesign,
                                ValuedComponentI* instance);
   bool errorOnNegativeConstant(DesignComponent* component,
-                               const std::string& value,
+                               std::string_view value,
                                CompileDesign* compileDesign,
                                ValuedComponentI* instance, PathId fileId,
                                unsigned int lineNo, unsigned short columnNo);
@@ -546,7 +546,7 @@ class CompileHelper final {
                   UHDM::constant* c, bool uniquify = false);
 
   /** task/func/scope */
-  UHDM::any* searchObjectName(const std::string& name,
+  UHDM::any* searchObjectName(std::string_view name,
                               DesignComponent* component,
                               CompileDesign* compileDesign, UHDM::any* stmt);
 
@@ -566,14 +566,14 @@ class CompileHelper final {
   UHDM::module* m_exprEvalPlaceHolder = nullptr;
   // Caches
   UHDM::int_typespec* buildIntTypespec(CompileDesign* compileDesign,
-                                       PathId fileId, const std::string& name,
-                                       const std::string& value,
+                                       PathId fileId, std::string_view name,
+                                       std::string_view value,
                                        unsigned int line, unsigned short column,
                                        unsigned int eline,
                                        unsigned short ecolumn);
   UHDM::typespec_member* buildTypespecMember(
-      CompileDesign* compileDesign, PathId fileId, const std::string& name,
-      const std::string& value, unsigned int line, unsigned short column,
+      CompileDesign* compileDesign, PathId fileId, std::string_view name,
+      std::string_view value, unsigned int line, unsigned short column,
       unsigned int eline, unsigned short ecolumn);
   std::unordered_map<std::string, UHDM::int_typespec*> m_cache_int_typespec;
   std::unordered_map<std::string, UHDM::typespec_member*>

--- a/include/Surelog/DesignCompile/ElaborationStep.h
+++ b/include/Surelog/DesignCompile/ElaborationStep.h
@@ -63,7 +63,7 @@ class ElaborationStep {
   const DataType* bindTypeDef_(TypeDef* typd, const DesignComponent* parent,
                                ErrorDefinition::ErrorType errtype);
 
-  const DataType* bindDataType_(const std::string& type_name,
+  const DataType* bindDataType_(std::string_view type_name,
                                 const FileContent* fC, NodeId id,
                                 const DesignComponent* parent,
                                 ErrorDefinition::ErrorType errtype);

--- a/include/Surelog/DesignCompile/NetlistElaboration.h
+++ b/include/Surelog/DesignCompile/NetlistElaboration.h
@@ -79,10 +79,10 @@ class NetlistElaboration : public TestbenchElaboration {
 
   UHDM::any* bind_net_(const FileContent* idfC, NodeId id,
                        ModuleInstance* instance, ModuleInstance* boundInstance,
-                       const std::string& name);
-  UHDM::any* bind_net_(ModuleInstance* instance, const std::string& name);
+                       std::string_view name);
+  UHDM::any* bind_net_(ModuleInstance* instance, std::string_view name);
   ModuleInstance* getInterfaceInstance_(ModuleInstance* instance,
-                                        const std::string& sigName);
+                                        std::string_view sigName);
 };
 
 };  // namespace SURELOG

--- a/include/Surelog/DesignCompile/UhdmWriter.h
+++ b/include/Surelog/DesignCompile/UhdmWriter.h
@@ -49,7 +49,7 @@ class UhdmWriter final {
   typedef std::map<ModPort*, UHDM::modport*> ModPortMap;
   typedef std::map<const DesignComponent*, UHDM::BaseClass*> ComponentMap;
   typedef std::map<Signal*, UHDM::BaseClass*> SignalBaseClassMap;
-  typedef std::map<std::string, Signal*> SignalMap;
+  typedef std::map<std::string, Signal*, std::less<>> SignalMap;
   typedef std::map<ModuleInstance*, UHDM::BaseClass*> InstanceMap;
   typedef std::map<std::string, UHDM::BaseClass*> VpiSignalMap;
 

--- a/include/Surelog/Expression/Value.h
+++ b/include/Surelog/Expression/Value.h
@@ -89,8 +89,8 @@ class Value : public RTTI {
   virtual void set(int64_t val) = 0;
   virtual void set(double val) = 0;
   virtual void set(uint64_t val, Type type, short size) = 0;
-  virtual void set(const std::string& val) = 0;
-  virtual void set(const std::string& val, Type type) = 0;
+  virtual void set(std::string_view val) = 0;
+  virtual void set(std::string_view val, Type type) = 0;
   virtual bool operator<(const Value& rhs) const = 0;
   virtual bool operator==(const Value& rhs) const = 0;
 
@@ -215,7 +215,8 @@ class SValue final : public Value {
   void set(int64_t val) final;
   void set(double val) final;
   void set(uint64_t val, Type type, short size) final;
-  void set(const std::string& val) final {
+
+  void set(std::string_view val) final {
     m_type = Value::Type::None;
     m_value.u_int = 0;
     m_size = 0;
@@ -223,7 +224,7 @@ class SValue final : public Value {
     m_negative = 0;
   }
 
-  void set(const std::string& val, Type type) final {
+  void set(std::string_view val, Type type) final {
     m_type = Value::Type::None;
     m_value.u_int = 0;
     m_size = 0;
@@ -370,8 +371,8 @@ class LValue final : public Value {
   void set(int64_t val) final;
   void set(double val) final;
   void set(uint64_t val, Type type, short size) final;
-  void set(const std::string& val) final {}
-  void set(const std::string& val, Type type) final {}
+  void set(std::string_view val) final {}
+  void set(std::string_view val, Type type) final {}
   bool operator<(const Value& rhs) const final;
   bool operator==(const Value& rhs) const final;
 
@@ -488,7 +489,7 @@ class StValue final : public Value {
     m_valid = true;
     m_signed = false;
   }
-  void set(const std::string& val, Type type) final {
+  void set(std::string_view val, Type type) final {
     m_type = type;
     m_value = val;
     m_size = val.size();
@@ -498,14 +499,14 @@ class StValue final : public Value {
     m_valid = true;
     m_signed = false;
   }
-  void set(const std::string& val, Type type, short size) {
+  void set(std::string_view val, Type type, short size) {
     m_type = type;
     m_value = val;
     m_size = size;
     m_valid = true;
     m_signed = false;
   }
-  void set(const std::string& val) final {
+  void set(std::string_view val) final {
     m_type = Type::String;
     m_value = val;
     m_size = val.size() * 8;

--- a/include/Surelog/Testbench/Property.h
+++ b/include/Surelog/Testbench/Property.h
@@ -36,7 +36,7 @@ class FileContent;
 class Property : public Variable {
  public:
   Property(DataType* dataType, const FileContent* fc, NodeId varId,
-           NodeId range, std::string name, bool is_local, bool is_static,
+           NodeId range, std::string_view name, bool is_local, bool is_static,
            bool is_protected, bool is_rand, bool is_randc)
       : Variable(dataType, fc, varId, range, name),
         m_is_local(is_local),

--- a/include/Surelog/Testbench/TypeDef.h
+++ b/include/Surelog/Testbench/TypeDef.h
@@ -39,7 +39,7 @@ class TypeDef : public DataType {
   SURELOG_IMPLEMENT_RTTI(TypeDef, DataType)
  public:
   TypeDef(const FileContent* fC, NodeId id, NodeId the_def,
-          const std::string& name, bool forwardDeclaration = false);
+          std::string_view name, bool forwardDeclaration = false);
   ~TypeDef() override = default;
 
   void setDataType(DataType* the_type) { m_datatype = the_type; }

--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -324,7 +324,7 @@ unsigned int SLgetLine(FileContent* fC, RawNodeId index) {
 
 std::string SLgetName(FileContent* fC, RawNodeId index) {
   if (!fC) return "";
-  return fC->SymName(NodeId(index));
+  return std::string(fC->SymName(NodeId(index)));
 }
 
 RawNodeId SLgetChild(FileContent* fC, RawNodeId parent, unsigned int type) {

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -437,7 +437,7 @@ Program* Design::getProgram(std::string_view name) const {
   }
 }
 
-ClassDefinition* Design::getClassDefinition(const std::string& name) const {
+ClassDefinition* Design::getClassDefinition(const std::string_view name) const {
   ClassNameClassDefinitionMap::const_iterator itr =
       m_uniqueClassDefinitions.find(name);
   if (itr == m_uniqueClassDefinitions.end()) {
@@ -501,7 +501,7 @@ Package* Design::addPackageDefinition(std::string_view packageName,
   }
 }
 
-void Design::addClassDefinition(const std::string& className,
+void Design::addClassDefinition(std::string_view className,
                                 ClassDefinition* classDef) {
   m_classDefinitions.emplace(className, classDef);
   m_uniqueClassDefinitions.emplace(className, classDef);

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -49,7 +49,7 @@ std::string_view FileContent::getName() const {
   return FileSystem::getInstance()->toPath(m_fileId);
 }
 
-const std::string& FileContent::SymName(NodeId index) const {
+std::string_view FileContent::SymName(NodeId index) const {
   if (index >= m_objects.size()) {
     Location loc(m_fileId);
     Error err(ErrorDefinition::COMP_INTERNAL_ERROR_OUT_OF_BOUND, loc);
@@ -104,7 +104,7 @@ std::string FileContent::printSubTree(NodeId nodeId) const {
   return text;
 }
 
-void FileContent::insertObjectLookup(const std::string& name, NodeId id,
+void FileContent::insertObjectLookup(std::string_view name, NodeId id,
                                      ErrorContainer* errors) {
   NameIdMap::iterator itr = m_objectLookup.find(name);
   if (itr == m_objectLookup.end()) {

--- a/src/Design/ModuleDefinition.cpp
+++ b/src/Design/ModuleDefinition.cpp
@@ -62,7 +62,7 @@ unsigned int ModuleDefinition::getSize() const {
   return size;
 }
 
-void ModuleDefinition::insertModPort(const std::string& modport,
+void ModuleDefinition::insertModPort(std::string_view modport,
                                      const Signal& signal, NodeId nodeId) {
   ModPortSignalMap::iterator itr = m_modportSignalMap.find(modport);
   if (itr == m_modportSignalMap.end()) {
@@ -89,7 +89,7 @@ const Signal* ModuleDefinition::getModPortSignal(const std::string& modport,
   return nullptr;
 }
 
-ModPort* ModuleDefinition::getModPort(const std::string& modport) {
+ModPort* ModuleDefinition::getModPort(std::string_view modport) {
   ModPortSignalMap::iterator itr = m_modportSignalMap.find(modport);
   if (itr == m_modportSignalMap.end()) {
     return nullptr;
@@ -98,7 +98,7 @@ ModPort* ModuleDefinition::getModPort(const std::string& modport) {
   }
 }
 
-void ModuleDefinition::insertModPort(const std::string& modport,
+void ModuleDefinition::insertModPort(std::string_view modport,
                                      ClockingBlock& cb) {
   ModPortClockingBlockMap::iterator itr =
       m_modportClockingBlockMap.find(modport);

--- a/src/Design/Parameter.cpp
+++ b/src/Design/Parameter.cpp
@@ -27,7 +27,7 @@
 namespace SURELOG {
 
 Parameter::Parameter(const FileContent* fC, NodeId nodeId,
-                     const std::string& name, NodeId node_type, bool port_param)
+                     std::string_view name, NodeId node_type, bool port_param)
     : DataType(fC, nodeId, name,
                fC ? fC->Type(node_type) : VObjectType::slParameter_declaration,
                true),

--- a/src/Design/Scope.cpp
+++ b/src/Design/Scope.cpp
@@ -30,7 +30,7 @@ void Scope::addVariable(Variable* var) {
   m_variables.emplace(var->getName(), var);
 }
 
-Variable* Scope::getVariable(const std::string& name) {
+Variable* Scope::getVariable(std::string_view name) {
   VariableMap::iterator itr = m_variables.find(name);
   if (itr == m_variables.end()) {
     if (m_parentScope) {

--- a/src/Design/Signal.cpp
+++ b/src/Design/Signal.cpp
@@ -99,7 +99,7 @@ std::string Signal::getInterfaceTypeName() const {
       VObjectType::slClass_scope) {
     NodeId Class_type = m_fileContent->Child(m_interfaceTypeNameId);
     NodeId Pack_name = m_fileContent->Child(Class_type);
-    type_name = m_fileContent->SymName(Pack_name) + "::";
+    type_name.assign(m_fileContent->SymName(Pack_name)).append("::");
     NodeId Struct_name = m_fileContent->Sibling(m_interfaceTypeNameId);
     type_name += m_fileContent->SymName(Struct_name);
   } else {
@@ -107,18 +107,18 @@ std::string Signal::getInterfaceTypeName() const {
     NodeId constant_select = m_fileContent->Sibling(m_interfaceTypeNameId);
     if (constant_select) {
       if (m_fileContent->Type(constant_select) == VObjectType::slStringConst) {
-        type_name += "." + m_fileContent->SymName(constant_select);
+        type_name.append(".").append(m_fileContent->SymName(constant_select));
       } else {
         NodeId selector = m_fileContent->Child(constant_select);
         if (m_fileContent->Type(selector) == VObjectType::slStringConst)
-          type_name += "." + m_fileContent->SymName(selector);
+          type_name.append(".").append(m_fileContent->SymName(selector));
       }
     }
   }
   return type_name;
 }
 
-const std::string& Signal::getName() const {
+std::string_view Signal::getName() const {
   return m_fileContent->SymName(m_nodeId);
 }
 

--- a/src/DesignCompile/Builtin.cpp
+++ b/src/DesignCompile/Builtin.cpp
@@ -376,10 +376,10 @@ void Builtin::addBuiltinClasses() {
                                   VObjectType::slAttr_spec);
     const std::string& libName = fC1->getLibrary()->getName();
     if (stId) {
-      const std::string& name = fC1->SymName(stId);
+      const std::string_view name = fC1->SymName(stId);
       fC1->insertObjectLookup(name, classId,
                               m_compiler->getCompiler()->getErrorContainer());
-      std::string fullName = libName + "@" + name;
+      std::string fullName = StrCat(libName, "@", name);
       ClassDefinition* def =
           new ClassDefinition(fullName, fC1->getLibrary(), nullptr, fC1,
                               classId, nullptr, s.MakeClass_defn());

--- a/src/DesignCompile/CompileExpression_test.cpp
+++ b/src/DesignCompile/CompileExpression_test.cpp
@@ -113,7 +113,7 @@ TEST(CompileExpression, ExprFromParseTree3) {
   EXPECT_EQ(assigns.size(), 2);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
-    const std::string &name = fC->SymName(param);
+    const std::string_view name = fC->SymName(param);
     NodeId rhs = fC->Sibling(param);
     const UHDM::expr *exp1 = (UHDM::expr *)helper.compileExpression(
         nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, false,
@@ -154,7 +154,7 @@ TEST(CompileExpression, ExprFromPpTree) {
   EXPECT_EQ(assigns.size(), 2);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
-    const std::string &name = fC->SymName(param);
+    const std::string_view name = fC->SymName(param);
     NodeId rhs = fC->Sibling(param);
     const UHDM::expr *exp1 = (UHDM::expr *)helper.compileExpression(
         nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, false,

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -244,7 +244,7 @@ bool CompileModule::collectUdpObjects_() {
         NodeId port = fC->Child(id);
         while (port) {
           UHDM::io_decl* io = s.MakeIo_decl();
-          const std::string& name = fC->SymName(port);
+          const std::string_view name = fC->SymName(port);
           fC->populateCoreMembers(port, port, io);
           io->VpiName(name);
           io->VpiParent(defn);
@@ -264,7 +264,7 @@ bool CompileModule::collectUdpObjects_() {
             Output = fC->Sibling(Output);
         }
 
-        const std::string& outputname = fC->SymName(Output);
+        const std::string_view outputname = fC->SymName(Output);
         std::vector<UHDM::io_decl*>* ios = defn->Io_decls();
         UHDM::logic_net* net = s.MakeLogic_net();
         fC->populateCoreMembers(id, id, net);
@@ -295,7 +295,7 @@ bool CompileModule::collectUdpObjects_() {
         }
         NodeId Identifier = fC->Child(Indentifier_list);
         while (Identifier) {
-          const std::string& inputname = fC->SymName(Identifier);
+          const std::string_view inputname = fC->SymName(Identifier);
           std::vector<UHDM::io_decl*>* ios = defn->Io_decls();
           if (ios) {
             UHDM::logic_net* net = s.MakeLogic_net();
@@ -331,7 +331,7 @@ bool CompileModule::collectUdpObjects_() {
             ventry += "* ";
             nbSymb = 1;
           } else {
-            const std::string& symb = fC->SymName(Symbol);
+            const std::string_view symb = fC->SymName(Symbol);
             nbSymb = symb.size();
             std::string symbols;
             for (unsigned int i = 0; i < nbSymb; i++) {
@@ -377,7 +377,7 @@ bool CompileModule::collectUdpObjects_() {
               } else if (fC->Type(Symbol) == VObjectType::slBinOp_Mult) {
                 ventry += "* ";
               } else {
-                const std::string& symb = fC->SymName(Symbol);
+                const std::string_view symb = fC->SymName(Symbol);
                 ventry += symb;
               }
               Level_Symbol = fC->Sibling(Level_Symbol);
@@ -395,7 +395,7 @@ bool CompileModule::collectUdpObjects_() {
               ventry += "* ";
               nbSymb = 1;
             } else {
-              const std::string& symb = fC->SymName(Symbol);
+              const std::string_view symb = fC->SymName(Symbol);
               nbSymb = symb.size();
               std::string symbols;
               for (unsigned int i = 0; i < nbSymb; i++) {
@@ -416,7 +416,7 @@ bool CompileModule::collectUdpObjects_() {
         } else if (fC->Type(Symbol) == VObjectType::slBinOp_Mult) {
           ventry += "* ";
         } else {
-          const std::string& symb = fC->SymName(Symbol);
+          const std::string_view symb = fC->SymName(Symbol);
           unsigned int nbSymb = symb.size();
           std::string symbols;
           for (unsigned int i = 0; i < nbSymb; i++) {
@@ -431,7 +431,7 @@ bool CompileModule::collectUdpObjects_() {
 
         if (fC->Type(Symbol) == VObjectType::slOutput_symbol) {
           Symbol = fC->Child(Symbol);
-          const std::string& symb = fC->SymName(Symbol);
+          const std::string_view symb = fC->SymName(Symbol);
           unsigned int nbSymb = symb.size();
           std::string symbols;
           for (unsigned int i = 0; i < nbSymb; i++) {
@@ -474,7 +474,7 @@ bool CompileModule::collectUdpObjects_() {
         assign_stmt->VpiParent(init);
         UHDM::constant* c = s.MakeConstant();
         assign_stmt->Rhs(c);
-        std::string val = "UINT:" + fC->SymName(Value);
+        std::string val = StrCat("UINT:", fC->SymName(Value));
         c->VpiValue(val);
         c->VpiDecompile(fC->SymName(Value));
         c->VpiSize(64);
@@ -734,7 +734,7 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
           if (fC->Type(nameId) == VObjectType::slVirtual) {
             nameId = fC->Sibling(nameId);
           }
-          std::string name = fC->SymName(nameId);
+          const std::string_view name = fC->SymName(nameId);
           FileCNodeId fnid(fC, nameId);
           m_module->addObject(type, fnid);
 
@@ -805,7 +805,7 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
           if (!sibling) {
             if (fC->Type(fC->Parent(id)) != VObjectType::slModule_declaration)
               break;
-            const std::string& endLabel = fC->SymName(id);
+            const std::string_view endLabel = fC->SymName(id);
             std::string_view moduleName = m_module->getName();
             moduleName = StringUtils::ltrim_until(moduleName, '@');
             moduleName = StringUtils::ltrim_until(moduleName, ':');
@@ -1034,7 +1034,7 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
            */
           {
             NodeId modportname = fC->Child(id);
-            const std::string& modportsymb = fC->SymName(modportname);
+            const std::string_view modportsymb = fC->SymName(modportname);
             NodeId modport_ports_declaration = fC->Sibling(modportname);
             VObjectType port_direction_type = VObjectType::slNoType;
             while (modport_ports_declaration) {
@@ -1178,7 +1178,7 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
           NodeId InterfaceIdentifier = fC->Sibling(id);
           if (InterfaceIdentifier) {
             NodeId label = fC->Child(InterfaceIdentifier);
-            const std::string& endLabel = fC->SymName(label);
+            const std::string_view endLabel = fC->SymName(label);
             std::string_view moduleName = m_module->getName();
             moduleName = StringUtils::ltrim_until(moduleName, '@');
             moduleName = StringUtils::ltrim_until(moduleName, ':');

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -213,7 +213,7 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
           if (fC->Type(nameId) == VObjectType::slVirtual) {
             nameId = fC->Sibling(nameId);
           }
-          const std::string& name = fC->SymName(nameId);
+          const std::string_view name = fC->SymName(nameId);
           FileCNodeId fnid(fC, nameId);
           m_package->addObject(type, fnid);
 
@@ -277,7 +277,7 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
           if (!sibling) {
             if (fC->Type(fC->Parent(id)) != VObjectType::slPackage_declaration)
               break;
-            const std::string& endLabel = fC->SymName(id);
+            const std::string_view endLabel = fC->SymName(id);
             std::string_view moduleName =
                 StringUtils::ltrim_until(m_package->getName(), '@');
             if (endLabel != moduleName) {

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -238,7 +238,7 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
         if (fC->Type(nameId) == VObjectType::slVirtual) {
           nameId = fC->Sibling(nameId);
         }
-        const std::string& name = fC->SymName(nameId);
+        const std::string_view name = fC->SymName(nameId);
         FileCNodeId fnid(fC, nameId);
         m_program->addObject(type, fnid);
 
@@ -311,7 +311,7 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
         if (!sibling) {
           if (fC->Type(fC->Parent(id)) != VObjectType::slProgram_declaration)
             break;
-          const std::string& endLabel = fC->SymName(id);
+          const std::string_view endLabel = fC->SymName(id);
           std::string_view moduleName =
               StringUtils::ltrim_until(m_program->getName(), '@');
           if (endLabel != moduleName) {

--- a/src/DesignCompile/Elaboration_test.cpp
+++ b/src/DesignCompile/Elaboration_test.cpp
@@ -81,7 +81,7 @@ TEST(Elaboration, ExprFromPpTree) {
   EXPECT_EQ(assigns.size(), 2);
   for (NodeId param_assign : assigns) {
     NodeId param = fC->Child(param_assign);
-    const std::string& name = fC->SymName(param);
+    const std::string_view name = fC->SymName(param);
     NodeId rhs = fC->Sibling(param);
     // Not reduced
     UHDM::expr* exp1 = (UHDM::expr*)helper.compileExpression(

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -114,7 +114,7 @@ void computeVarChain(const FileContent* fC, NodeId nodeId,
     VObjectType type = fC->Type(nodeId);
     switch (type) {
       case VObjectType::slStringConst: {
-        var_chain.push_back(fC->SymName(nodeId));
+        var_chain.emplace_back(fC->SymName(nodeId));
         break;
       }
       case VObjectType::slImplicit_class_handle: {
@@ -584,7 +584,7 @@ bool TestbenchElaboration::bindForeachLoop_(ClassDefinition* classDefinition,
     }
     VObjectType rangeType = sfC->Type(rangeTypeId);
     if (rangeType == VObjectType::slStringConst) {
-      const std::string& dataTypeName = sfC->SymName(rangeTypeId);
+      const std::string_view dataTypeName = sfC->SymName(rangeTypeId);
       itrDataType =
           bindDataType_(dataTypeName, sfC, rangeTypeId, classDefinition,
                         ErrorDefinition::COMP_UNDEFINED_TYPE);
@@ -703,7 +703,7 @@ bool TestbenchElaboration::bindProperties_() {
         defn->Variables(vars);
       }
 
-      const std::string& signame = sig->getName();
+      const std::string_view signame = sig->getName();
 
       // Packed and unpacked ranges
       int packedSize = 0;

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -91,7 +91,7 @@ bool UhdmChecker::registerFile(const FileContent* fC,
                                    VObjectType::slAttr_spec);
       if (stId) {
         std::string name =
-            fC->getLibrary()->getName() + "@" + fC->SymName(stId);
+            StrCat(fC->getLibrary()->getName(), "@", fC->SymName(stId));
         if (moduleNames.find(name) == moduleNames.end()) {
           skipModule = true;
         }

--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -70,8 +70,8 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
   switch (type) {
     case VObjectType::slPackage_scope: {
       Value* sval = nullptr;
-      const std::string& packageName = fC->SymName(child);
-      const std::string& name = fC->SymName(fC->Sibling(parent));
+      const std::string_view packageName = fC->SymName(child);
+      const std::string_view name = fC->SymName(fC->Sibling(parent));
       if (m_design) {
         Package* pack = m_design->getPackage(packageName);
         if (pack) {
@@ -85,7 +85,7 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
         }
       }
       std::string fullName;
-      if (sval == nullptr) fullName = packageName + "::" + name;
+      if (sval == nullptr) fullName = StrCat(packageName, "::", name);
       if (sval == nullptr) {
         if (muteErrors == false) {
           Location loc(fC->getFileId(parent), fC->Line(parent),
@@ -410,8 +410,8 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
         }
       } break;
       case VObjectType::slIntConst: {
-        const std::string& val = fC->SymName(child);
-        std::string size(StringUtils::rtrim_until(val, '\''));
+        const std::string_view val = fC->SymName(child);
+        const std::string_view size = StringUtils::rtrim_until(val, '\'');
         int64_t intsize = 0;
         if (NumUtils::parseInt64(size, &intsize) == nullptr) {
           intsize = 0;
@@ -496,8 +496,8 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
         break;
       }
       case VObjectType::slRealConst: {
-        const std::string& real = fC->SymName(child);
-        std::istringstream os(real);
+        const std::string_view real = fC->SymName(child);
+        std::istringstream os(real.data());
         double d;
         os >> d;
         value->set(d);
@@ -512,8 +512,8 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
         Value* sval = nullptr;
         std::string fullName;
         if (childType == VObjectType::slPackage_scope) {
-          const std::string& packageName = fC->SymName(fC->Child(child));
-          const std::string& name = fC->SymName(fC->Sibling(child));
+          const std::string_view packageName = fC->SymName(fC->Child(child));
+          const std::string_view name = fC->SymName(fC->Sibling(child));
           if (m_design) {
             Package* pack = m_design->getPackage(packageName);
             if (pack) {
@@ -526,9 +526,9 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
               }
             }
           }
-          if (sval == nullptr) fullName = packageName + "::" + name;
+          if (sval == nullptr) fullName = StrCat(packageName, "::", name);
         } else {
-          const std::string& name = fC->SymName(child);
+          const std::string_view name = fC->SymName(child);
           if (instance) {
             if (instance->getComplexValue(name)) {
               muteErrors = true;
@@ -562,10 +562,9 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
         break;
       }
       case VObjectType::slStringLiteral: {
-        std::string name = fC->SymName(child);
         m_valueFactory.deleteValue(value);
         value = m_valueFactory.newStValue();
-        name = StringUtils::unquoted(name);
+        const std::string_view name = StringUtils::unquoted(fC->SymName(child));
         value->set(name);
         break;
       }
@@ -629,7 +628,7 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
           args.push_back(evalExpr(fC, Expression, instance, muteErrors));
           Expression = fC->Sibling(Expression);
         }
-        const std::string& funcName = fC->SymName(function);
+        const std::string_view funcName = fC->SymName(function);
         if (funcName == "clog2") {
           int val = args[0]->getValueL();
           val = val - 1;
@@ -751,7 +750,7 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
       case VObjectType::slStringConst: {
         Value* sval = nullptr;
         std::string fullName;
-        const std::string& name = fC->SymName(parent);
+        const std::string_view name = fC->SymName(parent);
         if (instance) {
           if (instance->getComplexValue(name)) {
             muteErrors = true;
@@ -875,7 +874,7 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
         break;
       }
       case VObjectType::slIncDec_PlusPlus: {
-        const std::string& name = fC->SymName(fC->Sibling(parent));
+        const std::string_view name = fC->SymName(fC->Sibling(parent));
         Value* sval = nullptr;
         if (instance) {
           if (instance->getComplexValue(name)) {
@@ -892,7 +891,7 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
         break;
       }
       case VObjectType::slIncDec_MinusMinus: {
-        const std::string& name = fC->SymName(fC->Sibling(parent));
+        const std::string_view name = fC->SymName(fC->Sibling(parent));
         Value* sval = nullptr;
         if (instance) {
           if (instance->getComplexValue(name)) {

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -162,7 +162,8 @@ bool ParseLibraryDef::parseConfigDefinition() {
   std::vector<NodeId> configs = fC->sl_collect_all(fC->getRootNode(), types);
   for (auto config : configs) {
     NodeId ident = fC->Child(config);
-    std::string name = fC->getLibrary()->getName() + "@" + fC->SymName(ident);
+    std::string name =
+        StrCat(fC->getLibrary()->getName(), "@", fC->SymName(ident));
     m_symbolTable->registerSymbol(name);
     Config conf(name, fC, config);
 
@@ -214,7 +215,7 @@ bool ParseLibraryDef::parseConfigDefinition() {
         if (instNameS.empty())
           instNameS = fC->SymName(instName);
         else
-          instNameS += "." + fC->SymName(instName);
+          instNameS.append(".").append(fC->SymName(instName));
         instName = fC->Sibling(instName);
       }
       NodeId instClause = fC->Sibling(inst);
@@ -244,7 +245,7 @@ bool ParseLibraryDef::parseConfigDefinition() {
             if (useName.empty())
               useName = fC->SymName(use);
             else
-              useName += "." + fC->SymName(use);
+              useName.append(".").append(fC->SymName(use));
             use = fC->Sibling(use);
           }
           useName = StringUtils::replaceAll(useName, ".", "@");
@@ -262,7 +263,7 @@ bool ParseLibraryDef::parseConfigDefinition() {
           if (useName.empty())
             useName = fC->SymName(use);
           else
-            useName += "@" + fC->SymName(use);
+            useName.append("@").append(fC->SymName(use));
           use = fC->Sibling(use);
         }
         UseClause usec(UseClause::UseConfig, useName, fC, mem);

--- a/src/Testbench/TypeDef.cpp
+++ b/src/Testbench/TypeDef.cpp
@@ -27,7 +27,7 @@
 namespace SURELOG {
 
 TypeDef::TypeDef(const FileContent* fC, NodeId id, NodeId the_def,
-                 const std::string& name, bool forwardDeclaration)
+                 std::string_view name, bool forwardDeclaration)
     : DataType(fC, id, name, fC->Type(id)),
       m_the_def(the_def),
       m_datatype(nullptr),


### PR DESCRIPTION
FileContent::SymName now returns std::string_view instead of std::string

Other file changes are ripple effect from the change to the FileContent::SymName API.