### PR TITLE
Swap out std::strtoxxxx in favor of std::from_chars for portability

### DIFF
--- a/include/Surelog/Utils/NumUtils.h
+++ b/include/Surelog/Utils/NumUtils.h
@@ -25,123 +25,167 @@
 #define SURELOG_NUMUTILS_H
 #pragma once
 
+#include <cctype>
+#include <charconv>
 #include <cstdint>
 #include <string>
-#include <charconv>
 #include <string_view>
-#include <ctype.h>
 
 namespace SURELOG {
-
-// These functions parse a number from a std::string_view into "result".
-// Returns the end of the number on success, nullptr otherwise.
-// So this can be used in a simple boolean context for success testing, but
-// as well in parsing context where advancing to the next position after the
-// number is needed.
-// All these functions require to check the return value to verify that parsing
-// worked.
-
-// Parse any number type with std::from_chars
-namespace internal {
-template <typename number_type>
-const char *strto_num(std::string_view s, number_type *result) {
-  while (!s.empty() && isspace(s.front())) s.remove_prefix(1);
-  if (!s.empty() && s.front() == '+') s.remove_prefix(1);
-  auto success = std::from_chars(s.data(), s.data() + s.size(), *result);
-  return (success.ec == std::errc()) ? success.ptr : nullptr;
-}
-
-template <typename sint_type, typename uint_type, typename result_type>
-const char *strto_int(std::string_view s, result_type *result) {
-  // std::from_chars can't deal with leading spaces or plus, so remove them.
-  while (!s.empty() && isspace(s.front())) s.remove_prefix(1);
-  if (!s.empty() && s.front() == '+') s.remove_prefix(1);
-  std::from_chars_result parse_result;
-  if (s.front() == '-') {
-    sint_type n = 0;
-    parse_result = std::from_chars(s.data(), s.data() + s.size(), n);
-    *result = static_cast<result_type>(n);
-  } else {
-    uint_type n = 0;
-    parse_result = std::from_chars(s.data(), s.data() + s.size(), n);
-    *result = static_cast<result_type>(n);
-  }
-  return (parse_result.ec == std::errc()) ? parse_result.ptr : nullptr;
-}
-}  // namespace internal
-
-// Parse int values.
-// Returns the pointer to one char after the parsed value or nullptr on failure.
-
-// Parse integer of the given size (int32_t, uint32_t, int64_t, uint64_t),
-// but be lenient in the sign interpretation.
-// The full signed negative range and positive unsigned range for the integer
-// of that size is allowed. The final value is cast to the signed or unsigned
-// potentially flipping the sign (but we're leniently allowing that).
-template <typename result_type>
-[[nodiscard]] inline const char* parse_int_lenient(std::string_view s,
-                                                   result_type* result) {
- if constexpr (sizeof(result_type) == 4) {
-    return internal::strto_int<int32_t, uint32_t, result_type>(s, result);
-  } else  {
-    return internal::strto_int<int64_t, uint64_t, result_type>(s, result);
-  }
-}
-
-  // Parse signed int32, stricly matching its range
-[[nodiscard]] inline const char* parse_int32(std::string_view s,
-                                             int32_t* result) {
-  return internal::strto_num(s, result);
-}
-    // Parse uint32, stricly matching its range; no negative numbers
-[[nodiscard]] inline const char* parse_uint32(std::string_view s,
-                                              uint32_t* result) {
-  return internal::strto_num(s, result);
-}
-
-  // Parse signed int64, stricly matching its range; no negative numbers
-[[nodiscard]] inline const char* parse_int64(std::string_view s,
-                                             int64_t* result) {
-  return internal::strto_num(s, result);
-}
-
-    // Parse uint64, stricly matching its range; no negative numbers
-[[nodiscard]] inline const char* parse_uint64(std::string_view s,
-                                              uint64_t* result) {
-  return internal::strto_num(s, result);
-}
-
-// Parse float value.
-// Returns the pointer to one char after the parsed value or nullptr on failure.
-[[nodiscard]] const char* parse_float(std::string_view s, float* result);
-
-// Parse double value.
-// Returns the pointer to one char after the parsed value or nullptr on failure.
-[[nodiscard]] const char* parse_double(std::string_view s, double* result);
-
-// Parse long double value.
-// Returns the pointer to one char after the parsed value or nullptr on failure.
-[[nodiscard]] const char *parse_longdouble(std::string_view s,
-                                           long double *result);
-
 class NumUtils final {
- public:
-  static std::string hexToBin(const std::string &s);
+ private:
+  // These functions parse a number from a std::string_view into "result".
+  // Returns the end of the number on success, nullptr otherwise.
+  // So this can be used in a simple boolean context for success testing, but
+  // as well in parsing context where advancing to the next position after the
+  // number is needed.
+  // All these functions require to check the return value to verify that
+  // parsing worked.
 
-  static std::string binToHex(const std::string &s);
+  // Parse any number type with std::from_chars
+  template <typename number_type>
+  static const char* strToNum(std::string_view s, int32_t base,
+                              number_type* result) {
+    while (!s.empty() && std::isspace(s.front())) s.remove_prefix(1);
+    if (!s.empty() && (s.front() == '+')) s.remove_prefix(1);
+    if (s.empty()) return nullptr;
+    auto success =
+        std::from_chars(s.data(), s.data() + s.size(), *result, base);
+    return (success.ec == std::errc()) ? success.ptr : nullptr;
+  }
+
+  template <typename sint_type, typename uint_type, typename result_type>
+  static const char* strToInt(std::string_view s, int32_t base,
+                              result_type* result) {
+    // std::from_chars can't deal with leading spaces or plus, so remove them.
+    while (!s.empty() && std::isspace(s.front())) s.remove_prefix(1);
+    if (!s.empty() && (s.front() == '+')) s.remove_prefix(1);
+    if (s.empty()) return nullptr;
+    std::from_chars_result parse_result;
+    // Try parsing as signed first
+    sint_type sn = 0;
+    parse_result = std::from_chars(s.data(), s.data() + s.size(), sn, base);
+    if (parse_result.ec == std::errc()) {
+      *result = static_cast<result_type>(sn);
+      return parse_result.ptr;
+    }
+
+    // If the number surely isn't -ve, try parsing as unsigned
+    if ((s.front() != '-') &&
+        (parse_result.ec == std::errc::result_out_of_range)) {
+      uint_type un = 0;
+      parse_result = std::from_chars(s.data(), s.data() + s.size(), un, base);
+      if (parse_result.ec == std::errc()) {
+        *result = static_cast<result_type>(un);
+        return parse_result.ptr;
+      }
+    }
+
+    return nullptr;
+  }
+
+ public:
+  static std::string hexToBin(std::string_view s);
+
+  static std::string binToHex(std::string_view s);
 
   static std::string toBinary(int size, uint64_t val);
 
-  static std::string trimLeadingZeros(const std::string &s);
-
   static uint64_t getMask(uint64_t wide);
+
+  // Parse int values.
+  // Returns the pointer to one char after the parsed value or nullptr on
+  // failure.
+
+  // Parse integer of the given size (int32_t, uint32_t, int64_t, uint64_t),
+  // but be lenient in the sign interpretation.
+  // The full signed negative range and positive unsigned range for the integer
+  // of that size is allowed. The final value is cast to the signed or unsigned
+  // potentially flipping the sign (but we're leniently allowing that).
+  template <typename result_type>
+  [[nodiscard]] inline static const char* parseIntLenient(std::string_view s,
+                                                          result_type* result) {
+    if constexpr (sizeof(result_type) == 4) {
+      return strToInt<int32_t, uint32_t, result_type>(s, 10, result);
+    } else {
+      return strToInt<int64_t, uint64_t, result_type>(s, 10, result);
+    }
+  }
+
+  // Parse signed int32, stricly matching its range
+  [[nodiscard]] inline static const char* parseInt32(std::string_view s,
+                                                     int32_t* result) {
+    return strToNum(s, 10, result);
+  }
+  // Parse uint32, stricly matching its range; no negative numbers
+  [[nodiscard]] inline static const char* parseUint32(std::string_view s,
+                                                      uint32_t* result) {
+    return strToNum(s, 10, result);
+  }
+
+  // Parse signed int64, stricly matching its range; no negative numbers
+  [[nodiscard]] inline static const char* parseInt64(std::string_view s,
+                                                     int64_t* result) {
+    return strToNum(s, 10, result);
+  }
+  // Parse uint64, stricly matching its range; no negative numbers
+  [[nodiscard]] inline static const char* parseUint64(std::string_view s,
+                                                      uint64_t* result) {
+    return strToNum(s, 10, result);
+  }
+
+  template <typename result_type>
+  [[nodiscard]] inline static const char* parseBinary(std::string_view s,
+                                                      result_type* result) {
+    if constexpr (sizeof(result_type) == 4) {
+      return strToInt<int32_t, uint32_t, result_type>(s, 2, result);
+    } else {
+      return strToInt<int64_t, uint64_t, result_type>(s, 2, result);
+    }
+  }
+
+  template <typename result_type>
+  [[nodiscard]] inline static const char* parseOctal(std::string_view s,
+                                                     result_type* result) {
+    if constexpr (sizeof(result_type) == 4) {
+      return strToInt<int32_t, uint32_t, result_type>(s, 8, result);
+    } else {
+      return strToInt<int64_t, uint64_t, result_type>(s, 8, result);
+    }
+  }
+
+  template <typename result_type>
+  [[nodiscard]] inline static const char* parseHex(std::string_view s,
+                                                   result_type* result) {
+    if constexpr (sizeof(result_type) == 4) {
+      return strToInt<int32_t, uint32_t, result_type>(s, 16, result);
+    } else {
+      return strToInt<int64_t, uint64_t, result_type>(s, 16, result);
+    }
+  }
+
+  // Parse float value.
+  // Returns the pointer to one char after the parsed value or nullptr on
+  // failure.
+  [[nodiscard]] static const char* parseFloat(std::string_view s,
+                                              float* result);
+
+  // Parse double value.
+  // Returns the pointer to one char after the parsed value or nullptr on
+  // failure.
+  [[nodiscard]] static const char* parseDouble(std::string_view s,
+                                               double* result);
+
+  // Parse long double value.
+  // Returns the pointer to one char after the parsed value or nullptr on
+  // failure.
+  [[nodiscard]] static const char* parseLongDouble(std::string_view s,
+                                                   long double* result);
 
  private:
   NumUtils() = delete;
-  NumUtils(const NumUtils &orig) = delete;
+  NumUtils(const NumUtils& orig) = delete;
   ~NumUtils() = delete;
-
- private:
 };
 
 };  // namespace SURELOG

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -965,7 +965,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       }
       if (!def.empty()) {
         SymbolId id = m_symbolTable->registerSymbol(def);
-        m_paramList.emplace(id, value);
+        m_paramList.emplace(id, StringUtils::unquoted(value));
       }
     } else if (all_arguments[i].find("-pvalue+") == 0) {
       std::string def;
@@ -979,7 +979,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       }
       if (!def.empty()) {
         SymbolId id = m_symbolTable->registerSymbol(def);
-        m_paramList.emplace(id, value);
+        m_paramList.emplace(id, StringUtils::unquoted(value));
       }
     } else if (all_arguments[i].find("-I") == 0) {
       fs::path include = undecorateArg(all_arguments[i].substr(2));

--- a/src/Utils/NumUtils_test.cpp
+++ b/src/Utils/NumUtils_test.cpp
@@ -20,29 +20,29 @@
 namespace SURELOG {
 TEST(NumUtilsTest, ParseDecimalInt) {
   int64_t value;
-  EXPECT_FALSE(parse_int64("hello", &value));
-  EXPECT_TRUE(parse_int64("123", &value));
+  EXPECT_FALSE(NumUtils::parseInt64("hello", &value));
+  EXPECT_TRUE(NumUtils::parseInt64("123", &value));
   EXPECT_EQ(123, value);
-  EXPECT_TRUE(parse_int64("+456", &value));
+  EXPECT_TRUE(NumUtils::parseInt64("+456", &value));
   EXPECT_EQ(456, value);
-  EXPECT_TRUE(parse_int64("-789", &value));
+  EXPECT_TRUE(NumUtils::parseInt64("-789", &value));
   EXPECT_EQ(-789, value);
-  EXPECT_TRUE(parse_int64(" 123 ", &value));
+  EXPECT_TRUE(NumUtils::parseInt64(" 123 ", &value));
   EXPECT_EQ(123, value);
 
   // Make sure we can parse beyond 32 bit.
-  EXPECT_TRUE(parse_int64("12345678901234", &value));
+  EXPECT_TRUE(NumUtils::parseInt64("12345678901234", &value));
   EXPECT_EQ(12345678901234LL, value);
 
   // Make sure we're not assumming a nul-byte at a particular point
   std::string_view longer_string("4255");
-  EXPECT_TRUE(parse_int64(longer_string.substr(0, 2), &value));
+  EXPECT_TRUE(NumUtils::parseInt64(longer_string.substr(0, 2), &value));
   EXPECT_EQ(42, value);
 
   // Make sure the returned value points to the characters after the number.
   const std::string_view input = " +314cm";
   const std::string_view expected_remain = input.substr(input.find("cm"));
-  const char *remain_string = parse_int64(input, &value);
+  const char *remain_string = NumUtils::parseInt64(input, &value);
   ASSERT_TRUE(remain_string);
   EXPECT_EQ(314, value);
   EXPECT_EQ(remain_string, expected_remain.data());  // pointers must match.
@@ -50,196 +50,206 @@ TEST(NumUtilsTest, ParseDecimalInt) {
 
 TEST(NumUtilsTest, ValidateRangeSigned32) {
   int32_t value;
-  EXPECT_TRUE(parse_int32("-1", &value));
+  EXPECT_TRUE(NumUtils::parseInt32("-1", &value));
   EXPECT_EQ(value, -1);
 
-  EXPECT_TRUE(parse_int32("2147483647", &value));
+  EXPECT_TRUE(NumUtils::parseInt32("2147483647", &value));
   EXPECT_EQ(value, 2147483647);
 
-  EXPECT_TRUE(parse_int32(" +2147483647", &value));  // Leading space and +
+  EXPECT_TRUE(
+      NumUtils::parseInt32(" +2147483647", &value));  // Leading space and +
   EXPECT_EQ(value, 2147483647);
 
-  EXPECT_TRUE(parse_int32("-2147483648", &value));
+  EXPECT_TRUE(NumUtils::parseInt32("-2147483648", &value));
   EXPECT_EQ(value, -2147483648);
 
-  EXPECT_FALSE(parse_int32("2147483648", &value));   // out of range.
-  EXPECT_FALSE(parse_int32("-2147483649", &value));  // out of range.
+  EXPECT_FALSE(NumUtils::parseInt32("2147483648", &value));   // out of range.
+  EXPECT_FALSE(NumUtils::parseInt32("-2147483649", &value));  // out of range.
 }
 
 TEST(NumUtilsTest, ValidateRangeUnsigned32) {
   uint32_t value;
-  EXPECT_FALSE(parse_uint32("-1", &value));
+  EXPECT_FALSE(NumUtils::parseUint32("-1", &value));
 
-  EXPECT_TRUE(parse_uint32("4294967295", &value));
+  EXPECT_TRUE(NumUtils::parseUint32("4294967295", &value));
   EXPECT_EQ(value, 4294967295);
 
-  EXPECT_TRUE(parse_uint32(" +4294967295", &value));
+  EXPECT_TRUE(NumUtils::parseUint32(" +4294967295", &value));
   EXPECT_EQ(value, 4294967295);
 
-  EXPECT_FALSE(parse_uint32("4294967296", &value));  // out of range.
+  EXPECT_FALSE(NumUtils::parseUint32("4294967296", &value));  // out of range.
 }
 
 TEST(NumUtilsTest, ValidateRangeSigned64) {
   int64_t value;
-  EXPECT_TRUE(parse_int64("-1", &value));
+  EXPECT_TRUE(NumUtils::parseInt64("-1", &value));
   EXPECT_EQ(value, -1);
 
-  EXPECT_TRUE(parse_int64("9223372036854775807", &value));
+  EXPECT_TRUE(NumUtils::parseInt64("9223372036854775807", &value));
   EXPECT_EQ(value, 9223372036854775807LL);
 
-  EXPECT_TRUE(parse_int64(" +9223372036854775807", &value));
+  EXPECT_TRUE(NumUtils::parseInt64(" +9223372036854775807", &value));
   EXPECT_EQ(value, 9223372036854775807LL);
 
-  EXPECT_TRUE(parse_int64("-9223372036854775808", &value));
+  EXPECT_TRUE(NumUtils::parseInt64("-9223372036854775808", &value));
   EXPECT_EQ(value, -9223372036854775807LL - 1);
 
-  EXPECT_FALSE(parse_int64("9223372036854775808", &value));   // out of range.
-  EXPECT_FALSE(parse_int64("-9223372036854775809", &value));  // out of range.
+  EXPECT_FALSE(
+      NumUtils::parseInt64("9223372036854775808", &value));  // out of range.
+  EXPECT_FALSE(
+      NumUtils::parseInt64("-9223372036854775809", &value));  // out of range.
 }
 
 TEST(NumUtilsTest, ValidateRangeUnsigned64) {
   uint64_t value;
-  EXPECT_FALSE(parse_uint64("-1", &value));
+  EXPECT_FALSE(NumUtils::parseUint64("-1", &value));
 
-  EXPECT_TRUE(parse_uint64("18446744073709551615", &value));
+  EXPECT_TRUE(NumUtils::parseUint64("18446744073709551615", &value));
   EXPECT_EQ(value, 18446744073709551615UL);
 
-  EXPECT_TRUE(parse_uint64(" +18446744073709551615", &value));
+  EXPECT_TRUE(NumUtils::parseUint64(" +18446744073709551615", &value));
   EXPECT_EQ(value, 18446744073709551615UL);
 
-  EXPECT_FALSE(parse_uint64("18446744073709551616", &value));  // out of range.
+  EXPECT_FALSE(
+      NumUtils::parseUint64("18446744073709551616", &value));  // out of range.
 }
 
 TEST(NumUtilsTest, ParseLenientSigned32) {
   int32_t value;
 
   // Invalid values
-  EXPECT_FALSE(parse_int_lenient("", &value));
-  EXPECT_FALSE(parse_int_lenient(" ", &value));
-  EXPECT_FALSE(parse_int_lenient("a", &value));
+  EXPECT_FALSE(NumUtils::parseIntLenient("", &value));
+  EXPECT_FALSE(NumUtils::parseIntLenient(" ", &value));
+  EXPECT_FALSE(NumUtils::parseIntLenient("a", &value));
 
   // Full signed range allowed
-  EXPECT_TRUE(parse_int_lenient("2147483647", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient("2147483647", &value));
   EXPECT_EQ(value, 2147483647);
 
-  EXPECT_TRUE(parse_int_lenient(" +2147483647", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient(" +2147483647", &value));
   EXPECT_EQ(value, 2147483647);
 
-  EXPECT_TRUE(parse_int_lenient("-2147483648", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient("-2147483648", &value));
   EXPECT_EQ(value, -2147483648);
 
   // Also full unsigned range allowed
-  EXPECT_TRUE(parse_int_lenient("4294967295", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient("4294967295", &value));
   EXPECT_EQ(value, -1);  // ... that aliases into negative signed
 
-  EXPECT_FALSE(parse_int_lenient("-2147483649", &value));  // range
-  EXPECT_FALSE(parse_int_lenient("4294967296", &value));   // range
+  EXPECT_FALSE(NumUtils::parseIntLenient("-2147483649", &value));  // range
+  EXPECT_FALSE(NumUtils::parseIntLenient("4294967296", &value));   // range
 }
 
 TEST(NumUtilsTest, ParseLenientUnsigned32) {
   uint32_t value;
 
   // Invalid values
-  EXPECT_FALSE(parse_int_lenient("", &value));
-  EXPECT_FALSE(parse_int_lenient(" ", &value));
-  EXPECT_FALSE(parse_int_lenient("a", &value));
+  EXPECT_FALSE(NumUtils::parseIntLenient("", &value));
+  EXPECT_FALSE(NumUtils::parseIntLenient(" ", &value));
+  EXPECT_FALSE(NumUtils::parseIntLenient("a", &value));
 
-  EXPECT_TRUE(parse_int_lenient("4294967295", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient("4294967295", &value));
   EXPECT_EQ(value, 4294967295);
 
-  EXPECT_TRUE(parse_int_lenient(" +4294967295", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient(" +4294967295", &value));
   EXPECT_EQ(value, 4294967295);
 
-  EXPECT_TRUE(parse_int_lenient("-1", &value));  // Signed value
+  EXPECT_TRUE(NumUtils::parseIntLenient("-1", &value));  // Signed value
   EXPECT_EQ(value, 4294967295);  // .. interpreted as all bits set
 
-  EXPECT_TRUE(parse_int_lenient(" -1 ", &value));  // also recognize with space
+  EXPECT_TRUE(
+      NumUtils::parseIntLenient(" -1 ", &value));  // also recognize with space
   EXPECT_EQ(value, 4294967295);
 
   // Full signed range allowed
-  EXPECT_TRUE(parse_int_lenient("2147483647", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient("2147483647", &value));
   EXPECT_EQ(value, 2147483647);
 
-  EXPECT_TRUE(parse_int_lenient("-2147483648", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient("-2147483648", &value));
   EXPECT_EQ(value, 2147483648);
 
-  EXPECT_FALSE(parse_int_lenient("-2147483649", &value));  // range
-  EXPECT_FALSE(parse_int_lenient("4294967296", &value));   // range
+  EXPECT_FALSE(NumUtils::parseIntLenient("-2147483649", &value));  // range
+  EXPECT_FALSE(NumUtils::parseIntLenient("4294967296", &value));   // range
 }
 
 TEST(NumUtilsTest, ParseLenientSigned64) {
   int64_t value;
 
   // Invalid values
-  EXPECT_FALSE(parse_int_lenient("", &value));
-  EXPECT_FALSE(parse_int_lenient(" ", &value));
-  EXPECT_FALSE(parse_int_lenient("a", &value));
+  EXPECT_FALSE(NumUtils::parseIntLenient("", &value));
+  EXPECT_FALSE(NumUtils::parseIntLenient(" ", &value));
+  EXPECT_FALSE(NumUtils::parseIntLenient("a", &value));
 
   // Full signed range allowed
-  EXPECT_TRUE(parse_int_lenient("9223372036854775807", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient("9223372036854775807", &value));
   EXPECT_EQ(value, 9223372036854775807L);
 
-  EXPECT_TRUE(parse_int_lenient(" +9223372036854775807", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient(" +9223372036854775807", &value));
   EXPECT_EQ(value, 9223372036854775807L);
 
-  EXPECT_TRUE(parse_int_lenient("-9223372036854775808", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient("-9223372036854775808", &value));
   EXPECT_EQ(value, -9223372036854775807L - 1);
 
   // Also full unsigned range allowed
-  EXPECT_TRUE(parse_int_lenient("18446744073709551615", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient("18446744073709551615", &value));
   EXPECT_EQ(value, -1);  // ... that aliases into negative signed
 
-  EXPECT_FALSE(parse_int_lenient("-9223372036854775809", &value));  // range
-  EXPECT_FALSE(parse_int_lenient("18446744073709551616", &value));  // range
+  EXPECT_FALSE(
+      NumUtils::parseIntLenient("-9223372036854775809", &value));  // range
+  EXPECT_FALSE(
+      NumUtils::parseIntLenient("18446744073709551616", &value));  // range
 }
 
 TEST(NumUtilsTest, ParseLenientUnsigned64) {
   uint64_t value;
 
   // Invalid values
-  EXPECT_FALSE(parse_int_lenient("", &value));
-  EXPECT_FALSE(parse_int_lenient(" ", &value));
-  EXPECT_FALSE(parse_int_lenient("a", &value));
+  EXPECT_FALSE(NumUtils::parseIntLenient("", &value));
+  EXPECT_FALSE(NumUtils::parseIntLenient(" ", &value));
+  EXPECT_FALSE(NumUtils::parseIntLenient("a", &value));
 
-  EXPECT_TRUE(parse_int_lenient("18446744073709551615", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient("18446744073709551615", &value));
   EXPECT_EQ(value, 18446744073709551615UL);
 
-  EXPECT_TRUE(parse_int_lenient(" +18446744073709551615", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient(" +18446744073709551615", &value));
   EXPECT_EQ(value, 18446744073709551615UL);
 
-  EXPECT_TRUE(parse_int_lenient("-1", &value));  // Signed value
+  EXPECT_TRUE(NumUtils::parseIntLenient("-1", &value));  // Signed value
   EXPECT_EQ(value, 18446744073709551615UL);  // .. interpreted as all bits set
 
-  EXPECT_TRUE(parse_int_lenient(" -1 ", &value));  // also recognize with space
+  EXPECT_TRUE(
+      NumUtils::parseIntLenient(" -1 ", &value));  // also recognize with space
   EXPECT_EQ(value, 18446744073709551615UL);
 
   // Full signed range allowed
-  EXPECT_TRUE(parse_int_lenient("9223372036854775807", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient("9223372036854775807", &value));
   EXPECT_EQ(value, 9223372036854775807UL);
 
-  EXPECT_TRUE(parse_int_lenient("-9223372036854775808", &value));
+  EXPECT_TRUE(NumUtils::parseIntLenient("-9223372036854775808", &value));
   EXPECT_EQ(value, 9223372036854775808UL);
 
-  EXPECT_FALSE(parse_int_lenient("-9223372036854775809", &value));  // range
-  EXPECT_FALSE(parse_int_lenient("18446744073709551616", &value));  // range
+  EXPECT_FALSE(
+      NumUtils::parseIntLenient("-9223372036854775809", &value));  // range
+  EXPECT_FALSE(
+      NumUtils::parseIntLenient("18446744073709551616", &value));  // range
 }
 
 TEST(NumUtilsTest, ParseFloat) {
   float value;
-  EXPECT_FALSE(parse_float("hello", &value));
-  EXPECT_TRUE(parse_float("123", &value));
+  EXPECT_FALSE(NumUtils::parseFloat("hello", &value));
+  EXPECT_TRUE(NumUtils::parseFloat("123", &value));
   EXPECT_EQ(123, value);
-  EXPECT_TRUE(parse_float("+456.5", &value));
+  EXPECT_TRUE(NumUtils::parseFloat("+456.5", &value));
   EXPECT_EQ(456.5, value);
-  EXPECT_TRUE(parse_float("-789", &value));
+  EXPECT_TRUE(NumUtils::parseFloat("-789", &value));
   EXPECT_EQ(-789, value);
-  EXPECT_TRUE(parse_float(" 123 ", &value));  // leading space
+  EXPECT_TRUE(NumUtils::parseFloat(" 123 ", &value));  // leading space
   EXPECT_EQ(123, value);
 
   // Make sure the returned value points to the characters after the number.
   const std::string_view input = " +314.159cm";
   const std::string_view expected_remain = input.substr(input.find("cm"));
-  const char *remain_string = parse_float(input, &value);
+  const char *remain_string = NumUtils::parseFloat(input, &value);
   ASSERT_TRUE(remain_string);
   EXPECT_NEAR(314.159, value, 0.0001);
   EXPECT_EQ(remain_string, expected_remain.data());  // pointers must match.
@@ -247,22 +257,22 @@ TEST(NumUtilsTest, ParseFloat) {
 
 TEST(NumUtilsTest, ParseDouble) {
   double value;
-  EXPECT_FALSE(parse_double("hello", &value));
-  EXPECT_TRUE(parse_double("123", &value));
+  EXPECT_FALSE(NumUtils::parseDouble("hello", &value));
+  EXPECT_TRUE(NumUtils::parseDouble("123", &value));
   EXPECT_EQ(123, value);
-  EXPECT_TRUE(parse_double("+456.5", &value));
+  EXPECT_TRUE(NumUtils::parseDouble("+456.5", &value));
   EXPECT_EQ(456.5, value);
-  EXPECT_TRUE(parse_double("-789", &value));
+  EXPECT_TRUE(NumUtils::parseDouble("-789", &value));
   EXPECT_EQ(-789, value);
-  EXPECT_TRUE(parse_double(" 123 ", &value));
+  EXPECT_TRUE(NumUtils::parseDouble(" 123 ", &value));
   EXPECT_EQ(123, value);
-  EXPECT_TRUE(parse_double("6.022e23", &value));
+  EXPECT_TRUE(NumUtils::parseDouble("6.022e23", &value));
   EXPECT_EQ(6.022e23, value);
 
   // Make sure the returned value points to the characters after the number.
   const std::string_view input = " +314.159cm";
   const std::string_view expected_remain = input.substr(input.find("cm"));
-  const char *remain_string = parse_double(input, &value);
+  const char *remain_string = NumUtils::parseDouble(input, &value);
   ASSERT_TRUE(remain_string);
   EXPECT_NEAR(314.159, value, 0.00001);
   EXPECT_EQ(remain_string, expected_remain.data());  // pointers must match.
@@ -270,20 +280,20 @@ TEST(NumUtilsTest, ParseDouble) {
 
 TEST(NumUtilsTest, ParseLongDouble) {
   long double value;
-  EXPECT_FALSE(parse_longdouble("hello", &value));
-  EXPECT_TRUE(parse_longdouble("123", &value));
+  EXPECT_FALSE(NumUtils::parseLongDouble("hello", &value));
+  EXPECT_TRUE(NumUtils::parseLongDouble("123", &value));
   EXPECT_EQ(123, value);
-  EXPECT_TRUE(parse_longdouble("+456.5", &value));
+  EXPECT_TRUE(NumUtils::parseLongDouble("+456.5", &value));
   EXPECT_EQ(456.5, value);
-  EXPECT_TRUE(parse_longdouble("-789", &value));
+  EXPECT_TRUE(NumUtils::parseLongDouble("-789", &value));
   EXPECT_EQ(-789, value);
-  EXPECT_TRUE(parse_longdouble(" 123 ", &value));
+  EXPECT_TRUE(NumUtils::parseLongDouble(" 123 ", &value));
   EXPECT_EQ(123, value);
 
   // Make sure the returned value points to the characters after the number.
   const std::string_view input = " +314.159cm";
   const std::string_view expected_remain = input.substr(input.find("cm"));
-  const char *remain_string = parse_longdouble(input, &value);
+  const char *remain_string = NumUtils::parseLongDouble(input, &value);
   ASSERT_TRUE(remain_string);
   EXPECT_NEAR(314.159, value, 0.00001);
   EXPECT_EQ(remain_string, expected_remain.data());  // pointers must match.


### PR DESCRIPTION
Swap out std::strtoxxxx in favor of std::from_chars for portability

Implemented NumUtils to contain all number related utility functions. Moved from global namespace to NumUtils class.

Known Issues:
Number parsing errors are largely ignored, to keep the behavior the same as previous implementation. Accounting for parse errors results in regression test failures. Will need to revisit these individually as a follow up.