### PR TITLE
Implement string_view based functions in StringUtils

### DIFF
--- a/include/Surelog/Package/Package.h
+++ b/include/Surelog/Package/Package.h
@@ -67,7 +67,7 @@ class Package : public DesignComponent {
   void addClassDefinition(std::string className, ClassDefinition* classDef) {
     m_classDefinitions.insert(std::make_pair(className, classDef));
   }
-  ClassDefinition* getClassDefinition(const std::string& name);
+  ClassDefinition* getClassDefinition(std::string_view name);
   ExprBuilder* getExprBuilder() { return &m_exprBuilder; }
 
   UHDM::VectorOfattribute* Attributes() const { return attributes_; }

--- a/include/Surelog/SourceCompile/PreprocessFile.h
+++ b/include/Surelog/SourceCompile/PreprocessFile.h
@@ -299,8 +299,8 @@ class PreprocessFile final {
   void addError(Error& error);
 
   /* Shorthands for symbol manipulations */
-  SymbolId registerSymbol(const std::string& symbol) const;
-  SymbolId getId(const std::string& symbol) const;
+  SymbolId registerSymbol(std::string_view symbol) const;
+  SymbolId getId(std::string_view symbol) const;
   std::string getSymbol(SymbolId id) const;
 
   // For recursive macro definition detection

--- a/src/API/PythonAPI.cpp
+++ b/src/API/PythonAPI.cpp
@@ -241,7 +241,7 @@ void PythonAPI::initInterp_() {
 void PythonAPI::init(int argc, const char** argv) {
   std::string programPath = argv[0];
   programPath = StringUtils::replaceAll(programPath, "\\", "/");
-  m_programPath = StringUtils::rtrim(programPath, '/');
+  m_programPath = StringUtils::rtrim_until(programPath, '/');
   for (int i = 1; i < argc; i++) {
     if (!strcmp(argv[i], "-builtin")) {
       if (i < argc - 1) {

--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -64,8 +64,8 @@ void SLregisterNewErrorType(const char* messageId, const char* text,
                             const char* secondLine) {
   //[WARNI:PP0103]
   std::string errorId = messageId;
-  errorId = StringUtils::rtrim(errorId, ']');
-  errorId = StringUtils::ltrim(errorId, '[');
+  errorId = StringUtils::rtrim_until(errorId, ']');
+  errorId = StringUtils::ltrim_until(errorId, '[');
   ErrorDefinition::ErrorType type = ErrorDefinition::getErrorType(messageId);
   ErrorDefinition::ErrorSeverity severity =
       ErrorDefinition::getErrorSeverity(errorId.substr(0, 5));

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -226,7 +226,7 @@ bool CompileClass::compile() {
             break;
           const std::string& endLabel = fC->SymName(id);
           std::string moduleName = m_class->getName();
-          moduleName = StringUtils::ltrim(moduleName, '@');
+          moduleName = StringUtils::ltrim_until(moduleName, '@');
           if (endLabel != moduleName) {
             Location loc(fC->getFileId(m_class->getNodeIds()[0]),
                          fC->Line(m_class->getNodeIds()[0]),

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -313,11 +313,11 @@ std::pair<UHDM::task_func *, DesignComponent *> CompileHelper::getTaskFunc(
   std::pair<UHDM::task_func *, DesignComponent *> result = {nullptr, nullptr};
   DesignComponent *comp = component;
   if (name.find("::") != std::string::npos) {
-    std::vector<std::string> res;
+    std::vector<std::string_view> res;
     StringUtils::tokenizeMulti(name, "::", res);
     if (res.size() > 1) {
-      const std::string &packName = res[0];
-      const std::string &funcName = res[1];
+      const std::string_view packName = res[0];
+      const std::string_view funcName = res[1];
       Design *design = compileDesign->getCompiler()->getDesign();
       if (Package *pack = design->getPackage(packName)) {
         if (pack->getTask_funcs()) {
@@ -484,7 +484,7 @@ constant *compileConst(const FileContent *fC, NodeId child, Serializer &s) {
           size = "";
         }
         v = StringUtils::replaceAll(v, "_", "");
-        StringUtils::rtrim(size, '\'');
+        size = StringUtils::rtrim_until(size, '\'');
         if (size.empty()) {
           c->VpiSize(-1);
         } else {
@@ -710,11 +710,10 @@ constant *compileConst(const FileContent *fC, NodeId child, Serializer &s) {
     }
     case VObjectType::slStringLiteral: {
       UHDM::constant *c = s.MakeConstant();
-      std::string value = StringUtils::unquoted(fC->SymName(child));
+      std::string_view value = StringUtils::unquoted(fC->SymName(child));
       c->VpiDecompile(value);
       c->VpiSize(value.length());
-      value = "STRING:" + value;
-      c->VpiValue(value);
+      c->VpiValue(StrCat("STRING:", value));
       c->VpiConstType(vpiStringConst);
       result = c;
       break;
@@ -836,11 +835,11 @@ any *CompileHelper::getValue(const std::string &name,
     m_stackLevel++;
   }
   if (name.find("::") != std::string::npos) {
-    std::vector<std::string> res;
+    std::vector<std::string_view> res;
     StringUtils::tokenizeMulti(name, "::", res);
     if (res.size() > 1) {
-      const std::string &packName = res[0];
-      const std::string &varName = res[1];
+      const std::string_view packName = res[0];
+      const std::string_view varName = res[1];
       Design *design = compileDesign->getCompiler()->getDesign();
       if (Package *pack = design->getPackage(packName)) {
         if (expr *val = pack->getComplexValue(varName)) {
@@ -3783,10 +3782,10 @@ uint64_t CompileHelper::Bits(const UHDM::any *typespec, bool &invalidValue,
   if (typespec) {
     const std::string &name = typespec->VpiName();
     if (name.find("::") != std::string::npos) {
-      std::vector<std::string> res;
+      std::vector<std::string_view> res;
       StringUtils::tokenizeMulti(name, "::", res);
       if (res.size() > 1) {
-        const std::string &packName = res[0];
+        const std::string_view packName = res[0];
         Design *design = compileDesign->getCompiler()->getDesign();
         if (Package *pack = design->getPackage(packName)) {
           component = pack;
@@ -3918,11 +3917,11 @@ const typespec *CompileHelper::getTypespec(DesignComponent *component,
         } else if (exp->UhdmType() == uhdmref_obj) {
           basename = exp->VpiName();
           if (basename.find("::") != std::string::npos) {
-            std::vector<std::string> res;
+            std::vector<std::string_view> res;
             StringUtils::tokenizeMulti(basename, "::", res);
             if (res.size() > 1) {
-              const std::string &packName = res[0];
-              const std::string &typeName = res[1];
+              const std::string_view packName = res[0];
+              const std::string_view typeName = res[1];
               Package *p =
                   compileDesign->getCompiler()->getDesign()->getPackage(
                       packName);

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -805,9 +805,9 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
               break;
             const std::string& endLabel = fC->SymName(id);
             std::string moduleName = m_module->getName();
-            moduleName = StringUtils::ltrim(moduleName, '@');
-            moduleName = StringUtils::ltrim(moduleName, ':');
-            moduleName = StringUtils::ltrim(moduleName, ':');
+            moduleName = StringUtils::ltrim_until(moduleName, '@');
+            moduleName = StringUtils::ltrim_until(moduleName, ':');
+            moduleName = StringUtils::ltrim_until(moduleName, ':');
             if (endLabel != moduleName) {
               Location loc(fC->getFileId(m_module->getNodeIds()[0]),
                            fC->Line(m_module->getNodeIds()[0]),
@@ -1178,9 +1178,9 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
             NodeId label = fC->Child(InterfaceIdentifier);
             const std::string& endLabel = fC->SymName(label);
             std::string moduleName = m_module->getName();
-            moduleName = StringUtils::ltrim(moduleName, '@');
-            moduleName = StringUtils::ltrim(moduleName, ':');
-            moduleName = StringUtils::ltrim(moduleName, ':');
+            moduleName = StringUtils::ltrim_until(moduleName, '@');
+            moduleName = StringUtils::ltrim_until(moduleName, ':');
+            moduleName = StringUtils::ltrim_until(moduleName, ':');
             if (endLabel != moduleName) {
               Location loc(fC->getFileId(m_module->getNodeIds()[0]),
                            fC->Line(m_module->getNodeIds()[0]),

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -279,7 +279,7 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
               break;
             const std::string& endLabel = fC->SymName(id);
             std::string moduleName = m_package->getName();
-            moduleName = StringUtils::ltrim(moduleName, '@');
+            moduleName = StringUtils::ltrim_until(moduleName, '@');
             if (endLabel != moduleName) {
               Location loc(fC->getFileId(m_package->getNodeIds()[0]),
                            fC->Line(m_package->getNodeIds()[0]),

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -313,7 +313,7 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
             break;
           const std::string& endLabel = fC->SymName(id);
           std::string moduleName = m_program->getName();
-          moduleName = StringUtils::ltrim(moduleName, '@');
+          moduleName = StringUtils::ltrim_until(moduleName, '@');
           if (endLabel != moduleName) {
             Location loc(fC->getFileId(m_program->getNodeIds()[0]),
                          fC->Line(m_program->getNodeIds()[0]),

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -1614,7 +1614,7 @@ NodeId CompileHelper::setFuncTaskQualifiers(const FileContent* fC,
       if (func) func->VpiAccessType(vpiDPIImportAcc);
     }
     if (func_type == VObjectType::slStringLiteral) {
-      std::string ctype = StringUtils::unquoted(fC->SymName(func_decl));
+      std::string_view ctype = StringUtils::unquoted(fC->SymName(func_decl));
       if (ctype == "DPI-C") {
         if (func) func->VpiDPICStr(vpiDPIC);
       } else if (ctype == "DPI") {

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -667,16 +667,16 @@ const DataType* ElaborationStep::bindDataType_(
   }
   if (found == false) {
     if (type_name.find("::") != std::string::npos) {
-      std::vector<std::string> args;
+      std::vector<std::string_view> args;
       StringUtils::tokenizeMulti(type_name, "::", args);
-      std::string classOrPackageName = args[0];
-      std::string the_type_name = args[1];
-      itr1 = classes.find(libName + "@" + classOrPackageName);
+      std::string_view classOrPackageName = args[0];
+      std::string_view the_type_name = args[1];
+      itr1 = classes.find(StrCat(libName, "@", classOrPackageName));
       if (itr1 == classes.end()) {
         if (parent->getParentScope()) {
           std::string class_in_own_package =
-              ((DesignComponent*)parent->getParentScope())->getName() +
-              "::" + classOrPackageName;
+              StrCat(((DesignComponent*)parent->getParentScope())->getName(),
+                     "::", classOrPackageName);
           itr1 = classes.find(class_in_own_package);
         }
       }
@@ -953,8 +953,8 @@ void checkIfBuiltInTypeOrErrorOut(DesignComponent* def, const FileContent* fC,
 }
 
 bool bindStructInPackage(Design* design, Signal* signal,
-                         const std::string& packageName,
-                         const std::string& structName) {
+                         const std::string_view packageName,
+                         const std::string_view structName) {
   Package* p = design->getPackage(packageName);
   if (p) {
     const DataType* dtype = p->getDataType(structName);
@@ -1113,14 +1113,14 @@ bool ElaborationStep::bindPortType_(Signal* signal, const FileContent* fC,
       std::string modPort;
       if (interfName.find('.') != std::string::npos) {
         modPort = interfName;
-        StringUtils::ltrim(modPort, '.');
-        StringUtils::rtrim(baseName, '.');
+        modPort = StringUtils::ltrim_until(modPort, '.');
+        baseName = StringUtils::rtrim_until(baseName, '.');
       } else if (interfName.find("::") != std::string::npos) {
-        std::vector<std::string> result;
+        std::vector<std::string_view> result;
         StringUtils::tokenizeMulti(interfName, "::", result);
         if (result.size() > 1) {
-          const std::string& packName = result[0];
-          const std::string& structName = result[1];
+          const std::string_view packName = result[0];
+          const std::string_view structName = result[1];
           if (bindStructInPackage(design, signal, packName, structName))
             return true;
         }

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -2527,8 +2527,8 @@ any* NetlistElaboration::bind_net_(ModuleInstance* instance,
       std::string subname;
       if (basename.find('.') != std::string::npos) {
         subname = basename;
-        StringUtils::ltrim(subname, '.');
-        StringUtils::rtrim(basename, '.');
+        subname = StringUtils::ltrim_until(subname, '.');
+        basename = StringUtils::rtrim_until(basename, '.');
       }
       itr = symbols.find(basename);
       if (itr != symbols.end()) {

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -1028,10 +1028,10 @@ void UhdmWriter::writePackage(Package* pack, package* p, Serializer& s,
     for (auto tf : *pack->getTask_funcs()) {
       const std::string funcName = tf->VpiName();
       if (funcName.find("::") != std::string::npos) {
-        std::vector<std::string> res;
+        std::vector<std::string_view> res;
         StringUtils::tokenizeMulti(funcName, "::", res);
-        const std::string& className = res[0];
-        const std::string& funcName = res[1];
+        const std::string_view className = res[0];
+        const std::string_view funcName = res[1];
         bool foundParentClass = false;
         for (auto cl : *dest_classes) {
           if (cl->VpiName() == className) {
@@ -1048,8 +1048,8 @@ void UhdmWriter::writePackage(Package* pack, package* p, Serializer& s,
         if (foundParentClass) {
           tf->VpiName(funcName);
           ((task_func*)tf)
-              ->VpiFullName(pack->getName() + "::" + className +
-                            "::" + tf->VpiName());
+              ->VpiFullName(StrCat(pack->getName(), "::", className,
+                                   "::", tf->VpiName()));
         } else {
           tf->VpiParent(p);
           tf->Instance(p);
@@ -1902,11 +1902,11 @@ void UhdmWriter::lateTypedefBinding(UHDM::Serializer& s, DesignComponent* mod,
       name = StringUtils::trim(name);
 
       if (name.find("::") != std::string::npos) {
-        std::vector<std::string> res;
+        std::vector<std::string_view> res;
         StringUtils::tokenizeMulti(name, "::", res);
         if (res.size() > 1) {
-          const std::string& packName = res[0];
-          const std::string& typeName = res[1];
+          const std::string_view packName = res[0];
+          const std::string_view typeName = res[1];
           Package* pack =
               m_compileDesign->getCompiler()->getDesign()->getPackage(packName);
           if (pack) {
@@ -1921,7 +1921,7 @@ void UhdmWriter::lateTypedefBinding(UHDM::Serializer& s, DesignComponent* mod,
                     break;
                   }
                   const std::string pname =
-                      std::string(m->VpiName() + "::" + typeName);
+                      StrCat(m->VpiName(), "::", typeName);
                   if (n->VpiName() == pname) {
                     found = true;
                     tps = n;
@@ -2461,11 +2461,11 @@ void UhdmWriter::lateBinding(UHDM::Serializer& s, DesignComponent* mod,
     std::string name = ref->VpiName();
     name = StringUtils::trim(name);
     if (name.find("::") != std::string::npos) {
-      std::vector<std::string> res;
+      std::vector<std::string_view> res;
       StringUtils::tokenizeMulti(name, "::", res);
       if (res.size() > 1) {
-        const std::string& packName = res[0];
-        const std::string& typeName = res[1];
+        const std::string_view packName = res[0];
+        const std::string_view typeName = res[1];
         Package* pack =
             m_compileDesign->getCompiler()->getDesign()->getPackage(packName);
         if (pack) {
@@ -2480,8 +2480,7 @@ void UhdmWriter::lateBinding(UHDM::Serializer& s, DesignComponent* mod,
                   ref->Actual_group(n);
                   break;
                 }
-                const std::string pname =
-                    std::string(m->VpiName() + "::" + typeName);
+                const std::string pname = StrCat(m->VpiName(), "::", typeName);
                 if (n->VpiName() == pname) {
                   if (n->UhdmType() == uhdmref_var) continue;
                   if (n->UhdmType() == uhdmref_obj) continue;
@@ -2498,8 +2497,7 @@ void UhdmWriter::lateBinding(UHDM::Serializer& s, DesignComponent* mod,
                   ref->Actual_group(n);
                   break;
                 }
-                const std::string pname =
-                    std::string(m->VpiName() + "::" + typeName);
+                const std::string pname = StrCat(m->VpiName(), "::", typeName);
                 if (n->VpiName() == pname) {
                   if (n->UhdmType() == uhdmref_var) continue;
                   if (n->UhdmType() == uhdmref_obj) continue;

--- a/src/ErrorReporting/ErrorDefinition.cpp
+++ b/src/ErrorReporting/ErrorDefinition.cpp
@@ -47,8 +47,8 @@ void ErrorDefinition::setSeverity(ErrorDefinition::ErrorType type,
 
 ErrorDefinition::ErrorType ErrorDefinition::getErrorType(std::string errorId) {
   // TODO: this needs to take std::string_view
-  errorId = StringUtils::rtrim(errorId, ']');
-  errorId = StringUtils::ltrim(errorId, '[');
+  errorId = StringUtils::rtrim_until(errorId, ']');
+  errorId = StringUtils::ltrim_until(errorId, '[');
   errorId = errorId.erase(0, 8);
   unsigned int id = atoi(errorId.c_str());
   return (ErrorDefinition::ErrorType)id;

--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -411,8 +411,7 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
       } break;
       case VObjectType::slIntConst: {
         const std::string& val = fC->SymName(child);
-        std::string size = val;
-        StringUtils::rtrim(size, '\'');
+        std::string size(StringUtils::rtrim_until(val, '\''));
         int64_t intsize = 0;
         if (!size.empty()) intsize = std::strtoull(size.c_str(), nullptr, 10);
         if (val.find('\'') != std::string::npos) {
@@ -1015,8 +1014,7 @@ Value* ExprBuilder::fromString(const std::string& value) {
     sval = StringUtils::replaceAll(sval, "_", "");
     switch (base) {
       case 'h': {
-        std::string size = value;
-        StringUtils::rtrim(size, '\'');
+        std::string size(StringUtils::rtrim_until(value, '\''));
         int s = std::atoi(size.c_str());
         StValue* stval = (StValue*)m_valueFactory.newStValue();
         stval->set(sval, Value::Type::Hexadecimal, s);
@@ -1024,8 +1022,7 @@ Value* ExprBuilder::fromString(const std::string& value) {
         break;
       }
       case 'b': {
-        std::string size = value;
-        StringUtils::rtrim(size, '\'');
+        std::string size(StringUtils::rtrim_until(value, '\''));
         int s = std::atoi(size.c_str());
         StValue* stval = (StValue*)m_valueFactory.newStValue();
         stval->set(sval, Value::Type::Binary, s);
@@ -1033,8 +1030,7 @@ Value* ExprBuilder::fromString(const std::string& value) {
         break;
       }
       case 'o': {
-        std::string size = value;
-        StringUtils::rtrim(size, '\'');
+        std::string size(StringUtils::rtrim_until(value, '\''));
         int s = std::atoi(size.c_str());
         StValue* stval = (StValue*)m_valueFactory.newStValue();
         stval->set(sval, Value::Type::Octal, s);
@@ -1042,8 +1038,7 @@ Value* ExprBuilder::fromString(const std::string& value) {
         break;
       }
       case 'd': {
-        std::string size = value;
-        StringUtils::rtrim(size, '\'');
+        std::string size(StringUtils::rtrim_until(value, '\''));
         int s = std::atoi(size.c_str());
         const char* value_ptr = sval.c_str();
         long double v = std::strtold(value_ptr, &end_parse_ptr);
@@ -1070,8 +1065,7 @@ Value* ExprBuilder::fromString(const std::string& value) {
         break;
       }
       default: {
-        std::string size = value;
-        StringUtils::rtrim(size, '\'');
+        std::string size(StringUtils::rtrim_until(value, '\''));
         int s = std::atoi(size.c_str());
         StValue* stval = (StValue*)m_valueFactory.newStValue();
         stval->set(sval, Value::Type::Binary, s);

--- a/src/Package/Package.cpp
+++ b/src/Package/Package.cpp
@@ -44,7 +44,7 @@ unsigned int Package::getSize() const {
   return size;
 }
 
-ClassDefinition* Package::getClassDefinition(const std::string& name) {
+ClassDefinition* Package::getClassDefinition(std::string_view name) {
   ClassNameClassDefinitionMultiMap::iterator itr =
       m_classDefinitions.find(name);
   if (itr == m_classDefinitions.end()) {

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -45,10 +45,10 @@ void AnalyzeFile::checkSLlineDirective_(const std::string& line,
     std::string text;
     ss >> text;
     text = StringUtils::unquoted(text);
-    std::vector<std::string> parts;
+    std::vector<std::string_view> parts;
     StringUtils::tokenize(text, "^", parts);
-    std::string symbol = StringUtils::unquoted(parts[0]);
-    std::string file = StringUtils::unquoted(parts[1]);
+    std::string_view symbol = StringUtils::unquoted(parts[0]);
+    std::string_view file = StringUtils::unquoted(parts[1]);
     info.m_sectionSymbolId = m_clp->getSymbolTable()->registerSymbol(symbol);
     info.m_sectionFileId =
         FileSystem::getInstance()->toPathId(file, m_clp->getSymbolTable());

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -391,7 +391,7 @@ void SV3_1aPpTreeShapeListener::enterSimple_no_args_macro_definition(
     else if (ctx->Escaped_identifier()) {
       macroName = ctx->Escaped_identifier()->getText();
       macroName.erase(0, 1);
-      StringUtils::rtrim(macroName);
+      macroName = StringUtils::rtrim(macroName);
     }
     if (m_reservedMacroNamesSet.find(macroName) !=
         m_reservedMacroNamesSet.end()) {
@@ -447,7 +447,7 @@ void SV3_1aPpTreeShapeListener::enterMacroInstanceWithArgs(
     } else if (ctx->Macro_Escaped_identifier()) {
       macroName = ctx->Macro_Escaped_identifier()->getText();
       macroName.erase(0, 1);
-      StringUtils::rtrim(macroName);
+      macroName = StringUtils::rtrim(macroName);
       startLineCol = ParseUtils::getLineColumn(ctx->Macro_Escaped_identifier());
       endLineCol =
           ParseUtils::getEndLineColumn(ctx->Macro_Escaped_identifier());
@@ -594,7 +594,7 @@ void SV3_1aPpTreeShapeListener::enterMacroInstanceNoArgs(
     } else if (ctx->Macro_Escaped_identifier()) {
       macroName = ctx->Macro_Escaped_identifier()->getText();
       macroName.erase(0, 1);
-      StringUtils::rtrim(macroName);
+      macroName = StringUtils::rtrim(macroName);
       startLineCol = ParseUtils::getLineColumn(ctx->Macro_Escaped_identifier());
       endLineCol =
           ParseUtils::getEndLineColumn(ctx->Macro_Escaped_identifier());
@@ -784,7 +784,7 @@ void SV3_1aPpTreeShapeListener::enterLine_directive(
       ParseUtils::getLineColumn(m_pp->getTokenStream(), ctx);
   PathId newFileId;
   if (ctx->String()) {
-    std::string fileName = StringUtils::unquoted(ctx->String()->getText());
+    std::string fileName(StringUtils::unquoted(ctx->String()->getText()));
     newFileId = fileSystem->locate(
         fileName,
         m_pp->getCompileSourceFile()->getCommandLineParser()->getIncludePaths(),
@@ -825,7 +825,7 @@ void SV3_1aPpTreeShapeListener::enterDefine_directive(
     else if (ctx->Escaped_identifier()) {
       macroName = ctx->Escaped_identifier()->getText();
       macroName.erase(0, 1);
-      StringUtils::rtrim(macroName);
+      macroName = StringUtils::rtrim(macroName);
     }
     if (m_reservedMacroNamesSet.find(macroName) !=
         m_reservedMacroNamesSet.end()) {
@@ -843,7 +843,7 @@ void SV3_1aPpTreeShapeListener::exitDefine_directive(
     else if (ctx->Escaped_identifier()) {
       macroName = ctx->Escaped_identifier()->getText();
       macroName.erase(0, 1);
-      StringUtils::rtrim(macroName);
+      macroName = StringUtils::rtrim(macroName);
     }
     MacroInfo *macroInf = m_pp->getMacro(macroName);
     if (macroInf == nullptr) {
@@ -1018,7 +1018,7 @@ void SV3_1aPpTreeShapeListener::enterUndef_directive(
     lineCol = ParseUtils::getLineColumn(ctx->Escaped_identifier());
     macroName = ctx->Escaped_identifier()->getText();
     macroName.erase(0, 1);
-    StringUtils::rtrim(macroName);
+    macroName = StringUtils::rtrim(macroName);
   } else if (ctx->macro_instance()) {
     lineCol = ParseUtils::getLineColumn(m_pp->getTokenStream(),
                                         ctx->macro_instance());
@@ -1055,7 +1055,7 @@ void SV3_1aPpTreeShapeListener::enterIfdef_directive(
     lineCol = ParseUtils::getLineColumn(ctx->Escaped_identifier());
     macroName = ctx->Escaped_identifier()->getText();
     macroName.erase(0, 1);
-    StringUtils::rtrim(macroName);
+    macroName = StringUtils::rtrim(macroName);
   } else if (ctx->macro_instance()) {
     lineCol = ParseUtils::getLineColumn(m_pp->getTokenStream(),
                                         ctx->macro_instance());
@@ -1094,7 +1094,7 @@ void SV3_1aPpTreeShapeListener::enterIfndef_directive(
     lineCol = ParseUtils::getLineColumn(ctx->Escaped_identifier());
     macroName = ctx->Escaped_identifier()->getText();
     macroName.erase(0, 1);
-    StringUtils::rtrim(macroName);
+    macroName = StringUtils::rtrim(macroName);
   } else if (ctx->macro_instance()) {
     lineCol = ParseUtils::getLineColumn(m_pp->getTokenStream(),
                                         ctx->macro_instance());
@@ -1133,7 +1133,7 @@ void SV3_1aPpTreeShapeListener::enterElsif_directive(
     lineCol = ParseUtils::getLineColumn(ctx->Escaped_identifier());
     macroName = ctx->Escaped_identifier()->getText();
     macroName.erase(0, 1);
-    StringUtils::rtrim(macroName);
+    macroName = StringUtils::rtrim(macroName);
   } else if (ctx->macro_instance()) {
     lineCol = ParseUtils::getLineColumn(m_pp->getTokenStream(),
                                         ctx->macro_instance());
@@ -1426,7 +1426,7 @@ void SV3_1aPpTreeShapeListener::enterMultiline_no_args_macro_definition(
     else if (ctx->Escaped_identifier()) {
       macroName = ctx->Escaped_identifier()->getText();
       macroName.erase(0, 1);
-      StringUtils::rtrim(macroName);
+      macroName = StringUtils::rtrim(macroName);
     }
     if (m_reservedMacroNamesSet.find(macroName) !=
         m_reservedMacroNamesSet.end()) {
@@ -1478,7 +1478,7 @@ void SV3_1aPpTreeShapeListener::enterMultiline_args_macro_definition(
     else if (ctx->Escaped_identifier()) {
       macroName = ctx->Escaped_identifier()->getText();
       macroName.erase(0, 1);
-      StringUtils::rtrim(macroName);
+      macroName = StringUtils::rtrim(macroName);
     }
     if (m_reservedMacroNamesSet.find(macroName) !=
         m_reservedMacroNamesSet.end()) {
@@ -1529,7 +1529,7 @@ void SV3_1aPpTreeShapeListener::enterSimple_args_macro_definition(
     else if (ctx->Escaped_identifier()) {
       macroName = ctx->Escaped_identifier()->getText();
       macroName.erase(0, 1);
-      StringUtils::rtrim(macroName);
+      macroName = StringUtils::rtrim(macroName);
     }
     if (m_reservedMacroNamesSet.find(macroName) !=
         m_reservedMacroNamesSet.end()) {

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -179,11 +179,11 @@ void SV3_1aTreeShapeListener::exitSlline(SV3_1aParser::SllineContext *ctx) {
   unsigned int startLine = std::stoi(ctx->Integral_number()[0]->getText());
   IncludeFileInfo::Action action = static_cast<IncludeFileInfo::Action>(
       std::stoi(ctx->Integral_number()[1]->getText()));
-  std::string text = StringUtils::unquoted(ctx->String()->getText());
-  std::vector<std::string> parts;
+  std::string text(StringUtils::unquoted(ctx->String()->getText()));
+  std::vector<std::string_view> parts;
   StringUtils::tokenize(text, "^", parts);
-  std::string symbol = StringUtils::unquoted(parts[0]);
-  std::string file = StringUtils::unquoted(parts[1]);
+  std::string_view symbol = StringUtils::unquoted(parts[0]);
+  std::string_view file = StringUtils::unquoted(parts[1]);
 
   std::pair<int, int> startLineCol = ParseUtils::getLineColumn(m_tokens, ctx);
   std::pair<int, int> endLineCol = ParseUtils::getEndLineColumn(m_tokens, ctx);


### PR DESCRIPTION
Implement string_view based functions in StringUtils

Following functions now take string_view as argument and return string_view where applicable

* ltrim, rtrim, trim, and rtrimEqual
* tokenizeXXX functions
* unquote

Also, moved getFirstNonEmptyToken into PreprocessFile as it's a very special case implementation, applicable only in one specific scenario.

Unfortunately, tokensizeXXX functions still need the std::string flavor as the change to std::string_view change couldn't be localized easily.

Update the use cases across the code.