### PR TITLE
Few build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ add_custom_command(
   # Unfortunately, cmake does not provide simple equivalents to
   # gmake's $(nodir $(surelog_grammars)).
   # So, we list them here all manually passing to the command.
-  COMMAND java -jar ${ANTLR_JAR_LOCATION} -Werror -Dlanguage=Cpp -package SURELOG
+  COMMAND ${Java_JAVA_EXECUTABLE} -jar ${ANTLR_JAR_LOCATION} -Werror -Dlanguage=Cpp -package SURELOG
              -o ${GENDIR}/src/parser/
              SV3_1aLexer.g4    SV3_1aParser.g4
              SV3_1aPpLexer.g4  SV3_1aPpParser.g4
@@ -655,7 +655,7 @@ endif()
 
 # Installation target
 install(
-  TARGETS surelog-bin
+  TARGETS surelog-bin roundtrip
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Libraries
@@ -706,7 +706,7 @@ if (SURELOG_WITH_PYTHON)
 endif()
 
 install(DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/pkg
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/surelog)
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(
   FILES ${PROJECT_SOURCE_DIR}/include/Surelog/CommandLine/CommandLineParser.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Surelog/CommandLine)

--- a/src/Common/PlatformFileSystem.cpp
+++ b/src/Common/PlatformFileSystem.cpp
@@ -363,13 +363,12 @@ PathId PlatformFileSystem::getPrecompiledDir(PathId programId,
   if (programFile.empty() || !programFile.has_parent_path()) return BadPathId;
 
   const std::filesystem::path programPath = programFile.parent_path();
-  const std::vector<std::filesystem::path> search_path = {
-      programPath,                     // Build path
-      programPath / "lib" / "surelog"  // Installation path
+  const std::vector<std::filesystem::path> search_paths = {
+      programPath,  // Build path
   };
 
   std::error_code ec;
-  for (const std::filesystem::path &dir : search_path) {
+  for (const std::filesystem::path &dir : search_paths) {
     const std::filesystem::path pkgDir = dir / kPrecompiledDirName;
     if ((std::filesystem::exists(dir, ec) && !ec) &&
         (std::filesystem::is_directory(pkgDir, ec) && !ec)) {

--- a/tests/TestInstall/CMakeLists.txt
+++ b/tests/TestInstall/CMakeLists.txt
@@ -65,7 +65,7 @@ target_link_directories(test_hellosureworld
 if (SURELOG_WITH_PYTHON)
   target_link_libraries(test_hellosureworld
     surelog
-    antlr4-runtime$<$<CXX_COMPILER_ID:MSVC,Clang>:-static>
+    antlr4-runtime$<$<BOOL:${WIN32}>:-static>
     flatbuffers
     uhdm
     capnp
@@ -76,7 +76,7 @@ if (SURELOG_WITH_PYTHON)
 else()
   target_link_libraries(test_hellosureworld
     surelog
-    antlr4-runtime$<$<CXX_COMPILER_ID:MSVC,Clang>:-static>
+    antlr4-runtime$<$<BOOL:${WIN32}>:-static>
     flatbuffers
     uhdm
     capnp


### PR DESCRIPTION
Few build fixes

* When invoking java from CMake use the executable that was found by the process rather than one available by default, for instance one from system PATH variable.
* Move 'pkg' folder from lib to bin during Surelog installation. The location in lib folder was probably a long standing error and was being compensated for in code as well. This change bring running from installed folder in sync with how it runs under the debugger.
* Publish 'roundtrip' executable
* TestInstall wasn't working under MSYS, incidentally, it wasn't even being verified in CI at all. Fixed.