### PR TITLE
Fix a race condition

### DIFF
--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -306,7 +306,8 @@ bool PPCache::restore(bool errorsOnly) {
 
   CommandLineParser* clp = m_pp->getCompileSourceFile()->getCommandLineParser();
   Precompiled* prec = Precompiled::getSingleton();
-  if (prec->isFilePrecompiled(m_pp->getFileId(LINE1), clp->getSymbolTable())) {
+  if (prec->isFilePrecompiled(m_pp->getFileId(LINE1),
+                              m_pp->getCompileSourceFile()->getSymbolTable())) {
     if (!clp->precompiledCacheAllowed()) return false;
   } else {
     if (!clp->cacheAllowed()) return false;

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -181,7 +181,9 @@ bool ParseCache::restore() {
       m_parse->getCompileSourceFile()->getCommandLineParser();
 
   Precompiled* const prec = Precompiled::getSingleton();
-  if (prec->isFilePrecompiled(m_parse->getPpFileId(), clp->getSymbolTable())) {
+  if (prec->isFilePrecompiled(
+          m_parse->getPpFileId(),
+          m_parse->getCompileSourceFile()->getSymbolTable())) {
     if (!clp->precompiledCacheAllowed()) return false;
   } else {
     if (!clp->cacheAllowed()) return false;


### PR DESCRIPTION
Fix a race condition

Use the correct SymbolTable when retoring cache otherwise we end up creating a race condition.