### PR TITLE
Use ubuntu-20.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
   linux-build-test:
     name: "test-${{ matrix.compiler }} Linux"
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash
@@ -92,7 +92,7 @@ jobs:
   linux-regression:
     name: "Regression ${{ matrix.compiler }} ${{matrix.shard}} (Linux)"
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash
@@ -195,7 +195,7 @@ jobs:
   linux-various:
     name: "${{ matrix.mode }} Linux"
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash
@@ -306,7 +306,7 @@ jobs:
   linux-valgrind:
     name: "Valgrind ${{ matrix.project}} (Linux)"
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
ubuntu-latest is now ubuntu-22.04:
https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/

This fixes failing install dependencies in the CI:
```
The following packages have unmet dependencies:
 libunwind-14-dev : Breaks: libunwind-dev but 1.3.2-2build2 is to be installed
```

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>