### PR TITLE
Add an API to retrieve relative path in FileSystem

### DIFF
--- a/include/Surelog/Common/FileSystem.h
+++ b/include/Surelog/Common/FileSystem.h
@@ -59,12 +59,12 @@ class SymbolTable;
  *   Read/Write is used in context to text streams
  *   and Load/Save in context to binary streams.
  *
- * toPath vs. toPlatformPath:
+ * toPath vs. toPlatformAbsPath:
  *   toPath returns a printable representation of the PathId. This doesn't
  *     necessarily have to be a resolve-able path. What the string represent
  *     is up to the interpretation of the FileSystem implementation itself.
  * 
- *   toPlatformPath returns a std::filesystem::path representation of PathId.
+ *   toPlatformAbsPath returns a std::filesystem::path representation of PathId.
  *     The path itself can be non-existant, in certain cases, however
  *     it does have to exist because it is to be used by external processes
  *     like CMake or a system call to batch script. In short, the return path
@@ -72,11 +72,11 @@ class SymbolTable;
  *
  *   NOTE:
  *     toPath(id) == toPath(toPathId(toPath(id))) but
- *     toPlatformPath(id) <> toPlatformPath(toPathId(toPlatformPath(id)))
+ *     toPlatformAbsPath(id) <> toPlatformAbsPath(toPathId(toPlatformAbsPath(id)))
  * 
  *     i.e. string representation can be converted to id (and vice-versa)
  *     using toPathId & toPath but the same is not necessarily guaranteed
- *     between toPathId & toPlatformPath (primarily because of potential
+ *     between toPathId & toPlatformAbsPath (primarily because of potential
  *     normalization).
  *
  * Mappings:
@@ -122,7 +122,8 @@ class FileSystem {
   virtual std::string_view toPath(PathId id);
   // Returns platform specific path i.e. a path that can be mapped on disk
   // and can be used for, say, system commands.
-  virtual std::filesystem::path toPlatformPath(PathId id) = 0;
+  virtual std::filesystem::path toPlatformAbsPath(PathId id) = 0;
+  virtual std::filesystem::path toPlatformRelPath(PathId id) = 0;
 
   // Returns the current working directory as either the native filesystem
   // path or as a PathId registered in the input SymbolTable.

--- a/include/Surelog/Common/PlatformFileSystem.h
+++ b/include/Surelog/Common/PlatformFileSystem.h
@@ -56,7 +56,8 @@ class PlatformFileSystem : public FileSystem {
 
  public:
   PathId toPathId(std::string_view path, SymbolTable *symbolTable) override;
-  std::filesystem::path toPlatformPath(PathId id) override;
+  std::filesystem::path toPlatformAbsPath(PathId id) override;
+  std::filesystem::path toPlatformRelPath(PathId id) override;
 
   std::string getWorkingDir() override;
   std::set<std::string> getWorkingDirs() override;
@@ -173,7 +174,6 @@ class PlatformFileSystem : public FileSystem {
 
  protected:
   // Internal helpers
-  std::filesystem::path toRelPath(PathId id);
   void addConfiguration(const std::filesystem::path &sourceDir);
 
   virtual std::istream &openInput(const std::filesystem::path &filepath,

--- a/src/Common/PlatformFileSystem.cpp
+++ b/src/Common/PlatformFileSystem.cpp
@@ -68,11 +68,11 @@ PathId PlatformFileSystem::toPathId(std::string_view path,
   return PathId(symbolTable, (RawSymbolId)symbolId, symbol);
 }
 
-std::filesystem::path PlatformFileSystem::toPlatformPath(PathId id) {
+std::filesystem::path PlatformFileSystem::toPlatformAbsPath(PathId id) {
   return toPath(id);
 }
 
-std::filesystem::path PlatformFileSystem::toRelPath(PathId id) {
+std::filesystem::path PlatformFileSystem::toPlatformRelPath(PathId id) {
   int32_t minUpDirs = std::numeric_limits<int32_t>::max();
   std::filesystem::path bestPrefix;
   std::filesystem::path bestSuffix;
@@ -438,7 +438,7 @@ PathId PlatformFileSystem::getPpOutputFile(bool isUnitCompilation,
       isUnitCompilation ? kUnitCompileDirName : kAllCompileDirName;
   ppOutputFilepath /= kPreprocessLibraryDirName;
   ppOutputFilepath /= libraryName;
-  ppOutputFilepath /= toRelPath(sourceFileId);
+  ppOutputFilepath /= toPlatformRelPath(sourceFileId);
   PathId ppFileId = toPathId(ppOutputFilepath.string(), symbolTable);
   if (kEnableLogs) {
     std::cerr << "getPpOutputFile: " << PathIdPP(sourceFileId) << " => "
@@ -459,13 +459,13 @@ PathId PlatformFileSystem::getPpCacheFile(bool isUnitCompilation,
     ppCacheFile = getProgramPath().parent_path();
     ppCacheFile /= kPrecompiledDirName;
     ppCacheFile /= libraryName;
-    ppCacheFile /= toPlatformPath(sourceFileId).filename();
+    ppCacheFile /= toPlatformAbsPath(sourceFileId).filename();
   } else {
     ppCacheFile = m_outputDir;
     ppCacheFile /= isUnitCompilation ? kUnitCompileDirName : kAllCompileDirName;
     ppCacheFile /= kPreprocessCacheDirName;
     ppCacheFile /= libraryName;
-    ppCacheFile /= toRelPath(sourceFileId);
+    ppCacheFile /= toPlatformRelPath(sourceFileId);
   }
   ppCacheFile += ".slpp";
   const PathId ppCacheFileId = toPathId(ppCacheFile.string(), symbolTable);
@@ -523,7 +523,7 @@ PathId PlatformFileSystem::getPythonCacheFile(bool isUnitCompilation,
       isUnitCompilation ? kUnitCompileDirName : kAllCompileDirName;
   pythonCacheFile /= kPythonCacheDirName;
   pythonCacheFile /= libraryName;
-  pythonCacheFile /= toRelPath(sourceFileId);
+  pythonCacheFile /= toPlatformRelPath(sourceFileId);
   pythonCacheFile += ".slpy";
   PathId pyCacheFileId = toPathId(pythonCacheFile.string(), symbolTable);
   if (kEnableLogs) {

--- a/src/Common/PlatformFileSystem_test.cpp
+++ b/src/Common/PlatformFileSystem_test.cpp
@@ -249,7 +249,7 @@ TEST(PlatformFileSystemTest, LocateFile) {
   PathId now_exists =
       fileSystem->locate(search_file, directories, symbolTable.get());
   EXPECT_NE(now_exists, BadPathId);
-  EXPECT_EQ(fileSystem->toPlatformPath(now_exists), actual_loc_1);
+  EXPECT_EQ(fileSystem->toPlatformAbsPath(now_exists), actual_loc_1);
 
   PathId already_found =
       fileSystem->locate(search_file, directories, symbolTable.get());
@@ -261,7 +261,7 @@ TEST(PlatformFileSystemTest, LocateFile) {
   PathId now_exists_1 =
       fileSystem->locate(search_file, directories, symbolTable.get());
   EXPECT_NE(now_exists_1, BadPathId);
-  EXPECT_EQ(fileSystem->toPlatformPath(now_exists_1), actual_loc_1);
+  EXPECT_EQ(fileSystem->toPlatformAbsPath(now_exists_1), actual_loc_1);
 
   EXPECT_TRUE(fileSystem->remove(now_exists_1));
   EXPECT_FALSE(fileSystem->exists(now_exists_1));
@@ -269,7 +269,7 @@ TEST(PlatformFileSystemTest, LocateFile) {
   PathId now_exists_2 =
       fileSystem->locate(search_file, directories, symbolTable.get());
   EXPECT_NE(now_exists_2, BadPathId);
-  EXPECT_EQ(fileSystem->toPlatformPath(now_exists_2), actual_loc_2);
+  EXPECT_EQ(fileSystem->toPlatformAbsPath(now_exists_2), actual_loc_2);
 
   EXPECT_TRUE(fileSystem->rmtree(
       fileSystem->toPathId(basedir.string(), symbolTable.get())));
@@ -286,7 +286,7 @@ TEST(PlatformFileSystemTest, PathRelations) {
   PathId fileId =
       fileSystem->toPathId((base / "abc.txt").string(), symbolTable.get());
   PathId fileDirId = fileSystem->getParent(fileId, symbolTable.get());
-  EXPECT_EQ(base, fileSystem->toPlatformPath(fileDirId));
+  EXPECT_EQ(base, fileSystem->toPlatformAbsPath(fileDirId));
 
   PathId siblingId =
       fileSystem->getSibling(fileId, "def.txt", symbolTable.get());

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -4060,7 +4060,7 @@ vpiHandle UhdmWriter::write(PathId uhdmFileId) {
   adjuster->listenDesigns(designs);
   delete adjuster;
 
-  const fs::path uhdmFile = fileSystem->toPlatformPath(uhdmFileId);
+  const fs::path uhdmFile = fileSystem->toPlatformAbsPath(uhdmFileId);
   if (m_compileDesign->getCompiler()->getCommandLineParser()->writeUhdm()) {
     Error err(ErrorDefinition::UHDM_WRITE_DB, loc);
     m_compileDesign->getCompiler()->getErrorContainer()->addError(err);

--- a/src/ErrorReporting/Report.cpp
+++ b/src/ErrorReporting/Report.cpp
@@ -142,9 +142,10 @@ std::pair<bool, bool> Report::makeDiffCompUnitReport(CommandLineParser* clp,
 
   const PathId allCompileDirId = fileSystem->getCompileDir(false, st);
   const PathId unitCompileDirId = fileSystem->getCompileDir(true, st);
-  const fs::path allCompileDir = fileSystem->toPlatformPath(allCompileDirId);
-  const fs::path unitCompileDir = fileSystem->toPlatformPath(unitCompileDirId);
-  const fs::path diffFile = fileSystem->toPlatformPath(diffFileId);
+  const fs::path allCompileDir = fileSystem->toPlatformAbsPath(allCompileDirId);
+  const fs::path unitCompileDir =
+      fileSystem->toPlatformAbsPath(unitCompileDirId);
+  const fs::path diffFile = fileSystem->toPlatformAbsPath(diffFileId);
 
   std::string diffCmd = StrCat("diff -r ", unitCompileDir, " ", allCompileDir,
                                " --exclude cache --brief > ", diffFile);

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -350,9 +350,9 @@ bool Compiler::createMultiProcessParser_() {
   // Create CMakeLists.txt
   const bool muted = m_commandLineParser->muteStdout();
   const fs::path outputDir =
-      fileSystem->toPlatformPath(m_commandLineParser->getOutputDirId());
+      fileSystem->toPlatformAbsPath(m_commandLineParser->getOutputDirId());
   const fs::path programPath =
-      fileSystem->toPlatformPath(m_commandLineParser->getProgramId());
+      fileSystem->toPlatformAbsPath(m_commandLineParser->getProgramId());
   const std::string_view profile =
       m_commandLineParser->profile() ? " -profile " : " ";
   const std::string_view sverilog =
@@ -441,7 +441,7 @@ bool Compiler::createMultiProcessParser_() {
     absoluteIndex++;
     for (const auto compiler : jobArray[i]) {
       fs::path fileName =
-          fileSystem->toPlatformPath(compiler->getPpOutputFileId());
+          fileSystem->toPlatformAbsPath(compiler->getPpOutputFileId());
       std::string_view svFile =
           m_commandLineParser->isSVFile(compiler->getFileId()) ? " -sv " : " ";
       StrAppend(&fileList, svFile, fileName);
@@ -549,9 +549,9 @@ bool Compiler::createMultiProcessPreProcessor_() {
   const bool muted = m_commandLineParser->muteStdout();
   const fs::path workingDir = fileSystem->getWorkingDir();
   const fs::path outputDir =
-      fileSystem->toPlatformPath(m_commandLineParser->getOutputDirId());
+      fileSystem->toPlatformAbsPath(m_commandLineParser->getOutputDirId());
   const fs::path programPath =
-      fileSystem->toPlatformPath(m_commandLineParser->getProgramId());
+      fileSystem->toPlatformAbsPath(m_commandLineParser->getProgramId());
   const std::string_view profile =
       m_commandLineParser->profile() ? " -profile " : " ";
   const std::string_view sverilog =


### PR DESCRIPTION
Add an API to retrieve relative path in FileSystem

Also, renamed toPlatformPath to toPlatformAbsPath to be explicit about absolute vs. relative.