### PR TITLE
Few improvements to the AST listener API

### DIFF
--- a/include/Surelog/SourceCompile/AstListener.template.hpp
+++ b/include/Surelog/SourceCompile/AstListener.template.hpp
@@ -28,6 +28,8 @@
 #pragma once
 
 #include <Surelog/Common/NodeId.h>
+#include <Surelog/Common/PathId.h>
+#include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <cstdint>
 #include <type_traits>
@@ -95,31 +97,37 @@ class AstListener {
   AstListener() = default;
   virtual ~AstListener() = default;
 
-  virtual void enterSourceFile(const std::filesystem::path& filepath) {}
-  virtual void leaveSourceFile(const std::filesystem::path& filepath) {}
+  virtual void enterSourceFile(PathId fileId) {}
+  virtual void leaveSourceFile(PathId fileId) {}
 
   // clang-format off
 <PUBLIC_ENTER_LEAVE_DECLARATIONS>
   // clang-format on
 
   void listen(const AstNode& node);
-  void listenChildren(const AstNode& node);
+  void listenChildren(const AstNode& node, bool ordered);
+  void listenSiblings(const AstNode& node, bool ordered);
 
-  void listen(const std::filesystem::path& filepath, const VObject* objects,
-              uint32_t count, const SymbolTable* symbolTable);
+  void listen(PathId fileId, const VObject* objects, uint32_t count,
+              const SymbolTable* symbolTable);
 
+  VObjectType getNodeType(const AstNode& node) const;
   bool getNodeName(const AstNode& node, std::string& name) const;
-  bool getNodeFilePath(const AstNode& node,
-                       std::filesystem::path& filepath) const;
-  bool getNodeStartLine(const AstNode& node, int32_t& line) const;
-  bool getNodeStartColumn(const AstNode& node, int32_t& column) const;
-  bool getNodeEndLine(const AstNode& node, int32_t& line) const;
-  bool getNodeEndColumn(const AstNode& node, int32_t& column) const;
+  bool getNodeFileId(const AstNode& node, PathId& fileId) const;
+  bool getNodeStartLocation(const AstNode& node, int32_t& line,
+                            int32_t& column) const;
+  bool getNodeEndLocation(const AstNode& node, int32_t& line,
+                          int32_t& column) const;
+  bool getNodeLocation(const AstNode& node, int32_t& startLine,
+                       int32_t& startColumn, int32_t& endLine,
+                       int32_t& endColumn) const;
   AstNode getNodeParent(const AstNode& node) const;
-  void getChildren(const AstNode& node, bool ordered,
-                   astnode_vector_t& children) const;
-  void getSiblings(const AstNode& node, bool ordered,
-                   astnode_vector_t& siblings) const;
+  AstNode getNodePrevSibling(const AstNode& node) const;
+  AstNode getNodeNextSibling(const AstNode& node) const;
+  bool getNodeChildren(const AstNode& node, bool ordered,
+                       astnode_vector_t& children) const;
+  bool getNodeSiblings(const AstNode& node, bool ordered,
+                       astnode_vector_t& siblings) const;
 
  private:
   // clang-format off

--- a/include/Surelog/SourceCompile/AstTraceListener.template.hpp
+++ b/include/Surelog/SourceCompile/AstTraceListener.template.hpp
@@ -35,22 +35,19 @@
 // clang-format off
 #define TRACE_INIT_CONTEXT                \
   int32_t sl = 0, sc = 0, el = 0, ec = 0; \
-  getNodeStartLine(node, sl);             \
-  getNodeStartColumn(node, sc);           \
-  getNodeEndLine(node, el);               \
-  getNodeEndColumn(node, ec);             \
+  std::string name;                       \
+  getNodeLocation(node, sl, sc, el, ec);  \
+  getNodeName(node, name)
 
 #define TRACE_PRINT_CONTEXT \
-  "[" << sl << "," << sc <<  ":" << el << "," << ec <<  "]"
+  "[" << sl << "," << sc <<  ":" << el << "," << ec <<  "], " << name
 
-#define TRACE_ENTER                           \
-  TRACE_INIT_CONTEXT m_strm                   \
-  << std::string(m_indent++ * 2, ' ')         \
+#define TRACE_ENTER TRACE_INIT_CONTEXT;       \
+  m_strm << std::string(m_indent++ * 2, ' ')  \
   << __func__ << ": " << TRACE_PRINT_CONTEXT  \
   << std::endl
-#define TRACE_LEAVE                           \
-  TRACE_INIT_CONTEXT m_strm                   \
-  << std::string(2 * --m_indent, ' ')         \
+#define TRACE_LEAVE TRACE_INIT_CONTEXT;       \
+  m_strm << std::string(2 * --m_indent, ' ')  \
   << __func__ << ": " << TRACE_PRINT_CONTEXT  \
   << std::endl
 // clang-format on
@@ -61,13 +58,13 @@ class AstTraceListener final : public AstListener {
   AstTraceListener(std::ostream& strm) : m_strm(strm), m_indent(0) {}
   ~AstTraceListener() final = default;
 
-  virtual void enterSourceFile(const std::filesystem::path& filepath) {
-    m_strm << std::string(m_indent++ * 2, ' ') << __func__ << ": " << filepath
-           << std::endl;
+  void enterSourceFile(SURELOG::PathId fileId) final {
+    m_strm << std::string(m_indent++ * 2, ' ') << __func__ << ": "
+           << SURELOG::PathIdPP(fileId) << std::endl;
   }
-  virtual void leaveSourceFile(const std::filesystem::path& filepath) {
-    m_strm << std::string(2 * --m_indent, ' ') << __func__ << ": " << filepath
-           << std::endl;
+  void leaveSourceFile(SURELOG::PathId fileId) final {
+    m_strm << std::string(2 * --m_indent, ' ') << __func__ << ": "
+           << SURELOG::PathIdPP(fileId) << std::endl;
   }
 
   // clang-format off

--- a/scripts/generate_ast_listener.py
+++ b/scripts/generate_ast_listener.py
@@ -376,7 +376,7 @@ def _generate_source(input_filepath: str, output_filepath: str):
     private_listen_implementations.extend([
      f'void AstListener::listen{type_name}(const AstNode& node) {{',
      f'  enter{type_name}(node);',
-      '  listenChildren(node);',
+      '  listenChildren(node, true);',
      f'  leave{type_name}(node);',
       '}',
       ''

--- a/src/API/Surelog.cpp
+++ b/src/API/Surelog.cpp
@@ -60,14 +60,13 @@ vpiHandle get_uhdm_design(scompiler* compiler) {
 
 void walk_ast(scompiler* compiler, AstListener* listener) {
   if (!compiler || !listener) return;
-  FileSystem* const fileSystem = FileSystem::getInstance();
   Compiler* the_compiler = (Compiler*)compiler;
   for (const CompileSourceFile* csf : the_compiler->getCompileSourceFiles()) {
     const FileContent* const fC = csf->getParser()->getFileContent();
-    const std::filesystem::path filepath = fileSystem->toPath(fC->getFileId());
     const std::vector<VObject>& objects = fC->getVObjects();
     const SymbolTable* const symbolTable = fC->getSymbolTable();
-    listener->listen(filepath, objects.data(), objects.size(), symbolTable);
+    listener->listen(fC->getFileId(), objects.data(), objects.size(),
+                     symbolTable);
   }
 }
 


### PR DESCRIPTION
Few improvements to the AST listener API

* New API to get prev & next sibling
* Option to return ordered children i.e. in the order the callbacks are invoked.
* API uses PathId instead of std::filesystem