### PR TITLE
Issue #3370: Fix compilation errors on MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,10 @@ else()
   )
 endif()
 
+if (WIN32)
+  add_compile_definitions(WIN32_LEAN_AND_MEAN)
+endif()
+
 # Flatbuffer
 set(flatbuffer-GENERATED_SRC
     ${GENDIR}/include/Surelog/Cache/header_generated.h
@@ -851,4 +855,4 @@ install(
 ADD_CUSTOM_TARGET(
   link_target ALL
   COMMAND ${CMAKE_COMMAND} -E create_symlink
-  build/compile_commands.json ${PROJECT_SOURCE_DIR}/compile_commands.json)
+  ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json ${PROJECT_SOURCE_DIR}/compile_commands.json)

--- a/include/Surelog/ErrorReporting/ErrorDefinition.h
+++ b/include/Surelog/ErrorReporting/ErrorDefinition.h
@@ -25,6 +25,27 @@
 #define SURELOG_ERRORDEFINITION_H
 #pragma once
 
+#if defined(_WIN32)
+  #if defined(FATAL)
+    #undef FATAL
+  #endif
+  #if defined(SYNTAX)
+    #undef SYNTAX
+  #endif
+  #if defined(ERROR)
+    #undef ERROR
+  #endif
+  #if defined(WARNING)
+    #undef WARNING
+  #endif
+  #if defined(INFO)
+    #undef INFO
+  #endif
+  #if defined(NOTE)
+    #undef NOTE
+  #endif
+#endif
+
 #include <map>
 #include <string>
 #include <string_view>


### PR DESCRIPTION
Issue #3370: Fix compilation errors on MinGW

* When Windows.h is included, it defines macros like ERROR & WARNING Undefined them conditionally.
* Use WIN32_LEAN_AND_MEAN definition if building for Windows platform