### PR TITLE
Issue #3410: -nocache option shouldn't disable precompiled cache

### DIFF
--- a/include/Surelog/CommandLine/CommandLineParser.h
+++ b/include/Surelog/CommandLine/CommandLineParser.h
@@ -83,11 +83,15 @@ class CommandLineParser final {
   bool writePpOutput() const { return m_writePpOutput; }
   void setwritePpOutput(bool value) { m_writePpOutput = value; }
   bool cacheAllowed() const { return m_cacheAllowed; }
+  bool writeCache() const { return m_writeCache; }
+  bool precompiledCacheAllowed() const { return m_precompiledCacheAllowed; }
   bool debugCache() const { return m_debugCache; }
   void debugCache(bool on) { m_debugCache = on; }
   void noCacheHash(bool noCachePath) { m_noCacheHash = noCachePath; }
   bool noCacheHash() const { return m_noCacheHash; }
   void setCacheAllowed(bool val) { m_cacheAllowed = val; }
+  void setWriteCache(bool val) { m_writeCache = val; }
+  void setPrecompiledCacheAllowed(bool val) { m_precompiledCacheAllowed = val; }
   bool lineOffsetsAsComments() const { return m_lineOffsetsAsComments; }
   PathId getCacheDirId() const { return m_cacheDirId; }
   PathId getPrecompiledDirId() const { return m_precompiledDirId; }
@@ -305,6 +309,8 @@ class CommandLineParser final {
   bool m_diffCompMode;
   bool m_help;
   bool m_cacheAllowed;
+  bool m_writeCache;
+  bool m_precompiledCacheAllowed;
   bool m_debugCache;
   bool m_debugFSConfig;
   unsigned short int m_nbMaxTreads;

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -199,9 +199,7 @@ bool PPCache::restore_(PathId cacheFileId, const std::vector<char>& content,
 bool PPCache::checkCacheIsValid_(PathId cacheFileId,
                                  const std::vector<char>& content) const {
   if (!cacheFileId || content.empty()) return false;
-
-  CommandLineParser* clp = m_pp->getCompileSourceFile()->getCommandLineParser();
-  if (!clp->cacheAllowed() || m_pp->isMacroBody()) return false;
+  if (m_pp->isMacroBody()) return false;
 
   if (!MACROCACHE::PPCacheBufferHasIdentifier(content.data())) {
     return false;
@@ -225,6 +223,7 @@ bool PPCache::checkCacheIsValid_(PathId cacheFileId,
     return false;
   }
 
+  CommandLineParser* clp = m_pp->getCompileSourceFile()->getCommandLineParser();
   if (clp->parseOnly() || clp->lowMem()) return true;
 
   const auto cacheSymbols = ppcache->symbols();
@@ -288,9 +287,9 @@ bool PPCache::checkCacheIsValid_(PathId cacheFileId,
 
 bool PPCache::checkCacheIsValid_(PathId cacheFileId) const {
   if (!cacheFileId) return false;
+  if (m_pp->isMacroBody()) return false;
 
   CommandLineParser* clp = m_pp->getCompileSourceFile()->getCommandLineParser();
-  if (!clp->cacheAllowed() || m_pp->isMacroBody()) return false;
   if (clp->parseOnly() || clp->lowMem()) return true;
 
   std::vector<char> content;
@@ -303,8 +302,15 @@ bool PPCache::isValid() {
 }
 
 bool PPCache::restore(bool errorsOnly) {
+  if (m_pp->isMacroBody()) return false;
+
   CommandLineParser* clp = m_pp->getCompileSourceFile()->getCommandLineParser();
-  if (!clp->cacheAllowed() || m_pp->isMacroBody()) return false;
+  Precompiled* prec = Precompiled::getSingleton();
+  if (prec->isFilePrecompiled(m_pp->getFileId(LINE1), clp->getSymbolTable())) {
+    if (!clp->precompiledCacheAllowed()) return false;
+  } else {
+    if (!clp->cacheAllowed()) return false;
+  }
 
   PathId cacheFileId = getCacheFileId_(BadPathId);
   std::vector<char> content;
@@ -315,11 +321,14 @@ bool PPCache::restore(bool errorsOnly) {
 }
 
 bool PPCache::save() {
+  if (m_pp->isMacroBody()) return true;
+
   CommandLineParser* clp = m_pp->getCompileSourceFile()->getCommandLineParser();
-  if (!clp->cacheAllowed() || m_pp->isMacroBody()) return true;
+  if (!clp->writeCache()) return true;
 
   FileSystem* const fileSystem = FileSystem::getInstance();
   FileContent* fcontent = m_pp->getFileContent();
+
   if (fcontent && (fcontent->getVObjects().size() > Cache::Capacity)) {
     clp->setCacheAllowed(false);
     Location loc(BadSymbolId);

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -202,8 +202,12 @@ static const std::initializer_list<std::string_view> helpText = {
     "                        slpp_unit/)",
     "  -lineoffsetascomments Writes the preprocessor line offsets as comments",
     "                        as opposed as parser directives",
-    "  -nocache              Default allows to create a cache for include",
-    "                        files, this option prevents it",
+    "  -nocache              Default allows to read cache for include files,",
+    "                        this option prevents it",
+    "  -noprecompiledcache   Default allows to read precompiled cache, this",
+    "                        option prevents it",
+    "  -nowritecache         Default allows writing cache, this option",
+    "                        prevents it",
     "  -cache <dir>          Specifies the cache directory, default is",
     "                        slpp_all/cache or slpp_unit/cache",
     "  -nohash               Treat cache as always valid (no",
@@ -356,6 +360,8 @@ CommandLineParser::CommandLineParser(ErrorContainer* errors,
       m_diffCompMode(diffCompMode),
       m_help(false),
       m_cacheAllowed(true),
+      m_writeCache(true),
+      m_precompiledCacheAllowed(true),
       m_debugCache(false),
       m_debugFSConfig(false),
       m_nbMaxTreads(0),
@@ -1103,6 +1109,9 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       m_blackboxInstances.insert(all_arguments[i]);
     } else if (all_arguments[i] == "-createcache") {
       m_createCache = true;
+      m_writeCache = true;
+    } else if (all_arguments[i] == "-nowritecache") {
+      m_writeCache = false;
     } else if (all_arguments[i] == "-lineoffsetascomments") {
       m_lineOffsetsAsComments = true;
     } else if (all_arguments[i] == "-v") {
@@ -1252,6 +1261,7 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
       m_parseOnly = true;
     } else if (all_arguments[i] == "-init") {
       m_cacheAllowed = false;
+      m_writeCache = false;
       cleanCache();
     } else if (all_arguments[i] == "-sepcomp") {
       m_sepComp = true;
@@ -1348,6 +1358,10 @@ bool CommandLineParser::parseCommandLine(int argc, const char** argv) {
         std::cerr << "ERROR: No Python allowed, check your arguments!\n";
     } else if (all_arguments[i] == "-nocache") {
       m_cacheAllowed = false;
+    } else if (all_arguments[i] == "-nowritecache") {
+      m_writeCache = false;
+    } else if (all_arguments[i] == "-noprecompiledcache") {
+      m_precompiledCacheAllowed = false;
     } else if (all_arguments[i] == "-sv") {
       if (((i + 1) < all_arguments.size()) &&
           (all_arguments[i + 1][0] != '-')) {

--- a/src/Common/PlatformFileSystem.cpp
+++ b/src/Common/PlatformFileSystem.cpp
@@ -842,7 +842,12 @@ PathId PlatformFileSystem::locate(std::string_view name,
       const std::filesystem::path filepath =
           normalize(std::filesystem::path(toPath(dirId)) / name);
       if (!filepath.empty() && std::filesystem::exists(filepath, ec) && !ec) {
-        return toPathId(filepath.string(), symbolTable);
+        PathId resultId = toPathId(filepath.string(), symbolTable);
+        if (kEnableLogs) {
+          std::cerr << "locate: " << name << " => " << PathIdPP(resultId)
+                    << std::endl;
+        }
+        return resultId;
       }
     }
   }
@@ -869,6 +874,14 @@ PathIdVector &PlatformFileSystem::collect(PathId dirId,
           container.emplace_back(toPathId(filepath.string(), symbolTable));
         }
       }
+    }
+  }
+
+  if (kEnableLogs) {
+    std::cerr << "collect: " << PathIdPP(dirId) << ", " << extension << " => "
+              << std::endl;
+    for (const PathId &fileId : container) {
+      std::cerr << "    " << PathIdPP(fileId) << std::endl;
     }
   }
 
@@ -958,6 +971,14 @@ PathIdVector &PlatformFileSystem::matching(PathId dirId,
           container.emplace_back(toPathId(absolute.string(), symbolTable));
         }
       }
+    }
+  }
+
+  if (kEnableLogs) {
+    std::cerr << "matching: " << PathIdPP(dirId) << ", " << pattern << " => "
+              << std::endl;
+    for (PathId fileId : container) {
+      std::cerr << "    " << PathIdPP(fileId) << std::endl;
     }
   }
 

--- a/src/Common/PlatformFileSystem_test.cpp
+++ b/src/Common/PlatformFileSystem_test.cpp
@@ -607,6 +607,12 @@ class InMemoryFileSystem : public TestFileSystem {
     return *it.first->get();
   }
 
+  bool saveContent(PathId fileId, const char *content, std::streamsize length,
+                   bool useTemp) override {
+    // Can't use temporary with virtual file system
+    return TestFileSystem::saveContent(fileId, content, length, false);
+  }
+
   bool close(std::ostream &strm) override {
     std::scoped_lock<std::mutex> lock(m_outputStreamsMutex);
 

--- a/third_party/tests/BuildOVMPkg/BuildOVMPkg.sl
+++ b/third_party/tests/BuildOVMPkg/BuildOVMPkg.sl
@@ -1,1 +1,1 @@
-   -createcache +incdir+../../../UVM/ovm-2.1.2/src/ +incdir+../../../UVM/vmm-1.1.1a/sv ../../../UVM/ovm-2.1.2/src/ovm_pkg.sv  -writepp -verbose  -mt 0 -parse -nocache
+   -createcache -noprecompiledcache -nowritecache +incdir+../../../UVM/ovm-2.1.2/src/ +incdir+../../../UVM/vmm-1.1.1a/sv ../../../UVM/ovm-2.1.2/src/ovm_pkg.sv  -writepp -verbose  -mt 0 -parse -nocache

--- a/third_party/tests/BuildUVMPkg/BuildUVMPkg.sl
+++ b/third_party/tests/BuildUVMPkg/BuildUVMPkg.sl
@@ -1,1 +1,1 @@
-  ../../../UVM/1800.2-2017-1.0/pp_output/uvm_pkg.sv -verbose -parse -d coveruhdm -nocache -createcache
+  ../../../UVM/1800.2-2017-1.0/pp_output/uvm_pkg.sv -verbose -parse -d coveruhdm -nocache -createcache -noprecompiledcache -nowritecache


### PR DESCRIPTION
Issue #3410: -nocache option shouldn't disable precompiled cache

* Check for whether cache is allowed or not only in public API functions.
* Two new options - noprecompilecache & nowritecache
* nocache & noprecompilecache controls cache reading
* nowritecache controls cache writing