### PR TITLE
A few parser fixes/tweaks

### DIFF
--- a/grammar/SV3_1aLexer.g4
+++ b/grammar/SV3_1aLexer.g4
@@ -26,161 +26,161 @@ lexer grammar SV3_1aLexer;
 }
 
 channels {
-   WHITESPACES,
-   COMMENTS
+  WHITESPACES,
+  COMMENTS
 }
 
-QMARK : '?' ;
+QMARK: '?';
 
-TICK_b0 : '\'b0' ;
+TICK_b0: '\'b0';
 
-TICK_b1 : '\'b1' ;
+TICK_b1: '\'b1';
 
-TICK_B0 : '\'B0' ;
+TICK_B0: '\'B0';
 
-TICK_B1 : '\'B1' ;
+TICK_B1: '\'B1';
 
-TICK_0 : '\'0' ;
+TICK_0: '\'0';
 
-TICK_1 : '\'1' ;
+TICK_1: '\'1';
 
-ONE_TICK_b0 : '1\'b0' ;
+ONE_TICK_b0: '1\'b0';
 
-ONE_TICK_b1 : '1\'b1' ;
+ONE_TICK_b1: '1\'b1';
 
-ONE_TICK_bx : '1\'bx' ;
+ONE_TICK_bx: '1\'bx';
 
-ONE_TICK_bX : '1\'bX' ;
+ONE_TICK_bX: '1\'bX';
 
-ONE_TICK_B0 : '1\'B0' ;
+ONE_TICK_B0: '1\'B0';
 
-ONE_TICK_B1 : '1\'B1' ;
+ONE_TICK_B1: '1\'B1';
 
-ONE_TICK_Bx : '1\'Bx' ;
+ONE_TICK_Bx: '1\'Bx';
 
-ONE_TICK_BX : '1\'BX' ;
+ONE_TICK_BX: '1\'BX';
 
-Pound_Pound_delay : '##' (' ')* [0-9] [0-9_.]* ;
+Pound_Pound_delay: '##' ' '* [0-9] [0-9_.]*;
 
-Pound_delay : '#' (' ')* [0-9] [0-9_.]* ;
+Pound_delay: '#' ' '* [0-9] [0-9_.]*;
 
-fragment
-Non_zero_unsigned_number : '1'..'9' ( '_' | Decimal_digit )* ;
+fragment Non_zero_unsigned_number
+  : '1' ..'9' ('_' | Decimal_digit)*
+  ;
 
-fragment
-Decimal_number
-    : Unsigned_number
-    | ( Non_zero_unsigned_number ' '* )? Decimal_base ' '* Unsigned_number
-    | ( Non_zero_unsigned_number ' '* )? Decimal_base ' '* X_digit ( '_' )*
-    | ( Non_zero_unsigned_number ' '* )? Decimal_base ' '* Z_digit ( '_' )*
-    ;
+fragment Decimal_number
+  : Unsigned_number
+  | (Non_zero_unsigned_number ' '*)? Decimal_base ' '* Unsigned_number
+  | (Non_zero_unsigned_number ' '*)? Decimal_base ' '* X_digit '_'*
+  | (Non_zero_unsigned_number ' '*)? Decimal_base ' '* Z_digit '_'*
+  ;
 
 /* binary_number ::= [ size ] binary_base binary_value */
 
-fragment
-Binary_number : ( Non_zero_unsigned_number ' '* )? Binary_base ' '* Binary_value ;
+fragment Binary_number
+  : (Non_zero_unsigned_number ' '*)? Binary_base ' '* Binary_value
+  ;
 
 /* octal_number ::= [ size ] octal_base octal_value */
 
-fragment
-Octal_number : ( Non_zero_unsigned_number ' '* )? Octal_base ' '* Octal_value ;
+fragment Octal_number
+  : (Non_zero_unsigned_number ' '*)? Octal_base ' '* Octal_value
+  ;
 
 /* hex_number ::= [ size ] hex_base hex_value */
 
-fragment
-Hex_number : ( Non_zero_unsigned_number ' '* )? Hex_base ' '* Hex_value ;
+fragment Hex_number
+  : (Non_zero_unsigned_number ' '*)? Hex_base ' '* Hex_value
+  ;
 
 Integral_number
-    :   Decimal_number
-    |   Octal_number
-    |   Binary_number
-    |   Hex_number
-    ;
+  : Decimal_number
+  | Octal_number
+  | Binary_number
+  | Hex_number
+  ;
 
 /* real_number ::=
-fixed_point_number
-| unsigned_number [ . unsigned_number ] exp [ sign ] unsigned_number */
+ fixed_point_number
+ | unsigned_number [ . unsigned_number ] exp [ sign ]
+ unsigned_number
+ */
 
 Real_number
-    :   Fixed_point_number
-    |   Unsigned_number ( '.' Unsigned_number )? ('e'|'E') ( PLUS | MINUS )? Unsigned_number
-    ;
+  : Fixed_point_number
+  | Unsigned_number ('.' Unsigned_number)? ('e' | 'E') (
+    PLUS
+    | MINUS
+  )? Unsigned_number
+  ;
 
 /* fixed_point_number <<1>> ::= unsigned_number . unsigned_number */
 
-fragment
-Fixed_point_number : Unsigned_number DOT Unsigned_number ;
+fragment Fixed_point_number
+  : Unsigned_number DOT Unsigned_number
+  ;
 
 /* unsigned_number <<1>> ::= decimal_digit { _ | decimal_digit } */
 
-fragment
-Unsigned_number : Decimal_digit ( '_' | Decimal_digit )* ;
+fragment Unsigned_number: Decimal_digit ('_' | Decimal_digit)*;
 
-/* binary_value <<1>> ::= binary_digit { _ | binary_digit } */
+/* binary_value <<1>> ::= binary_digit {_ | binary_digit} */
 
-fragment
-Binary_value : ('_')* Binary_digit ( '_' | Binary_digit )* ;
+fragment Binary_value
+  : '_'* Binary_digit ('_' | Binary_digit)*
+  ;
 
 /* octal_value <<1>> ::= octal_digit { _ | octal_digit } */
 
-fragment
-Octal_value : ('_')* Octal_digit ( '_' | Octal_digit )* ;
+fragment Octal_value: '_'* Octal_digit ('_' | Octal_digit)*;
 
 /* hex_value <<1>> ::= hex_digit { _ | hex_digit } */
 
-fragment
-Hex_value : ('_')* Hex_digit ( '_' | Hex_digit )* ;
+fragment Hex_value: '_'* Hex_digit ('_' | Hex_digit)*;
 
 /* decimal_base <<1>> ::= [s|S]d | [s|S]D */
 
-fragment
-Decimal_base : '\'' ('s' | 'S')? ('d' | 'D') ;
+fragment Decimal_base: '\'' ('s' | 'S')? ('d' | 'D');
 
 /* binary_base <<1>> ::= [s|S]b | [s|S]B */
 
-fragment
-Binary_base : '\'' ('s' | 'S')? ('b' | 'B') ;
+fragment Binary_base: '\'' ('s' | 'S')? ('b' | 'B');
 
 /* octal_base <<1>> ::= [s|S]o | [s|S]O */
 
-fragment
-Octal_base : '\'' ('s' | 'S')? ( 'o' | 'O') ;
+fragment Octal_base: '\'' ('s' | 'S')? ('o' | 'O');
 
 /* hex_base <<1>> ::ps [s|S]h | [s|S]H */
 
-fragment
-Hex_base : '\'' ('s' | 'S')?  ('h' | 'H') ;
-
+fragment Hex_base: '\'' ('s' | 'S')? ('h' | 'H');
 
 /* decimal_digit ::= 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 */
 
-fragment
-Decimal_digit : '0'..'9' ;
+fragment Decimal_digit: '0' ..'9';
 
 /* binary_digit ::= x_digit | z_digit | 0 | 1 */
 
-fragment
-Binary_digit : X_digit | Z_digit | ('0' | '1') ;
+fragment Binary_digit: X_digit | Z_digit | ('0' | '1');
 
 /* octal_digit ::= x_digit | z_digit | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 */
 
-fragment
-Octal_digit : X_digit | Z_digit | '0'..'7' ;
+fragment Octal_digit: X_digit | Z_digit | '0' ..'7';
 
 /* hex_digit ::= x_digit | z_digit | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | a | b | c | d | e | f | A | B | C | D | E | F */
 
-fragment
-Hex_digit : X_digit | Z_digit | ('0'..'9' | 'a'..'f' | 'A'..'F') ;
+fragment Hex_digit
+  : X_digit
+  | Z_digit
+  | ('0' .. '9' | 'a' .. 'f' | 'A' .. 'F')
+  ;
 
 /* x_digit ::= x | X */
 
-fragment
-X_digit : ('x'| 'X') ;
+fragment X_digit: ('x' | 'X');
 
 /* z_digit ::= z | Z | ? */
 
-fragment
-Z_digit : ('z'| 'Z' | QMARK)  ;
+fragment Z_digit: ('z' | 'Z' | QMARK);
 
 /* edge_descriptor */
 
@@ -189,716 +189,724 @@ Z_digit : ('z'| 'Z' | QMARK)  ;
 // A.8.8 Strings
 
 String
- : '"'                          // a opening quote
-   (                            // start group
-     '\\' ~('\r')        // an escaped char other than a line break char
-     |                          // OR
-     ~('\\' | '"'| '\r' | '\n') // any char other than '"', '\' and line breaks
-   )*                           // end group and repeat zero or more times
-   '"'                          // the closing quote
- ;
+  : '"' // a opening quote
+  (
+    // start group
+    '\\' ~'\r' // an escaped char other than a line break char
+    | // OR
+    ~(
+      '\\'
+      | '"'
+      | '\r'
+      | '\n'
+    ) // any char other than '"', '\' and line breaks
+  )* // end group and repeat zero or more times
+  '"'
+  ; // the closing quote
 
 // A.9.2 Comments
 
 /* one_line_comment ::= // comment_text \n */
 
-One_line_comment : '//' Comment_text '\r'? ('\n' | EOF) -> channel(COMMENTS);
+One_line_comment
+  : '//' Comment_text '\r'? ('\n' | EOF) -> channel(COMMENTS)
+  ;
 
 // block_comment ::= /* comment_text */
 
-Block_comment : '/*' Comment_text '*/' -> channel(COMMENTS);
+Block_comment: '/*' Comment_text '*/' -> channel(COMMENTS);
 
 /* comment_text ::= { Any_ASCII_character } */
 
-fragment Comment_text : .*? ;
+fragment Comment_text: .*?;
 
-ASSOCIATIVE_UNSPECIFIED : '[' [ ]* '*' [ ]* ']' ;
+ASSOCIATIVE_UNSPECIFIED: '[' [ ]* '*' [ ]* ']';
 
-ATSTAR : '@' ' '? '*' ;
+ATSTAR: '@' ' '? '*';
 
-AT_PARENS_STAR : '@' ' '? '(' ' '? '*' ' '? ')' ;
+AT_PARENS_STAR: '@' ' '? '(' ' '? '*' ' '? ')';
 
 // 9.4 White space
 
-White_space : [ \t\n\r]+ -> channel(WHITESPACES) ;
+White_space: [ \t\n\r]+ -> channel(WHITESPACES);
 
 // ######################### LEXER RULES ################################
 
-INCLUDE : 'include';
+INCLUDE: 'include';
 
-LIBRARY : 'library' ;
+LIBRARY: 'library';
 
-INCDIR : '-incdir' ;
+INCDIR: '-incdir';
 
-COMMA : ',' ;
+COMMA: ',';
 
-SEMICOLON : ';' ;
+SEMICOLON: ';';
 
-COLONCOLON : '::' ;
+COLONCOLON: '::';
 
-COLON : ':' ;
+COLON: ':';
 
-DESIGN : 'design' ;
+DESIGN: 'design';
 
-DOT : '.' ;
+DOT: '.';
 
-DEFAULT : 'default' ;
+DEFAULT: 'default';
 
-INSTANCE : 'instance' ;
+INSTANCE: 'instance';
 
-CELL : 'cell' ;
+CELL: 'cell';
 
-LIBLIST : 'liblist' ;
+LIBLIST: 'liblist';
 
-USE : 'use' ;
+USE: 'use';
 
-MODULE : 'module';
+MODULE: 'module';
 
-ENDMODULE : 'endmodule' ;
+ENDMODULE: 'endmodule';
 
-OPEN_PARENS : '(' ;
+OPEN_PARENS: '(';
 
-CLOSE_PARENS : ')' ;
+CLOSE_PARENS: ')';
 
-STAR : '*' ;
+STAR: '*';
 
-EXTERN : 'extern' ;
+EXTERN: 'extern';
 
-MACROMODULE : 'macromodule' ;
+MACROMODULE: 'macromodule';
 
-INTERFACE : 'interface' ;
+INTERFACE: 'interface';
 
-ENDINTERFACE : 'endinterface' ;
+ENDINTERFACE: 'endinterface';
 
-PROGRAM : 'program' ;
+PROGRAM: 'program';
 
-ENDPROGRAM : 'endprogram' ;
+ENDPROGRAM: 'endprogram';
 
-VIRTUAL : 'virtual' ;
+VIRTUAL: 'virtual';
 
-CLASS : 'class' ;
+CLASS: 'class';
 
-ENDCLASS : 'endclass' ;
+ENDCLASS: 'endclass';
 
-EXTENDS : 'extends' ;
+EXTENDS: 'extends';
 
-PACKAGE : 'package' ;
+PACKAGE: 'package';
 
-ENDPACKAGE : 'endpackage' ;
+ENDPACKAGE: 'endpackage';
 
-TIMEUNIT : 'timeunit' ;
+TIMEUNIT: 'timeunit';
 
-TIMEPRECISION : 'timeprecision' ;
+TIMEPRECISION: 'timeprecision';
 
-CHECKER : 'checker' ;
+CHECKER: 'checker';
 
-ENDCHECKER : 'endchecker' ;
+ENDCHECKER: 'endchecker';
 
-CONFIG : 'config' ;
+CONFIG: 'config';
 
-ENDCONFIG : 'endconfig' ;
+ENDCONFIG: 'endconfig';
 
-TYPE : 'type' { sverilog }?;
+TYPE: 'type' { sverilog }?;
 
-UNTYPED : 'untyped' ;
+UNTYPED: 'untyped';
 
-INPUT : 'input' ;
+INPUT: 'input';
 
-OUTPUT : 'output' ;
+OUTPUT: 'output';
 
-INOUT : 'inout' ;
+INOUT: 'inout';
 
-REF : 'ref' { sverilog }?;
+REF: 'ref' { sverilog }?;
 
-CLOCKING : 'clocking' ;
+CLOCKING: 'clocking';
 
-DEFPARAM : 'defparam' ;
+DEFPARAM: 'defparam';
 
-BIND : 'bind' ;
+BIND: 'bind';
 
-FORKJOIN : 'forkjoin' ;
+FORKJOIN: 'forkjoin';
 
-CONST : 'const' ;
+CONST: 'const';
 
-FUNCTION : 'function' ;
+FUNCTION: 'function';
 
-NEW : 'new' { sverilog }?;
+NEW: 'new' { sverilog }?;
 
-STATIC : 'static' ;
+STATIC: 'static';
 
-PROTECTED : 'protected' ;
+PROTECTED: 'protected';
 
-LOCAL : 'local' ;
+LOCAL: 'local';
 
-RAND : 'rand' ;
+RAND: 'rand';
 
-RANDC : 'randc' ;
+RANDC: 'randc';
 
-SUPER : 'super' ;
+SUPER: 'super';
 
-ENDFUNCTION : 'endfunction' ;
+ENDFUNCTION: 'endfunction';
 
-CONSTRAINT : 'constraint' ;
+CONSTRAINT: 'constraint';
 
-OPEN_CURLY : '{' ;
+OPEN_CURLY: '{';
 
-CLOSE_CURLY : '}' ;
+CLOSE_CURLY: '}';
 
-SOLVE : 'solve' ;
+SOLVE: 'solve';
 
-BEFORE : 'before' ;
+BEFORE: 'before';
 
-IMPLY : '->' ;
+IMPLY: '->';
 
-IF : 'if' ;
+IF: 'if';
 
-ELSE : 'else';
+ELSE: 'else';
 
-FOREACH : 'foreach' ;
+FOREACH: 'foreach';
 
-ASSIGN_VALUE : ':=' ;
+ASSIGN_VALUE: ':=';
 
 /* Replaced by COLON DIV :  ASSIGN_RANGE : ':/' ; */
 
-AUTOMATIC : 'automatic' ;
+AUTOMATIC: 'automatic';
 
-LOCALPARAM : 'localparam' ;
+LOCALPARAM: 'localparam';
 
-PARAMETER : 'parameter' ;
+PARAMETER: 'parameter';
 
-SPECPARAM : 'specparam' ;
+SPECPARAM: 'specparam';
 
-IMPORT : 'import' ;
+IMPORT: 'import';
 
-GENVAR : 'genvar' ;
+GENVAR: 'genvar';
 
-VECTORED : 'vectored' ;
+VECTORED: 'vectored';
 
-SCALARED : 'scalared' ;
+SCALARED: 'scalared';
 
-TYPEDEF : 'typedef' ;
+TYPEDEF: 'typedef';
 
-ENUM : 'enum';
+ENUM: 'enum';
 
-STRUCT : 'struct' ;
+STRUCT: 'struct';
 
-UNION : 'union' ;
+UNION: 'union';
 
-PACKED : 'packed' ;
+PACKED: 'packed';
 
-STRING : 'string' ;
+STRING: 'string';
 
-CHANDLE : 'chandle' ;
+CHANDLE: 'chandle';
 
-EVENT : 'event' ;
+EVENT: 'event';
 
-OPEN_BRACKET : '[' ;
+OPEN_BRACKET: '[';
 
-CLOSE_BRACKET : ']' ;
+CLOSE_BRACKET: ']';
 
-BYTE : 'byte' { sverilog }?;
+BYTE: 'byte' { sverilog }?;
 
-SHORTINT : 'shortint';
+SHORTINT: 'shortint';
 
-INT : 'int' ;
+INT: 'int';
 
-LONGINT : 'longint' ;
+LONGINT: 'longint';
 
-INTEGER : 'integer' ;
+INTEGER: 'integer';
 
-TIME : 'time' ;
+TIME: 'time';
 
-BIT : 'bit' { sverilog }?;
+BIT: 'bit' { sverilog }?;
 
-LOGIC : 'logic' { sverilog }?;
+LOGIC: 'logic' { sverilog }?;
 
-REG : 'reg' ;
+REG: 'reg';
 
-SHORTREAL : 'shortreal' ;
+SHORTREAL: 'shortreal';
 
-REAL : 'real' ;
+REAL: 'real';
 
-REALTIME : 'realtime' ;
+REALTIME: 'realtime';
 
-NEXTTIME : 'nexttime' ;
+NEXTTIME: 'nexttime';
 
-S_NEXTTIME : 's_nexttime' ;
+S_NEXTTIME: 's_nexttime';
 
-S_ALWAYS : 's_always' ;
+S_ALWAYS: 's_always';
 
-UNTIL_WITH : 'until_with' ;
+UNTIL_WITH: 'until_with';
 
-S_UNTIL_WITH : 's_until_with';
+S_UNTIL_WITH: 's_until_with';
 
-ACCEPT_ON      : 'accept_on' ;
+ACCEPT_ON: 'accept_on';
 
-REJECT_ON      : 'reject_on' ;
+REJECT_ON: 'reject_on';
 
-SYNC_ACCEPT_ON : 'sync_accept_on' ;
+SYNC_ACCEPT_ON: 'sync_accept_on';
 
-SYNC_REJECT_ON : 'sync_reject_on' ;
+SYNC_REJECT_ON: 'sync_reject_on';
 
-EVENTUALLY : 'eventually' ;
+EVENTUALLY: 'eventually';
 
-S_EVENTUALLY : 's_eventually' ;
+S_EVENTUALLY: 's_eventually';
 
-SUPPLY0 : 'supply0' ;
+SUPPLY0: 'supply0';
 
-SUPPLY1 : 'supply1' ;
+SUPPLY1: 'supply1';
 
-TRI : 'tri' ;
+TRI: 'tri';
 
-TRIAND : 'triand' ;
+TRIAND: 'triand';
 
-TRIOR : 'trior' ;
+TRIOR: 'trior';
 
-TRI0 : 'tri0' ;
+TRI0: 'tri0';
 
-TRI1 : 'tri1' ;
+TRI1: 'tri1';
 
-WIRE : 'wire' ;
+WIRE: 'wire';
 
-UWIRE : 'uwire' ;
+UWIRE: 'uwire';
 
-WAND : 'wand' ;
+WAND: 'wand';
 
-WOR : 'wor' ;
+WOR: 'wor';
 
-TRIREG : 'trireg' ;
+TRIREG: 'trireg';
 
-SIGNED : 'signed';
+SIGNED: 'signed';
 
-UNSIGNED : 'unsigned';
+UNSIGNED: 'unsigned';
 
-INTERCONNECT : 'interconnect' ;
+INTERCONNECT: 'interconnect';
 
-VAR : 'var' { sverilog }?;
+VAR: 'var' { sverilog }?;
 
-VOID : 'void' ;
+VOID: 'void';
 
-HIGHZ0 : 'highz0' ;
+HIGHZ0: 'highz0';
 
-HIGHZ1 : 'highz1' ;
+HIGHZ1: 'highz1';
 
-STRONG : 'strong' ;
+STRONG: 'strong';
 
-WEAK : 'weak' ;
+WEAK: 'weak';
 
-STRONG0 : 'strong0' ;
+STRONG0: 'strong0';
 
-PULL0 : 'pull0' ;
+PULL0: 'pull0';
 
-WEAK0 : 'weak0' ;
+WEAK0: 'weak0';
 
-STRONG1 : 'strong1' ;
+STRONG1: 'strong1';
 
-PULL1 : 'pull1' ;
+PULL1: 'pull1';
 
-WEAK1 : 'weak1' ;
+WEAK1: 'weak1';
 
-SMALL : '(small)';
+SMALL: '(small)';
 
-MEDIUM : '(medium)' ;
+MEDIUM: '(medium)';
 
-LARGE : '(large)' ;
+LARGE: '(large)';
 
-PATHPULSE : 'PATHPULSE' ;
+PATHPULSE: 'PATHPULSE';
 
-DOLLAR : '$' ;
+DOLLAR: '$';
 
-EXPORT : 'export' ;
+EXPORT: 'export';
 
-CONTEXT : 'context' { sverilog }?;
+CONTEXT: 'context' { sverilog }?;
 
-PURE : 'pure' ;
+PURE: 'pure';
 
-IMPLEMENTS : 'implements' ;
+IMPLEMENTS: 'implements';
 
-ENDTASK : 'endtask' ;
+ENDTASK: 'endtask';
 
-PLUSPLUS : '++' ;
+PLUSPLUS: '++';
 
-PLUS : '+' ;
+PLUS: '+';
 
-MINUSMINUS : '--' ;
+MINUSMINUS: '--';
 
-MINUS : '-' ;
+MINUS: '-';
 
-STARCOLONCOLONSTAR : '*::*' ;
+STARCOLONCOLONSTAR: '*::*';
 
-STARSTAR : '**' ;
+STARSTAR: '**';
 
-DIV : '/' ;
+DIV: '/';
 
-PERCENT : '%' ;
+PERCENT: '%';
 
-EQUIV : '==' ;
+EQUIV: '==';
 
-NOTEQUAL : '!=' ;
+NOTEQUAL: '!=';
 
-LESS : '<' ;
+LESS: '<';
 
-LESS_EQUAL : '<=' ;
+LESS_EQUAL: '<=';
 
-GREATER : '>' ;
+GREATER: '>';
 
-EQUIVALENCE : '<->' ;
+EQUIVALENCE: '<->';
 
-GREATER_EQUAL : '>=' ;
+GREATER_EQUAL: '>=';
 
-MODPORT : 'modport' ;
+MODPORT: 'modport';
 
-DOLLAR_UNIT : DOLLAR 'unit' ;
+DOLLAR_UNIT: DOLLAR 'unit';
 
-OPEN_PARENS_STAR : '(*' ;
+OPEN_PARENS_STAR: '(*';
 
-STAR_CLOSE_PARENS : '*)' ;
+STAR_CLOSE_PARENS: '*)';
 
-ASSERT : 'assert' ;
+ASSERT: 'assert';
 
-PROPERTY : 'property' ;
+PROPERTY: 'property';
 
-ASSUME : 'assume' ;
+ASSUME: 'assume';
 
-COVER : 'cover' ;
+COVER: 'cover';
 
-EXPECT : 'expect' { sverilog }?;
+EXPECT: 'expect' { sverilog }?;
 
-ENDPROPERTY : 'endproperty' ;
+ENDPROPERTY: 'endproperty';
 
-DISABLE : 'disable' ;
+DISABLE: 'disable';
 
-IFF : 'iff' ;
+IFF: 'iff';
 
-OVERLAP_IMPLY : '|->' ;
+OVERLAP_IMPLY: '|->';
 
-NON_OVERLAP_IMPLY : '|=>' ;
+NON_OVERLAP_IMPLY: '|=>';
 
-NOT : 'not' ;
+NOT: 'not';
 
-OR : 'or' ;
+OR: 'or';
 
-AND : 'and' ;
+AND: 'and';
 
-SEQUENCE : 'sequence' ;
+SEQUENCE: 'sequence';
 
-ENDSEQUENCE : 'endsequence' ;
+ENDSEQUENCE: 'endsequence';
 
-INTERSECT : 'intersect' ;
+INTERSECT: 'intersect';
 
-FIRST_MATCH : 'first_match' ;
+FIRST_MATCH: 'first_match';
 
-THROUGHOUT : 'throughout' ;
+THROUGHOUT: 'throughout';
 
-WITHIN : 'within' ;
+WITHIN: 'within';
 
-POUNDPOUND : '##' ;
+POUNDPOUND: '##';
 
-OVERLAPPED : '#-#' ;
+OVERLAPPED: '#-#';
 
-NONOVERLAPPED : '#=#' ;
+NONOVERLAPPED: '#=#';
 
-POUND : '#' ;
+POUND: '#';
 
-CONSECUTIVE_REP : '[*' ;
+CONSECUTIVE_REP: '[*';
 
-NON_CONSECUTIVE_REP : '[=' ;
+NON_CONSECUTIVE_REP: '[=';
 
-GOTO_REP : '[->' ;
+GOTO_REP: '[->';
 
-DIST : 'dist' ;
+DIST: 'dist';
 
-COVERGROUP : 'covergroup' ;
+COVERGROUP: 'covergroup';
 
-ENDGROUP : 'endgroup' ;
+ENDGROUP: 'endgroup';
 
-OPTION_DOT : 'option' DOT;
+OPTION_DOT: 'option' DOT;
 
-TYPE_OPTION_DOT : 'type_option' DOT;
+TYPE_OPTION_DOT: 'type_option' DOT;
 
-ATAT : '@@' ;
+ATAT: '@@';
 
-BEGIN : 'begin' ;
+BEGIN: 'begin';
 
-END : 'end' ;
+END: 'end';
 
-WILDCARD : 'wildcard' ;
+WILDCARD: 'wildcard';
 
-BINS : 'bins';
+BINS: 'bins';
 
-ILLEGAL_BINS : 'illegal_bins' ;
+ILLEGAL_BINS: 'illegal_bins';
 
-IGNORE_BINS : 'ignore_bins' ;
+IGNORE_BINS: 'ignore_bins';
 
-TRANSITION_OP : '=>' ;
+TRANSITION_OP: '=>';
 
-BANG : '!' ;
+BANG: '!';
 
-SOFT : 'soft' { sverilog }?;
+SOFT: 'soft' { sverilog }?;
 
-UNTIL : 'until' ;
+UNTIL: 'until';
 
-S_UNTIL : 's_until' ;
+S_UNTIL: 's_until';
 
-IMPLIES : 'implies' ;
+IMPLIES: 'implies';
 
-LOGICAL_AND : '&&' ;
+LOGICAL_AND: '&&';
 
-LOGICAL_OR : '||' ;
+LOGICAL_OR: '||';
 
-BINSOF : 'binsof' ;
+BINSOF: 'binsof';
 
-PULLDOWN : 'pulldown' ;
+PULLDOWN: 'pulldown';
 
-PULLUP : 'pullup' ;
+PULLUP: 'pullup';
 
-CMOS : 'cmos' ;
+CMOS: 'cmos';
 
-RCMOS : 'rcmos' ;
+RCMOS: 'rcmos';
 
-BUFIF0 : 'bufif0' ;
+BUFIF0: 'bufif0';
 
-BUFIF1 : 'bufif1' ;
+BUFIF1: 'bufif1';
 
-NOTIF0 : 'notif0' ;
+NOTIF0: 'notif0';
 
-NOTIF1 : 'notif1' ;
+NOTIF1: 'notif1';
 
-NMOS : 'nmos' ;
+NMOS: 'nmos';
 
-PMOS : 'pmos' ;
+PMOS: 'pmos';
 
-RNMOS : 'rnmos' ;
+RNMOS: 'rnmos';
 
-RPMOS  : 'rpmos' ;
+RPMOS: 'rpmos';
 
-NAND : 'nand' ;
+NAND: 'nand';
 
-NOR  : 'nor' ;
+NOR: 'nor';
 
-XOR  : 'xor' ;
+XOR: 'xor';
 
-XNOR : 'xnor' ;
+XNOR: 'xnor';
 
-BUF  : 'buf' ;
+BUF: 'buf';
 
-TRANIF0  : 'tranif0' ;
+TRANIF0: 'tranif0';
 
-TRANIF1  : 'tranif1' ;
+TRANIF1: 'tranif1';
 
-RTRANIF1  : 'rtranif1' ;
+RTRANIF1: 'rtranif1';
 
-RTRANIF0  : 'rtranif0' ;
+RTRANIF0: 'rtranif0';
 
-TRAN  : 'tran' ;
+TRAN: 'tran';
 
-RTRAN : 'rtran' ;
+RTRAN: 'rtran';
 
-DOTSTAR : '.*' ;
+DOTSTAR: '.*';
 
-GENERATE : 'generate' ;
+GENERATE: 'generate';
 
-ENDGENERATE : 'endgenerate' ;
+ENDGENERATE: 'endgenerate';
 
-CASE : 'case' ;
+CASE: 'case';
 
-ENDCASE : 'endcase' ;
+ENDCASE: 'endcase';
 
-FOR : 'for' ;
+FOR: 'for';
 
-GLOBAL : 'global' { sverilog }?;
+GLOBAL: 'global' { sverilog }?;
 
-PRIMITIVE : 'primitive' ;
+PRIMITIVE: 'primitive';
 
-ENDPRIMITIVE : 'endprimitive' ;
+ENDPRIMITIVE: 'endprimitive';
 
-TABLE : 'table' ;
+TABLE: 'table';
 
-ENDTABLE : 'endtable' ;
+ENDTABLE: 'endtable';
 
-INITIAL : 'initial' ;
+INITIAL: 'initial';
 
-ASSIGN : 'assign' ;
+ASSIGN: 'assign';
 
-ALIAS : 'alias' ;
+ALIAS: 'alias';
 
-ALWAYS : 'always' ;
+ALWAYS: 'always';
 
-ALWAYS_COMB : 'always_comb' ;
+ALWAYS_COMB: 'always_comb';
 
-ALWAYS_LATCH : 'always_latch' ;
+ALWAYS_LATCH: 'always_latch';
 
-ALWAYS_FF : 'always_ff' ;
+ALWAYS_FF: 'always_ff';
 
-ADD_ASSIGN : '+=' ;
+ADD_ASSIGN: '+=';
 
-SUB_ASSIGN : '-=' ;
+SUB_ASSIGN: '-=';
 
-MULT_ASSIGN : '*=' ;
+MULT_ASSIGN: '*=';
 
-DIV_ASSIGN : '/=' ;
+DIV_ASSIGN: '/=';
 
-MODULO_ASSIGN : '%=' ;
+MODULO_ASSIGN: '%=';
 
-BITW_AND_ASSIGN : '&=' ;
+BITW_AND_ASSIGN: '&=';
 
-BITW_OR_ASSIGN : '|=' ;
+BITW_OR_ASSIGN: '|=';
 
-BITW_XOR_ASSIGN : '^=' ;
+BITW_XOR_ASSIGN: '^=';
 
-BITW_LEFT_SHIFT_ASSIGN : '<<=' ;
+BITW_LEFT_SHIFT_ASSIGN: '<<=';
 
-BITW_RIGHT_SHIFT_ASSIGN : '>>=' ;
+BITW_RIGHT_SHIFT_ASSIGN: '>>=';
 
-DEASSIGN : 'deassign' ;
+DEASSIGN: 'deassign';
 
-FORCE : 'force' ;
+FORCE: 'force';
 
-RELEASE : 'release' ;
+RELEASE: 'release';
 
-FORK : 'fork' ;
+FORK: 'fork';
 
-JOIN : 'join' ;
+JOIN: 'join';
 
-JOIN_ANY : 'join_any' ;
+JOIN_ANY: 'join_any';
 
-JOIN_NONE : 'join_none' ;
+JOIN_NONE: 'join_none';
 
-REPEAT : 'repeat' ;
+REPEAT: 'repeat';
 
-AT : '@' ;
+AT: '@';
 
-RETURN : 'return' ;
+RETURN: 'return';
 
-BREAK : 'break' ;
+BREAK: 'break';
 
-CONTINUE : 'continue' ;
+CONTINUE: 'continue';
 
-WAIT : 'wait' ;
+WAIT: 'wait';
 
-WAIT_ORDER : 'wait_order' ;
+WAIT_ORDER: 'wait_order';
 
-UNIQUE : 'unique' ;
+UNIQUE: 'unique';
 
-UNIQUE0 : 'unique0' ;
+UNIQUE0: 'unique0';
 
-PRIORITY : 'priority' ;
+PRIORITY: 'priority';
 
-MATCHES : 'matches' ;
+MATCHES: 'matches';
 
-CASEZ : 'casez' ;
+CASEZ: 'casez';
 
-CASEX : 'casex' ;
+CASEX: 'casex';
 
-RANDCASE : 'randcase' ;
+RANDCASE: 'randcase';
 
-TAGGED : 'tagged' ;
+TAGGED: 'tagged';
 
-FOREVER : 'forever' ;
+FOREVER: 'forever';
 
-WHILE : 'while' ;
+WHILE: 'while';
 
-DO : 'do' { sverilog }?;
+DO: 'do' { sverilog }?;
 
-RESTRICT : 'restrict' ;
+RESTRICT: 'restrict';
 
-LET : 'let' ;
+LET: 'let';
 
-TICK : '\'';
+TICK: '\'';
 
-ENDCLOCKING : 'endclocking' ;
+ENDCLOCKING: 'endclocking';
 
-RANDSEQUENCE : 'randsequence' ;
+RANDSEQUENCE: 'randsequence';
 
-SHIFT_RIGHT : '>>' ;
+SHIFT_RIGHT: '>>';
 
-SHIFT_LEFT : '<<' ;
+SHIFT_LEFT: '<<';
 
-WITH : 'with' ;
+WITH: 'with';
 
-INC_PART_SELECT_OP : '+:' ;
+INC_PART_SELECT_OP: '+:';
 
-DEC_PART_SELECT_OP : '-:' ;
+DEC_PART_SELECT_OP: '-:';
 
-INSIDE : 'inside' ;
+INSIDE: 'inside';
 
-NULL_KEYWORD : 'null' ;
+NULL_KEYWORD: 'null';
 
-THIS : 'this' { sverilog }?;
+THIS: 'this' { sverilog }?;
 
-DOLLAR_ROOT : DOLLAR 'root' ;
+DOLLAR_ROOT: DOLLAR 'root';
 
-RANDOMIZE : 'randomize' { sverilog }?;
+RANDOMIZE: 'randomize' { sverilog }?;
 
-FINAL : 'final' { sverilog }?;
+FINAL: 'final' { sverilog }?;
 
-TASK : 'task' ;
+TASK: 'task';
 
-COVERPOINT : 'coverpoint' ;
+COVERPOINT: 'coverpoint';
 
-CROSS : 'cross' ;
+CROSS: 'cross';
 
-POSEDGE : 'posedge' ;
+POSEDGE: 'posedge';
 
-NEGEDGE : 'negedge' ;
+NEGEDGE: 'negedge';
 
-SPECIFY : 'specify' ;
+SPECIFY: 'specify';
 
-ENDSPECIFY : 'endspecify' ;
+ENDSPECIFY: 'endspecify';
 
-PULSESTYLE_ONEVENT : 'pulsestyle_onevent' ;
+PULSESTYLE_ONEVENT: 'pulsestyle_onevent';
 
-PULSESTYLE_ONDETECT : 'pulsestyle_ondetect' ;
+PULSESTYLE_ONDETECT: 'pulsestyle_ondetect';
 
-SHOWCANCELLED : 'showcancelled' ;
+SHOWCANCELLED: 'showcancelled';
 
-NOSHOWCANCELLED : 'noshowcancelled' ;
+NOSHOWCANCELLED: 'noshowcancelled';
 
-IFNONE : 'ifnone' ;
+IFNONE: 'ifnone';
 
-SAMPLE : 'sample' { sverilog }?;
+SAMPLE: 'sample' { sverilog }?;
 
-EDGE : 'edge' ;
+EDGE: 'edge';
 
-NON_BLOCKING_TRIGGER_EVENT_OP : '->>' ;
+NON_BLOCKING_TRIGGER_EVENT_OP: '->>';
 
-ARITH_SHIFT_RIGHT : '>>>' ;
+ARITH_SHIFT_RIGHT: '>>>';
 
-ARITH_SHIFT_LEFT : '<<<' ;
+ARITH_SHIFT_LEFT: '<<<';
 
-ARITH_SHIFT_LEFT_ASSIGN : '<<<=' ;
+ARITH_SHIFT_LEFT_ASSIGN: '<<<=';
 
-ARITH_SHIFT_RIGHT_ASSIGN : '>>>=' ;
+ARITH_SHIFT_RIGHT_ASSIGN: '>>>=';
 
-FOUR_STATE_LOGIC_EQUAL : '===' ;
+FOUR_STATE_LOGIC_EQUAL: '===';
 
-FOUR_STATE_LOGIC_NOTEQUAL : '!==' ;
+FOUR_STATE_LOGIC_NOTEQUAL: '!==';
 
-BINARY_WILDCARD_EQUAL : '==?' ;
+BINARY_WILDCARD_EQUAL: '==?';
 
-BINARY_WILDCARD_NOTEQUAL : '!=?' ;
+BINARY_WILDCARD_NOTEQUAL: '!=?';
 
-FULL_CONN_OP : '*>' ;
+FULL_CONN_OP: '*>';
 
-COND_PRED_OP : '&&&' ;
+COND_PRED_OP: '&&&';
 
-BITW_AND : '&' ;
+BITW_AND: '&';
 
-BITW_OR : '|' ;
+BITW_OR: '|';
 
-REDUCTION_NOR : '~|' ;
+REDUCTION_NOR: '~|';
 
-REDUCTION_NAND : '~&' ;
+REDUCTION_NAND: '~&';
 
-REDUCTION_XNOR1 : '^~' ;
+REDUCTION_XNOR1: '^~';
 
-WILD_EQUAL_OP : '=?=' ;
+WILD_EQUAL_OP: '=?=';
 
-WILD_NOTEQUAL_OP : '!?=' ;
+WILD_NOTEQUAL_OP: '!?=';
 
-ASSIGN_OP : '=' ;
+ASSIGN_OP: '=';
 
-NETTYPE : 'nettype' ;
+NETTYPE: 'nettype';
 
 // A.9.3 Identifiers
 
@@ -907,94 +915,96 @@ NETTYPE : 'nettype' ;
 
 //Escaped_identifier : '^^^' [\\|+a-zA-Z0-9_$:,-/*{}()`~!=;'"<>?.]* '^^^' ;
 
-Escaped_identifier : '#~@' .*? '#~@' ;
+Escaped_identifier: '#~@' .*? '#~@';
 
-TILDA : '~' ;
+TILDA: '~';
 
-BITW_XOR : '^';
+BITW_XOR: '^';
 
-REDUCTION_XNOR2 : '~^' ;
+REDUCTION_XNOR2: '~^';
 
 /* simple_identifier <<2>> ::= [ a-zA-Z_ ] { [ a-zA-Z0-9_$ ] } */
 
-Simple_identifier : [a-zA-Z_] [a-zA-Z0-9_$]* ;
+Simple_identifier: [a-zA-Z_] [a-zA-Z0-9_$]*;
 
-TICK_LINE : '`line' ;
+TICK_LINE: '`line';
 
-TICK_TIMESCALE : '`timescale' ;
+TICK_TIMESCALE: '`timescale';
 
-TICK_BEGIN_KEYWORDS : '`begin_keywords' ;
+TICK_BEGIN_KEYWORDS: '`begin_keywords';
 
-TICK_END_KEYWORDS : '`end_keywords' ;
+TICK_END_KEYWORDS: '`end_keywords';
 
-TICK_UNCONNECTED_DRIVE : '`unconnected_drive' ;
+TICK_UNCONNECTED_DRIVE: '`unconnected_drive';
 
-TICK_NOUNCONNECTED_DRIVE : '`nounconnected_drive' ;
+TICK_NOUNCONNECTED_DRIVE: '`nounconnected_drive';
 
-TICK_CELLDEFINE : '`celldefine' ;
+TICK_CELLDEFINE: '`celldefine';
 
-TICK_ENDCELLDEFINE : '`endcelldefine' ;
+TICK_ENDCELLDEFINE: '`endcelldefine';
 
-TICK_DEFAULT_NETTYPE : '`default_nettype' ;
+TICK_DEFAULT_NETTYPE: '`default_nettype';
 
-TICK_DEFAULT_DECAY_TIME : '`default_decay_time' ;
+TICK_DEFAULT_DECAY_TIME: '`default_decay_time';
 
-TICK_DEFAULT_TRIREG_STRENGTH : '`default_trireg_strength' ;
+TICK_DEFAULT_TRIREG_STRENGTH: '`default_trireg_strength';
 
-TICK_DELAY_MODE_DISTRIBUTED : '`delay_mode_distributed' ;
+TICK_DELAY_MODE_DISTRIBUTED: '`delay_mode_distributed';
 
-TICK_DELAY_MODE_PATH : '`delay_mode_path' ;
+TICK_DELAY_MODE_PATH: '`delay_mode_path';
 
-TICK_DELAY_MODE_UNIT : '`delay_mode_unit' ;
+TICK_DELAY_MODE_UNIT: '`delay_mode_unit';
 
-TICK_DELAY_MODE_ZERO : '`delay_mode_zero' ;
+TICK_DELAY_MODE_ZERO: '`delay_mode_zero';
 
-TICK_ACCELERATE : '`accelerate';
+TICK_ACCELERATE: '`accelerate';
 
-TICK_NOACCELERATE : '`noaccelerate';
+TICK_NOACCELERATE: '`noaccelerate';
 
-TICK_PROTECT : '`protect' ;
+TICK_PROTECT: '`protect';
 
-TICK_DISABLE_PORTFAULTS : '`disable_portfaults' ;
+TICK_DISABLE_PORTFAULTS: '`disable_portfaults';
 
-TICK_ENABLE_PORTFAULTS : '`enable_portfaults' ;
+TICK_ENABLE_PORTFAULTS: '`enable_portfaults';
 
-TICK_NOSUPPRESS_FAULTS : '`nosuppress_faults' ;
+TICK_NOSUPPRESS_FAULTS: '`nosuppress_faults';
 
-TICK_SUPPRESS_FAULTS : '`suppress_faults' ;
+TICK_SUPPRESS_FAULTS: '`suppress_faults';
 
-TICK_SIGNED : '`signed' ;
+TICK_SIGNED: '`signed';
 
-TICK_UNSIGNED : '`unsigned' ;
+TICK_UNSIGNED: '`unsigned';
 
-TICK_ENDPROTECT : '`endprotect' ;
+TICK_ENDPROTECT: '`endprotect';
 
-TICK_PROTECTED : '`protected' ;
+TICK_PROTECTED: '`protected';
 
-TICK_ENDPROTECTED : '`endprotected' ;
+TICK_ENDPROTECTED: '`endprotected';
 
-TICK_EXPAND_VECTORNETS : '`expand_vectornets' ;
+TICK_EXPAND_VECTORNETS: '`expand_vectornets';
 
-TICK_NOEXPAND_VECTORNETS : '`noexpand_vectornets' ;
+TICK_NOEXPAND_VECTORNETS: '`noexpand_vectornets';
 
-TICK_AUTOEXPAND_VECTORNETS : '`autoexpand_vectornets' ;
+TICK_AUTOEXPAND_VECTORNETS: '`autoexpand_vectornets';
 
-TICK_REMOVE_GATENAME : '`remove_gatename' ;
+TICK_REMOVE_GATENAME: '`remove_gatename';
 
-TICK_NOREMOVE_GATENAMES : '`noremove_gatenames' ;
+TICK_NOREMOVE_GATENAMES: '`noremove_gatenames';
 
-TICK_REMOVE_NETNAME : '`remove_netname' ;
+TICK_REMOVE_NETNAME: '`remove_netname';
 
-TICK_NOREMOVE_NETNAMES : '`noremove_netnames' ;
+TICK_NOREMOVE_NETNAMES: '`noremove_netnames';
 
-ONESTEP : '1step' ;
+ONESTEP: '1step';
 
-TICK_USELIB : '`uselib' ;
+TICK_USELIB: '`uselib';
 
-TICK_PRAGMA : '`pragma' ;
+TICK_PRAGMA: '`pragma';
 
-BACK_TICK : '`' ;
+BACK_TICK: '`';
 
-SURELOG_MACRO_NOT_DEFINED : 'SURELOG_MACRO_NOT_DEFINED:' Simple_identifier '!!!' ;
+SURELOG_MACRO_NOT_DEFINED
+  : 'SURELOG_MACRO_NOT_DEFINED:' Simple_identifier '!!!'
+  ;
 
-ANY: . ;
+ANY: .;

--- a/grammar/SV3_1aParser.g4
+++ b/grammar/SV3_1aParser.g4
@@ -1964,7 +1964,7 @@ named_port_connection
   ;
 
 checker_instantiation
-  : ps_identifier name_of_instance OPEN_PARENS list_of_checker_port_connections CLOSE_PARENS
+  : ps_identifier name_of_instance OPEN_PARENS list_of_checker_port_connections CLOSE_PARENS SEMICOLON
   ;
 
 list_of_checker_port_connections

--- a/grammar/SV3_1aPpLexer.g4
+++ b/grammar/SV3_1aPpLexer.g4
@@ -16,321 +16,347 @@
 
 lexer grammar SV3_1aPpLexer;
 
-Escaped_identifier
-    :   '\\' ~[WS\r\t\n]*? WS
-    ;
+Escaped_identifier: '\\' ~[WS\r\t\n]*? WS;
 
 // A.9.2 Comments
 
-One_line_comment : '//' Comment_text '\r'? '\n' ;
+One_line_comment: '//' Comment_text '\r'? '\n';
 
-Block_comment : '/*' Comment_text '*/' ;
+Block_comment: '/*' Comment_text '*/';
 
-fragment Comment_text : .*? ;
+fragment Comment_text: .*?;
 
-TICK_VARIABLE : '``' [a-zA-Z0-9_]+ '``' ;
+TICK_VARIABLE: '``' [a-zA-Z0-9_]+ '``';
 
-TICK_DEFINE : '`define' ;
+TICK_DEFINE: '`define';
 
-TICK_CELLDEFINE : '`celldefine' ;
+TICK_CELLDEFINE: '`celldefine';
 
-TICK_ENDCELLDEFINE : '`endcelldefine' ;
+TICK_ENDCELLDEFINE: '`endcelldefine';
 
-TICK_DEFAULT_NETTYPE : '`default_nettype' ;
+TICK_DEFAULT_NETTYPE: '`default_nettype';
 
-TICK_UNDEF : '`undef' ;
+TICK_UNDEF: '`undef';
 
-TICK_IFDEF : '`ifdef' ;
+TICK_IFDEF: '`ifdef';
 
-TICK_IFNDEF : '`ifndef' ;
+TICK_IFNDEF: '`ifndef';
 
-TICK_ELSE : '`else' ;
+TICK_ELSE: '`else';
 
-TICK_ELSIF : '`elsif' ;
+TICK_ELSIF: '`elsif';
 
-TICK_ELSEIF : '`elseif' ;
+TICK_ELSEIF: '`elseif';
 
-TICK_ENDIF : '`endif' ;
+TICK_ENDIF: '`endif';
 
-TICK_INCLUDE : '`include' ;
+TICK_INCLUDE: '`include';
 
-TICK_PRAGMA : '`pragma' ;
+TICK_PRAGMA: '`pragma';
 
-TICK_BEGIN_KEYWORDS : '`begin_keywords' ;
+TICK_BEGIN_KEYWORDS: '`begin_keywords';
 
-TICK_END_KEYWORDS : '`end_keywords' ;
+TICK_END_KEYWORDS: '`end_keywords';
 
-TICK_RESETALL : '`resetall' ;
+TICK_RESETALL: '`resetall';
 
-TICK_TIMESCALE : '`timescale' ;
+TICK_TIMESCALE: '`timescale';
 
-TICK_UNCONNECTED_DRIVE : '`unconnected_drive' ;
+TICK_UNCONNECTED_DRIVE: '`unconnected_drive';
 
-TICK_NOUNCONNECTED_DRIVE : '`nounconnected_drive' ;
+TICK_NOUNCONNECTED_DRIVE: '`nounconnected_drive';
 
-TICK_LINE : '`line' ;
+TICK_LINE: '`line';
 
-TICK_DEFAULT_DECAY_TIME : '`default_decay_time' ;
+TICK_DEFAULT_DECAY_TIME: '`default_decay_time';
 
-TICK_DEFAULT_TRIREG_STRENGTH : '`default_trireg_strength' ;
+TICK_DEFAULT_TRIREG_STRENGTH: '`default_trireg_strength';
 
-TICK_DELAY_MODE_DISTRIBUTED : '`delay_mode_distributed' ;
+TICK_DELAY_MODE_DISTRIBUTED: '`delay_mode_distributed';
 
-TICK_DELAY_MODE_PATH : '`delay_mode_path' ;
+TICK_DELAY_MODE_PATH: '`delay_mode_path';
 
-TICK_DELAY_MODE_UNIT : '`delay_mode_unit' ;
+TICK_DELAY_MODE_UNIT: '`delay_mode_unit';
 
-TICK_DELAY_MODE_ZERO : '`delay_mode_zero' ;
+TICK_DELAY_MODE_ZERO: '`delay_mode_zero';
 
-TICK_UNDEFINEALL : '`undefineall' ;
+TICK_UNDEFINEALL: '`undefineall';
 
-TICK_ACCELERATE : '`accelerate';
+TICK_ACCELERATE: '`accelerate';
 
-TICK_NOACCELERATE : '`noaccelerate';
+TICK_NOACCELERATE: '`noaccelerate';
 
-TICK_PROTECT : '`protect' ;
+TICK_PROTECT: '`protect';
 
-TICK_USELIB : '`uselib' ;
+TICK_USELIB: '`uselib';
 
-TICK_DISABLE_PORTFAULTS : '`disable_portfaults' ;
+TICK_DISABLE_PORTFAULTS: '`disable_portfaults';
 
-TICK_ENABLE_PORTFAULTS : '`enable_portfaults' ;
+TICK_ENABLE_PORTFAULTS: '`enable_portfaults';
 
-TICK_NOSUPPRESS_FAULTS : '`nosuppress_faults' ;
+TICK_NOSUPPRESS_FAULTS: '`nosuppress_faults';
 
-TICK_SUPPRESS_FAULTS : '`suppress_faults' ;
+TICK_SUPPRESS_FAULTS: '`suppress_faults';
 
-TICK_SIGNED : '`signed' ;
+TICK_SIGNED: '`signed';
 
-TICK_UNSIGNED : '`unsigned' ;
+TICK_UNSIGNED: '`unsigned';
 
-TICK_ENDPROTECT : '`endprotect' ;
+TICK_ENDPROTECT: '`endprotect';
 
-TICK_PROTECTED : '`protected' ;
+TICK_PROTECTED: '`protected';
 
-TICK_ENDPROTECTED : '`endprotected' ;
+TICK_ENDPROTECTED: '`endprotected';
 
-TICK_EXPAND_VECTORNETS : '`expand_vectornets' ;
+TICK_EXPAND_VECTORNETS: '`expand_vectornets';
 
-TICK_NOEXPAND_VECTORNETS : '`noexpand_vectornets' ;
+TICK_NOEXPAND_VECTORNETS: '`noexpand_vectornets';
 
-TICK_AUTOEXPAND_VECTORNETS : '`autoexpand_vectornets' ;
+TICK_AUTOEXPAND_VECTORNETS: '`autoexpand_vectornets';
 
-TICK_REMOVE_GATENAME : '`remove_gatename' ;
+TICK_REMOVE_GATENAME: '`remove_gatename';
 
-TICK_NOREMOVE_GATENAMES : '`noremove_gatenames' ;
+TICK_NOREMOVE_GATENAMES: '`noremove_gatenames';
 
-TICK_REMOVE_NETNAME : '`remove_netname' ;
+TICK_REMOVE_NETNAME: '`remove_netname';
 
-TICK_NOREMOVE_NETNAMES : '`noremove_netnames' ;
+TICK_NOREMOVE_NETNAMES: '`noremove_netnames';
 
-TICK_FILE__ : '`__FILE__' ;
+TICK_FILE__: '`__FILE__';
 
-TICK_LINE__ : '`__LINE__' ;
+TICK_LINE__: '`__LINE__';
 
-MODULE : 'module';
+MODULE: 'module';
 
-ENDMODULE : 'endmodule' ;
+ENDMODULE: 'endmodule';
 
-INTERFACE : 'interface' ;
+INTERFACE: 'interface';
 
-ENDINTERFACE : 'endinterface' ;
+ENDINTERFACE: 'endinterface';
 
-PROGRAM : 'program' ;
+PROGRAM: 'program';
 
-ENDPROGRAM : 'endprogram' ;
+ENDPROGRAM: 'endprogram';
 
-PRIMITIVE : 'primivite' ;
+PRIMITIVE: 'primivite';
 
-ENDPRIMITIVE : 'endprimitive' ;
+ENDPRIMITIVE: 'endprimitive';
 
-PACKAGE : 'package' ;
+PACKAGE: 'package';
 
-ENDPACKAGE : 'endpackage' ;
+ENDPACKAGE: 'endpackage';
 
-CHECKER : 'checker' ;
+CHECKER: 'checker';
 
-ENDCHECKER : 'endchecker' ;
+ENDCHECKER: 'endchecker';
 
-CONFIG : 'config' ;
+CONFIG: 'config';
 
-ENDCONFIG : 'endconfig' ;
+ENDCONFIG: 'endconfig';
 
-Macro_identifier : '`' [a-zA-Z_] [a-zA-Z0-9_$]* ;
+Macro_identifier: '`' [a-zA-Z_] [a-zA-Z0-9_$]*;
 
-Macro_Escaped_identifier
-    :   '`\\' ~[WS\r\t\n]*? WS
-    ;
+Macro_Escaped_identifier: '`\\' ~[WS\r\t\n]*? WS;
 
 String
- : '"'                          // a opening quote
-   (                            // start group
-     '\\' ~('\r')        // an escaped char other than a line break char
-     |                          // OR
-     ~('\\' | '"'| '\r' | '\n') // any char other than '"', '\' and line breaks
-   )*                           // end group and repeat zero or more times
-   '"'                          // the closing quote
- ;
+  : '"' // a opening quote
+  (
+    // start group
+    '\\' ~'\r' // an escaped char other than a line break char
+    | // OR
+    ~(
+      '\\'
+      | '"'
+      | '\r'
+      | '\n'
+    ) // any char other than '"', '\' and line breaks
+  )* // end group and repeat zero or more times
+  '"'
+  ; // the closing quote
 
-Simple_identifier : [a-zA-Z_] [a-zA-Z0-9_$]* ;
+Simple_identifier: [a-zA-Z_] [a-zA-Z0-9_$]*;
 
-Spaces : (WS | TAB)+;
+Spaces: (WS | TAB)+;
 
-Pound_Pound_delay : '##' WS* [0-9] [0-9_.]*;
+Pound_Pound_delay: '##' WS* [0-9] [0-9_.]*;
 
-Pound_delay : '#' WS* [0-9] [0-9_.]*;
+Pound_delay: '#' WS* [0-9] [0-9_.]*;
 
-TIMESCALE : (WS | TAB)* [0-9]+ (WS | TAB)* ('ms' | 'us' | 'ns' | 'ps'  | 'fs' | 's' ) (WS | TAB)* '/' (WS | TAB)* [0-9]+ (WS | TAB)* ('ms' | 'us' | 'ns' | 'ps'  | 'fs' | 's')  ;
+TIMESCALE
+  : (WS | TAB)* [0-9]+ (WS | TAB)* (
+    'ms'
+    | 'us'
+    | 'ns'
+    | 'ps'
+    | 'fs'
+    | 's'
+  ) (WS | TAB)* '/' (WS | TAB)* [0-9]+ (WS | TAB)* (
+    'ms'
+    | 'us'
+    | 'ns'
+    | 'ps'
+    | 'fs'
+    | 's'
+  )
+  ;
 
-fragment
-Non_zero_unsigned_number : '1'..'9' ( '_' | Decimal_digit )* ;
+fragment Non_zero_unsigned_number
+  : '1' ..'9' ('_' | Decimal_digit)*
+  ;
 
-fragment
-Decimal_number
-    : Unsigned_number
-    | ( Non_zero_unsigned_number WS* )? Decimal_base WS* Unsigned_number*
-    | ( Non_zero_unsigned_number WS* )? Decimal_base WS* X_digit ( '_' )*
-    | ( Non_zero_unsigned_number WS* )? Decimal_base WS* Z_digit ( '_' )*
-    ;
+fragment Decimal_number
+  : Unsigned_number
+  | (Non_zero_unsigned_number WS*)? Decimal_base WS* Unsigned_number*
+  | (Non_zero_unsigned_number WS*)? Decimal_base WS* X_digit '_'*
+  | (Non_zero_unsigned_number WS*)? Decimal_base WS* Z_digit '_'*
+  ;
 
 /* binary_number ::= [ size ] binary_base binary_value */
 
-fragment
-Binary_number : ( Non_zero_unsigned_number WS* )? Binary_base WS* Binary_value ;
+fragment Binary_number
+  : (Non_zero_unsigned_number WS*)? Binary_base WS* Binary_value
+  ;
 
 /* octal_number ::= [ size ] octal_base octal_value */
 
-fragment
-Octal_number : ( Non_zero_unsigned_number WS* )? Octal_base WS* Octal_value ;
+fragment Octal_number
+  : (Non_zero_unsigned_number WS*)? Octal_base WS* Octal_value
+  ;
 
 /* hex_number ::= [ size ] hex_base hex_value */
 
-fragment
-Hex_number : ( Non_zero_unsigned_number WS* )? Hex_base WS* Hex_value ;
+fragment Hex_number
+  : (Non_zero_unsigned_number WS*)? Hex_base WS* Hex_value
+  ;
 
 Number
-    :   Decimal_number
-    |   Octal_number
-    |   Binary_number
-    |   Hex_number
-    ;
+  : Decimal_number
+  | Octal_number
+  | Binary_number
+  | Hex_number
+  ;
 
 /* unsigned_number <<1>> ::= decimal_digit { _ | decimal_digit } */
 
-fragment
-Unsigned_number : Decimal_digit ( '_' | Decimal_digit | ' ' )* ;
+fragment Unsigned_number
+  : Decimal_digit ('_' | Decimal_digit | ' ')*
+  ;
 
 /* binary_value <<1>> ::= binary_digit { _ | binary_digit } */
 
-fragment
-Binary_value : ('_')* Binary_digit* ( ' ' | '_' | Binary_digit_no_qm )*;
+fragment Binary_value
+  : '_'* Binary_digit* (' ' | '_' | Binary_digit_no_qm)*
+  ;
 
 /* octal_value <<1>> ::= octal_digit { _ | octal_digit } */
 
-fragment
-Octal_value : ('_')* Octal_digit* ( ' ' | '_' | Octal_digit_no_qm )*;
+fragment Octal_value
+  : '_'* Octal_digit* (' ' | '_' | Octal_digit_no_qm)*
+  ;
 
 /* hex_value <<1>> ::= hex_digit { _ | hex_digit } */
 
-fragment
-Hex_value : ('_')* Hex_digit* ( ' ' | '_' | Hex_digit_no_qm )*;
+fragment Hex_value
+  : '_'* Hex_digit* (' ' | '_' | Hex_digit_no_qm)*
+  ;
 
 /* decimal_base <<1>> ::= [s|S]d | [s|S]D */
 
-fragment
-Decimal_base : '\'' ('s' | 'S')? ('d' | 'D') ;
+fragment Decimal_base: '\'' ('s' | 'S')? ('d' | 'D');
 
 /* binary_base <<1>> ::= [s|S]b | [s|S]B */
 
-fragment
-Binary_base : '\'' ('s' | 'S')? ('b' | 'B') ;
+fragment Binary_base: '\'' ('s' | 'S')? ('b' | 'B');
 
 /* octal_base <<1>> ::= [s|S]o | [s|S]O */
 
-fragment
-Octal_base : '\'' ('s' | 'S')? ( 'o' | 'O') ;
+fragment Octal_base: '\'' ('s' | 'S')? ( 'o' | 'O');
 
 /* hex_base <<1>> ::ps [s|S]h | [s|S]H */
 
-fragment
-Hex_base : '\'' ('s' | 'S')?  ('h' | 'H') ;
-
+fragment Hex_base: '\'' ('s' | 'S')? ('h' | 'H');
 
 /* decimal_digit ::= 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 */
 
-fragment
-Decimal_digit : '0'..'9' ;
+fragment Decimal_digit: '0' ..'9';
 
 /* binary_digit ::= x_digit | z_digit | 0 | 1 */
 
-fragment
-Binary_digit : X_digit | Z_digit | ('0' | '1') ;
+fragment Binary_digit: X_digit | Z_digit | ('0' | '1');
 
-fragment
-Binary_digit_no_qm : X_digit | Z_digit_no_qm | ('0' | '1') ;
+fragment Binary_digit_no_qm
+  : X_digit
+  | Z_digit_no_qm
+  | ('0' | '1')
+  ;
 
 /* octal_digit ::= x_digit | z_digit | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 */
 
-fragment
-Octal_digit : X_digit | Z_digit | '0'..'7' ;
+fragment Octal_digit: X_digit | Z_digit | '0' ..'7';
 
-fragment
-Octal_digit_no_qm : X_digit | Z_digit_no_qm | '0'..'7' ;
+fragment Octal_digit_no_qm
+  : X_digit
+  | Z_digit_no_qm
+  | '0' ..'7'
+  ;
 
 /* hex_digit ::= x_digit | z_digit | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | a | b | c | d | e | f | A | B | C | D | E | F */
 
-fragment
-Hex_digit : X_digit | Z_digit | ('0'..'9' | 'a'..'f' | 'A'..'F') ;
+fragment Hex_digit
+  : X_digit
+  | Z_digit
+  | ('0' .. '9' | 'a' .. 'f' | 'A' .. 'F')
+  ;
 
-fragment
-Hex_digit_no_qm : X_digit | Z_digit_no_qm | ('0'..'9' | 'a'..'f' | 'A'..'F') ;
+fragment Hex_digit_no_qm
+  : X_digit
+  | Z_digit_no_qm
+  | ('0' .. '9' | 'a' .. 'f' | 'A' .. 'F')
+  ;
 
 /* x_digit ::= x | X */
 
-fragment
-X_digit : ('x'| 'X') ;
+fragment X_digit: ('x' | 'X');
 
 /* z_digit ::= z | Z | ? */
 
-fragment
-Z_digit : ('z'| 'Z' | '?')  ;
+fragment Z_digit: ('z' | 'Z' | '?');
 
-fragment
-Z_digit_no_qm : ('z'| 'Z')  ;
+fragment Z_digit_no_qm: ('z' | 'Z');
 
-Fixed_point_number : [0-9]+ '.' [0-9]+ ;
+Fixed_point_number: [0-9]+ '.' [0-9]+;
 
-fragment WS : [ ]+ ;
+fragment WS: [ ]+;
 
-fragment TAB : [\t]+ ;
+fragment TAB: [\t]+;
 
-TEXT_CR : '\\' [nr];
+TEXT_CR: '\\' [nr];
 
-ESCAPED_CR : '\\' [\r\n] ;
+ESCAPED_CR: '\\' [\r\n];
 
-CR : [\r\n] ;
+CR: [\r\n];
 
-TICK_QUOTE : '`"' ;
+TICK_QUOTE: '`"';
 
-TICK_BACKSLASH_TICK_QUOTE : '`\\`"' ;
+TICK_BACKSLASH_TICK_QUOTE: '`\\`"';
 
-TICK_TICK: '``' ;
+TICK_TICK: '``';
 
-PARENS_OPEN : '(' ;
+PARENS_OPEN: '(';
 
-PARENS_CLOSE : ')' ;
+PARENS_CLOSE: ')';
 
-COMMA : ',' ;
+COMMA: ',';
 
-EQUAL_OP : '=' ;
+EQUAL_OP: '=';
 
-DOUBLE_QUOTE : '"';
+DOUBLE_QUOTE: '"';
 
-CURLY_OPEN : '{' ;
-CURLY_CLOSE : '}' ;
-SQUARE_OPEN : '[' ;
-SQUARE_CLOSE : ']' ;
+CURLY_OPEN: '{';
+CURLY_CLOSE: '}';
+SQUARE_OPEN: '[';
+SQUARE_CLOSE: ']';
 
-Special : [~!@#$%^&*+|:;'<>.?/-]+? ;
+Special: [~!@#$%^&*+|:;'<>.?/-]+?;
 
-ANY : .;
+ANY: .;

--- a/grammar/SV3_1aPpParser.g4
+++ b/grammar/SV3_1aPpParser.g4
@@ -16,487 +16,769 @@
 
 parser grammar SV3_1aPpParser;
 
-options { tokenVocab = SV3_1aPpLexer; }
-
-top_level_rule : null_rule source_text EOF ; // SV files
-
-source_text : ( description ) *;
-
-null_rule : ; // Placeholder rule that create the "0" VObject, DO NOT REMOVE
-
-description :
-            escaped_identifier
-            | unterminated_string
-            | string
-            | number
-            | macro_definition
-            | comments
-            | celldefine_directive
-            | endcelldefine_directive
-            | default_nettype_directive
-            | undef_directive
-            | ifdef_directive
-            | ifndef_directive
-            | else_directive
-            | elsif_directive
-            | elseif_directive
-            | endif_directive
-            | include_directive
-            | resetall_directive
-            | begin_keywords_directive
-            | end_keywords_directive
-            | timescale_directive
-            | unconnected_drive_directive
-            | nounconnected_drive_directive
-            | line_directive
-            | default_decay_time_directive
-            | default_trireg_strenght_directive
-            | delay_mode_distributed_directive
-            | delay_mode_path_directive
-            | delay_mode_unit_directive
-            | delay_mode_zero_directive
-            | protect_directive
-            | endprotect_directive
-            | protected_directive
-            | endprotected_directive
-            | expand_vectornets_directive
-            | noexpand_vectornets_directive
-            | autoexpand_vectornets_directive
-            | remove_gatename_directive
-            | noremove_gatenames_directive
-            | remove_netname_directive
-            | noremove_netnames_directive
-            | accelerate_directive
-            | noaccelerate_directive
-            | undefineall_directive
-            | uselib_directive
-            | disable_portfaults_directive
-            | enable_portfaults_directive
-            | nosuppress_faults_directive
-            | suppress_faults_directive
-            | signed_directive
-            | unsigned_directive
-            | pragma_directive
-            | sv_file_directive
-            | sv_line_directive
-            | macro_instance
-            | module
-            | endmodule
-            | sv_interface
-            | endinterface
-            | program
-            | endprogram
-            | primitive
-            | endprimitive
-            | sv_package
-            | endpackage
-            | checker
-            | endchecker
-            | config
-            | endconfig
-            | text_blob
-            ;
+options {
+  tokenVocab = SV3_1aPpLexer;
+}
+
+top_level_rule: null_rule source_text EOF; // SV files
+
+source_text: description*;
+
+null_rule
+  :
+  ; // Placeholder rule that create the "0" VObject, DO NOT REMOVE
+
+description
+  : escaped_identifier
+  | unterminated_string
+  | string
+  | number
+  | macro_definition
+  | comments
+  | celldefine_directive
+  | endcelldefine_directive
+  | default_nettype_directive
+  | undef_directive
+  | ifdef_directive
+  | ifndef_directive
+  | else_directive
+  | elsif_directive
+  | elseif_directive
+  | endif_directive
+  | include_directive
+  | resetall_directive
+  | begin_keywords_directive
+  | end_keywords_directive
+  | timescale_directive
+  | unconnected_drive_directive
+  | nounconnected_drive_directive
+  | line_directive
+  | default_decay_time_directive
+  | default_trireg_strenght_directive
+  | delay_mode_distributed_directive
+  | delay_mode_path_directive
+  | delay_mode_unit_directive
+  | delay_mode_zero_directive
+  | protect_directive
+  | endprotect_directive
+  | protected_directive
+  | endprotected_directive
+  | expand_vectornets_directive
+  | noexpand_vectornets_directive
+  | autoexpand_vectornets_directive
+  | remove_gatename_directive
+  | noremove_gatenames_directive
+  | remove_netname_directive
+  | noremove_netnames_directive
+  | accelerate_directive
+  | noaccelerate_directive
+  | undefineall_directive
+  | uselib_directive
+  | disable_portfaults_directive
+  | enable_portfaults_directive
+  | nosuppress_faults_directive
+  | suppress_faults_directive
+  | signed_directive
+  | unsigned_directive
+  | pragma_directive
+  | sv_file_directive
+  | sv_line_directive
+  | macro_instance
+  | module
+  | endmodule
+  | sv_interface
+  | endinterface
+  | program
+  | endprogram
+  | primitive
+  | endprimitive
+  | sv_package
+  | endpackage
+  | checker
+  | endchecker
+  | config
+  | endconfig
+  | text_blob
+  ;
+
+escaped_identifier: Escaped_identifier;
+
+macro_instance
+  : (Macro_identifier | Macro_Escaped_identifier) Spaces* PARENS_OPEN macro_actual_args PARENS_CLOSE 
+      # MacroInstanceWithArgs
+  | (Macro_identifier | Macro_Escaped_identifier) # MacroInstanceNoArgs
+  ;
+
+unterminated_string: DOUBLE_QUOTE string_blob* CR;
+
+macro_actual_args: macro_arg* (COMMA macro_arg*)*;
+
+comments: One_line_comment | Block_comment;
+
+number: Number;
+
+pound_delay: Pound_delay;
+
+pound_pound_delay: Pound_Pound_delay;
+
+macro_definition
+  : define_directive
+  | multiline_args_macro_definition
+  | simple_no_args_macro_definition
+  | multiline_no_args_macro_definition
+  | simple_args_macro_definition
+  ;
+
+include_directive
+  : TICK_INCLUDE Spaces (
+    String
+    | Simple_identifier
+    | Escaped_identifier
+    | macro_instance
+  )
+  ;
+
+line_directive: TICK_LINE Spaces number String Spaces number;
+
+default_nettype_directive
+  : TICK_DEFAULT_NETTYPE Spaces Simple_identifier
+  ;
+
+sv_file_directive: TICK_FILE__;
+
+sv_line_directive: TICK_LINE__;
+
+timescale_directive: TICK_TIMESCALE TIMESCALE;
+
+undef_directive
+  : TICK_UNDEF Spaces (
+    Simple_identifier
+    | Escaped_identifier
+    | macro_instance
+  )
+  ;
+
+ifdef_directive
+  : TICK_IFDEF Spaces (
+    Simple_identifier
+    | Escaped_identifier
+    | macro_instance
+  )
+  ;
+ifdef_directive_in_macro_body
+  : TICK_IFDEF Spaces (
+    identifier_in_macro_body
+    | Escaped_identifier
+    | macro_instance
+  )
+  ;
+
+ifndef_directive
+  : TICK_IFNDEF Spaces (
+    Simple_identifier
+    | Escaped_identifier
+    | macro_instance
+  )
+  ;
+ifndef_directive_in_macro_body
+  : TICK_IFNDEF Spaces (
+    identifier_in_macro_body
+    | Escaped_identifier
+    | macro_instance
+  )
+  ;
 
-escaped_identifier : Escaped_identifier;
+elsif_directive
+  : TICK_ELSIF Spaces (
+    Simple_identifier
+    | Escaped_identifier
+    | macro_instance
+  )
+  ;
+elsif_directive_in_macro_body
+  : TICK_ELSIF Spaces (
+    identifier_in_macro_body
+    | Escaped_identifier
+    | macro_instance
+  )
+  ;
 
-macro_instance : (Macro_identifier | Macro_Escaped_identifier) Spaces* PARENS_OPEN macro_actual_args PARENS_CLOSE # MacroInstanceWithArgs
-               | (Macro_identifier | Macro_Escaped_identifier)                                                    # MacroInstanceNoArgs
-               ;
+elseif_directive
+  : TICK_ELSEIF Spaces (
+    Simple_identifier
+    | Escaped_identifier
+    | macro_instance
+  )
+  ;
+elseif_directive_in_macro_body
+  : TICK_ELSEIF Spaces (
+    identifier_in_macro_body
+    | Escaped_identifier
+    | macro_instance
+  )
+  ;
 
-unterminated_string : DOUBLE_QUOTE (string_blob)* CR;
+else_directive: TICK_ELSE;
 
-macro_actual_args : (macro_arg)* (COMMA macro_arg*)* ;
+endif_directive
+  : TICK_ENDIF Spaces* One_line_comment
+  | TICK_ENDIF
+  ;
 
-comments :    One_line_comment
-            | Block_comment
-            ;
+resetall_directive: TICK_RESETALL;
 
-number : Number ;
+begin_keywords_directive: TICK_BEGIN_KEYWORDS Spaces String;
 
-pound_delay : Pound_delay ;
+end_keywords_directive: TICK_END_KEYWORDS;
 
-pound_pound_delay : Pound_Pound_delay ;
+pragma_directive
+  : TICK_PRAGMA Spaces Simple_identifier (
+    pragma_expression (Special pragma_expression)*
+  )*
+  ;
 
-macro_definition :
-              define_directive
-            | multiline_args_macro_definition
-            | simple_no_args_macro_definition
-            | multiline_no_args_macro_definition
-            | simple_args_macro_definition
-            ;
+celldefine_directive: TICK_CELLDEFINE Spaces* CR;
 
-include_directive : TICK_INCLUDE Spaces (String | Simple_identifier | Escaped_identifier | macro_instance);
+endcelldefine_directive: TICK_ENDCELLDEFINE Spaces* CR;
 
-line_directive : TICK_LINE Spaces number String Spaces number;
+protect_directive: TICK_PROTECT Spaces* CR;
 
-default_nettype_directive : TICK_DEFAULT_NETTYPE Spaces Simple_identifier;
+endprotect_directive: TICK_ENDPROTECT Spaces* CR;
 
-sv_file_directive : TICK_FILE__ ;
+protected_directive: TICK_PROTECTED;
 
-sv_line_directive : TICK_LINE__ ;
+endprotected_directive: TICK_ENDPROTECTED;
 
-timescale_directive : TICK_TIMESCALE TIMESCALE ;
+expand_vectornets_directive: TICK_EXPAND_VECTORNETS;
 
-undef_directive : TICK_UNDEF Spaces (Simple_identifier | Escaped_identifier | macro_instance);
+noexpand_vectornets_directive: TICK_NOEXPAND_VECTORNETS;
 
-ifdef_directive : TICK_IFDEF Spaces (Simple_identifier | Escaped_identifier | macro_instance) ;
-ifdef_directive_in_macro_body : TICK_IFDEF Spaces (identifier_in_macro_body | Escaped_identifier | macro_instance) ;
+autoexpand_vectornets_directive: TICK_AUTOEXPAND_VECTORNETS;
 
-ifndef_directive : TICK_IFNDEF Spaces (Simple_identifier | Escaped_identifier | macro_instance);
-ifndef_directive_in_macro_body : TICK_IFNDEF Spaces (identifier_in_macro_body | Escaped_identifier | macro_instance);
+uselib_directive: TICK_USELIB text_blob+;
 
-elsif_directive : TICK_ELSIF Spaces (Simple_identifier | Escaped_identifier | macro_instance);
-elsif_directive_in_macro_body : TICK_ELSIF Spaces (identifier_in_macro_body | Escaped_identifier | macro_instance);
+disable_portfaults_directive: TICK_DISABLE_PORTFAULTS;
 
-elseif_directive : TICK_ELSEIF Spaces (Simple_identifier | Escaped_identifier | macro_instance);
-elseif_directive_in_macro_body : TICK_ELSEIF Spaces (identifier_in_macro_body | Escaped_identifier | macro_instance);
+enable_portfaults_directive: TICK_ENABLE_PORTFAULTS;
 
-else_directive : TICK_ELSE;
+nosuppress_faults_directive: TICK_NOSUPPRESS_FAULTS;
 
-endif_directive : TICK_ENDIF Spaces* One_line_comment
-                | TICK_ENDIF ;
+suppress_faults_directive: TICK_SUPPRESS_FAULTS;
 
-resetall_directive : TICK_RESETALL;
+signed_directive: TICK_SIGNED;
 
-begin_keywords_directive : TICK_BEGIN_KEYWORDS Spaces String;
+unsigned_directive: TICK_UNSIGNED;
 
-end_keywords_directive : TICK_END_KEYWORDS;
+remove_gatename_directive: TICK_REMOVE_GATENAME;
 
-pragma_directive : TICK_PRAGMA Spaces Simple_identifier ( pragma_expression ( Special pragma_expression )* )* ;
+noremove_gatenames_directive: TICK_NOREMOVE_GATENAMES;
 
-celldefine_directive : TICK_CELLDEFINE Spaces* CR;
+remove_netname_directive: TICK_REMOVE_NETNAME;
 
-endcelldefine_directive : TICK_ENDCELLDEFINE Spaces* CR;
+noremove_netnames_directive: TICK_NOREMOVE_NETNAMES;
 
-protect_directive : TICK_PROTECT Spaces* CR;
+accelerate_directive: TICK_ACCELERATE;
 
-endprotect_directive : TICK_ENDPROTECT Spaces* CR;
+noaccelerate_directive: TICK_NOACCELERATE;
 
-protected_directive : TICK_PROTECTED;
-
-endprotected_directive : TICK_ENDPROTECTED;
-
-expand_vectornets_directive : TICK_EXPAND_VECTORNETS ;
-
-noexpand_vectornets_directive : TICK_NOEXPAND_VECTORNETS;
-
-autoexpand_vectornets_directive : TICK_AUTOEXPAND_VECTORNETS;
-
-uselib_directive : TICK_USELIB ( text_blob )+;
-
-disable_portfaults_directive : TICK_DISABLE_PORTFAULTS;
-
-enable_portfaults_directive : TICK_ENABLE_PORTFAULTS;
-
-nosuppress_faults_directive : TICK_NOSUPPRESS_FAULTS;
-
-suppress_faults_directive : TICK_SUPPRESS_FAULTS;
-
-signed_directive : TICK_SIGNED;
-
-unsigned_directive : TICK_UNSIGNED;
-
-remove_gatename_directive : TICK_REMOVE_GATENAME;
-
-noremove_gatenames_directive : TICK_NOREMOVE_GATENAMES;
-
-remove_netname_directive : TICK_REMOVE_NETNAME;
-
-noremove_netnames_directive : TICK_NOREMOVE_NETNAMES;
-
-accelerate_directive : TICK_ACCELERATE;
-
-noaccelerate_directive : TICK_NOACCELERATE;
-
-default_trireg_strenght_directive : TICK_DEFAULT_TRIREG_STRENGTH Spaces number;
-
-default_decay_time_directive : TICK_DEFAULT_DECAY_TIME Spaces ( number | Simple_identifier | Fixed_point_number );
-
-unconnected_drive_directive : TICK_UNCONNECTED_DRIVE Spaces Simple_identifier;
-
-nounconnected_drive_directive : TICK_NOUNCONNECTED_DRIVE Spaces* CR;
-
-delay_mode_distributed_directive : TICK_DELAY_MODE_DISTRIBUTED;
-
-delay_mode_path_directive : TICK_DELAY_MODE_PATH;
-
-delay_mode_unit_directive : TICK_DELAY_MODE_UNIT;
-
-delay_mode_zero_directive : TICK_DELAY_MODE_ZERO;
-
-undefineall_directive : TICK_UNDEFINEALL;
-
-module : MODULE ;
-endmodule : ENDMODULE  ;
-
-sv_interface : INTERFACE  ;
-endinterface : ENDINTERFACE  ;
-
-program : PROGRAM  ;
-endprogram : ENDPROGRAM  ;
-
-primitive : PRIMITIVE ;
-endprimitive : ENDPRIMITIVE ;
-
-sv_package : PACKAGE  ;
-endpackage : ENDPACKAGE  ;
-
-checker : CHECKER ;
-endchecker : ENDCHECKER ;
-
-config : CONFIG ;
-endconfig : ENDCONFIG ;
-
-define_directive : TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) Spaces* CR ;
-
-multiline_no_args_macro_definition : TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) Spaces* escaped_macro_definition_body  ;
-
-multiline_args_macro_definition : TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) macro_arguments Spaces* escaped_macro_definition_body;
-
-simple_no_args_macro_definition :
-              TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) Spaces simple_macro_definition_body (CR | One_line_comment)
-            | TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) Spaces* CR
-            ;
-
-simple_args_macro_definition :
-              TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) macro_arguments Spaces simple_macro_definition_body (CR | One_line_comment)
-            | TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) macro_arguments Spaces* CR
-            ;
-
-identifier_in_macro_body : (Simple_identifier TICK_TICK?)* ;
-
-simple_no_args_macro_definition_in_macro_body :
-              TICK_DEFINE Spaces (identifier_in_macro_body | Escaped_identifier)  Spaces simple_macro_definition_body_in_macro_body
-            | TICK_DEFINE Spaces (identifier_in_macro_body | Escaped_identifier) Spaces*
-            | TICK_DEFINE Spaces (identifier_in_macro_body | Escaped_identifier) TICK_VARIABLE simple_macro_definition_body_in_macro_body
-            ;
-
-simple_args_macro_definition_in_macro_body :
-              TICK_DEFINE Spaces (identifier_in_macro_body | Escaped_identifier) macro_arguments Spaces simple_macro_definition_body_in_macro_body
-            | TICK_DEFINE Spaces (identifier_in_macro_body | Escaped_identifier) macro_arguments
-            ;
-
-directive_in_macro :
-              celldefine_directive
-            | endcelldefine_directive
-            | default_nettype_directive
-            | undef_directive
-            | ifdef_directive
-            | ifndef_directive
-            | else_directive
-            | elsif_directive
-            | elseif_directive
-            | endif_directive
-            | include_directive
-            | resetall_directive
-            | timescale_directive
-            | unconnected_drive_directive
-            | nounconnected_drive_directive
-            | line_directive
-            | default_decay_time_directive
-            | default_trireg_strenght_directive
-            | delay_mode_distributed_directive
-            | delay_mode_path_directive
-            | delay_mode_unit_directive
-            | delay_mode_zero_directive
-            | protect_directive
-            | endprotect_directive
-            | protected_directive
-            | endprotected_directive
-            | expand_vectornets_directive
-            | noexpand_vectornets_directive
-            | autoexpand_vectornets_directive
-            | remove_gatename_directive
-            | noremove_gatenames_directive
-            | remove_netname_directive
-            | noremove_netnames_directive
-            | accelerate_directive
-            | noaccelerate_directive
-            | undefineall_directive
-            | uselib_directive
-            | disable_portfaults_directive
-            | enable_portfaults_directive
-            | nosuppress_faults_directive
-            | suppress_faults_directive
-            | signed_directive
-            | unsigned_directive
-            | sv_file_directive
-            | sv_line_directive
-            | sv_package
-            | endpackage
-            | module
-            | endmodule
-            | sv_interface
-            | endinterface
-            | program
-            | endprogram
-            | primitive
-            | endprimitive
-            | checker
-            | endchecker
-            | config
-            | endconfig
-            | simple_args_macro_definition_in_macro_body //(ESCAPED_CR | CR) Adds long runtime on Verilator t_preproc.v case but fixes Syntax Error
-            | simple_no_args_macro_definition_in_macro_body //(ESCAPED_CR | CR)
-            | pound_delay
-            | pound_pound_delay
-            ;
-
-macro_arguments : PARENS_OPEN ((Spaces* Simple_identifier Spaces* (EQUAL_OP default_value*)*)
-                               (COMMA Spaces* (Simple_identifier Spaces* (EQUAL_OP default_value*)*))*)* PARENS_CLOSE ;
-
-escaped_macro_definition_body : escaped_macro_definition_body_alt1
-                              | escaped_macro_definition_body_alt2;
-
-escaped_macro_definition_body_alt1 : (  unterminated_string | Macro_identifier | Macro_Escaped_identifier |
-                                        escaped_identifier | Simple_identifier |
-                                        number | TEXT_CR | pound_delay | pound_pound_delay | ESCAPED_CR | PARENS_OPEN | PARENS_CLOSE | COMMA |
-                                        EQUAL_OP | DOUBLE_QUOTE | TICK_VARIABLE | directive_in_macro | Spaces |
-                                        Fixed_point_number | String | comments | TICK_QUOTE | TICK_BACKSLASH_TICK_QUOTE |
-                                        TICK_TICK | Special | CURLY_OPEN | CURLY_CLOSE | SQUARE_OPEN |
-                                        SQUARE_CLOSE)*? ESCAPED_CR Spaces* (CR | EOF);
-
-escaped_macro_definition_body_alt2 : (  unterminated_string | Macro_identifier | Macro_Escaped_identifier |
-                                        escaped_identifier |
-                                        Simple_identifier | number | TEXT_CR | pound_delay | pound_pound_delay | ESCAPED_CR | PARENS_OPEN |
-                                        PARENS_CLOSE | COMMA | EQUAL_OP | DOUBLE_QUOTE | TICK_VARIABLE |
-                                        directive_in_macro | Spaces | Fixed_point_number | String | comments |
-                                        TICK_QUOTE | TICK_BACKSLASH_TICK_QUOTE | TICK_TICK | Special | CURLY_OPEN |
-                                        CURLY_CLOSE | SQUARE_OPEN | SQUARE_CLOSE)*? (CR Spaces* | EOF) ;
-
-simple_macro_definition_body : (  unterminated_string | Macro_identifier | Macro_Escaped_identifier |
-                                  escaped_identifier |
-                                  Simple_identifier | number | pound_delay | pound_pound_delay | TEXT_CR | PARENS_OPEN |
-                                  PARENS_CLOSE | COMMA | EQUAL_OP | DOUBLE_QUOTE | TICK_VARIABLE |
-                                  Spaces | Fixed_point_number | String | comments |
-                                  TICK_QUOTE | TICK_BACKSLASH_TICK_QUOTE | TICK_TICK | Special |
-                                  CURLY_OPEN | CURLY_CLOSE | SQUARE_OPEN | SQUARE_CLOSE | TICK_INCLUDE | directive_in_macro )*? ;
-
-simple_macro_definition_body_in_macro_body : (  unterminated_string | Macro_identifier | Macro_Escaped_identifier |
-                                  escaped_identifier |
-                                  Simple_identifier | number | pound_delay | pound_pound_delay | TEXT_CR |
-                                  PARENS_OPEN | PARENS_CLOSE | COMMA | EQUAL_OP | DOUBLE_QUOTE | TICK_VARIABLE |
-                                  Spaces | Fixed_point_number | String | comments |
-                                  TICK_QUOTE | TICK_BACKSLASH_TICK_QUOTE | TICK_TICK | Special | CURLY_OPEN |
-                                  CURLY_CLOSE | SQUARE_OPEN | SQUARE_CLOSE )*? ;
-
-
-pragma_expression : Simple_identifier
-                 | number
-                 | Spaces
-                 | Fixed_point_number
-                 | String
-                 | CURLY_OPEN
-                 | CURLY_CLOSE
-                 | SQUARE_OPEN
-                 | SQUARE_CLOSE
-                 | PARENS_OPEN
-                 | PARENS_CLOSE
-                 | COMMA
-                 | EQUAL_OP
-                 | DOUBLE_QUOTE
-                 | escaped_identifier
-                 | pound_delay
-                 | pound_pound_delay
-                 | Special
-                 | ANY
-                 ;
-
-macro_arg : Simple_identifier
-                 | number
-                 | Spaces
-                 | Fixed_point_number
-                 | String
-                 | paired_parens
-                 | EQUAL_OP
-                 | DOUBLE_QUOTE
-                 | macro_instance
-                 | CR
-                 | TEXT_CR
-                 | escaped_identifier
-                 | simple_args_macro_definition_in_macro_body
-                 | simple_no_args_macro_definition_in_macro_body
-                 | comments
-                 | pound_delay
-                 | pound_pound_delay
-                 | Special
-                 | ANY
-                 ;
-
-paired_parens : ( PARENS_OPEN ( Simple_identifier | number
-                 | Spaces | Fixed_point_number | String | COMMA | EQUAL_OP
-                 | DOUBLE_QUOTE | macro_instance | TEXT_CR | CR | paired_parens | escaped_identifier | comments | Special | ANY )* PARENS_CLOSE )
-              | ( CURLY_OPEN ( Simple_identifier | number
-                 | Spaces | Fixed_point_number | String | COMMA | EQUAL_OP
-                 | DOUBLE_QUOTE | macro_instance | CR | paired_parens | escaped_identifier | comments | Special | ANY )* CURLY_CLOSE )
-              | ( SQUARE_OPEN ( Simple_identifier | number
-                 | Spaces | Fixed_point_number | String | COMMA | EQUAL_OP
-                 | DOUBLE_QUOTE | macro_instance | CR | paired_parens | escaped_identifier | comments | Special | ANY )* SQUARE_CLOSE ) ;
-
-text_blob :   Simple_identifier
-            | CR
-            | Spaces
-            | Fixed_point_number
-            | ESCAPED_CR
-            | String
-            | PARENS_OPEN
-            | PARENS_CLOSE
-            | COMMA
-            | EQUAL_OP
-            | DOUBLE_QUOTE
-            | CURLY_OPEN
-            | CURLY_CLOSE
-            | SQUARE_OPEN
-            | SQUARE_CLOSE
-            | TICK_TICK
-            | TICK_VARIABLE
-            | TIMESCALE
-            | pound_delay
-            | pound_pound_delay
-            | TICK_QUOTE
-            | TICK_BACKSLASH_TICK_QUOTE
-            | TEXT_CR
-            | Special
-            | ANY
-            ;
-
-string : String ;
-
-default_value : Simple_identifier
-            | number
-            | Spaces
-            | Fixed_point_number
-            | String
-            | CURLY_OPEN
-            | CURLY_CLOSE
-            | SQUARE_OPEN
-            | SQUARE_CLOSE
-            | paired_parens
-            | escaped_identifier
-            | macro_instance
-            | Special
-            | ANY
-            ;
-
-string_blob : Simple_identifier
-            | number
-            | Spaces
-            | Fixed_point_number
-            | ESCAPED_CR
-            | PARENS_OPEN
-            | PARENS_CLOSE
-            | COMMA
-            | EQUAL_OP
-            | DOUBLE_QUOTE
-            | CURLY_OPEN
-            | CURLY_CLOSE
-            | SQUARE_OPEN
-            | SQUARE_CLOSE
-            | escaped_identifier
-            | TIMESCALE
-            | pound_delay
-            | pound_pound_delay
-            | TEXT_CR
-            | Special
-            | ANY
-            ;
+default_trireg_strenght_directive
+  : TICK_DEFAULT_TRIREG_STRENGTH Spaces number
+  ;
+
+default_decay_time_directive
+  : TICK_DEFAULT_DECAY_TIME Spaces (
+    number
+    | Simple_identifier
+    | Fixed_point_number
+  )
+  ;
+
+unconnected_drive_directive
+  : TICK_UNCONNECTED_DRIVE Spaces Simple_identifier
+  ;
+
+nounconnected_drive_directive
+  : TICK_NOUNCONNECTED_DRIVE Spaces* CR
+  ;
+
+delay_mode_distributed_directive: TICK_DELAY_MODE_DISTRIBUTED;
+
+delay_mode_path_directive: TICK_DELAY_MODE_PATH;
+
+delay_mode_unit_directive: TICK_DELAY_MODE_UNIT;
+
+delay_mode_zero_directive: TICK_DELAY_MODE_ZERO;
+
+undefineall_directive: TICK_UNDEFINEALL;
+
+module: MODULE;
+endmodule: ENDMODULE;
+
+sv_interface: INTERFACE;
+endinterface: ENDINTERFACE;
+
+program: PROGRAM;
+endprogram: ENDPROGRAM;
+
+primitive: PRIMITIVE;
+endprimitive: ENDPRIMITIVE;
+
+sv_package: PACKAGE;
+endpackage: ENDPACKAGE;
+
+checker: CHECKER;
+endchecker: ENDCHECKER;
+
+config: CONFIG;
+endconfig: ENDCONFIG;
+
+define_directive
+  : TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) Spaces* CR
+  ;
+
+multiline_no_args_macro_definition
+  : TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) Spaces*
+      escaped_macro_definition_body
+  ;
+
+multiline_args_macro_definition
+  : TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) macro_arguments Spaces*
+      escaped_macro_definition_body
+  ;
+
+simple_no_args_macro_definition
+  : TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) Spaces simple_macro_definition_body
+      (
+    CR
+    | One_line_comment
+  )
+  | TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) Spaces* CR
+  ;
+
+simple_args_macro_definition
+  : TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) macro_arguments Spaces
+      simple_macro_definition_body (CR | One_line_comment)
+  | TICK_DEFINE Spaces (Simple_identifier | Escaped_identifier) macro_arguments Spaces* CR
+  ;
+
+identifier_in_macro_body: (Simple_identifier TICK_TICK?)*;
+
+simple_no_args_macro_definition_in_macro_body
+  : TICK_DEFINE Spaces (
+    identifier_in_macro_body
+    | Escaped_identifier
+  ) Spaces simple_macro_definition_body_in_macro_body
+  | TICK_DEFINE Spaces (
+    identifier_in_macro_body
+    | Escaped_identifier
+  ) Spaces*
+  | TICK_DEFINE Spaces (
+    identifier_in_macro_body
+    | Escaped_identifier
+  ) TICK_VARIABLE simple_macro_definition_body_in_macro_body
+  ;
+
+simple_args_macro_definition_in_macro_body
+  : TICK_DEFINE Spaces (
+    identifier_in_macro_body
+    | Escaped_identifier
+  ) macro_arguments Spaces simple_macro_definition_body_in_macro_body
+  | TICK_DEFINE Spaces (
+    identifier_in_macro_body
+    | Escaped_identifier
+  ) macro_arguments
+  ;
+
+directive_in_macro
+  : celldefine_directive
+  | endcelldefine_directive
+  | default_nettype_directive
+  | undef_directive
+  | ifdef_directive
+  | ifndef_directive
+  | else_directive
+  | elsif_directive
+  | elseif_directive
+  | endif_directive
+  | include_directive
+  | resetall_directive
+  | timescale_directive
+  | unconnected_drive_directive
+  | nounconnected_drive_directive
+  | line_directive
+  | default_decay_time_directive
+  | default_trireg_strenght_directive
+  | delay_mode_distributed_directive
+  | delay_mode_path_directive
+  | delay_mode_unit_directive
+  | delay_mode_zero_directive
+  | protect_directive
+  | endprotect_directive
+  | protected_directive
+  | endprotected_directive
+  | expand_vectornets_directive
+  | noexpand_vectornets_directive
+  | autoexpand_vectornets_directive
+  | remove_gatename_directive
+  | noremove_gatenames_directive
+  | remove_netname_directive
+  | noremove_netnames_directive
+  | accelerate_directive
+  | noaccelerate_directive
+  | undefineall_directive
+  | uselib_directive
+  | disable_portfaults_directive
+  | enable_portfaults_directive
+  | nosuppress_faults_directive
+  | suppress_faults_directive
+  | signed_directive
+  | unsigned_directive
+  | sv_file_directive
+  | sv_line_directive
+  | sv_package
+  | endpackage
+  | module
+  | endmodule
+  | sv_interface
+  | endinterface
+  | program
+  | endprogram
+  | primitive
+  | endprimitive
+  | checker
+  | endchecker
+  | config
+  | endconfig
+  | simple_args_macro_definition_in_macro_body
+  //(ESCAPED_CR | CR) Adds long runtime on Verilator t_preproc.v case but fixes Syntax Error
+  | simple_no_args_macro_definition_in_macro_body //(ESCAPED_CR | CR)
+  | pound_delay
+  | pound_pound_delay
+  ;
+
+macro_arguments
+  : PARENS_OPEN (
+    (
+      Spaces* Simple_identifier Spaces* (EQUAL_OP default_value*)*
+    ) (
+      COMMA Spaces* (
+        Simple_identifier Spaces* (EQUAL_OP default_value*)*
+      )
+    )*
+  )* PARENS_CLOSE
+  ;
+
+escaped_macro_definition_body
+  : escaped_macro_definition_body_alt1
+  | escaped_macro_definition_body_alt2
+  ;
+
+escaped_macro_definition_body_alt1
+  : (
+    unterminated_string
+    | Macro_identifier
+    | Macro_Escaped_identifier
+    | escaped_identifier
+    | Simple_identifier
+    | number
+    | TEXT_CR
+    | pound_delay
+    | pound_pound_delay
+    | ESCAPED_CR
+    | PARENS_OPEN
+    | PARENS_CLOSE
+    | COMMA
+    | EQUAL_OP
+    | DOUBLE_QUOTE
+    | TICK_VARIABLE
+    | directive_in_macro
+    | Spaces
+    | Fixed_point_number
+    | String
+    | comments
+    | TICK_QUOTE
+    | TICK_BACKSLASH_TICK_QUOTE
+    | TICK_TICK
+    | Special
+    | CURLY_OPEN
+    | CURLY_CLOSE
+    | SQUARE_OPEN
+    | SQUARE_CLOSE
+  )*? ESCAPED_CR Spaces* (CR | EOF)
+  ;
+
+escaped_macro_definition_body_alt2
+  : (
+    unterminated_string
+    | Macro_identifier
+    | Macro_Escaped_identifier
+    | escaped_identifier
+    | Simple_identifier
+    | number
+    | TEXT_CR
+    | pound_delay
+    | pound_pound_delay
+    | ESCAPED_CR
+    | PARENS_OPEN
+    | PARENS_CLOSE
+    | COMMA
+    | EQUAL_OP
+    | DOUBLE_QUOTE
+    | TICK_VARIABLE
+    | directive_in_macro
+    | Spaces
+    | Fixed_point_number
+    | String
+    | comments
+    | TICK_QUOTE
+    | TICK_BACKSLASH_TICK_QUOTE
+    | TICK_TICK
+    | Special
+    | CURLY_OPEN
+    | CURLY_CLOSE
+    | SQUARE_OPEN
+    | SQUARE_CLOSE
+  )*? (CR Spaces* | EOF)
+  ;
+
+simple_macro_definition_body
+  : (
+    unterminated_string
+    | Macro_identifier
+    | Macro_Escaped_identifier
+    | escaped_identifier
+    | Simple_identifier
+    | number
+    | pound_delay
+    | pound_pound_delay
+    | TEXT_CR
+    | PARENS_OPEN
+    | PARENS_CLOSE
+    | COMMA
+    | EQUAL_OP
+    | DOUBLE_QUOTE
+    | TICK_VARIABLE
+    | Spaces
+    | Fixed_point_number
+    | String
+    | comments
+    | TICK_QUOTE
+    | TICK_BACKSLASH_TICK_QUOTE
+    | TICK_TICK
+    | Special
+    | CURLY_OPEN
+    | CURLY_CLOSE
+    | SQUARE_OPEN
+    | SQUARE_CLOSE
+    | TICK_INCLUDE
+    | directive_in_macro
+  )*?
+  ;
+
+simple_macro_definition_body_in_macro_body
+  : (
+    unterminated_string
+    | Macro_identifier
+    | Macro_Escaped_identifier
+    | escaped_identifier
+    | Simple_identifier
+    | number
+    | pound_delay
+    | pound_pound_delay
+    | TEXT_CR
+    | PARENS_OPEN
+    | PARENS_CLOSE
+    | COMMA
+    | EQUAL_OP
+    | DOUBLE_QUOTE
+    | TICK_VARIABLE
+    | Spaces
+    | Fixed_point_number
+    | String
+    | comments
+    | TICK_QUOTE
+    | TICK_BACKSLASH_TICK_QUOTE
+    | TICK_TICK
+    | Special
+    | CURLY_OPEN
+    | CURLY_CLOSE
+    | SQUARE_OPEN
+    | SQUARE_CLOSE
+  )*?
+  ;
+
+pragma_expression
+  : Simple_identifier
+  | number
+  | Spaces
+  | Fixed_point_number
+  | String
+  | CURLY_OPEN
+  | CURLY_CLOSE
+  | SQUARE_OPEN
+  | SQUARE_CLOSE
+  | PARENS_OPEN
+  | PARENS_CLOSE
+  | COMMA
+  | EQUAL_OP
+  | DOUBLE_QUOTE
+  | escaped_identifier
+  | pound_delay
+  | pound_pound_delay
+  | Special
+  | ANY
+  ;
+
+macro_arg
+  : Simple_identifier
+  | number
+  | Spaces
+  | Fixed_point_number
+  | String
+  | paired_parens
+  | EQUAL_OP
+  | DOUBLE_QUOTE
+  | macro_instance
+  | CR
+  | TEXT_CR
+  | escaped_identifier
+  | simple_args_macro_definition_in_macro_body
+  | simple_no_args_macro_definition_in_macro_body
+  | comments
+  | pound_delay
+  | pound_pound_delay
+  | Special
+  | ANY
+  ;
+
+paired_parens
+  : (
+    PARENS_OPEN (
+      Simple_identifier
+      | number
+      | Spaces
+      | Fixed_point_number
+      | String
+      | COMMA
+      | EQUAL_OP
+      | DOUBLE_QUOTE
+      | macro_instance
+      | TEXT_CR
+      | CR
+      | paired_parens
+      | escaped_identifier
+      | comments
+      | Special
+      | ANY
+    )* PARENS_CLOSE
+  )
+  | (
+    CURLY_OPEN (
+      Simple_identifier
+      | number
+      | Spaces
+      | Fixed_point_number
+      | String
+      | COMMA
+      | EQUAL_OP
+      | DOUBLE_QUOTE
+      | macro_instance
+      | CR
+      | paired_parens
+      | escaped_identifier
+      | comments
+      | Special
+      | ANY
+    )* CURLY_CLOSE
+  )
+  | (
+    SQUARE_OPEN (
+      Simple_identifier
+      | number
+      | Spaces
+      | Fixed_point_number
+      | String
+      | COMMA
+      | EQUAL_OP
+      | DOUBLE_QUOTE
+      | macro_instance
+      | CR
+      | paired_parens
+      | escaped_identifier
+      | comments
+      | Special
+      | ANY
+    )* SQUARE_CLOSE
+  )
+  ;
+
+text_blob
+  : Simple_identifier
+  | CR
+  | Spaces
+  | Fixed_point_number
+  | ESCAPED_CR
+  | String
+  | PARENS_OPEN
+  | PARENS_CLOSE
+  | COMMA
+  | EQUAL_OP
+  | DOUBLE_QUOTE
+  | CURLY_OPEN
+  | CURLY_CLOSE
+  | SQUARE_OPEN
+  | SQUARE_CLOSE
+  | TICK_TICK
+  | TICK_VARIABLE
+  | TIMESCALE
+  | pound_delay
+  | pound_pound_delay
+  | TICK_QUOTE
+  | TICK_BACKSLASH_TICK_QUOTE
+  | TEXT_CR
+  | Special
+  | ANY
+  ;
+
+string: String;
+
+default_value
+  : Simple_identifier
+  | number
+  | Spaces
+  | Fixed_point_number
+  | String
+  | CURLY_OPEN
+  | CURLY_CLOSE
+  | SQUARE_OPEN
+  | SQUARE_CLOSE
+  | paired_parens
+  | escaped_identifier
+  | macro_instance
+  | Special
+  | ANY
+  ;
+
+string_blob
+  : Simple_identifier
+  | number
+  | Spaces
+  | Fixed_point_number
+  | ESCAPED_CR
+  | PARENS_OPEN
+  | PARENS_CLOSE
+  | COMMA
+  | EQUAL_OP
+  | DOUBLE_QUOTE
+  | CURLY_OPEN
+  | CURLY_CLOSE
+  | SQUARE_OPEN
+  | SQUARE_CLOSE
+  | escaped_identifier
+  | TIMESCALE
+  | pound_delay
+  | pound_pound_delay
+  | TEXT_CR
+  | Special
+  | ANY
+  ;

--- a/grammar/SV3_1aSplitterLexer.g4
+++ b/grammar/SV3_1aSplitterLexer.g4
@@ -18,59 +18,62 @@ lexer grammar SV3_1aSplitterLexer;
 
 // A.9.2 Comments
 
-One_line_comment : '//' Comment_text '\r'? '\n' ;
+One_line_comment: '//' Comment_text '\r'? '\n';
 
-Block_comment : '/*' Comment_text '*/' ;
+Block_comment: '/*' Comment_text '*/';
 
-fragment Comment_text : (WS | CR | TAB)* | .*? ;
+fragment Comment_text: (WS | CR | TAB)* | .*?;
 
-MODULE : 'module';
+MODULE: 'module';
 
-ENDMODULE : 'endmodule' ;
+ENDMODULE: 'endmodule';
 
-INTERFACE : 'interface' ;
+INTERFACE: 'interface';
 
-ENDINTERFACE : 'endinterface' ;
+ENDINTERFACE: 'endinterface';
 
-PROGRAM : 'program' ;
+PROGRAM: 'program';
 
-ENDPROGRAM : 'endprogram' ;
+ENDPROGRAM: 'endprogram';
 
-PRIMITIVE : 'primivite' ;
+PRIMITIVE: 'primivite';
 
-ENDPRIMITIVE : 'endprimitive' ;
+ENDPRIMITIVE: 'endprimitive';
 
-PACKAGE : 'package' ;
+PACKAGE: 'package';
 
-ENDPACKAGE : 'endpackage' ;
+ENDPACKAGE: 'endpackage';
 
-CHECKER : 'checker' ;
+CHECKER: 'checker';
 
-ENDCHECKER : 'endchecker' ;
+ENDCHECKER: 'endchecker';
 
-CONFIG : 'config' ;
+CONFIG: 'config';
 
-ENDCONFIG : 'endconfig' ;
+ENDCONFIG: 'endconfig';
 
 String
- : '"'                          // a opening quote
-   (                            // start group
-     '\\' ~('\r')        // an escaped char other than a line break char
-     |                          // OR
-     ~('\\' | '"'| '\r' | '\n') // any char other than '"', '\' and line breaks
-   )*                           // end group and repeat zero or more times
-   '"'                          // the closing quote
- ;
+  : '"' // a opening quote
+  (
+    // start group
+    '\\' ~'\r' // an escaped char other than a line break char
+    | // OR
+    ~(
+      '\\'
+      | '"'
+      | '\r'
+      | '\n'
+    ) // any char other than '"', '\' and line breaks
+  )* // end group and repeat zero or more times
+  '"'
+  ; // the closing quote
 
-Spaces : (WS | TAB)+;
+Spaces: (WS | TAB)+;
 
+fragment WS: [ ]+;
 
+fragment TAB: [\t]+;
 
-fragment WS : [ ]+ ;
+CR: [\r\n];
 
-fragment TAB : [\t]+ ;
-
-CR : [\r\n] ;
-
-
-ANY : .;
+ANY: .;

--- a/grammar/SV3_1aSplitterParser.g4
+++ b/grammar/SV3_1aSplitterParser.g4
@@ -16,49 +16,49 @@
 
 parser grammar SV3_1aSplitterParser;
 
+options {
+  tokenVocab = SV3_1aSplitterLexer;
+}
 
-options { tokenVocab = SV3_1aSplitterLexer; }
+source_text: description*;
 
-source_text : ( description ) *;
+description
+  : module
+  | endmodule
+  | sv_interface
+  | endinterface
+  | program
+  | endprogram
+  | primitive
+  | endprimitive
+  | sv_package
+  | endpackage
+  | checker
+  | endchecker
+  | config
+  | endconfig
+  | ANY
+  ;
 
-description :
-              module
-            | endmodule
-            | sv_interface
-            | endinterface
-            | program
-            | endprogram
-            | primitive
-            | endprimitive
-            | sv_package
-            | endpackage
-            | checker
-            | endchecker
-            | config
-            | endconfig
-            | ANY
-            ;
+module: MODULE;
+endmodule: ENDMODULE;
 
+sv_interface: INTERFACE;
+endinterface: ENDINTERFACE;
 
-module : MODULE ;
-endmodule : ENDMODULE  ;
+program: PROGRAM;
+endprogram: ENDPROGRAM;
 
-sv_interface : INTERFACE  ;
-endinterface : ENDINTERFACE  ;
+primitive: PRIMITIVE;
+endprimitive: ENDPRIMITIVE;
 
-program : PROGRAM  ;
-endprogram : ENDPROGRAM  ;
+sv_package: PACKAGE;
+endpackage: ENDPACKAGE;
 
-primitive : PRIMITIVE ;
-endprimitive : ENDPRIMITIVE ;
+checker: CHECKER;
+endchecker: ENDCHECKER;
 
-sv_package : PACKAGE  ;
-endpackage : ENDPACKAGE  ;
+config: CONFIG;
+endconfig: ENDCONFIG;
 
-checker : CHECKER ;
-endchecker : ENDCHECKER ;
-
-config : CONFIG ;
-endconfig : ENDCONFIG ;
-
-any : ANY ;
+any: ANY;

--- a/scripts/generate_ast_listener.py
+++ b/scripts/generate_ast_listener.py
@@ -105,7 +105,6 @@ _type_names = set([
   'slDot',
   'slDotStar',
   'slNonBlockingTriggerEvent',
-  'slPound_Pound_delay',
 
   'slPortDir_Inp',
   'slPortDir_Out',
@@ -211,7 +210,6 @@ _type_names = set([
   'slTagged',
   'slQmark',
   'slMatches',
-  'slIff',
   'slNull',
   'slWith',
   'slImport',

--- a/scripts/generate_parser_listener.py
+++ b/scripts/generate_parser_listener.py
@@ -106,7 +106,6 @@ _type_names = set([
   'slDot',
   'slDotStar',
   'slNonBlockingTriggerEvent',
-  'slPound_Pound_delay',
 
   'slPortDir_Inp',
   'slPortDir_Out',
@@ -212,7 +211,6 @@ _type_names = set([
   'slTagged',
   'slQmark',
   'slMatches',
-  'slIff',
   'slNull',
   'slWith',
   'slImport',

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -442,6 +442,10 @@ bool CompileClass::compile_class_method_(const FileContent* fC, NodeId id) {
     NodeId data_type = fC->Child(function_data_type);
     NodeId type = fC->Child(data_type);
     VObjectType the_type = fC->Type(type);
+    if (the_type == VObjectType::slVirtual) {
+      type = fC->Sibling(type);
+      the_type = fC->Type(type);
+    }
     std::string typeName;
     if (the_type == VObjectType::slStringConst) {
       typeName = fC->SymName(type);

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -1462,7 +1462,7 @@ UHDM::any *CompileHelper::compileExpression(
     }
     case VObjectType::slExpression: {
       NodeId Iff = fC->Sibling(parent);
-      if (fC->Type(Iff) == VObjectType::slIff) {
+      if (fC->Type(Iff) == VObjectType::slIFF) {
         operation *op = s.MakeOperation();
         op->VpiOpType(vpiIffOp);
         op->VpiParent(pexpr);
@@ -2226,7 +2226,7 @@ UHDM::any *CompileHelper::compileExpression(
             int operationType = UhdmWriter::getVpiOpType(type);
             if (NodeId subOp1 = fC->Child(oper)) {
               VObjectType subOp1type = fC->Type(subOp1);
-              if (subOp1type == VObjectType::slPound_Pound_delay) {
+              if (subOp1type == VObjectType::slPound_pound_delay) {
                 if (NodeId subOp2 = fC->Sibling(subOp1)) {
                   VObjectType subOp2type = fC->Type(subOp2);
                   if (subOp2type == VObjectType::slAssociative_dimension) {
@@ -2843,7 +2843,7 @@ UHDM::any *CompileHelper::compileExpression(
           int operationType = UhdmWriter::getVpiOpType(type);
           if (NodeId subOp1 = fC->Child(child)) {
             VObjectType subOp1type = fC->Type(subOp1);
-            if (subOp1type == VObjectType::slPound_Pound_delay) {
+            if (subOp1type == VObjectType::slPound_pound_delay) {
               operationType = vpiUnaryCycleDelayOp;
               if (NodeId subOp2 = fC->Sibling(subOp1)) {
                 VObjectType subOp2type = fC->Type(subOp2);

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -4275,8 +4275,11 @@ UHDM::any *CompileHelper::compileTypename(
   UHDM::Serializer &s = compileDesign->getSerializer();
   UHDM::any *result = nullptr;
   UHDM::constant *c = s.MakeConstant();
-  if (fC->Type(Expression) == VObjectType::slData_type)
+  if (fC->Type(Expression) == VObjectType::slData_type) {
     Expression = fC->Child(Expression);
+    if (fC->Type(Expression) == VObjectType::slVirtual)
+      Expression = fC->Sibling(Expression);
+  }
   VObjectType type = fC->Type(Expression);
   switch (type) {
     case VObjectType::slIntVec_TypeLogic:

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -794,6 +794,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
   } else {
     bool forwardDeclaration = false;
     NodeId stype = fC->Child(data_type);
+    if (fC->Type(stype) == VObjectType::slVirtual) stype = fC->Sibling(stype);
     if (!stype && (fC->Type(data_type) == VObjectType::slStringConst)) {
       stype = data_type;
       if (!fC->Sibling(stype)) {
@@ -2143,6 +2144,8 @@ bool CompileHelper::compileDataDeclaration(
       }
       NodeId data_type = fC->Child(variable_declaration);
       NodeId intVec_TypeReg = fC->Child(data_type);
+      if (fC->Type(intVec_TypeReg) == VObjectType::slVirtual)
+        intVec_TypeReg = fC->Sibling(intVec_TypeReg);
       NodeId packedDimension = fC->Sibling(intVec_TypeReg);
       if (fC->Type(packedDimension) == VObjectType::slStringConst) {
         // class or package name;
@@ -2700,6 +2703,8 @@ bool CompileHelper::compileParameterDeclaration(
       bool skip = false;
       if (ntype && fC->Type(ntype) == VObjectType::slData_type) {
         ntype = fC->Child(ntype);
+        if (fC->Type(ntype) == VObjectType::slVirtual)
+          ntype = fC->Sibling(ntype);
         skip = true;
       } else {
         ntype = InvalidNodeId;

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -1527,6 +1527,7 @@ std::vector<io_decl*>* CompileHelper::compileTfPortList(
     }
     fC->populateCoreMembers(tf_param_name, tf_param_name, decl);
     NodeId type = fC->Child(tf_data_type);
+    if (fC->Type(type) == VObjectType::slVirtual) type = fC->Sibling(type);
 
     NodeId unpackedDimension =
         fC->Sibling(fC->Sibling(fC->Child(tf_port_item)));

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -204,6 +204,10 @@ UHDM::any* CompileHelper::compileVariable(
       the_type == VObjectType::slPs_or_hierarchical_identifier) {
     variable = fC->Child(variable);
     the_type = fC->Type(variable);
+    if (the_type == VObjectType::slVirtual) {
+      variable = fC->Sibling(variable);
+      the_type = fC->Type(variable);
+    }
   } else if (the_type == VObjectType::slImplicit_class_handle) {
     NodeId Handle = fC->Child(variable);
     if (fC->Type(Handle) == VObjectType::slThis_keyword) {
@@ -1054,6 +1058,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
       (the_type == VObjectType::slData_type)) {
     if (fC->Child(type)) {
       type = fC->Child(type);
+      if (fC->Type(type) == VObjectType::slVirtual) type = fC->Sibling(type);
     } else {
       // Implicit type
     }

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -369,7 +369,7 @@ unsigned int UhdmWriter::getVpiOpType(VObjectType type) {
     case VObjectType::slBinOp_WildcardNotEqual:
     case VObjectType::slBinOp_WildNotEqual:
       return vpiWildNeqOp;
-    case VObjectType::slIff:
+    case VObjectType::slIFF:
       return vpiIffOp;
     case VObjectType::slNON_OVERLAP_IMPLY:
       return vpiNonOverlapImplyOp;
@@ -389,8 +389,6 @@ unsigned int UhdmWriter::getVpiOpType(VObjectType type) {
       return vpiUntilWithOp;
     case VObjectType::slIMPLIES:
       return vpiImpliesOp;
-    case VObjectType::slIFF:
-      return vpiIffOp;
     case VObjectType::slCycle_delay_range:
       return vpiCycleDelayOp;
     case VObjectType::slConsecutive_repetition:

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -87,8 +87,22 @@ void SV3_1aTreeShapeListener::enterModule_declaration(
 
 void SV3_1aTreeShapeListener::exitModule_declaration(
     SV3_1aParser::Module_declarationContext *ctx) {
+  if (ctx->ENDMODULE() != nullptr) {
+    addVObject((antlr4::ParserRuleContext *)ctx->ENDMODULE(),
+               VObjectType::slEndmodule);
+  }
   addVObject(ctx, VObjectType::slModule_declaration);
   m_nestedElements.pop();
+}
+
+void SV3_1aTreeShapeListener::exitModule_keyword(
+    SV3_1aParser::Module_keywordContext *ctx) {
+  if (ctx->MODULE() != nullptr) {
+    addVObject(ctx, ctx->MODULE()->getText(), VObjectType::slModule_keyword);
+  } else if (ctx->MACROMODULE() != nullptr) {
+    addVObject(ctx, ctx->MACROMODULE()->getText(),
+               VObjectType::slModule_keyword);
+  }
 }
 
 void SV3_1aTreeShapeListener::exitClass_constructor_declaration(

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -879,7 +879,7 @@ void SV3_1aTreeShapeListener::exitPound_delay_value(
     addVObject(ctx, ctx->Pound_delay()->getText(), VObjectType::slIntConst);
   } else if (ctx->Pound_Pound_delay()) {
     addVObject(ctx, ctx->Pound_Pound_delay()->getText(),
-               VObjectType::slPound_Pound_delay);
+               VObjectType::slPound_pound_delay);
   } else if (ctx->delay_value()) {
     const std::string text = ctx->delay_value()->getText();
     if (std::isdigit(text[0])) {
@@ -1499,7 +1499,7 @@ void SV3_1aTreeShapeListener::exitExpression(
 void SV3_1aTreeShapeListener::exitEvent_expression(
     SV3_1aParser::Event_expressionContext *ctx) {
   if (ctx->IFF()) {
-    addVObject((antlr4::ParserRuleContext *)ctx->IFF(), VObjectType::slIff);
+    addVObject((antlr4::ParserRuleContext *)ctx->IFF(), VObjectType::slIFF);
   }
   addVObject(ctx, VObjectType::slEvent_expression);
 }
@@ -1760,7 +1760,7 @@ void SV3_1aTreeShapeListener::exitCycle_delay(
   if (ctx->Pound_Pound_delay()) {
     addVObject((antlr4::ParserRuleContext *)ctx->Pound_Pound_delay(),
                ctx->Pound_Pound_delay()->getText(),
-               VObjectType::slPound_Pound_delay);
+               VObjectType::slPound_pound_delay);
   }
   addVObject(ctx, VObjectType::slCycle_delay);
 }
@@ -1770,11 +1770,11 @@ void SV3_1aTreeShapeListener::exitCycle_delay_range(
   if (ctx->Pound_Pound_delay()) {
     addVObject((antlr4::ParserRuleContext *)ctx->Pound_Pound_delay(),
                ctx->Pound_Pound_delay()->getText(),
-               VObjectType::slPound_Pound_delay);
+               VObjectType::slPound_pound_delay);
   }
   if (ctx->POUNDPOUND()) {
     addVObject((antlr4::ParserRuleContext *)ctx->POUNDPOUND(),
-               ctx->POUNDPOUND()->getText(), VObjectType::slPound_Pound_delay);
+               ctx->POUNDPOUND()->getText(), VObjectType::slPound_pound_delay);
   }
   if (ctx->PLUS()) {
     addVObject((antlr4::ParserRuleContext *)ctx->PLUS(),
@@ -1879,7 +1879,7 @@ void SV3_1aTreeShapeListener::exitDeferred_immediate_assert_statement(
   } else if (ctx->Pound_Pound_delay()) {
     addVObject((antlr4::ParserRuleContext *)ctx->Pound_Pound_delay(),
                ctx->Pound_Pound_delay()->getText(),
-               VObjectType::slPound_Pound_delay);
+               VObjectType::slPound_pound_delay);
   }
   addVObject(ctx, VObjectType::slDeferred_immediate_assert_statement);
 }
@@ -1892,7 +1892,7 @@ void SV3_1aTreeShapeListener::exitDeferred_immediate_assume_statement(
   } else if (ctx->Pound_Pound_delay()) {
     addVObject((antlr4::ParserRuleContext *)ctx->Pound_Pound_delay(),
                ctx->Pound_Pound_delay()->getText(),
-               VObjectType::slPound_Pound_delay);
+               VObjectType::slPound_pound_delay);
   }
   addVObject(ctx, VObjectType::slDeferred_immediate_assume_statement);
 }
@@ -1905,7 +1905,7 @@ void SV3_1aTreeShapeListener::exitDeferred_immediate_cover_statement(
   } else if (ctx->Pound_Pound_delay()) {
     addVObject((antlr4::ParserRuleContext *)ctx->Pound_Pound_delay(),
                ctx->Pound_Pound_delay()->getText(),
-               VObjectType::slPound_Pound_delay);
+               VObjectType::slPound_pound_delay);
   }
   addVObject(ctx, VObjectType::slDeferred_immediate_cover_statement);
 }

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -890,6 +890,15 @@ void SV3_1aTreeShapeListener::exitPound_delay_value(
   }
 }
 
+void SV3_1aTreeShapeListener::exitData_type(
+    SV3_1aParser::Data_typeContext *ctx) {
+  if (ctx->VIRTUAL()) {
+    addVObject((antlr4::ParserRuleContext *)ctx->VIRTUAL(),
+               VObjectType::slVirtual);
+  }
+  addVObject(ctx, VObjectType::slData_type);
+}
+
 void SV3_1aTreeShapeListener::exitString_value(
     SV3_1aParser::String_valueContext *ctx) {
   std::string ident;


### PR DESCRIPTION
A few parser fixes/tweaks

* Formatted the grammar files (no other edits)
* Add EndModule as an AST node & add support for MACROMODULE
* Remove duplicate entries for Pound_pound_delay & iff
* Add AST node for virtual keyword in forward typedefs
* Checker instantiation was missing a semicolon in grammar

P.S. Each of the above change is an independent commit in this PR to assist with reviewing.