### PR TITLE
Remove use of std::make_pair when inserting elements into standard containers

### DIFF
--- a/include/Surelog/CommandLine/CommandLineParser.h
+++ b/include/Surelog/CommandLine/CommandLineParser.h
@@ -208,8 +208,12 @@ class CommandLineParser final {
   PathId getProgramId() const { return m_programId; }
   std::string getExeCommand() const { return m_exeCommand; }
   std::set<std::string>& getTopLevelModules() { return m_topLevelModules; }
-  std::set<std::string>& getBlackBoxModules() { return m_blackboxModules; }
-  std::set<std::string>& getBlackBoxInstances() { return m_blackboxInstances; }
+  std::set<std::string, std::less<>>& getBlackBoxModules() {
+    return m_blackboxModules;
+  }
+  std::set<std::string, std::less<>>& getBlackBoxInstances() {
+    return m_blackboxInstances;
+  }
   void setTopLevelModule(const std::string& module) {
     m_topLevelModules.insert(module);
   }
@@ -326,8 +330,8 @@ class CommandLineParser final {
   PathId m_programId;
   std::string m_exeCommand;
   std::set<std::string> m_topLevelModules;
-  std::set<std::string> m_blackboxModules;
-  std::set<std::string> m_blackboxInstances;
+  std::set<std::string, std::less<>> m_blackboxModules;
+  std::set<std::string, std::less<>> m_blackboxInstances;
   bool m_sverilog;
   bool m_dumpUhdm;
   bool m_elabUhdm;

--- a/include/Surelog/Design/DefParam.h
+++ b/include/Surelog/Design/DefParam.h
@@ -50,7 +50,7 @@ class DefParam final {
   void setValue(Value* value) { m_value = value; }
 
   void setChild(std::string name, DefParam* child) {
-    m_children.insert(std::make_pair(name, child));
+    m_children.emplace(name, child);
   }
   std::map<std::string, DefParam*>& getChildren() { return m_children; }
   bool isUsed() const { return m_used; }

--- a/include/Surelog/Design/Design.h
+++ b/include/Surelog/Design/Design.h
@@ -177,7 +177,7 @@ class Design final {
 
   void addModuleDefinition(const std::string& moduleName,
                            ModuleDefinition* def) {
-    m_moduleDefinitions.insert(std::make_pair(moduleName, def));
+    m_moduleDefinitions.emplace(moduleName, def);
   }
 
   void addTopLevelModuleInstance(ModuleInstance* instance) {
@@ -191,7 +191,7 @@ class Design final {
                           ClassDefinition* classDef);
 
   void addProgramDefinition(const std::string programName, Program* program) {
-    m_programDefinitions.insert(std::make_pair(programName, program));
+    m_programDefinitions.emplace(programName, program);
   }
 
   Package* addPackageDefinition(const std::string& packageName,

--- a/include/Surelog/Design/Design.h
+++ b/include/Surelog/Design/Design.h
@@ -156,11 +156,11 @@ class Design final {
 
   ErrorContainer* getErrorContainer() { return m_errors; }
 
-  typedef std::multimap<const std::string, BindStmt*> BindMap;
+  typedef std::multimap<const std::string, BindStmt*, std::less<>> BindMap;
 
   BindMap& getBindMap() { return m_bindMap; }
 
-  std::vector<BindStmt*> getBindStmts(const std::string& targetName);
+  std::vector<BindStmt*> getBindStmts(std::string_view targetName);
 
   void addBindStmt(const std::string& targetName, BindStmt* stmt);
 

--- a/include/Surelog/Design/DesignComponent.h
+++ b/include/Surelog/Design/DesignComponent.h
@@ -170,7 +170,7 @@ class DesignComponent : public ValuedComponentI, public PortNetHolder {
   void setUhdmInstance(UHDM::instance* instance) { m_instance = instance; }
   UHDM::instance* getUhdmInstance() { return m_instance; }
   void scheduleParamExprEval(std::string_view name, ExprEval& expr_eval) {
-    m_scheduledParamExprEval.emplace_back(std::make_pair(name, expr_eval));
+    m_scheduledParamExprEval.emplace_back(name, expr_eval);
   }
   std::vector<std::pair<std::string, ExprEval>>& getScheduledParamExprEval() {
     return m_scheduledParamExprEval;

--- a/include/Surelog/Design/DesignComponent.h
+++ b/include/Surelog/Design/DesignComponent.h
@@ -76,7 +76,7 @@ class DesignComponent : public ValuedComponentI, public PortNetHolder {
   virtual unsigned int getSize() const = 0;
   virtual VObjectType getType() const = 0;
   virtual bool isInstance() const = 0;
-  virtual std::string getName() const = 0;
+  virtual std::string_view getName() const = 0;
   void append(DesignComponent*);
 
   typedef std::map<std::string, DataType*, StringViewCompare> DataTypeMap;

--- a/include/Surelog/Design/Enum.h
+++ b/include/Surelog/Design/Enum.h
@@ -48,7 +48,7 @@ class Enum : public DataType {
   typedef std::map<std::string, std::pair<unsigned int, Value*>> NameValueMap;
 
   void addValue(const std::string& name, unsigned int lineNb, Value* value) {
-    m_values.insert(std::make_pair(name, std::make_pair(lineNb, value)));
+    m_values.emplace(name, std::make_pair(lineNb, value));
   }
   Value* getValue(const std::string& name) const;
   NodeId getDefinitionId() const { return m_nameId; }

--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -97,7 +97,7 @@ class FileContent : public DesignComponent {
   unsigned int getSize() const override { return m_objects.size(); }
   VObjectType getType() const override { return VObjectType::slNoType; }
   bool isInstance() const override { return false; }
-  std::string getName() const override;
+  std::string_view getName() const override;
   NodeId getRootNode() const;
   std::string printObjects() const;  // The whole file content
   std::string printSubTree(

--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -174,17 +174,17 @@ class FileContent : public DesignComponent {
   }
   void addModuleDefinition(const std::string& moduleName,
                            ModuleDefinition* def) {
-    m_moduleDefinitions.insert(std::make_pair(moduleName, def));
+    m_moduleDefinitions.emplace(moduleName, def);
   }
   void addPackageDefinition(const std::string& packageName, Package* package) {
-    m_packageDefinitions.insert(std::make_pair(packageName, package));
+    m_packageDefinitions.emplace(packageName, package);
   }
   void addProgramDefinition(const std::string& programName, Program* program) {
-    m_programDefinitions.insert(std::make_pair(programName, program));
+    m_programDefinitions.emplace(programName, program);
   }
   void addClassDefinition(const std::string& className,
                           ClassDefinition* classDef) {
-    m_classDefinitions.insert(std::make_pair(className, classDef));
+    m_classDefinitions.emplace(className, classDef);
   }
 
   const ModuleDefinition* getModuleDefinition(

--- a/include/Surelog/Design/ModuleDefinition.h
+++ b/include/Surelog/Design/ModuleDefinition.h
@@ -52,7 +52,7 @@ class ModuleDefinition : public DesignComponent, public ClockingBlockHolder {
 
   ~ModuleDefinition() override = default;
 
-  std::string getName() const override { return m_name; }
+  std::string_view getName() const override { return m_name; }
   VObjectType getType() const override;
   bool isInstance() const override;
   unsigned int getSize() const override;

--- a/include/Surelog/Design/ModuleDefinition.h
+++ b/include/Surelog/Design/ModuleDefinition.h
@@ -80,7 +80,7 @@ class ModuleDefinition : public DesignComponent, public ClockingBlockHolder {
   }
   void addClassDefinition(const std::string& className,
                           ClassDefinition* classDef) {
-    m_classDefinitions.insert(std::make_pair(className, classDef));
+    m_classDefinitions.emplace(className, classDef);
   }
   ClassDefinition* getClassDefinition(const std::string& name);
 

--- a/include/Surelog/Design/ModuleInstance.h
+++ b/include/Surelog/Design/ModuleInstance.h
@@ -88,7 +88,7 @@ class ModuleInstance : public ValuedComponentI {
   SymbolId getModuleNameId(SymbolTable* symbols) const;
   std::string getInstanceName() const;
   std::string getFullPathName() const;
-  std::string getModuleName() const;
+  std::string_view getModuleName() const;
   unsigned int getDepth() const;
 
   void setNodeId(NodeId id) { m_nodeId = id; }  // Used for generate stmt

--- a/include/Surelog/Design/Scope.h
+++ b/include/Surelog/Design/Scope.h
@@ -60,7 +60,7 @@ class Scope : public RTTI {
   DataTypeMap& getUsedDataTypeMap() { return m_usedDataTypes; }
   DataType* getUsedDataType(const std::string& name);
   void insertUsedDataType(const std::string& dataTypeName, DataType* dataType) {
-    m_usedDataTypes.insert(std::make_pair(dataTypeName, dataType));
+    m_usedDataTypes.emplace(dataTypeName, dataType);
   }
 
   void addStmt(Statement* stmt) { m_statements.push_back(stmt); }

--- a/include/Surelog/Design/Statement.h
+++ b/include/Surelog/Design/Statement.h
@@ -132,7 +132,7 @@ class ForLoopStmt : public Scope, public Statement {
         m_iteratorType(VObjectType::slNoType) {}
 
   void addIteratorId(NodeId itrId, NodeId init_expression) {
-    m_iteratorIds.push_back(std::make_pair(itrId, init_expression));
+    m_iteratorIds.emplace_back(itrId, init_expression);
   }
   std::vector<std::pair<NodeId, NodeId>>& getIteratorIds() {
     return m_iteratorIds;

--- a/include/Surelog/DesignCompile/NetlistElaboration.h
+++ b/include/Surelog/DesignCompile/NetlistElaboration.h
@@ -61,14 +61,14 @@ class NetlistElaboration : public TestbenchElaboration {
   bool elab_generates_(ModuleInstance* instance);
   UHDM::interface* elab_interface_(
       ModuleInstance* instance, ModuleInstance* interf_instance,
-      const std::string& instName, const std::string& defName,
+      std::string_view instName, std::string_view defName,
       ModuleDefinition* mod, PathId fileId, int lineNb,
       UHDM::interface_array* interf_array, const std::string& modPortName);
   UHDM::modport* elab_modport_(ModuleInstance* instance,
                                ModuleInstance* interfInstance,
-                               const std::string& instName,
-                               const std::string& defName,
-                               ModuleDefinition* mod, PathId fileId, int lineNb,
+                               std::string_view instName,
+                               std::string_view defName, ModuleDefinition* mod,
+                               PathId fileId, int lineNb,
                                const std::string& modPortName,
                                UHDM::interface_array* interf_array);
   bool elab_ports_nets_(ModuleInstance* instance, bool ports);

--- a/include/Surelog/DesignCompile/UhdmChecker.h
+++ b/include/Surelog/DesignCompile/UhdmChecker.h
@@ -25,11 +25,11 @@
 #define SURELOG_UHDMCHECKER_H
 #pragma once
 
+#include <Surelog/Common/PathId.h>
+
 #include <map>
 #include <set>
 #include <vector>
-
-#include <Surelog/Common/PathId.h>
 
 namespace SURELOG {
 
@@ -46,7 +46,8 @@ class UhdmChecker final {
   bool check(PathId uhdmFileId);
 
  private:
-  bool registerFile(const FileContent* fC, std::set<std::string>& moduleNames);
+  bool registerFile(const FileContent* fC,
+                    std::set<std::string_view>& moduleNames);
   bool reportHtml(PathId uhdmFileId, float overallCoverage);
   float reportCoverage(PathId uhdmFileId);
   void annotate();

--- a/include/Surelog/Package/Package.h
+++ b/include/Surelog/Package/Package.h
@@ -59,7 +59,7 @@ class Package : public DesignComponent {
     return VObjectType::slPackage_declaration;
   }
   bool isInstance() const override { return false; }
-  std::string getName() const override { return m_name; }
+  std::string_view getName() const override { return m_name; }
 
   ClassNameClassDefinitionMultiMap& getClassDefinitions() {
     return m_classDefinitions;

--- a/include/Surelog/Package/Package.h
+++ b/include/Surelog/Package/Package.h
@@ -65,7 +65,7 @@ class Package : public DesignComponent {
     return m_classDefinitions;
   }
   void addClassDefinition(std::string className, ClassDefinition* classDef) {
-    m_classDefinitions.insert(std::make_pair(className, classDef));
+    m_classDefinitions.emplace(className, classDef);
   }
   ClassDefinition* getClassDefinition(std::string_view name);
   ExprBuilder* getExprBuilder() { return &m_exprBuilder; }

--- a/include/Surelog/Testbench/ClassDefinition.h
+++ b/include/Surelog/Testbench/ClassDefinition.h
@@ -63,7 +63,7 @@ class ClassDefinition : public DesignComponent, public DataType {
     return VObjectType::slClass_declaration;
   }
   bool isInstance() const override { return false; }
-  std::string getName() const override { return m_name; }
+  std::string_view getName() const override { return m_name; }
   Library* getLibrary() { return m_library; }
   DesignComponent* getContainer() const { return m_container; }
   void setContainer(DesignComponent* container) { m_container = container; }

--- a/include/Surelog/Testbench/Program.h
+++ b/include/Surelog/Testbench/Program.h
@@ -51,7 +51,7 @@ class Program : public DesignComponent, public ClockingBlockHolder {
   unsigned int getSize() const override;
   VObjectType getType() const override;
   bool isInstance() const override { return true; }
-  std::string getName() const override { return m_name; }
+  std::string_view getName() const override { return m_name; }
 
   ClassNameClassDefinitionMultiMap& getClassDefinitions() {
     return m_classDefinitions;

--- a/include/Surelog/Testbench/Program.h
+++ b/include/Surelog/Testbench/Program.h
@@ -58,7 +58,7 @@ class Program : public DesignComponent, public ClockingBlockHolder {
   }
   void addClassDefinition(const std::string& className,
                           ClassDefinition* classDef) {
-    m_classDefinitions.insert(std::make_pair(className, classDef));
+    m_classDefinitions.emplace(className, classDef);
   }
   ClassDefinition* getClassDefinition(const std::string& name);
 

--- a/include/Surelog/Utils/StringUtils.h
+++ b/include/Surelog/Utils/StringUtils.h
@@ -148,7 +148,7 @@ class StringUtils final {
   static std::string evaluateEnvVars(std::string_view text);
 
   static void registerEnvVar(std::string_view var, std::string_view value) {
-    envVars.insert(std::make_pair(var, value));
+    envVars.emplace(var, value);
   }
 
   // Strip quotes, if any. "abc" => abc

--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -462,7 +462,7 @@ ModuleInstance* SLgetTopModuleInstance(Design* design, unsigned int index) {
 
 std::string SLgetModuleName(ModuleDefinition* module) {
   if (!module) return "";
-  return module->getName();
+  return std::string(module->getName());
 }
 
 template <typename ClassOrPackageOrProgram>
@@ -501,7 +501,7 @@ RawNodeId SLgetModuleRootNode(ModuleDefinition* module) {
 
 std::string SLgetClassName(ClassDefinition* module) {
   if (!module) return "";
-  return module->getName();
+  return std::string(module->getName());
 }
 
 std::string SLgetClassFile(ClassDefinition* module) {
@@ -533,7 +533,7 @@ RawNodeId SLgetClassRootNode(ClassDefinition* module) {
 
 std::string SLgetPackageName(Package* module) {
   if (!module) return "";
-  return module->getName();
+  return std::string(module->getName());
 }
 
 std::string SLgetPackageFile(Package* module) {
@@ -564,7 +564,7 @@ RawNodeId SLgetPackageRootNode(Package* module) {
 
 std::string SLgetProgramName(Program* module) {
   if (!module) return "";
-  return module->getName();
+  return std::string(module->getName());
 }
 
 std::string SLgetProgramFile(Program* module) {
@@ -615,7 +615,7 @@ std::string SLgetInstanceFullPathName(ModuleInstance* instance) {
 
 std::string SLgetInstanceModuleName(ModuleInstance* instance) {
   if (!instance) return "";
-  return instance->getModuleName();
+  return std::string(instance->getModuleName());
 }
 
 DesignComponent* SLgetInstanceDefinition(ModuleInstance* instance) {

--- a/src/Common/ClockingBlockHolder.cpp
+++ b/src/Common/ClockingBlockHolder.cpp
@@ -26,7 +26,7 @@
 namespace SURELOG {
 void ClockingBlockHolder::addClockingBlock(SymbolId blockId,
                                            ClockingBlock& block) {
-  m_clockingBlockMap.insert(std::make_pair(blockId, block));
+  m_clockingBlockMap.emplace(blockId, block);
 }
 
 ClockingBlock* ClockingBlockHolder::getClockingBlock(SymbolId blockId) {

--- a/src/Config/Config.cpp
+++ b/src/Config/Config.cpp
@@ -41,13 +41,13 @@ void Config::addInstanceUseClause(std::string_view instance,
     m_instanceUseClauses.erase(previous);
   }
 
-  m_instanceUseClauses.insert(std::make_pair(instance, use));
+  m_instanceUseClauses.emplace(instance, use);
 }
 void Config::addCellUseClause(std::string_view cell, const UseClause& use) {
   auto previous = m_cellUseClauses.find(cell);
   if (previous != m_cellUseClauses.end()) {
     m_instanceUseClauses.erase(previous);
   }
-  m_cellUseClauses.insert(std::make_pair(cell, use));
+  m_cellUseClauses.emplace(cell, use);
 }
 }  // namespace SURELOG

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -65,13 +65,13 @@ Design::~Design() {
 
 void Design::addFileContent(PathId fileId, FileContent* content) {
   m_mutex.lock();
-  m_fileContents.push_back(std::make_pair(fileId, content));
+  m_fileContents.emplace_back(fileId, content);
   m_mutex.unlock();
 }
 
 void Design::addPPFileContent(PathId fileId, FileContent* content) {
   m_mutex.lock();
-  m_ppFileContents.push_back(std::make_pair(fileId, content));
+  m_ppFileContents.emplace_back(fileId, content);
   m_mutex.unlock();
 }
 
@@ -341,7 +341,7 @@ void Design::addDefParam(const std::string& name, const FileContent* fC,
     addDefParam_(vpath, fC, nodeId, value, (*itr).second);
   } else {
     DefParam* def = new DefParam(vpath[0]);
-    m_defParams.insert(std::make_pair(vpath[0], def));
+    m_defParams.emplace(vpath[0], def);
     vpath.erase(vpath.begin());
     addDefParam_(vpath, fC, nodeId, value, def);
   }
@@ -464,7 +464,7 @@ void Design::orderPackages() {
       if (packageName == name_pack->first) {
         MultiDefCount::iterator itr = multiDefCount.find(packageName);
         if (itr == multiDefCount.end()) {
-          multiDefCount.insert(std::make_pair(packageName, 1));
+          multiDefCount.emplace(packageName, 1);
         } else {
           int level = (*itr).second;
           (*itr).second++;
@@ -485,7 +485,7 @@ Package* Design::addPackageDefinition(const std::string& packageName,
   PackageNamePackageDefinitionMultiMap::iterator itr =
       m_packageDefinitions.find(packageName);
   if (itr == m_packageDefinitions.end()) {
-    m_packageDefinitions.insert(std::make_pair(packageName, package));
+    m_packageDefinitions.emplace(packageName, package);
     return package;
   } else {
     Package* old = (*itr).second;
@@ -495,7 +495,7 @@ Package* Design::addPackageDefinition(const std::string& packageName,
       old->append(package);
       return old;
     } else {
-      m_packageDefinitions.insert(std::make_pair(packageName, package));
+      m_packageDefinitions.emplace(packageName, package);
       return package;
     }
   }
@@ -503,8 +503,8 @@ Package* Design::addPackageDefinition(const std::string& packageName,
 
 void Design::addClassDefinition(const std::string& className,
                                 ClassDefinition* classDef) {
-  m_classDefinitions.insert(std::make_pair(className, classDef));
-  m_uniqueClassDefinitions.insert(std::make_pair(className, classDef));
+  m_classDefinitions.emplace(className, classDef);
+  m_uniqueClassDefinitions.emplace(className, classDef);
 }
 
 void Design::clearContainers() {
@@ -542,6 +542,6 @@ std::vector<BindStmt*> Design::getBindStmts(std::string_view targetName) {
 }
 
 void Design::addBindStmt(const std::string& targetName, BindStmt* stmt) {
-  m_bindMap.insert(std::make_pair(targetName, stmt));
+  m_bindMap.emplace(targetName, stmt);
 }
 }  // namespace SURELOG

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -197,7 +197,7 @@ void Design::reportInstanceTreeStats(unsigned int& nbTopLevelModules,
   numberOfLeafInstances = 0;
   nbUndefinedModules = 0;
   nbUndefinedInstances = 0;
-  std::set<std::string> undefModules;
+  std::set<std::string_view> undefModules;
   ModuleInstance* tmp;
   std::queue<ModuleInstance*> queue;
   for (auto instance : m_topLevelModuleInstances) {
@@ -528,7 +528,7 @@ void Design::clearContainers() {
   m_orderedPackageNames.clear();
 }
 
-std::vector<BindStmt*> Design::getBindStmts(const std::string& targetName) {
+std::vector<BindStmt*> Design::getBindStmts(std::string_view targetName) {
   std::vector<BindStmt*> results;
   BindMap::iterator itr = m_bindMap.find(targetName);
   while (itr != m_bindMap.end()) {

--- a/src/Design/DesignComponent.cpp
+++ b/src/Design/DesignComponent.cpp
@@ -56,7 +56,7 @@ void DesignComponent::addObject(VObjectType type, FileCNodeId object) {
   if (itr == m_objects.end()) {
     std::vector<FileCNodeId> tmp;
     tmp.push_back(object);
-    m_objects.insert(std::make_pair(type, tmp));
+    m_objects.emplace(type, tmp);
   } else {
     (*itr).second.push_back(object);
   }
@@ -64,7 +64,7 @@ void DesignComponent::addObject(VObjectType type, FileCNodeId object) {
 
 void DesignComponent::addNamedObject(std::string_view name, FileCNodeId object,
                                      DesignComponent* def) {
-  m_namedObjects.insert(std::make_pair(name, std::make_pair(object, def)));
+  m_namedObjects.emplace(name, std::make_pair(object, def));
 }
 
 const std::pair<FileCNodeId, DesignComponent*>* DesignComponent::getNamedObject(
@@ -92,7 +92,7 @@ void DesignComponent::append(DesignComponent* comp) {
 
 void DesignComponent::insertDataType(std::string_view dataTypeName,
                                      DataType* dataType) {
-  m_dataTypes.insert(std::make_pair(dataTypeName, dataType));
+  m_dataTypes.emplace(dataTypeName, dataType);
 }
 
 const DataType* DesignComponent::getDataType(std::string_view name) const {
@@ -110,7 +110,7 @@ const DataType* DesignComponent::getDataType(std::string_view name) const {
 
 void DesignComponent::insertUsedDataType(std::string_view dataTypeName,
                                          DataType* dataType) {
-  m_usedDataTypes.insert(std::make_pair(dataTypeName, dataType));
+  m_usedDataTypes.emplace(dataTypeName, dataType);
 }
 
 DataType* DesignComponent::getUsedDataType(std::string_view name) {
@@ -137,7 +137,7 @@ const TypeDef* DesignComponent::getTypeDef(std::string_view name) const {
 }
 
 void DesignComponent::insertTypeDef(TypeDef* p) {
-  m_typedefs.insert(std::make_pair(p->getName(), p));
+  m_typedefs.emplace(p->getName(), p);
 }
 
 Function* DesignComponent::getFunction(std::string_view name) const {
@@ -155,7 +155,7 @@ Function* DesignComponent::getFunction(std::string_view name) const {
 }
 
 void DesignComponent::insertFunction(Function* p) {
-  m_functions.insert(std::make_pair(p->getName(), p));
+  m_functions.emplace(p->getName(), p);
 }
 
 Task* DesignComponent::getTask(std::string_view name) const {
@@ -172,12 +172,10 @@ Task* DesignComponent::getTask(std::string_view name) const {
   }
 }
 
-void DesignComponent::insertTask(Task* p) {
-  m_tasks.insert(std::make_pair(p->getName(), p));
-}
+void DesignComponent::insertTask(Task* p) { m_tasks.emplace(p->getName(), p); }
 
 void DesignComponent::addVariable(Variable* var) {
-  m_variables.insert(std::make_pair(var->getName(), var));
+  m_variables.emplace(var->getName(), var);
 }
 
 Variable* DesignComponent::getVariable(std::string_view name) {
@@ -199,7 +197,7 @@ Parameter* DesignComponent::getParameter(std::string_view name) const {
 }
 
 void DesignComponent::insertParameter(Parameter* p) {
-  m_parameterMap.insert(std::make_pair(p->getName(), p));
+  m_parameterMap.emplace(p->getName(), p);
   m_orderedParameters.push_back(p);
 }
 

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -45,8 +45,8 @@ FileContent::FileContent(PathId fileId, Library* library,
             InvalidNodeId, InvalidNodeId, InvalidNodeId, InvalidNodeId);
 }
 
-std::string FileContent::getName() const {
-  return std::string(FileSystem::getInstance()->toPath(m_fileId));
+std::string_view FileContent::getName() const {
+  return FileSystem::getInstance()->toPath(m_fileId);
 }
 
 const std::string& FileContent::SymName(NodeId index) const {

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -108,7 +108,7 @@ void FileContent::insertObjectLookup(const std::string& name, NodeId id,
                                      ErrorContainer* errors) {
   NameIdMap::iterator itr = m_objectLookup.find(name);
   if (itr == m_objectLookup.end()) {
-    m_objectLookup.insert(std::make_pair(name, id));
+    m_objectLookup.emplace(name, id);
   } else {
     Location loc(getFileId(id), Line(id), Column(id),
                  errors->getSymbolTable()->registerSymbol(name));
@@ -193,7 +193,7 @@ std::vector<std::string> FileContent::collectSubTree(NodeId index) const {
 }
 
 void FileContent::SetDefinitionFile(NodeId index, PathId def) {
-  m_definitionFiles.insert(std::make_pair(index, def));
+  m_definitionFiles.emplace(index, def);
 }
 
 PathId FileContent::GetDefinitionFile(NodeId index) const {
@@ -635,7 +635,7 @@ bool FileContent::diffTree(NodeId root, const FileContent* oFc, NodeId oroot,
 void FileContent::addDesignElement(const std::string& name,
                                    DesignElement* elem) {
   m_elements.push_back(elem);
-  m_elementMap.insert(std::make_pair(name, elem));
+  m_elementMap.emplace(name, elem);
 }
 
 const DesignElement* FileContent::getDesignElement(

--- a/src/Design/ModuleDefinition.cpp
+++ b/src/Design/ModuleDefinition.cpp
@@ -68,7 +68,7 @@ void ModuleDefinition::insertModPort(const std::string& modport,
   if (itr == m_modportSignalMap.end()) {
     ModPort modp(this, modport, m_fileContents[0], nodeId);
     modp.addSignal(signal);
-    m_modportSignalMap.insert(std::make_pair(modport, modp));
+    m_modportSignalMap.emplace(modport, modp);
   } else {
     (*itr).second.addSignal(signal);
   }
@@ -105,7 +105,7 @@ void ModuleDefinition::insertModPort(const std::string& modport,
   if (itr == m_modportClockingBlockMap.end()) {
     std::vector<ClockingBlock> cbs;
     cbs.push_back(cb);
-    m_modportClockingBlockMap.insert(std::make_pair(modport, cbs));
+    m_modportClockingBlockMap.emplace(modport, cbs);
   } else {
     (*itr).second.push_back(cb);
   }

--- a/src/Design/ModuleInstance.cpp
+++ b/src/Design/ModuleInstance.cpp
@@ -270,10 +270,9 @@ std::string ModuleInstance::getInstanceName() const {
   }
 }
 
-std::string ModuleInstance::getModuleName() const {
+std::string_view ModuleInstance::getModuleName() const {
   if (m_definition == nullptr) {
-    std::string name = m_instName.substr(0, m_instName.find("&", 0, 1));
-    return name;
+    return std::string_view(m_instName).substr(0, m_instName.find("&", 0, 1));
   } else {
     return m_definition->getName();
   }

--- a/src/Design/Scope.cpp
+++ b/src/Design/Scope.cpp
@@ -27,7 +27,7 @@
 namespace SURELOG {
 
 void Scope::addVariable(Variable* var) {
-  m_variables.insert(std::make_pair(var->getName(), var));
+  m_variables.emplace(var->getName(), var);
 }
 
 Variable* Scope::getVariable(const std::string& name) {

--- a/src/Design/ValuedComponentI.cpp
+++ b/src/Design/ValuedComponentI.cpp
@@ -78,15 +78,14 @@ void ValuedComponentI::forgetValue(std::string_view name) {
 void ValuedComponentI::setValue(std::string_view name, Value* val,  // NOLINT
                                 ExprBuilder& exprBuilder, int lineNb) {
   deleteValue(name, exprBuilder);
-  m_paramMap.insert(
-      std::make_pair(name, std::make_pair(exprBuilder.clone(val), lineNb)));
+  m_paramMap.emplace(name, std::make_pair(exprBuilder.clone(val), lineNb));
   forgetComplexValue(name);
 }
 
 void ValuedComponentI::setComplexValue(std::string_view name, UHDM::expr* val) {
   auto itr = m_complexValues.find(name);
   if (itr != m_complexValues.end()) m_complexValues.erase(itr);
-  m_complexValues.insert(std::make_pair(name, val));
+  m_complexValues.emplace(name, val);
   forgetValue(name);
 }
 

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -57,7 +57,7 @@ bool CompileClass::compile() {
   if (fC == nullptr) return true;
   NodeId nodeId = m_class->m_nodeIds[0];
 
-  std::vector<std::string> names;
+  std::vector<std::string_view> names;
   ClassDefinition* parent = m_class;
   DesignComponent* tmp_container = nullptr;
   while (parent) {
@@ -68,7 +68,7 @@ bool CompileClass::compile() {
 
   std::string fullName;
   if (tmp_container) {
-    fullName = tmp_container->getName() + "::";
+    fullName.append(tmp_container->getName()).append("::");
   }
   if (!names.empty()) {
     unsigned int index = names.size() - 1;
@@ -225,8 +225,8 @@ bool CompileClass::compile() {
           if (fC->Type(fC->Parent(id)) != VObjectType::slClass_declaration)
             break;
           const std::string& endLabel = fC->SymName(id);
-          std::string moduleName = m_class->getName();
-          moduleName = StringUtils::ltrim_until(moduleName, '@');
+          std::string_view moduleName =
+              StringUtils::ltrim_until(m_class->getName(), '@');
           if (endLabel != moduleName) {
             Location loc(fC->getFileId(m_class->getNodeIds()[0]),
                          fC->Line(m_class->getNodeIds()[0]),

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -52,6 +52,7 @@
 #include <Surelog/Testbench/TypeDef.h>
 #include <Surelog/Testbench/Variable.h>
 #include <Surelog/Utils/NumUtils.h>
+#include <Surelog/Utils/StringUtils.h>
 
 // UHDM
 #include <string.h>
@@ -129,7 +130,7 @@ bool CompileHelper::importPackage(DesignComponent* scope, Design* design,
       if (!object_name.empty()) {
         if (name != object_name) continue;
       }
-      std::string fullName = def->getName() + "::" + name;
+      std::string fullName = StrCat(def->getName(), "::", name);
       DesignComponent* comp = packageFile->getComponentDefinition(fullName);
       FileCNodeId fnid(packageFile, classDef);
       scope->addNamedObject(name, fnid, comp);
@@ -573,7 +574,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
   std::string name = fC->SymName(type_name);
   std::string fullName = name;
   if (Package* pack = valuedcomponenti_cast<Package*>(scope)) {
-    fullName = pack->getName() + "::" + name;
+    fullName.assign(pack->getName()).append("::").append(name);
   }
   if (scope) {
     const TypeDef* prevDef = scope->getTypeDef(name);

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -3251,7 +3251,7 @@ VectorOfany* CompileHelper::compileTfCallArguments(
                             instance, reduce, muteErrors);
       if (exp) {
         if (exp->VpiParent() == nullptr) exp->VpiParent(call);
-        args.insert(std::make_pair(fC->SymName(argument), exp));
+        args.emplace(fC->SymName(argument), exp);
         argOrder.push_back(exp);
       }
       argumentNode = fC->Sibling(argumentNode);

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -98,17 +98,19 @@ bool CompileModule::compile() {
 
   CommandLineParser* clp =
       m_compileDesign->getCompiler()->getCommandLineParser();
-  std::set<std::string>& blackboxModules = clp->getBlackBoxModules();
+  std::set<std::string, std::less<>>& blackboxModules =
+      clp->getBlackBoxModules();
   bool skipModule = false;
   std::string libName;
   if (!m_module->getFileContents().empty())
     libName = m_module->getFileContents()[0]->getLibrary()->getName();
-  const std::string& modName = m_module->getName();
+  const std::string_view modName = m_module->getName();
   if (blackboxModules.find(modName) != blackboxModules.end()) {
     errType = ErrorDefinition::COMP_SKIPPING_BLACKBOX_MODULE;
     skipModule = true;
   }
-  std::set<std::string>& blackboxInstances = clp->getBlackBoxInstances();
+  std::set<std::string, std::less<>>& blackboxInstances =
+      clp->getBlackBoxInstances();
   std::string instanceName;
   if (m_instance) {
     if (ModuleInstance* inst =
@@ -736,7 +738,7 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
           FileCNodeId fnid(fC, nameId);
           m_module->addObject(type, fnid);
 
-          std::string completeName = m_module->getName() + "::" + name;
+          std::string completeName = StrCat(m_module->getName(), "::", name);
 
           DesignComponent* comp = fC->getComponentDefinition(completeName);
 
@@ -804,7 +806,7 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
             if (fC->Type(fC->Parent(id)) != VObjectType::slModule_declaration)
               break;
             const std::string& endLabel = fC->SymName(id);
-            std::string moduleName = m_module->getName();
+            std::string_view moduleName = m_module->getName();
             moduleName = StringUtils::ltrim_until(moduleName, '@');
             moduleName = StringUtils::ltrim_until(moduleName, ':');
             moduleName = StringUtils::ltrim_until(moduleName, ':');
@@ -1177,7 +1179,7 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
           if (InterfaceIdentifier) {
             NodeId label = fC->Child(InterfaceIdentifier);
             const std::string& endLabel = fC->SymName(label);
-            std::string moduleName = m_module->getName();
+            std::string_view moduleName = m_module->getName();
             moduleName = StringUtils::ltrim_until(moduleName, '@');
             moduleName = StringUtils::ltrim_until(moduleName, ':');
             moduleName = StringUtils::ltrim_until(moduleName, ':');

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -217,7 +217,7 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
           FileCNodeId fnid(fC, nameId);
           m_package->addObject(type, fnid);
 
-          std::string completeName = m_package->getName() + "::" + name;
+          std::string completeName = StrCat(m_package->getName(), "::", name);
 
           DesignComponent* comp = fC->getComponentDefinition(completeName);
 
@@ -278,8 +278,8 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
             if (fC->Type(fC->Parent(id)) != VObjectType::slPackage_declaration)
               break;
             const std::string& endLabel = fC->SymName(id);
-            std::string moduleName = m_package->getName();
-            moduleName = StringUtils::ltrim_until(moduleName, '@');
+            std::string_view moduleName =
+                StringUtils::ltrim_until(m_package->getName(), '@');
             if (endLabel != moduleName) {
               Location loc(fC->getFileId(m_package->getNodeIds()[0]),
                            fC->Line(m_package->getNodeIds()[0]),

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -242,7 +242,7 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
         FileCNodeId fnid(fC, nameId);
         m_program->addObject(type, fnid);
 
-        std::string completeName = m_program->getName() + "::" + name;
+        std::string completeName = StrCat(m_program->getName(), "::", name);
 
         DesignComponent* comp = fC->getComponentDefinition(completeName);
 
@@ -312,8 +312,8 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
           if (fC->Type(fC->Parent(id)) != VObjectType::slProgram_declaration)
             break;
           const std::string& endLabel = fC->SymName(id);
-          std::string moduleName = m_program->getName();
-          moduleName = StringUtils::ltrim_until(moduleName, '@');
+          std::string_view moduleName =
+              StringUtils::ltrim_until(m_program->getName(), '@');
           if (endLabel != moduleName) {
             Location loc(fC->getFileId(m_program->getNodeIds()[0]),
                          fC->Line(m_program->getNodeIds()[0]),

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -1402,7 +1402,7 @@ n<> u<142> t<Tf_item_declaration> p<386> c<141> s<384> l<28>
           decl->VpiDirection(
               UhdmWriter::getVpiDirection(tf_port_direction_type));
           decl->VpiName(name);
-          ioMap.insert(std::make_pair(name, decl));
+          ioMap.emplace(name, decl);
           fC->populateCoreMembers(nameId, nameId, decl);
           decl->Typespec(ts);
           decl->Ranges(ranges);

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -283,14 +283,15 @@ UHDM::any* CompileHelper::compileVariable(
       if (result == nullptr) {
         ClassDefinition* cl = design->getClassDefinition(typeName);
         if (cl == nullptr) {
-          cl = design->getClassDefinition(component->getName() +
-                                          "::" + typeName);
+          cl = design->getClassDefinition(
+              StrCat(component->getName(), "::", typeName));
         }
         if (cl == nullptr) {
           if (const DesignComponent* p =
                   valuedcomponenti_cast<const DesignComponent*>(
                       component->getParentScope())) {
-            cl = design->getClassDefinition(p->getName() + "::" + typeName);
+            cl = design->getClassDefinition(
+                StrCat(p->getName(), "::", typeName));
           }
         }
         if (cl) {
@@ -429,14 +430,15 @@ UHDM::any* CompileHelper::compileVariable(
       if (var == nullptr) {
         ClassDefinition* cl = design->getClassDefinition(packageName);
         if (cl == nullptr) {
-          cl = design->getClassDefinition(component->getName() +
-                                          "::" + packageName);
+          cl = design->getClassDefinition(
+              StrCat(component->getName(), "::", packageName));
         }
         if (cl == nullptr) {
           if (const DesignComponent* p =
                   valuedcomponenti_cast<const DesignComponent*>(
                       component->getParentScope())) {
-            cl = design->getClassDefinition(p->getName() + "::" + packageName);
+            cl = design->getClassDefinition(
+                StrCat(p->getName(), "::", packageName));
           }
         }
         if (cl) {
@@ -560,13 +562,13 @@ typespec* CompileHelper::compileDatastructureTypespec(
           libName + "@" + typeName);
       if (dt == nullptr) {
         dt = compileDesign->getCompiler()->getDesign()->getClassDefinition(
-            component->getName() + "::" + typeName);
+            StrCat(component->getName(), "::", typeName));
       }
       if (dt == nullptr) {
         if (component->getParentScope())
           dt = compileDesign->getCompiler()->getDesign()->getClassDefinition(
-              ((DesignComponent*)component->getParentScope())->getName() +
-              "::" + typeName);
+              StrCat(((DesignComponent*)component->getParentScope())->getName(),
+                     "::", typeName));
       }
       if (dt == nullptr) {
         dt = compileDesign->getCompiler()->getDesign()->getClassDefinition(
@@ -1581,14 +1583,15 @@ UHDM::typespec* CompileHelper::compileTypespec(
           Design* design = compileDesign->getCompiler()->getDesign();
           ClassDefinition* cl = design->getClassDefinition(typeName);
           if (cl == nullptr) {
-            cl = design->getClassDefinition(component->getName() +
-                                            "::" + typeName);
+            cl = design->getClassDefinition(
+                StrCat(component->getName(), "::", typeName));
           }
           if (cl == nullptr) {
             if (const DesignComponent* p =
                     valuedcomponenti_cast<const DesignComponent*>(
                         component->getParentScope())) {
-              cl = design->getClassDefinition(p->getName() + "::" + typeName);
+              cl = design->getClassDefinition(
+                  StrCat(p->getName(), "::", typeName));
             }
           }
           if (cl) {

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -662,7 +662,8 @@ void DesignElaboration::elaborateInstance_(
 
   CommandLineParser* clp =
       m_compileDesign->getCompiler()->getCommandLineParser();
-  std::set<std::string>& blackboxModules = clp->getBlackBoxModules();
+  std::set<std::string, std::less<>>& blackboxModules =
+      clp->getBlackBoxModules();
   std::string modName;
   if (DesignComponent* def = parent->getDefinition()) {
     modName = def->getName();
@@ -677,7 +678,8 @@ void DesignElaboration::elaborateInstance_(
                                                                   false);
     return;
   }
-  std::set<std::string>& blackboxInstances = clp->getBlackBoxInstances();
+  std::set<std::string, std::less<>>& blackboxInstances =
+      clp->getBlackBoxInstances();
   std::string instanceName;
   if (parent) {
     instanceName = parent->getFullPathName();
@@ -956,7 +958,7 @@ void DesignElaboration::elaborateInstance_(
           fullName += parent->getFullPathName();
           reuseInstance = true;
         } else {
-          fullName += parent->getModuleName() + "." + instName;
+          StrAppend(&fullName, parent->getModuleName(), ".", instName);
         }
 
         NodeId conditionId = fC->Child(subInstanceId);
@@ -1310,7 +1312,7 @@ void DesignElaboration::elaborateInstance_(
       // Named blocks
       else if (type == VObjectType::slSeq_block ||
                type == VObjectType::slPar_block) {
-        std::string fullName = parent->getModuleName() + "." + instName;
+        std::string fullName = StrCat(parent->getModuleName(), ".", instName);
 
         def = design->getComponentDefinition(fullName);
         if (def == nullptr) {
@@ -1338,10 +1340,10 @@ void DesignElaboration::elaborateInstance_(
 
         std::string fullName;
         if (instName.empty())
-          fullName = parent->getModuleName() + "." + genBlkBaseName +
-                     std::to_string(genBlkIndex);
+          fullName = StrCat(parent->getModuleName(), ".", genBlkBaseName,
+                            std::to_string(genBlkIndex));
         else
-          fullName = parent->getModuleName() + "." + instName;
+          fullName = StrCat(parent->getModuleName(), ".", instName);
 
         def = design->getComponentDefinition(fullName);
         NodeId childId = fC->Child(subInstanceId);
@@ -1393,7 +1395,9 @@ void DesignElaboration::elaborateInstance_(
           if (def) {
             break;
           } else {
-            modName = parent->getDefinition()->getName() + "::" + mname;
+            modName.assign(parent->getDefinition()->getName())
+                .append("::")
+                .append(mname);
             def = design->getComponentDefinition(modName);
             if (def) {
               break;
@@ -2291,10 +2295,10 @@ void DesignElaboration::reduceUnnamedBlocks_() {
            typeP == VObjectType::slGenerate_module_loop_statement ||
            typeP == VObjectType::slGenerate_interface_loop_statement ||
            typeP == VObjectType::slGenerate_region)) {
-        std::string fullModName = current->getModuleName();
-        fullModName = StringUtils::leaf(fullModName);
-        std::string fullModNameP = parent->getModuleName();
-        fullModNameP = StringUtils::leaf(fullModNameP);
+        std::string_view fullModName =
+            StringUtils::leaf(current->getModuleName());
+        std::string_view fullModNameP =
+            StringUtils::leaf(parent->getModuleName());
         if (typeP == VObjectType::slGenerate_region) {
           parent->getParent()->overrideParentChild(parent->getParent(), parent,
                                                    current);

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -186,12 +186,12 @@ bool DesignElaboration::setupConfigurations_() {
       std::string top = config.getDesignTop();
       std::string name = lib + "@" + top;
       m_toplevelConfigModules.insert(name);
-      m_instConfig.insert(std::make_pair(name, config));
-      m_cellConfig.insert(std::make_pair(name, config));
+      m_instConfig.emplace(name, config);
+      m_cellConfig.emplace(name, config);
 
       for (auto& instClause : config.getInstanceUseClauses()) {
-        m_instUseClause.insert(
-            std::make_pair(lib + "@" + instClause.first, instClause.second));
+        m_instUseClause.emplace(lib + "@" + instClause.first,
+                                instClause.second);
         if (instClause.second.getType() == UseClause::UseConfig) {
           Config* config =
               configSet->getMutableConfigByName(instClause.second.getName());
@@ -203,8 +203,7 @@ bool DesignElaboration::setupConfigurations_() {
         }
       }
       for (auto& cellClause : config.getCellUseClauses()) {
-        m_cellUseClause.insert(
-            std::make_pair(cellClause.first, cellClause.second));
+        m_cellUseClause.emplace(cellClause.first, cellClause.second);
       }
     }
   }
@@ -224,7 +223,7 @@ void DesignElaboration::recurseBuildInstanceClause_(
   for (auto& useClause : config->getInstanceUseClauses()) {
     std::string inst = useClause.first;
     std::string fullPath = parentPath + "." + inst;
-    m_instUseClause.insert(std::make_pair(fullPath, useClause.second));
+    m_instUseClause.emplace(fullPath, useClause.second);
     if (useClause.second.getType() == UseClause::UseConfig) {
       Config* config =
           configSet->getMutableConfigByName(useClause.second.getName());
@@ -237,7 +236,7 @@ void DesignElaboration::recurseBuildInstanceClause_(
   for (auto& useClause : config->getCellUseClauses()) {
     std::string inst = useClause.first;
     std::string fullPath = inst;
-    m_cellUseClause.insert(std::make_pair(fullPath, useClause.second));
+    m_cellUseClause.emplace(fullPath, useClause.second);
   }
 }
 
@@ -272,8 +271,7 @@ bool DesignElaboration::identifyTopModules_() {
         if (!file.second->getParent()) {
           // Files that have parent are splited files (When a module is too
           // large it is splited)
-          all_modules.insert(
-              std::make_pair(topname, std::make_pair(element, file.second)));
+          all_modules.emplace(topname, std::make_pair(element, file.second));
         }
 
         modulePresent = true;

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -135,18 +135,18 @@ bool ElaborationStep::bindTypedefs_() {
       if (prevDef->getTypespec() == nullptr)
         noTypespec = true;
       else {
-        specs.insert(std::make_pair(prevDef->getTypespec()->VpiName(),
-                                    prevDef->getTypespec()));
+        specs.emplace(prevDef->getTypespec()->VpiName(),
+                      prevDef->getTypespec());
         if (Package* pack = valuedcomponenti_cast<Package*>(comp)) {
           std::string name =
               StrCat(pack->getName(), "::", prevDef->getTypespec()->VpiName());
-          specs.insert(std::make_pair(name, prevDef->getTypespec()));
+          specs.emplace(name, prevDef->getTypespec());
         }
         if (ClassDefinition* pack =
                 valuedcomponenti_cast<ClassDefinition*>(comp)) {
           std::string name =
               StrCat(pack->getName(), "::", prevDef->getTypespec()->VpiName());
-          specs.insert(std::make_pair(name, prevDef->getTypespec()));
+          specs.emplace(name, prevDef->getTypespec());
         }
       }
     }
@@ -184,10 +184,10 @@ bool ElaborationStep::bindTypedefs_() {
           if (tpclone) {
             typd->setTypespec(tpclone);
             tpclone->VpiName(typd->getName());
-            specs.insert(std::make_pair(typd->getName(), tpclone));
+            specs.emplace(typd->getName(), tpclone);
             if (Package* pack = valuedcomponenti_cast<Package*>(comp)) {
               std::string name = StrCat(pack->getName(), "::", typd->getName());
-              specs.insert(std::make_pair(name, tpclone));
+              specs.emplace(name, tpclone);
             }
           }
         }
@@ -206,15 +206,15 @@ bool ElaborationStep::bindTypedefs_() {
           } else {
             name = typd->getName();
           }
-          specs.insert(std::make_pair(typd->getName(), ts));
+          specs.emplace(typd->getName(), ts);
           if (Package* pack = valuedcomponenti_cast<Package*>(comp)) {
             std::string name = StrCat(pack->getName(), "::", typd->getName());
-            specs.insert(std::make_pair(name, ts));
+            specs.emplace(name, ts);
           }
           if (ClassDefinition* pack =
                   valuedcomponenti_cast<ClassDefinition*>(comp)) {
             std::string name = StrCat(pack->getName(), "::", typd->getName());
-            specs.insert(std::make_pair(name, ts));
+            specs.emplace(name, ts);
           }
           if (ts->UhdmType() == uhdmunsupported_typespec) {
             Location loc1(fileSystem->toPathId(ts->VpiFile(), symbols),
@@ -242,11 +242,11 @@ bool ElaborationStep::bindTypedefs_() {
             defTuple.second, typd->getFileContent(), typd->getDefinitionNode(),
             m_compileDesign, nullptr, nullptr, true);
         if (ts) {
-          specs.insert(std::make_pair(typd->getName(), ts));
+          specs.emplace(typd->getName(), ts);
           ts->VpiName(typd->getName());
           if (Package* pack = valuedcomponenti_cast<Package*>(comp)) {
             std::string name = StrCat(pack->getName(), "::", typd->getName());
-            specs.insert(std::make_pair(name, ts));
+            specs.emplace(name, ts);
           }
         }
         typd->setTypespec(ts);
@@ -930,7 +930,7 @@ Variable* ElaborationStep::locateStaticVariable_(
       }
     }
   }
-  m_staticVariables.insert(std::make_pair(name, result));
+  m_staticVariables.emplace(name, result);
   return result;
 }
 

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -139,13 +139,13 @@ bool ElaborationStep::bindTypedefs_() {
                                     prevDef->getTypespec()));
         if (Package* pack = valuedcomponenti_cast<Package*>(comp)) {
           std::string name =
-              pack->getName() + "::" + prevDef->getTypespec()->VpiName();
+              StrCat(pack->getName(), "::", prevDef->getTypespec()->VpiName());
           specs.insert(std::make_pair(name, prevDef->getTypespec()));
         }
         if (ClassDefinition* pack =
                 valuedcomponenti_cast<ClassDefinition*>(comp)) {
           std::string name =
-              pack->getName() + "::" + prevDef->getTypespec()->VpiName();
+              StrCat(pack->getName(), "::", prevDef->getTypespec()->VpiName());
           specs.insert(std::make_pair(name, prevDef->getTypespec()));
         }
       }
@@ -186,7 +186,7 @@ bool ElaborationStep::bindTypedefs_() {
             tpclone->VpiName(typd->getName());
             specs.insert(std::make_pair(typd->getName(), tpclone));
             if (Package* pack = valuedcomponenti_cast<Package*>(comp)) {
-              std::string name = pack->getName() + "::" + typd->getName();
+              std::string name = StrCat(pack->getName(), "::", typd->getName());
               specs.insert(std::make_pair(name, tpclone));
             }
           }
@@ -208,12 +208,12 @@ bool ElaborationStep::bindTypedefs_() {
           }
           specs.insert(std::make_pair(typd->getName(), ts));
           if (Package* pack = valuedcomponenti_cast<Package*>(comp)) {
-            std::string name = pack->getName() + "::" + typd->getName();
+            std::string name = StrCat(pack->getName(), "::", typd->getName());
             specs.insert(std::make_pair(name, ts));
           }
           if (ClassDefinition* pack =
                   valuedcomponenti_cast<ClassDefinition*>(comp)) {
-            std::string name = pack->getName() + "::" + typd->getName();
+            std::string name = StrCat(pack->getName(), "::", typd->getName());
             specs.insert(std::make_pair(name, ts));
           }
           if (ts->UhdmType() == uhdmunsupported_typespec) {
@@ -245,7 +245,7 @@ bool ElaborationStep::bindTypedefs_() {
           specs.insert(std::make_pair(typd->getName(), ts));
           ts->VpiName(typd->getName());
           if (Package* pack = valuedcomponenti_cast<Package*>(comp)) {
-            std::string name = pack->getName() + "::" + typd->getName();
+            std::string name = StrCat(pack->getName(), "::", typd->getName());
             specs.insert(std::make_pair(name, ts));
           }
         }
@@ -572,7 +572,7 @@ const DataType* ElaborationStep::bindDataType_(
     }
   }
   if (found == false) {
-    std::string class_in_class = parent->getName() + "::" + type_name;
+    std::string class_in_class = StrCat(parent->getName(), "::", type_name);
     itr1 = classes.find(class_in_class);
 
     if (itr1 != classes.end()) {
@@ -583,8 +583,8 @@ const DataType* ElaborationStep::bindDataType_(
   if (found == false) {
     if (parent->getParentScope()) {
       std::string class_in_own_package =
-          ((DesignComponent*)parent->getParentScope())->getName() +
-          "::" + type_name;
+          StrCat(((DesignComponent*)parent->getParentScope())->getName(),
+                 "::", type_name);
       itr1 = classes.find(class_in_own_package);
       if (itr1 != classes.end()) {
         found = true;
@@ -594,7 +594,8 @@ const DataType* ElaborationStep::bindDataType_(
   }
   if (found == false) {
     for (const auto& package : parent->getAccessPackages()) {
-      std::string class_in_package = package->getName() + "::" + type_name;
+      std::string class_in_package =
+          StrCat(package->getName(), "::", type_name);
       itr1 = classes.find(class_in_package);
       if (itr1 != classes.end()) {
         found = true;
@@ -1064,8 +1065,8 @@ bool ElaborationStep::bindPortType_(Signal* signal, const FileContent* fC,
           const std::pair<FileCNodeId, DesignComponent*>* datatype =
               parentComponent->getNamedObject(interfName);
           if (!datatype) {
-            def = design->getClassDefinition(parentComponent->getName() +
-                                             "::" + interfName);
+            def = design->getClassDefinition(
+                StrCat(parentComponent->getName(), "::", interfName));
           }
           if (datatype) {
             def = datatype->second;
@@ -1138,7 +1139,7 @@ bool ElaborationStep::bindPortType_(Signal* signal, const FileContent* fC,
           signal->setDataType(dt);
         }
       } else {
-        std::string name = parentComponent->getName() + "::" + interfName;
+        std::string name = StrCat(parentComponent->getName(), "::", interfName);
         def = design->getClassDefinition(name);
         DataType* dt = valuedcomponenti_cast<ClassDefinition*>(def);
         if (dt) {

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -1388,9 +1388,9 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
 
 interface* NetlistElaboration::elab_interface_(
     ModuleInstance* instance, ModuleInstance* interf_instance,
-    const std::string& instName, const std::string& defName,
-    ModuleDefinition* mod, PathId fileId, int lineNb,
-    interface_array* interf_array, const std::string& modPortName) {
+    std::string_view instName, std::string_view defName, ModuleDefinition* mod,
+    PathId fileId, int lineNb, interface_array* interf_array,
+    const std::string& modPortName) {
   FileSystem* const fileSystem = FileSystem::getInstance();
   Netlist* netlist = instance->getNetlist();
   if (netlist == nullptr) {
@@ -1420,7 +1420,7 @@ interface* NetlistElaboration::elab_interface_(
         std::make_pair(instName, std::make_pair(interf_instance, sm)));
     netlist->getSymbolTable().insert(std::make_pair(instName, sm));
   }
-  const std::string prefix = instName + ".";
+  const std::string prefix = StrCat(instName, ".");
   elab_ports_nets_(instance, interf_instance, instance->getNetlist(),
                    interf_instance->getNetlist(), mod, prefix, true);
   elab_ports_nets_(instance, interf_instance, instance->getNetlist(),
@@ -1430,7 +1430,8 @@ interface* NetlistElaboration::elab_interface_(
       mod->getModPortSignalMap();
   VectorOfmodport* dest_modports = s.MakeModportVec();
   for (auto& orig_modport : orig_modports) {
-    const std::string modportfullname = instName + "." + orig_modport.first;
+    const std::string modportfullname =
+        StrCat(instName, ".", orig_modport.first);
     if (!modPortName.empty() && (modportfullname != modPortName)) continue;
     modport* dest_modport = s.MakeModport();
     dest_modport->Interface(sm);
@@ -1481,11 +1482,11 @@ interface* NetlistElaboration::elab_interface_(
 
 modport* NetlistElaboration::elab_modport_(
     ModuleInstance* instance, ModuleInstance* interfaceInstance,
-    const std::string& instName, const std::string& defName,
-    ModuleDefinition* mod, PathId fileId, int lineNb,
-    const std::string& modPortName, UHDM::interface_array* interf_array) {
+    std::string_view instName, std::string_view defName, ModuleDefinition* mod,
+    PathId fileId, int lineNb, const std::string& modPortName,
+    UHDM::interface_array* interf_array) {
   Netlist* netlist = instance->getNetlist();
-  std::string fullname = instName + "." + modPortName;
+  std::string fullname = StrCat(instName, ".", modPortName);
   Netlist::ModPortMap::iterator itr = netlist->getModPortMap().find(fullname);
   if (itr == netlist->getModPortMap().end()) {
     elab_interface_(instance, interfaceInstance, instName, defName, mod, fileId,

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -1412,13 +1412,13 @@ interface* NetlistElaboration::elab_interface_(
   subInterfaces->push_back(sm);
   if (interf_array) {
     interf_array->Instances()->push_back(sm);
-    netlist->getInstanceMap().insert(std::make_pair(
-        instName, std::make_pair(interf_instance, interf_array)));
-    netlist->getSymbolTable().insert(std::make_pair(instName, interf_array));
+    netlist->getInstanceMap().emplace(
+        instName, std::make_pair(interf_instance, interf_array));
+    netlist->getSymbolTable().emplace(instName, interf_array);
   } else {
-    netlist->getInstanceMap().insert(
-        std::make_pair(instName, std::make_pair(interf_instance, sm)));
-    netlist->getSymbolTable().insert(std::make_pair(instName, sm));
+    netlist->getInstanceMap().emplace(instName,
+                                      std::make_pair(interf_instance, sm));
+    netlist->getSymbolTable().emplace(instName, sm);
   }
   const std::string prefix = StrCat(instName, ".");
   elab_ports_nets_(instance, interf_instance, instance->getNetlist(),
@@ -1439,10 +1439,9 @@ interface* NetlistElaboration::elab_interface_(
     const FileContent* orig_fC = orig_modport.second.getFileContent();
     const NodeId orig_nodeId = orig_modport.second.getNodeId();
     orig_fC->populateCoreMembers(orig_nodeId, orig_nodeId, dest_modport);
-    netlist->getModPortMap().insert(std::make_pair(
-        modportfullname, std::make_pair(&orig_modport.second, dest_modport)));
-    netlist->getSymbolTable().insert(
-        std::make_pair(modportfullname, dest_modport));
+    netlist->getModPortMap().emplace(
+        modportfullname, std::make_pair(&orig_modport.second, dest_modport));
+    netlist->getSymbolTable().emplace(modportfullname, dest_modport);
     dest_modport->VpiName(orig_modport.first);
     VectorOfio_decl* ios = s.MakeIo_declVec();
     for (auto& sig : orig_modport.second.getPorts()) {
@@ -1646,7 +1645,7 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
       tps = m_helper.compileTypespec(comp, fC, typeSpecId, m_compileDesign,
                                      nullptr, child, true, true);
       m_helper.checkForLoops(false);
-      tscache.insert(std::make_pair(typeSpecId, tps));
+      tscache.emplace(typeSpecId, tps);
     } else {
       tps = (*itr).second;
     }
@@ -1660,7 +1659,7 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
                                        m_compileDesign, nullptr, child, true,
                                        true);
         m_helper.checkForLoops(false);
-        tscache.insert(std::make_pair(sig->getInterfaceTypeNameId(), tps));
+        tscache.emplace(sig->getInterfaceTypeNameId(), tps);
       } else {
         tps = (*itr).second;
       }
@@ -2058,8 +2057,8 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
       }
     }
     if (parentNetlist)
-      parentNetlist->getSymbolTable().insert(std::make_pair(parentSymbol, obj));
-    if (netlist) netlist->getSymbolTable().insert(std::make_pair(signame, obj));
+      parentNetlist->getSymbolTable().emplace(parentSymbol, obj);
+    if (netlist) netlist->getSymbolTable().emplace(signame, obj);
 
     if (exp && (!signalIsPort)) {
       cont_assign* assign = s.MakeCont_assign();
@@ -2098,8 +2097,8 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
       }
     }
     if (parentNetlist)
-      parentNetlist->getSymbolTable().insert(std::make_pair(parentSymbol, obj));
-    netlist->getSymbolTable().insert(std::make_pair(signame, obj));
+      parentNetlist->getSymbolTable().emplace(parentSymbol, obj);
+    netlist->getSymbolTable().emplace(signame, obj);
   } else {
     // Unsupported type
     ErrorContainer* errors =
@@ -2203,7 +2202,7 @@ bool NetlistElaboration::elab_ports_nets_(
                 m_helper.compileTypespec(comp, fC, typeSpecId, m_compileDesign,
                                          dest_port, instance, true, true);
             m_helper.checkForLoops(false);
-            tscache.insert(std::make_pair(typeSpecId, tps));
+            tscache.emplace(typeSpecId, tps);
           } else {
             tps = (*itr).second;
           }
@@ -2507,7 +2506,7 @@ UHDM::any* NetlistElaboration::bind_net_(const FileContent* origfC, NodeId id,
           netlist->nets(nets);
         }
         nets->push_back(net);
-        symbols.insert(std::make_pair(name, result));
+        symbols.emplace(name, result);
       }
     }
   }

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -53,7 +53,7 @@ using UHDM::uhdmunsupported_stmt;
 using UHDM::uhdmunsupported_typespec;
 
 bool UhdmChecker::registerFile(const FileContent* fC,
-                               std::set<std::string>& moduleNames) {
+                               std::set<std::string_view>& moduleNames) {
   const VObject& current = fC->Object(NodeId(fC->getSize() - 2));
   NodeId id = current.m_child;
   PathId fileId = fC->getFileId();
@@ -611,7 +611,7 @@ void UhdmChecker::annotate() {
 }
 
 void collectUsedFileContents(std::set<const FileContent*>& files,
-                             std::set<std::string>& moduleNames,
+                             std::set<std::string_view>& moduleNames,
                              ModuleInstance* instance) {
   if (instance) {
     DesignComponent* def = instance->getDefinition();
@@ -634,7 +634,7 @@ bool UhdmChecker::check(PathId uhdmFileId) {
       m_compileDesign->getCompiler()->getCommandLineParser();
   SymbolTable* symbols = m_compileDesign->getCompiler()->getSymbolTable();
   std::set<const FileContent*> files;
-  std::set<std::string> moduleNames;
+  std::set<std::string_view> moduleNames;
   for (ModuleInstance* top : m_design->getTopLevelModuleInstances()) {
     collectUsedFileContents(files, moduleNames, top);
   }

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -65,7 +65,7 @@ bool UhdmChecker::registerFile(const FileContent* fC,
   FileNodeCoverMap::iterator fileItr = fileNodeCoverMap.find(fC);
   if (fileItr == fileNodeCoverMap.end()) {
     RangesMap uhdmCover;
-    fileNodeCoverMap.insert(std::make_pair(fC, uhdmCover));
+    fileNodeCoverMap.emplace(fC, uhdmCover);
     fileItr = fileNodeCoverMap.find(fC);
   }
   RangesMap& uhdmCover = (*fileItr).second;
@@ -186,7 +186,7 @@ bool UhdmChecker::registerFile(const FileContent* fC,
           crange.to = to;
           crange.covered = Status::COVERED;
           ranges.push_back(crange);
-          uhdmCover.insert(std::make_pair(current.m_line, ranges));
+          uhdmCover.emplace(current.m_line, ranges);
         }
       }
       skip = true;  // Only skip the item itself
@@ -223,7 +223,7 @@ bool UhdmChecker::registerFile(const FileContent* fC,
         crange.to = to;
         crange.covered = Status::EXIST;
         ranges.push_back(crange);
-        uhdmCover.insert(std::make_pair(current.m_line, ranges));
+        uhdmCover.emplace(current.m_line, ranges);
       }
     }
     if (id == endModuleNode) {
@@ -394,17 +394,14 @@ bool UhdmChecker::reportHtml(PathId uhdmFileId, float overallCoverage) {
       }
     }
     if (!redCoverage.empty()) {
-      orderedCoverageMap.insert(
-          std::make_pair(static_cast<int>(cov), redCoverage));
+      orderedCoverageMap.emplace(static_cast<int>(cov), redCoverage);
     } else {
       if (!pinkCoverage.empty()) {
-        orderedCoverageMap.insert(
-            std::make_pair(static_cast<int>(cov), pinkCoverage));
+        orderedCoverageMap.emplace(static_cast<int>(cov), pinkCoverage);
       }
     }
     if (uncovered == false) {
-      orderedCoverageMap.insert(
-          std::make_pair(static_cast<int>(cov), fileStatGreen));
+      orderedCoverageMap.emplace(static_cast<int>(cov), fileStatGreen);
     }
     reportF << "</body>\n</html>\n";
     fileSystem->close(reportF);

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -858,7 +858,7 @@ void UhdmWriter::writeClass(ClassDefinition* classDef,
     componentMap.insert(std::make_pair(classDef, c));
     c->VpiParent(parent);
     dest_classes->push_back(c);
-    const std::string& name = classDef->getName();
+    const std::string_view name = classDef->getName();
     if (c->VpiName().empty()) c->VpiName(name);
     if (c->VpiFullName().empty()) c->VpiFullName(name);
     c->Attributes(classDef->Attributes());
@@ -981,7 +981,7 @@ void reInstanceTypespec(Serializer& serializer, any* root, package* p) {
 void UhdmWriter::writePackage(Package* pack, package* p, Serializer& s,
                               UhdmWriter::ComponentMap& componentMap,
                               bool elaborated) {
-  p->VpiFullName(pack->getName() + "::");
+  p->VpiFullName(StrCat(pack->getName(), "::"));
   VectorOfclass_defn* dest_classes = nullptr;
 
   // Typepecs
@@ -1005,10 +1005,11 @@ void UhdmWriter::writePackage(Package* pack, package* p, Serializer& s,
     for (auto ps : *p->Parameters()) {
       ps->VpiParent(p);
       if (ps->UhdmType() == uhdmparameter) {
-        ((parameter*)ps)->VpiFullName(pack->getName() + "::" + ps->VpiName());
+        ((parameter*)ps)
+            ->VpiFullName(StrCat(pack->getName(), "::", ps->VpiName()));
       } else {
         ((type_parameter*)ps)
-            ->VpiFullName(pack->getName() + "::" + ps->VpiName());
+            ->VpiFullName(StrCat(pack->getName(), "::", ps->VpiName()));
       }
     }
   }
@@ -1054,13 +1055,15 @@ void UhdmWriter::writePackage(Package* pack, package* p, Serializer& s,
           tf->VpiParent(p);
           tf->Instance(p);
           p->Task_funcs()->push_back(tf);
-          ((task_func*)tf)->VpiFullName(pack->getName() + "::" + tf->VpiName());
+          ((task_func*)tf)
+              ->VpiFullName(StrCat(pack->getName(), "::", tf->VpiName()));
         }
       } else {
         tf->VpiParent(p);
         tf->Instance(p);
         p->Task_funcs()->push_back(tf);
-        ((task_func*)tf)->VpiFullName(pack->getName() + "::" + tf->VpiName());
+        ((task_func*)tf)
+            ->VpiFullName(StrCat(pack->getName(), "::", tf->VpiName()));
       }
     }
   }
@@ -1071,7 +1074,8 @@ void UhdmWriter::writePackage(Package* pack, package* p, Serializer& s,
     if (netlist->variables()) {
       for (auto obj : *netlist->variables()) {
         obj->VpiParent(p);
-        ((variables*)obj)->VpiFullName(pack->getName() + "::" + obj->VpiName());
+        ((variables*)obj)
+            ->VpiFullName(StrCat(pack->getName(), "::", obj->VpiName()));
       }
     }
   }

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -489,7 +489,7 @@ bool writeElabParameters(Serializer& s, ModuleInstance* instance,
           ElaboratorListener listener(&s, false, true);
           any* pclone = UHDM::clone_tree(orig, s, &listener);
           pclone->VpiParent(m);
-          paramSet.insert(std::make_pair(name, pclone));
+          paramSet.emplace(name, pclone);
           /*
 
             Keep the value of the parameter used during definition. The
@@ -606,8 +606,8 @@ void UhdmWriter::writePorts(std::vector<Signal*>& orig_ports, BaseClass* parent,
   int lastPortDirection = vpiInout;
   for (Signal* orig_port : orig_ports) {
     port* dest_port = s.MakePort();
-    signalBaseMap.insert(std::make_pair(orig_port, dest_port));
-    signalMap.insert(std::make_pair(orig_port->getName(), orig_port));
+    signalBaseMap.emplace(orig_port, dest_port);
+    signalMap.emplace(orig_port->getName(), orig_port);
     const FileContent* fC = orig_port->getFileContent();
     if (fC->Type(orig_port->getNodeId()) == VObjectType::slStringConst)
       dest_port->VpiName(orig_port->getName());
@@ -760,8 +760,8 @@ void writeNets(std::vector<Signal*>& orig_nets, BaseClass* parent,
             }
           }
         }
-        signalBaseMap.insert(std::make_pair(orig_net, dest_net));
-        signalMap.insert(std::make_pair(orig_net->getName(), orig_net));
+        signalBaseMap.emplace(orig_net, dest_net);
+        signalMap.emplace(orig_net->getName(), orig_net);
         dest_net->VpiName(orig_net->getName());
         orig_net->getFileContent()->populateCoreMembers(
             orig_net->getNodeId(), orig_net->getNodeId(), dest_net);
@@ -855,7 +855,7 @@ void UhdmWriter::writeClass(ClassDefinition* classDef,
         ps->VpiParent(c);
       }
     }
-    componentMap.insert(std::make_pair(classDef, c));
+    componentMap.emplace(classDef, c);
     c->VpiParent(parent);
     dest_classes->push_back(c);
     const std::string_view name = classDef->getName();
@@ -1311,7 +1311,7 @@ void UhdmWriter::writeInterface(ModuleDefinition* mod, interface* m,
     const FileContent* orig_fC = orig_modport.second.getFileContent();
     const NodeId orig_nodeId = orig_modport.second.getNodeId();
     orig_fC->populateCoreMembers(orig_nodeId, orig_nodeId, dest_modport);
-    modPortMap.insert(std::make_pair(&orig_modport.second, dest_modport));
+    modPortMap.emplace(&orig_modport.second, dest_modport);
     dest_modport->VpiName(orig_modport.first);
     VectorOfio_decl* ios = s.MakeIo_declVec();
     for (auto& sig : orig_modport.second.getPorts()) {
@@ -3813,7 +3813,7 @@ vpiHandle UhdmWriter::write(PathId uhdmFileId) {
           pack->getType() == VObjectType::slPackage_declaration) {
         const FileContent* fC = pack->getFileContents()[0];
         package* p = (package*)pack->getUhdmInstance();
-        componentMap.insert(std::make_pair(pack, p));
+        componentMap.emplace(pack, p);
         p->VpiParent(d);
         p->VpiTop(true);
         p->VpiDefName(pack->getName());
@@ -3862,7 +3862,7 @@ vpiHandle UhdmWriter::write(PathId uhdmFileId) {
           prog->getType() == VObjectType::slProgram_declaration) {
         const FileContent* fC = prog->getFileContents()[0];
         program* p = s.MakeProgram();
-        componentMap.insert(std::make_pair(prog, p));
+        componentMap.emplace(prog, p);
         p->VpiParent(d);
         p->VpiDefName(prog->getName());
         const NodeId modId = prog->getNodeIds()[0];
@@ -3885,7 +3885,7 @@ vpiHandle UhdmWriter::write(PathId uhdmFileId) {
       } else if (mod->getType() == VObjectType::slInterface_declaration) {
         const FileContent* fC = mod->getFileContents()[0];
         interface* m = s.MakeInterface();
-        componentMap.insert(std::make_pair(mod, m));
+        componentMap.emplace(mod, m);
         m->VpiParent(d);
         m->VpiDefName(mod->getName());
         const NodeId modId = mod->getNodeIds()[0];
@@ -3913,7 +3913,7 @@ vpiHandle UhdmWriter::write(PathId uhdmFileId) {
                 mod->getFileContents()[0]->getFileId())) {
           m->VpiCellInstance(true);
         }
-        componentMap.insert(std::make_pair(mod, m));
+        componentMap.emplace(mod, m);
         m->VpiParent(d);
         m->VpiDefName(mod->getName());
         m->Attributes(mod->Attributes());

--- a/src/ErrorReporting/Waiver.cpp
+++ b/src/ErrorReporting/Waiver.cpp
@@ -42,7 +42,7 @@ void Waiver::setWaiver(const std::string& messageId,
                        const std::string& objectName) {
   ErrorDefinition::ErrorType type = ErrorDefinition::getErrorType(messageId);
   Waiver::WaiverData data(type, fileName, line, objectName);
-  m_waivers.insert(std::make_pair(type, data));
+  m_waivers.emplace(type, data);
 }
 
 void Waiver::initWaivers() { m_macroArgCheck.insert("vmm_sformatf"); }

--- a/src/SourceCompile/CommonListenerHelper.cpp
+++ b/src/SourceCompile/CommonListenerHelper.cpp
@@ -97,7 +97,7 @@ int CommonListenerHelper::addVObject(ParserRuleContext* ctx, SymbolId sym,
   NodeId objectIndex = m_fileContent->addObject(sym, fileId, objtype, line,
                                                 column, endLine, endColumn);
   VObject* inserted = m_fileContent->MutableObject(objectIndex);
-  m_contextToObjectMap.insert(std::make_pair(ctx, objectIndex));
+  m_contextToObjectMap.emplace(ctx, objectIndex);
   addParentChildRelations(objectIndex, ctx);
   std::vector<SURELOG::DesignElement*>& delements =
       m_fileContent->getDesignElements();

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -1094,10 +1094,10 @@ void Compiler::registerAntlrPpHandlerForId(
   if (itr != m_antlrPpMap.end()) {
     delete (*itr).second;
     m_antlrPpMap.erase(itr);
-    m_antlrPpMap.insert(std::make_pair(id, pp));
+    m_antlrPpMap.emplace(id, pp);
     return;
   }
-  m_antlrPpMap.insert(std::make_pair(id, pp));
+  m_antlrPpMap.emplace(id, pp);
 }
 
 PreprocessFile::AntlrParserHandler* Compiler::getAntlrPpHandlerForId(

--- a/src/SourceCompile/LoopCheck.cpp
+++ b/src/SourceCompile/LoopCheck.cpp
@@ -48,13 +48,13 @@ bool LoopCheck::addEdge(SymbolId from, SymbolId to) {
   Node* nodeTo = nullptr;
   if (fromIt == m_nodes.end()) {
     nodeFrom = new Node(from);
-    m_nodes.insert(std::make_pair(from, nodeFrom));
+    m_nodes.emplace(from, nodeFrom);
   } else {
     nodeFrom = (*fromIt).second;
   }
   if (toIt == m_nodes.end()) {
     nodeTo = new Node(to);
-    m_nodes.insert(std::make_pair(to, nodeTo));
+    m_nodes.emplace(to, nodeTo);
   } else {
     nodeTo = (*toIt).second;
   }

--- a/src/Testbench/ClassDefinition.cpp
+++ b/src/Testbench/ClassDefinition.cpp
@@ -75,7 +75,7 @@ Property* ClassDefinition::getProperty(std::string_view name) const {
 }
 
 void ClassDefinition::insertProperty(Property* p) {
-  m_properties.emplace(std::make_pair(p->getName(), p));
+  m_properties.emplace(p->getName(), p);
 }
 
 Function* ClassDefinition::getFunction(std::string_view name) const {
@@ -122,7 +122,7 @@ TaskMethod* ClassDefinition::getTask(std::string_view name) const {
 }
 
 void ClassDefinition::insertTask(TaskMethod* p) {
-  m_tasks.emplace(std::make_pair(p->getName(), p));
+  m_tasks.emplace(p->getName(), p);
 }
 
 Constraint* ClassDefinition::getConstraint(std::string_view name) {
@@ -135,7 +135,7 @@ Constraint* ClassDefinition::getConstraint(std::string_view name) {
 }
 
 void ClassDefinition::insertConstraint(Constraint* p) {
-  m_constraints.emplace(std::make_pair(p->getName(), p));
+  m_constraints.emplace(p->getName(), p);
 }
 
 ClassDefinition* ClassDefinition::getClass(std::string_view name) {
@@ -148,7 +148,7 @@ ClassDefinition* ClassDefinition::getClass(std::string_view name) {
 }
 
 void ClassDefinition::insertClass(ClassDefinition* p) {
-  m_classes.emplace(std::make_pair(p->getName(), p));
+  m_classes.emplace(p->getName(), p);
 }
 
 CoverGroupDefinition* ClassDefinition::getCoverGroup(std::string_view name) {
@@ -161,7 +161,7 @@ CoverGroupDefinition* ClassDefinition::getCoverGroup(std::string_view name) {
 }
 
 void ClassDefinition::insertCoverGroup(CoverGroupDefinition* p) {
-  m_covergroups.emplace(std::make_pair(p->getName(), p));
+  m_covergroups.emplace(p->getName(), p);
 }
 
 const DataType* ClassDefinition::getBaseClass(std::string_view name) const {
@@ -174,7 +174,7 @@ const DataType* ClassDefinition::getBaseClass(std::string_view name) const {
 }
 
 void ClassDefinition::insertBaseClass(DataType* p) {
-  m_baseclasses.emplace(std::make_pair(p->getName(), p));
+  m_baseclasses.emplace(p->getName(), p);
 }
 
 const DataType* ClassDefinition::getBaseDataType(std::string_view name) const {

--- a/src/Testbench/ClassObject.cpp
+++ b/src/Testbench/ClassObject.cpp
@@ -33,7 +33,7 @@ bool ClassObject::setValue(const std::string& property, Value* value) {
     if (prop == nullptr) {
       return false;
     }
-    m_properties.insert(std::make_pair(property, std::make_pair(prop, value)));
+    m_properties.emplace(property, std::make_pair(prop, value));
   } else {
     (*itr).second.second = value;
   }


### PR DESCRIPTION
Remove use of std::make_pair when inserting elements into standard containers

Use emplace/emplace_back in place of insert/push_back to insert elements
into standard containers.

This change is in preparation for a future change to widely use
std::string_view in place of std::string when passing/returning
strings.

P.S. This PR includes the other #3344 