### PR TITLE
DesignComponent::getName returns a std::string_view instead of std::string

### DIFF
--- a/include/Surelog/CommandLine/CommandLineParser.h
+++ b/include/Surelog/CommandLine/CommandLineParser.h
@@ -208,8 +208,12 @@ class CommandLineParser final {
   PathId getProgramId() const { return m_programId; }
   std::string getExeCommand() const { return m_exeCommand; }
   std::set<std::string>& getTopLevelModules() { return m_topLevelModules; }
-  std::set<std::string>& getBlackBoxModules() { return m_blackboxModules; }
-  std::set<std::string>& getBlackBoxInstances() { return m_blackboxInstances; }
+  std::set<std::string, std::less<>>& getBlackBoxModules() {
+    return m_blackboxModules;
+  }
+  std::set<std::string, std::less<>>& getBlackBoxInstances() {
+    return m_blackboxInstances;
+  }
   void setTopLevelModule(const std::string& module) {
     m_topLevelModules.insert(module);
   }
@@ -326,8 +330,8 @@ class CommandLineParser final {
   PathId m_programId;
   std::string m_exeCommand;
   std::set<std::string> m_topLevelModules;
-  std::set<std::string> m_blackboxModules;
-  std::set<std::string> m_blackboxInstances;
+  std::set<std::string, std::less<>> m_blackboxModules;
+  std::set<std::string, std::less<>> m_blackboxInstances;
   bool m_sverilog;
   bool m_dumpUhdm;
   bool m_elabUhdm;

--- a/include/Surelog/Design/Design.h
+++ b/include/Surelog/Design/Design.h
@@ -156,11 +156,11 @@ class Design final {
 
   ErrorContainer* getErrorContainer() { return m_errors; }
 
-  typedef std::multimap<const std::string, BindStmt*> BindMap;
+  typedef std::multimap<const std::string, BindStmt*, std::less<>> BindMap;
 
   BindMap& getBindMap() { return m_bindMap; }
 
-  std::vector<BindStmt*> getBindStmts(const std::string& targetName);
+  std::vector<BindStmt*> getBindStmts(std::string_view targetName);
 
   void addBindStmt(const std::string& targetName, BindStmt* stmt);
 

--- a/include/Surelog/Design/DesignComponent.h
+++ b/include/Surelog/Design/DesignComponent.h
@@ -76,7 +76,7 @@ class DesignComponent : public ValuedComponentI, public PortNetHolder {
   virtual unsigned int getSize() const = 0;
   virtual VObjectType getType() const = 0;
   virtual bool isInstance() const = 0;
-  virtual std::string getName() const = 0;
+  virtual std::string_view getName() const = 0;
   void append(DesignComponent*);
 
   typedef std::map<std::string, DataType*, StringViewCompare> DataTypeMap;

--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -97,7 +97,7 @@ class FileContent : public DesignComponent {
   unsigned int getSize() const override { return m_objects.size(); }
   VObjectType getType() const override { return VObjectType::slNoType; }
   bool isInstance() const override { return false; }
-  std::string getName() const override;
+  std::string_view getName() const override;
   NodeId getRootNode() const;
   std::string printObjects() const;  // The whole file content
   std::string printSubTree(

--- a/include/Surelog/Design/ModuleDefinition.h
+++ b/include/Surelog/Design/ModuleDefinition.h
@@ -52,7 +52,7 @@ class ModuleDefinition : public DesignComponent, public ClockingBlockHolder {
 
   ~ModuleDefinition() override = default;
 
-  std::string getName() const override { return m_name; }
+  std::string_view getName() const override { return m_name; }
   VObjectType getType() const override;
   bool isInstance() const override;
   unsigned int getSize() const override;

--- a/include/Surelog/Design/ModuleInstance.h
+++ b/include/Surelog/Design/ModuleInstance.h
@@ -88,7 +88,7 @@ class ModuleInstance : public ValuedComponentI {
   SymbolId getModuleNameId(SymbolTable* symbols) const;
   std::string getInstanceName() const;
   std::string getFullPathName() const;
-  std::string getModuleName() const;
+  std::string_view getModuleName() const;
   unsigned int getDepth() const;
 
   void setNodeId(NodeId id) { m_nodeId = id; }  // Used for generate stmt

--- a/include/Surelog/DesignCompile/NetlistElaboration.h
+++ b/include/Surelog/DesignCompile/NetlistElaboration.h
@@ -61,14 +61,14 @@ class NetlistElaboration : public TestbenchElaboration {
   bool elab_generates_(ModuleInstance* instance);
   UHDM::interface* elab_interface_(
       ModuleInstance* instance, ModuleInstance* interf_instance,
-      const std::string& instName, const std::string& defName,
+      std::string_view instName, std::string_view defName,
       ModuleDefinition* mod, PathId fileId, int lineNb,
       UHDM::interface_array* interf_array, const std::string& modPortName);
   UHDM::modport* elab_modport_(ModuleInstance* instance,
                                ModuleInstance* interfInstance,
-                               const std::string& instName,
-                               const std::string& defName,
-                               ModuleDefinition* mod, PathId fileId, int lineNb,
+                               std::string_view instName,
+                               std::string_view defName, ModuleDefinition* mod,
+                               PathId fileId, int lineNb,
                                const std::string& modPortName,
                                UHDM::interface_array* interf_array);
   bool elab_ports_nets_(ModuleInstance* instance, bool ports);

--- a/include/Surelog/DesignCompile/UhdmChecker.h
+++ b/include/Surelog/DesignCompile/UhdmChecker.h
@@ -25,11 +25,11 @@
 #define SURELOG_UHDMCHECKER_H
 #pragma once
 
+#include <Surelog/Common/PathId.h>
+
 #include <map>
 #include <set>
 #include <vector>
-
-#include <Surelog/Common/PathId.h>
 
 namespace SURELOG {
 
@@ -46,7 +46,8 @@ class UhdmChecker final {
   bool check(PathId uhdmFileId);
 
  private:
-  bool registerFile(const FileContent* fC, std::set<std::string>& moduleNames);
+  bool registerFile(const FileContent* fC,
+                    std::set<std::string_view>& moduleNames);
   bool reportHtml(PathId uhdmFileId, float overallCoverage);
   float reportCoverage(PathId uhdmFileId);
   void annotate();

--- a/include/Surelog/Package/Package.h
+++ b/include/Surelog/Package/Package.h
@@ -59,7 +59,7 @@ class Package : public DesignComponent {
     return VObjectType::slPackage_declaration;
   }
   bool isInstance() const override { return false; }
-  std::string getName() const override { return m_name; }
+  std::string_view getName() const override { return m_name; }
 
   ClassNameClassDefinitionMultiMap& getClassDefinitions() {
     return m_classDefinitions;

--- a/include/Surelog/Testbench/ClassDefinition.h
+++ b/include/Surelog/Testbench/ClassDefinition.h
@@ -63,7 +63,7 @@ class ClassDefinition : public DesignComponent, public DataType {
     return VObjectType::slClass_declaration;
   }
   bool isInstance() const override { return false; }
-  std::string getName() const override { return m_name; }
+  std::string_view getName() const override { return m_name; }
   Library* getLibrary() { return m_library; }
   DesignComponent* getContainer() const { return m_container; }
   void setContainer(DesignComponent* container) { m_container = container; }

--- a/include/Surelog/Testbench/Program.h
+++ b/include/Surelog/Testbench/Program.h
@@ -51,7 +51,7 @@ class Program : public DesignComponent, public ClockingBlockHolder {
   unsigned int getSize() const override;
   VObjectType getType() const override;
   bool isInstance() const override { return true; }
-  std::string getName() const override { return m_name; }
+  std::string_view getName() const override { return m_name; }
 
   ClassNameClassDefinitionMultiMap& getClassDefinitions() {
     return m_classDefinitions;

--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -462,7 +462,7 @@ ModuleInstance* SLgetTopModuleInstance(Design* design, unsigned int index) {
 
 std::string SLgetModuleName(ModuleDefinition* module) {
   if (!module) return "";
-  return module->getName();
+  return std::string(module->getName());
 }
 
 template <typename ClassOrPackageOrProgram>
@@ -501,7 +501,7 @@ RawNodeId SLgetModuleRootNode(ModuleDefinition* module) {
 
 std::string SLgetClassName(ClassDefinition* module) {
   if (!module) return "";
-  return module->getName();
+  return std::string(module->getName());
 }
 
 std::string SLgetClassFile(ClassDefinition* module) {
@@ -533,7 +533,7 @@ RawNodeId SLgetClassRootNode(ClassDefinition* module) {
 
 std::string SLgetPackageName(Package* module) {
   if (!module) return "";
-  return module->getName();
+  return std::string(module->getName());
 }
 
 std::string SLgetPackageFile(Package* module) {
@@ -564,7 +564,7 @@ RawNodeId SLgetPackageRootNode(Package* module) {
 
 std::string SLgetProgramName(Program* module) {
   if (!module) return "";
-  return module->getName();
+  return std::string(module->getName());
 }
 
 std::string SLgetProgramFile(Program* module) {
@@ -615,7 +615,7 @@ std::string SLgetInstanceFullPathName(ModuleInstance* instance) {
 
 std::string SLgetInstanceModuleName(ModuleInstance* instance) {
   if (!instance) return "";
-  return instance->getModuleName();
+  return std::string(instance->getModuleName());
 }
 
 DesignComponent* SLgetInstanceDefinition(ModuleInstance* instance) {

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -197,7 +197,7 @@ void Design::reportInstanceTreeStats(unsigned int& nbTopLevelModules,
   numberOfLeafInstances = 0;
   nbUndefinedModules = 0;
   nbUndefinedInstances = 0;
-  std::set<std::string> undefModules;
+  std::set<std::string_view> undefModules;
   ModuleInstance* tmp;
   std::queue<ModuleInstance*> queue;
   for (auto instance : m_topLevelModuleInstances) {
@@ -528,7 +528,7 @@ void Design::clearContainers() {
   m_orderedPackageNames.clear();
 }
 
-std::vector<BindStmt*> Design::getBindStmts(const std::string& targetName) {
+std::vector<BindStmt*> Design::getBindStmts(std::string_view targetName) {
   std::vector<BindStmt*> results;
   BindMap::iterator itr = m_bindMap.find(targetName);
   while (itr != m_bindMap.end()) {

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -45,8 +45,8 @@ FileContent::FileContent(PathId fileId, Library* library,
             InvalidNodeId, InvalidNodeId, InvalidNodeId, InvalidNodeId);
 }
 
-std::string FileContent::getName() const {
-  return std::string(FileSystem::getInstance()->toPath(m_fileId));
+std::string_view FileContent::getName() const {
+  return FileSystem::getInstance()->toPath(m_fileId);
 }
 
 const std::string& FileContent::SymName(NodeId index) const {

--- a/src/Design/ModuleInstance.cpp
+++ b/src/Design/ModuleInstance.cpp
@@ -270,10 +270,9 @@ std::string ModuleInstance::getInstanceName() const {
   }
 }
 
-std::string ModuleInstance::getModuleName() const {
+std::string_view ModuleInstance::getModuleName() const {
   if (m_definition == nullptr) {
-    std::string name = m_instName.substr(0, m_instName.find("&", 0, 1));
-    return name;
+    return std::string_view(m_instName).substr(0, m_instName.find("&", 0, 1));
   } else {
     return m_definition->getName();
   }

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -57,7 +57,7 @@ bool CompileClass::compile() {
   if (fC == nullptr) return true;
   NodeId nodeId = m_class->m_nodeIds[0];
 
-  std::vector<std::string> names;
+  std::vector<std::string_view> names;
   ClassDefinition* parent = m_class;
   DesignComponent* tmp_container = nullptr;
   while (parent) {
@@ -68,7 +68,7 @@ bool CompileClass::compile() {
 
   std::string fullName;
   if (tmp_container) {
-    fullName = tmp_container->getName() + "::";
+    fullName.append(tmp_container->getName()).append("::");
   }
   if (!names.empty()) {
     unsigned int index = names.size() - 1;
@@ -225,8 +225,8 @@ bool CompileClass::compile() {
           if (fC->Type(fC->Parent(id)) != VObjectType::slClass_declaration)
             break;
           const std::string& endLabel = fC->SymName(id);
-          std::string moduleName = m_class->getName();
-          moduleName = StringUtils::ltrim_until(moduleName, '@');
+          std::string_view moduleName =
+              StringUtils::ltrim_until(m_class->getName(), '@');
           if (endLabel != moduleName) {
             Location loc(fC->getFileId(m_class->getNodeIds()[0]),
                          fC->Line(m_class->getNodeIds()[0]),

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -52,6 +52,7 @@
 #include <Surelog/Testbench/TypeDef.h>
 #include <Surelog/Testbench/Variable.h>
 #include <Surelog/Utils/NumUtils.h>
+#include <Surelog/Utils/StringUtils.h>
 
 // UHDM
 #include <string.h>
@@ -129,7 +130,7 @@ bool CompileHelper::importPackage(DesignComponent* scope, Design* design,
       if (!object_name.empty()) {
         if (name != object_name) continue;
       }
-      std::string fullName = def->getName() + "::" + name;
+      std::string fullName = StrCat(def->getName(), "::", name);
       DesignComponent* comp = packageFile->getComponentDefinition(fullName);
       FileCNodeId fnid(packageFile, classDef);
       scope->addNamedObject(name, fnid, comp);
@@ -573,7 +574,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
   std::string name = fC->SymName(type_name);
   std::string fullName = name;
   if (Package* pack = valuedcomponenti_cast<Package*>(scope)) {
-    fullName = pack->getName() + "::" + name;
+    fullName.assign(pack->getName()).append("::").append(name);
   }
   if (scope) {
     const TypeDef* prevDef = scope->getTypeDef(name);

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -98,17 +98,19 @@ bool CompileModule::compile() {
 
   CommandLineParser* clp =
       m_compileDesign->getCompiler()->getCommandLineParser();
-  std::set<std::string>& blackboxModules = clp->getBlackBoxModules();
+  std::set<std::string, std::less<>>& blackboxModules =
+      clp->getBlackBoxModules();
   bool skipModule = false;
   std::string libName;
   if (!m_module->getFileContents().empty())
     libName = m_module->getFileContents()[0]->getLibrary()->getName();
-  const std::string& modName = m_module->getName();
+  const std::string_view modName = m_module->getName();
   if (blackboxModules.find(modName) != blackboxModules.end()) {
     errType = ErrorDefinition::COMP_SKIPPING_BLACKBOX_MODULE;
     skipModule = true;
   }
-  std::set<std::string>& blackboxInstances = clp->getBlackBoxInstances();
+  std::set<std::string, std::less<>>& blackboxInstances =
+      clp->getBlackBoxInstances();
   std::string instanceName;
   if (m_instance) {
     if (ModuleInstance* inst =
@@ -736,7 +738,7 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
           FileCNodeId fnid(fC, nameId);
           m_module->addObject(type, fnid);
 
-          std::string completeName = m_module->getName() + "::" + name;
+          std::string completeName = StrCat(m_module->getName(), "::", name);
 
           DesignComponent* comp = fC->getComponentDefinition(completeName);
 
@@ -804,7 +806,7 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
             if (fC->Type(fC->Parent(id)) != VObjectType::slModule_declaration)
               break;
             const std::string& endLabel = fC->SymName(id);
-            std::string moduleName = m_module->getName();
+            std::string_view moduleName = m_module->getName();
             moduleName = StringUtils::ltrim_until(moduleName, '@');
             moduleName = StringUtils::ltrim_until(moduleName, ':');
             moduleName = StringUtils::ltrim_until(moduleName, ':');
@@ -1177,7 +1179,7 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
           if (InterfaceIdentifier) {
             NodeId label = fC->Child(InterfaceIdentifier);
             const std::string& endLabel = fC->SymName(label);
-            std::string moduleName = m_module->getName();
+            std::string_view moduleName = m_module->getName();
             moduleName = StringUtils::ltrim_until(moduleName, '@');
             moduleName = StringUtils::ltrim_until(moduleName, ':');
             moduleName = StringUtils::ltrim_until(moduleName, ':');

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -217,7 +217,7 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
           FileCNodeId fnid(fC, nameId);
           m_package->addObject(type, fnid);
 
-          std::string completeName = m_package->getName() + "::" + name;
+          std::string completeName = StrCat(m_package->getName(), "::", name);
 
           DesignComponent* comp = fC->getComponentDefinition(completeName);
 
@@ -278,8 +278,8 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
             if (fC->Type(fC->Parent(id)) != VObjectType::slPackage_declaration)
               break;
             const std::string& endLabel = fC->SymName(id);
-            std::string moduleName = m_package->getName();
-            moduleName = StringUtils::ltrim_until(moduleName, '@');
+            std::string_view moduleName =
+                StringUtils::ltrim_until(m_package->getName(), '@');
             if (endLabel != moduleName) {
               Location loc(fC->getFileId(m_package->getNodeIds()[0]),
                            fC->Line(m_package->getNodeIds()[0]),

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -242,7 +242,7 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
         FileCNodeId fnid(fC, nameId);
         m_program->addObject(type, fnid);
 
-        std::string completeName = m_program->getName() + "::" + name;
+        std::string completeName = StrCat(m_program->getName(), "::", name);
 
         DesignComponent* comp = fC->getComponentDefinition(completeName);
 
@@ -312,8 +312,8 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
           if (fC->Type(fC->Parent(id)) != VObjectType::slProgram_declaration)
             break;
           const std::string& endLabel = fC->SymName(id);
-          std::string moduleName = m_program->getName();
-          moduleName = StringUtils::ltrim_until(moduleName, '@');
+          std::string_view moduleName =
+              StringUtils::ltrim_until(m_program->getName(), '@');
           if (endLabel != moduleName) {
             Location loc(fC->getFileId(m_program->getNodeIds()[0]),
                          fC->Line(m_program->getNodeIds()[0]),

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -283,14 +283,15 @@ UHDM::any* CompileHelper::compileVariable(
       if (result == nullptr) {
         ClassDefinition* cl = design->getClassDefinition(typeName);
         if (cl == nullptr) {
-          cl = design->getClassDefinition(component->getName() +
-                                          "::" + typeName);
+          cl = design->getClassDefinition(
+              StrCat(component->getName(), "::", typeName));
         }
         if (cl == nullptr) {
           if (const DesignComponent* p =
                   valuedcomponenti_cast<const DesignComponent*>(
                       component->getParentScope())) {
-            cl = design->getClassDefinition(p->getName() + "::" + typeName);
+            cl = design->getClassDefinition(
+                StrCat(p->getName(), "::", typeName));
           }
         }
         if (cl) {
@@ -429,14 +430,15 @@ UHDM::any* CompileHelper::compileVariable(
       if (var == nullptr) {
         ClassDefinition* cl = design->getClassDefinition(packageName);
         if (cl == nullptr) {
-          cl = design->getClassDefinition(component->getName() +
-                                          "::" + packageName);
+          cl = design->getClassDefinition(
+              StrCat(component->getName(), "::", packageName));
         }
         if (cl == nullptr) {
           if (const DesignComponent* p =
                   valuedcomponenti_cast<const DesignComponent*>(
                       component->getParentScope())) {
-            cl = design->getClassDefinition(p->getName() + "::" + packageName);
+            cl = design->getClassDefinition(
+                StrCat(p->getName(), "::", packageName));
           }
         }
         if (cl) {
@@ -560,13 +562,13 @@ typespec* CompileHelper::compileDatastructureTypespec(
           libName + "@" + typeName);
       if (dt == nullptr) {
         dt = compileDesign->getCompiler()->getDesign()->getClassDefinition(
-            component->getName() + "::" + typeName);
+            StrCat(component->getName(), "::", typeName));
       }
       if (dt == nullptr) {
         if (component->getParentScope())
           dt = compileDesign->getCompiler()->getDesign()->getClassDefinition(
-              ((DesignComponent*)component->getParentScope())->getName() +
-              "::" + typeName);
+              StrCat(((DesignComponent*)component->getParentScope())->getName(),
+                     "::", typeName));
       }
       if (dt == nullptr) {
         dt = compileDesign->getCompiler()->getDesign()->getClassDefinition(
@@ -1581,14 +1583,15 @@ UHDM::typespec* CompileHelper::compileTypespec(
           Design* design = compileDesign->getCompiler()->getDesign();
           ClassDefinition* cl = design->getClassDefinition(typeName);
           if (cl == nullptr) {
-            cl = design->getClassDefinition(component->getName() +
-                                            "::" + typeName);
+            cl = design->getClassDefinition(
+                StrCat(component->getName(), "::", typeName));
           }
           if (cl == nullptr) {
             if (const DesignComponent* p =
                     valuedcomponenti_cast<const DesignComponent*>(
                         component->getParentScope())) {
-              cl = design->getClassDefinition(p->getName() + "::" + typeName);
+              cl = design->getClassDefinition(
+                  StrCat(p->getName(), "::", typeName));
             }
           }
           if (cl) {

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -662,7 +662,8 @@ void DesignElaboration::elaborateInstance_(
 
   CommandLineParser* clp =
       m_compileDesign->getCompiler()->getCommandLineParser();
-  std::set<std::string>& blackboxModules = clp->getBlackBoxModules();
+  std::set<std::string, std::less<>>& blackboxModules =
+      clp->getBlackBoxModules();
   std::string modName;
   if (DesignComponent* def = parent->getDefinition()) {
     modName = def->getName();
@@ -677,7 +678,8 @@ void DesignElaboration::elaborateInstance_(
                                                                   false);
     return;
   }
-  std::set<std::string>& blackboxInstances = clp->getBlackBoxInstances();
+  std::set<std::string, std::less<>>& blackboxInstances =
+      clp->getBlackBoxInstances();
   std::string instanceName;
   if (parent) {
     instanceName = parent->getFullPathName();
@@ -956,7 +958,7 @@ void DesignElaboration::elaborateInstance_(
           fullName += parent->getFullPathName();
           reuseInstance = true;
         } else {
-          fullName += parent->getModuleName() + "." + instName;
+          StrAppend(&fullName, parent->getModuleName(), ".", instName);
         }
 
         NodeId conditionId = fC->Child(subInstanceId);
@@ -1310,7 +1312,7 @@ void DesignElaboration::elaborateInstance_(
       // Named blocks
       else if (type == VObjectType::slSeq_block ||
                type == VObjectType::slPar_block) {
-        std::string fullName = parent->getModuleName() + "." + instName;
+        std::string fullName = StrCat(parent->getModuleName(), ".", instName);
 
         def = design->getComponentDefinition(fullName);
         if (def == nullptr) {
@@ -1338,10 +1340,10 @@ void DesignElaboration::elaborateInstance_(
 
         std::string fullName;
         if (instName.empty())
-          fullName = parent->getModuleName() + "." + genBlkBaseName +
-                     std::to_string(genBlkIndex);
+          fullName = StrCat(parent->getModuleName(), ".", genBlkBaseName,
+                            std::to_string(genBlkIndex));
         else
-          fullName = parent->getModuleName() + "." + instName;
+          fullName = StrCat(parent->getModuleName(), ".", instName);
 
         def = design->getComponentDefinition(fullName);
         NodeId childId = fC->Child(subInstanceId);
@@ -1393,7 +1395,9 @@ void DesignElaboration::elaborateInstance_(
           if (def) {
             break;
           } else {
-            modName = parent->getDefinition()->getName() + "::" + mname;
+            modName.assign(parent->getDefinition()->getName())
+                .append("::")
+                .append(mname);
             def = design->getComponentDefinition(modName);
             if (def) {
               break;
@@ -2291,10 +2295,10 @@ void DesignElaboration::reduceUnnamedBlocks_() {
            typeP == VObjectType::slGenerate_module_loop_statement ||
            typeP == VObjectType::slGenerate_interface_loop_statement ||
            typeP == VObjectType::slGenerate_region)) {
-        std::string fullModName = current->getModuleName();
-        fullModName = StringUtils::leaf(fullModName);
-        std::string fullModNameP = parent->getModuleName();
-        fullModNameP = StringUtils::leaf(fullModNameP);
+        std::string_view fullModName =
+            StringUtils::leaf(current->getModuleName());
+        std::string_view fullModNameP =
+            StringUtils::leaf(parent->getModuleName());
         if (typeP == VObjectType::slGenerate_region) {
           parent->getParent()->overrideParentChild(parent->getParent(), parent,
                                                    current);

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -139,13 +139,13 @@ bool ElaborationStep::bindTypedefs_() {
                                     prevDef->getTypespec()));
         if (Package* pack = valuedcomponenti_cast<Package*>(comp)) {
           std::string name =
-              pack->getName() + "::" + prevDef->getTypespec()->VpiName();
+              StrCat(pack->getName(), "::", prevDef->getTypespec()->VpiName());
           specs.insert(std::make_pair(name, prevDef->getTypespec()));
         }
         if (ClassDefinition* pack =
                 valuedcomponenti_cast<ClassDefinition*>(comp)) {
           std::string name =
-              pack->getName() + "::" + prevDef->getTypespec()->VpiName();
+              StrCat(pack->getName(), "::", prevDef->getTypespec()->VpiName());
           specs.insert(std::make_pair(name, prevDef->getTypespec()));
         }
       }
@@ -186,7 +186,7 @@ bool ElaborationStep::bindTypedefs_() {
             tpclone->VpiName(typd->getName());
             specs.insert(std::make_pair(typd->getName(), tpclone));
             if (Package* pack = valuedcomponenti_cast<Package*>(comp)) {
-              std::string name = pack->getName() + "::" + typd->getName();
+              std::string name = StrCat(pack->getName(), "::", typd->getName());
               specs.insert(std::make_pair(name, tpclone));
             }
           }
@@ -208,12 +208,12 @@ bool ElaborationStep::bindTypedefs_() {
           }
           specs.insert(std::make_pair(typd->getName(), ts));
           if (Package* pack = valuedcomponenti_cast<Package*>(comp)) {
-            std::string name = pack->getName() + "::" + typd->getName();
+            std::string name = StrCat(pack->getName(), "::", typd->getName());
             specs.insert(std::make_pair(name, ts));
           }
           if (ClassDefinition* pack =
                   valuedcomponenti_cast<ClassDefinition*>(comp)) {
-            std::string name = pack->getName() + "::" + typd->getName();
+            std::string name = StrCat(pack->getName(), "::", typd->getName());
             specs.insert(std::make_pair(name, ts));
           }
           if (ts->UhdmType() == uhdmunsupported_typespec) {
@@ -245,7 +245,7 @@ bool ElaborationStep::bindTypedefs_() {
           specs.insert(std::make_pair(typd->getName(), ts));
           ts->VpiName(typd->getName());
           if (Package* pack = valuedcomponenti_cast<Package*>(comp)) {
-            std::string name = pack->getName() + "::" + typd->getName();
+            std::string name = StrCat(pack->getName(), "::", typd->getName());
             specs.insert(std::make_pair(name, ts));
           }
         }
@@ -572,7 +572,7 @@ const DataType* ElaborationStep::bindDataType_(
     }
   }
   if (found == false) {
-    std::string class_in_class = parent->getName() + "::" + type_name;
+    std::string class_in_class = StrCat(parent->getName(), "::", type_name);
     itr1 = classes.find(class_in_class);
 
     if (itr1 != classes.end()) {
@@ -583,8 +583,8 @@ const DataType* ElaborationStep::bindDataType_(
   if (found == false) {
     if (parent->getParentScope()) {
       std::string class_in_own_package =
-          ((DesignComponent*)parent->getParentScope())->getName() +
-          "::" + type_name;
+          StrCat(((DesignComponent*)parent->getParentScope())->getName(),
+                 "::", type_name);
       itr1 = classes.find(class_in_own_package);
       if (itr1 != classes.end()) {
         found = true;
@@ -594,7 +594,8 @@ const DataType* ElaborationStep::bindDataType_(
   }
   if (found == false) {
     for (const auto& package : parent->getAccessPackages()) {
-      std::string class_in_package = package->getName() + "::" + type_name;
+      std::string class_in_package =
+          StrCat(package->getName(), "::", type_name);
       itr1 = classes.find(class_in_package);
       if (itr1 != classes.end()) {
         found = true;
@@ -1064,8 +1065,8 @@ bool ElaborationStep::bindPortType_(Signal* signal, const FileContent* fC,
           const std::pair<FileCNodeId, DesignComponent*>* datatype =
               parentComponent->getNamedObject(interfName);
           if (!datatype) {
-            def = design->getClassDefinition(parentComponent->getName() +
-                                             "::" + interfName);
+            def = design->getClassDefinition(
+                StrCat(parentComponent->getName(), "::", interfName));
           }
           if (datatype) {
             def = datatype->second;
@@ -1138,7 +1139,7 @@ bool ElaborationStep::bindPortType_(Signal* signal, const FileContent* fC,
           signal->setDataType(dt);
         }
       } else {
-        std::string name = parentComponent->getName() + "::" + interfName;
+        std::string name = StrCat(parentComponent->getName(), "::", interfName);
         def = design->getClassDefinition(name);
         DataType* dt = valuedcomponenti_cast<ClassDefinition*>(def);
         if (dt) {

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -1388,9 +1388,9 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
 
 interface* NetlistElaboration::elab_interface_(
     ModuleInstance* instance, ModuleInstance* interf_instance,
-    const std::string& instName, const std::string& defName,
-    ModuleDefinition* mod, PathId fileId, int lineNb,
-    interface_array* interf_array, const std::string& modPortName) {
+    std::string_view instName, std::string_view defName, ModuleDefinition* mod,
+    PathId fileId, int lineNb, interface_array* interf_array,
+    const std::string& modPortName) {
   FileSystem* const fileSystem = FileSystem::getInstance();
   Netlist* netlist = instance->getNetlist();
   if (netlist == nullptr) {
@@ -1420,7 +1420,7 @@ interface* NetlistElaboration::elab_interface_(
         std::make_pair(instName, std::make_pair(interf_instance, sm)));
     netlist->getSymbolTable().insert(std::make_pair(instName, sm));
   }
-  const std::string prefix = instName + ".";
+  const std::string prefix = StrCat(instName, ".");
   elab_ports_nets_(instance, interf_instance, instance->getNetlist(),
                    interf_instance->getNetlist(), mod, prefix, true);
   elab_ports_nets_(instance, interf_instance, instance->getNetlist(),
@@ -1430,7 +1430,8 @@ interface* NetlistElaboration::elab_interface_(
       mod->getModPortSignalMap();
   VectorOfmodport* dest_modports = s.MakeModportVec();
   for (auto& orig_modport : orig_modports) {
-    const std::string modportfullname = instName + "." + orig_modport.first;
+    const std::string modportfullname =
+        StrCat(instName, ".", orig_modport.first);
     if (!modPortName.empty() && (modportfullname != modPortName)) continue;
     modport* dest_modport = s.MakeModport();
     dest_modport->Interface(sm);
@@ -1481,11 +1482,11 @@ interface* NetlistElaboration::elab_interface_(
 
 modport* NetlistElaboration::elab_modport_(
     ModuleInstance* instance, ModuleInstance* interfaceInstance,
-    const std::string& instName, const std::string& defName,
-    ModuleDefinition* mod, PathId fileId, int lineNb,
-    const std::string& modPortName, UHDM::interface_array* interf_array) {
+    std::string_view instName, std::string_view defName, ModuleDefinition* mod,
+    PathId fileId, int lineNb, const std::string& modPortName,
+    UHDM::interface_array* interf_array) {
   Netlist* netlist = instance->getNetlist();
-  std::string fullname = instName + "." + modPortName;
+  std::string fullname = StrCat(instName, ".", modPortName);
   Netlist::ModPortMap::iterator itr = netlist->getModPortMap().find(fullname);
   if (itr == netlist->getModPortMap().end()) {
     elab_interface_(instance, interfaceInstance, instName, defName, mod, fileId,

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -53,7 +53,7 @@ using UHDM::uhdmunsupported_stmt;
 using UHDM::uhdmunsupported_typespec;
 
 bool UhdmChecker::registerFile(const FileContent* fC,
-                               std::set<std::string>& moduleNames) {
+                               std::set<std::string_view>& moduleNames) {
   const VObject& current = fC->Object(NodeId(fC->getSize() - 2));
   NodeId id = current.m_child;
   PathId fileId = fC->getFileId();
@@ -611,7 +611,7 @@ void UhdmChecker::annotate() {
 }
 
 void collectUsedFileContents(std::set<const FileContent*>& files,
-                             std::set<std::string>& moduleNames,
+                             std::set<std::string_view>& moduleNames,
                              ModuleInstance* instance) {
   if (instance) {
     DesignComponent* def = instance->getDefinition();
@@ -634,7 +634,7 @@ bool UhdmChecker::check(PathId uhdmFileId) {
       m_compileDesign->getCompiler()->getCommandLineParser();
   SymbolTable* symbols = m_compileDesign->getCompiler()->getSymbolTable();
   std::set<const FileContent*> files;
-  std::set<std::string> moduleNames;
+  std::set<std::string_view> moduleNames;
   for (ModuleInstance* top : m_design->getTopLevelModuleInstances()) {
     collectUsedFileContents(files, moduleNames, top);
   }

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -858,7 +858,7 @@ void UhdmWriter::writeClass(ClassDefinition* classDef,
     componentMap.insert(std::make_pair(classDef, c));
     c->VpiParent(parent);
     dest_classes->push_back(c);
-    const std::string& name = classDef->getName();
+    const std::string_view name = classDef->getName();
     if (c->VpiName().empty()) c->VpiName(name);
     if (c->VpiFullName().empty()) c->VpiFullName(name);
     c->Attributes(classDef->Attributes());
@@ -981,7 +981,7 @@ void reInstanceTypespec(Serializer& serializer, any* root, package* p) {
 void UhdmWriter::writePackage(Package* pack, package* p, Serializer& s,
                               UhdmWriter::ComponentMap& componentMap,
                               bool elaborated) {
-  p->VpiFullName(pack->getName() + "::");
+  p->VpiFullName(StrCat(pack->getName(), "::"));
   VectorOfclass_defn* dest_classes = nullptr;
 
   // Typepecs
@@ -1005,10 +1005,11 @@ void UhdmWriter::writePackage(Package* pack, package* p, Serializer& s,
     for (auto ps : *p->Parameters()) {
       ps->VpiParent(p);
       if (ps->UhdmType() == uhdmparameter) {
-        ((parameter*)ps)->VpiFullName(pack->getName() + "::" + ps->VpiName());
+        ((parameter*)ps)
+            ->VpiFullName(StrCat(pack->getName(), "::", ps->VpiName()));
       } else {
         ((type_parameter*)ps)
-            ->VpiFullName(pack->getName() + "::" + ps->VpiName());
+            ->VpiFullName(StrCat(pack->getName(), "::", ps->VpiName()));
       }
     }
   }
@@ -1054,13 +1055,15 @@ void UhdmWriter::writePackage(Package* pack, package* p, Serializer& s,
           tf->VpiParent(p);
           tf->Instance(p);
           p->Task_funcs()->push_back(tf);
-          ((task_func*)tf)->VpiFullName(pack->getName() + "::" + tf->VpiName());
+          ((task_func*)tf)
+              ->VpiFullName(StrCat(pack->getName(), "::", tf->VpiName()));
         }
       } else {
         tf->VpiParent(p);
         tf->Instance(p);
         p->Task_funcs()->push_back(tf);
-        ((task_func*)tf)->VpiFullName(pack->getName() + "::" + tf->VpiName());
+        ((task_func*)tf)
+            ->VpiFullName(StrCat(pack->getName(), "::", tf->VpiName()));
       }
     }
   }
@@ -1071,7 +1074,8 @@ void UhdmWriter::writePackage(Package* pack, package* p, Serializer& s,
     if (netlist->variables()) {
       for (auto obj : *netlist->variables()) {
         obj->VpiParent(p);
-        ((variables*)obj)->VpiFullName(pack->getName() + "::" + obj->VpiName());
+        ((variables*)obj)
+            ->VpiFullName(StrCat(pack->getName(), "::", obj->VpiName()));
       }
     }
   }


### PR DESCRIPTION
DesignComponent::getName returns a std::string_view instead of std:string

Updated all the subclasses and call sites to compensate for the change.