### PR TITLE
Don't allocate list of buildin-funtions. Also make code more readable.

### DIFF
--- a/include/Surelog/Design/Design.h
+++ b/include/Surelog/Design/Design.h
@@ -194,7 +194,7 @@ class Design final {
     m_programDefinitions.emplace(programName, program);
   }
 
-  Package* addPackageDefinition(const std::string& packageName,
+  Package* addPackageDefinition(std::string_view packageName,
                                 Package* package);
 
   void clearContainers();

--- a/include/Surelog/Design/Function.h
+++ b/include/Surelog/Design/Function.h
@@ -44,7 +44,7 @@ class Procedure : public Scope, public Statement {
   SURELOG_IMPLEMENT_RTTI_2_BASES(Procedure, Scope, Statement)
  public:
   Procedure(DesignComponent* parent, const FileContent* fC, NodeId id,
-            const std::string& name);
+            std::string_view name);
   ~Procedure() override = default;
 
   DesignComponent* getParent() const { return m_parent; }
@@ -76,7 +76,7 @@ class Function : public Procedure {
   SURELOG_IMPLEMENT_RTTI(Function, Procedure)
  public:
   Function(DesignComponent* parent, const FileContent* fC, NodeId id,
-           std::string name, DataType* returnType)
+           std::string_view name, DataType* returnType)
       : Procedure(parent, fC, id, name), m_returnType(returnType) {}
   bool compile(CompileHelper& compile_helper);
   ~Function() override = default;

--- a/include/Surelog/Design/Scope.h
+++ b/include/Surelog/Design/Scope.h
@@ -45,7 +45,7 @@ class Scope : public RTTI {
   typedef std::vector<Statement*> StmtVector;
   typedef std::vector<Scope*> ScopeVector;
 
-  Scope(const std::string& name, Scope* parent)
+  Scope(std::string_view name, Scope* parent)
       : m_name(name), m_parentScope(parent) {}
   ~Scope() override {}
 

--- a/include/Surelog/Package/Package.h
+++ b/include/Surelog/Package/Package.h
@@ -64,7 +64,8 @@ class Package : public DesignComponent {
   ClassNameClassDefinitionMultiMap& getClassDefinitions() {
     return m_classDefinitions;
   }
-  void addClassDefinition(std::string className, ClassDefinition* classDef) {
+  void addClassDefinition(std::string_view className,
+                          ClassDefinition* classDef) {
     m_classDefinitions.emplace(className, classDef);
   }
   ClassDefinition* getClassDefinition(std::string_view name);

--- a/include/Surelog/Testbench/FunctionMethod.h
+++ b/include/Surelog/Testbench/FunctionMethod.h
@@ -32,7 +32,7 @@ namespace SURELOG {
 class FunctionMethod : public Function {
  public:
   FunctionMethod(DesignComponent* parent, const FileContent* fC, NodeId id,
-                 std::string name, DataType* returnType, bool is_virtual,
+                 std::string_view name, DataType* returnType, bool is_virtual,
                  bool is_extern, bool is_static, bool is_local,
                  bool is_protected, bool is_pure)
       : Function(parent, fC, id, name, returnType),

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -480,7 +480,7 @@ void Design::orderPackages() {
   }
 }
 
-Package* Design::addPackageDefinition(const std::string& packageName,
+Package* Design::addPackageDefinition(std::string_view packageName,
                                       Package* package) {
   PackageNamePackageDefinitionMultiMap::iterator itr =
       m_packageDefinitions.find(packageName);

--- a/src/Design/Function.cpp
+++ b/src/Design/Function.cpp
@@ -27,7 +27,7 @@
 
 namespace SURELOG {
 Procedure::Procedure(DesignComponent* parent, const FileContent* fC, NodeId id,
-                     const std::string& name)
+                     std::string_view name)
     : Scope(name, nullptr),
       Statement(this, nullptr, fC, id,
                 fC ? fC->Type(id) : VObjectType::slFunction_prototype),


### PR DESCRIPTION
Instead of a vector, use a struct FunctionDefinition which provides named fields (Also it exposed that there are sometimes more fields that that are never used.)

Also, to avoid any allocation here, make the outer vector just an array and don't allocate std::strings, but have a lightweight std::string_view wrapper around string literals. No memory allocation needed at runtime.
In fact, the whole static initialization now can be expressed as a `constexpr`.
