### PR TITLE
Tell unittest ctest to run tests in parallel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ endif
 
 PREFIX ?= /usr/local
 ADDITIONAL_CMAKE_OPTIONS ?=
+export CTEST_PARALLEL_LEVEL = $(CPU_CORES)
 
 release: run-cmake-release
 	cmake --build build -j $(CPU_CORES)


### PR DESCRIPTION
This will help discover if tests are truly
independent (e.g. not modify the same files in
TempDir()).
