### PR TITLE
Issue #3434: vpiModule & vpiInterface are part of standard

### DIFF
--- a/src/hellodesign.cpp
+++ b/src/hellodesign.cpp
@@ -39,10 +39,10 @@ class DesignListener final : public UHDM::VpiListener {
   void enterModule_inst(const UHDM::module_inst *const object,
                         vpiHandle handle) final {
     std::string_view instName = object->VpiName();
-    m_flatTraversal = (instName.empty()) &&
-                      ((object->VpiParent() == 0) ||
-                       ((object->VpiParent() != 0) &&
-                        (object->VpiParent()->VpiType() != vpiModuleInst)));
+    m_flatTraversal =
+        (instName.empty()) && ((object->VpiParent() == 0) ||
+                               ((object->VpiParent() != 0) &&
+                                (object->VpiParent()->VpiType() != vpiModule)));
     if (m_flatTraversal)
       std::cout << "Entering Module Definition: " << object->VpiDefName() << " "
                 << intptr_t(object) << " " << object->UhdmId() << std::endl;

--- a/src/hellouhdm.cpp
+++ b/src/hellouhdm.cpp
@@ -102,7 +102,7 @@ int main(int argc, const char** argv) {
     result += "Module List:\n";
     vpiHandle modItr = vpi_iterate(UHDM::uhdmallModules, the_design);
     while (vpiHandle obj_h = vpi_scan(modItr)) {
-      if (vpi_get(vpiType, obj_h) != vpiModuleInst) {
+      if (vpi_get(vpiType, obj_h) != vpiModule) {
         result += "ERROR: this is not a module\n";
       }
       std::string defName;
@@ -173,16 +173,16 @@ int main(int argc, const char** argv) {
 
             // Recursive tree traversal
             margin = "  " + margin;
-            if (vpi_get(vpiType, obj_h) == vpiModuleInst ||
+            if (vpi_get(vpiType, obj_h) == vpiModule ||
                 vpi_get(vpiType, obj_h) == vpiGenScope) {
-              vpiHandle subItr = vpi_iterate(vpiModuleInst, obj_h);
+              vpiHandle subItr = vpi_iterate(vpiModule, obj_h);
               while (vpiHandle sub_h = vpi_scan(subItr)) {
                 res += inst_visit(sub_h, margin);
                 vpi_release_handle(sub_h);
               }
               vpi_release_handle(subItr);
             }
-            if (vpi_get(vpiType, obj_h) == vpiModuleInst ||
+            if (vpi_get(vpiType, obj_h) == vpiModule ||
                 vpi_get(vpiType, obj_h) == vpiGenScope) {
               vpiHandle subItr = vpi_iterate(vpiGenScopeArray, obj_h);
               while (vpiHandle sub_h = vpi_scan(subItr)) {


### PR DESCRIPTION
Issue #3434: vpiModule & vpiInterface are part of standard

Follow up to a previous change where vpiModule & vpiInterface were renamed to vpiModuleInst & vpiInterfaceInst, respectively. This is flawed and doesn't meet the vpi standard. Reverting the names back to vpiModule & vpiInterface. However, the classes generated against the models remain named module_inst & interface_inst.

Paired with chipsalliance/UHDM#860