### PR TITLE
Use StrCat() for some string concatenations.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,13 +16,13 @@ AnalyzeTemporaryDtors: false
 Checks: >
   clang-diagnostic-*,clang-analyzer-*,
   -clang-analyzer-core.CallAndMessage,
-  -clang-analyzer-core.NullDereference,
   -clang-analyzer-cplusplus.NewDeleteLeaks,
   readability-*,
   -readability-braces-around-statements,
   -readability-convert-member-functions-to-static,
   -readability-else-after-return,
   -readability-function-cognitive-complexity,
+  -readability-identifier-length,
   -readability-implicit-bool-conversion,
   -readability-inconsistent-declaration-parameter-name,
   -readability-isolate-declaration,
@@ -41,19 +41,19 @@ Checks: >
   -google-readability-todo,
   -google-runtime-int,
   performance-*,
-  -performance-inefficient-string-concatenation,
   bugprone-*,
-  -bugprone-narrowing-conversions,
   -bugprone-branch-clone,
+  -bugprone-narrowing-conversions,
+  -bugprone-easily-swappable-parameters,
   modernize-loop-convert,
   modernize-raw-string-literal,
   modernize-use-override,
 
 CheckOptions:
   - key: performance-unnecessary-value-param.AllowedTypes
-    value: 'NodeId;SymbolId'
+    value: 'NodeId;SymbolId;PathId'
   - key: performance-unnecessary-copy-initialization.AllowedTypes
-    value: 'NodeId;SymbolId'
+    value: 'NodeId;SymbolId;PathId'
   - key: performance-for-range-copy.AllowedTypes
-    value: 'NodeId;SymbolId'
+    value: 'NodeId;SymbolId;PathId'
 ...

--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -53,9 +53,11 @@ Checks: >
     google-default-arguments,
     google-explicit-constructor,
     modernize-loop-convert,
+    modernize-raw-string-literal,
     modernize-use-override,
     performance-faster-string-find,
     performance-for-range-copy,
+    performance-inefficient-string-concatenation,
     performance-inefficient-vector-operation,
     performance-unnecessary-copy-initialization,
     performance-unnecessary-value-param,
@@ -97,10 +99,11 @@ find src/ -name "*.cpp" -or -name "*.h" \
 
 cat ${TIDY_OUT}
 
-sed 's|\(.*\)\(\[[a-zA-Z.-]*\]$\)|\2|p;d' < ${TIDY_OUT} | sort | uniq -c | sort -n
+sed 's|\(.*\)\(\[[a-zA-Z.-]*\]$\)|\2|p;d' < ${TIDY_OUT} \
+    | sort | uniq -c | sort -rn
 
 if [ -s ${TIDY_OUT} ]; then
-    echo "There were clang-tidy warnings. Please fix."
+    echo "There were clang-tidy warnings (see ${TIDY_OUT}). Please fix."
     exit 1
 fi
 

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -159,7 +159,8 @@ std::string Design::reportInstanceTree() const {
       m_errors->addError(err);
     }
 
-    tree += type_s + " " + def + undef + " " + tmp->getFullPathName() + "\n";
+    StrAppend(&tree, type_s, " ", def, undef, " ", tmp->getFullPathName(),
+              "\n");
 
     bool extraInfo = false;
     if (extraInfo) {
@@ -170,11 +171,11 @@ std::string Design::reportInstanceTree() const {
           for (const auto& ps : inst->getMappedValues()) {
             const std::string& name = ps.first;
             Value* val = ps.second.first;
-            tree += "    " + name + " = " + val->uhdmValue() + "\n";
+            StrAppend(&tree, "    ", name, " = ", val->uhdmValue(), "\n");
           }
           for (const auto& ps : inst->getComplexValues()) {
             const std::string& name = ps.first;
-            tree += "    " + name + " = " + "complex" + "\n";
+            StrAppend(&tree, "    ", name, " = ", "complex", "\n");
           }
         }
       }

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -573,7 +573,7 @@ void DesignElaboration::recurseInstanceLoop_(
           instanceName.erase(instanceName.end() - 1);
         }
       }
-      instanceName = instanceName + "[" + std::to_string(index) + "]";
+      StrAppend(&instanceName, "[", index, "]");
     }
     ModuleInstance* child = factory->newModuleInstance(
         def, fC, subInstanceId, parent, instanceName, modName);
@@ -1499,7 +1499,7 @@ void DesignElaboration::elaborateInstance_(
         libs.emplace_back(libName);
 
         for (const auto& lib : libs) {
-          modName = lib + "@" + mname;
+          modName = StrCat(lib, "@", mname);
           def = design->getComponentDefinition(modName);
           if (def) {
             break;
@@ -1526,7 +1526,7 @@ void DesignElaboration::elaborateInstance_(
             }
             case UseClause::UseLib: {
               for (const auto& lib : use.getLibs()) {
-                modName = lib + "@" + mname;
+                modName = StrCat(lib, "@", mname);
                 def = design->getComponentDefinition(modName);
                 if (def) {
                   use.setUsed();
@@ -1586,7 +1586,7 @@ void DesignElaboration::elaborateInstance_(
               }
               case UseClause::UseLib: {
                 for (const auto& lib : use.getLibs()) {
-                  modName = lib + "@" + mname;
+                  modName = StrCat(lib, "@", mname);
                   def = design->getComponentDefinition(modName);
                   if (def) {
                     use.setUsed();
@@ -2224,7 +2224,7 @@ std::vector<std::string_view> DesignElaboration::collectParams_(
     } else {
       prefix = instance->getFullPathName() + ".";
     }
-    path = prefix + path;
+    path = StrCat(prefix, path);
     Value* val = m_exprBuilder.evalExpr(fC, value, instance);
     design->addDefParam(path, fC, hIdent, val);
   }

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -293,28 +293,28 @@ bool UhdmChecker::reportHtml(PathId uhdmFileId, float overallCoverage) {
     std::stringstream strst;
     strst << std::setprecision(3) << cov;
 
-    const std::string coverage = std::string(" Cov: ") + strst.str() + "% ";
-    const std::string fileStatGreen =
+    const std::string coverage = StrCat(" Cov: ", strst.str(), "% ");
+    const std::string fileStatGreen = StrCat(
         "<div style=\"overflow: hidden;\"> <h3 style=\"background-color: "
-        "#82E0AA; margin:0; min-width: 110px; padding:10; float: left; \">" +
-        coverage +
-        "</h3> <h3 style=\"margin:0; padding:10; float: left; \"> <a href=" +
-        fname + "> " + filepath + "</a></h3></div>\n";
-    const std::string fileStatPink =
+        "#82E0AA; margin:0; min-width: 110px; padding:10; float: left; \">",
+        coverage,
+        "</h3> <h3 style=\"margin:0; padding:10; float: left; \"> <a href=",
+        fname + "> ", filepath, "</a></h3></div>\n");
+    const std::string fileStatPink = StrCat(
         "<div style=\"overflow: hidden;\"> <h3 style=\"background-color: "
-        "#FFB6C1; margin:0; min-width: 110px; padding:10; float: left; \">" +
-        coverage +
-        "</h3> <h3 style=\"margin:0; padding:10; float: left; \"> <a href=" +
-        fname + "> " + filepath + "</a></h3></div>\n";
-    const std::string fileStatRed =
+        "#FFB6C1; margin:0; min-width: 110px; padding:10; float: left; \">",
+        coverage,
+        "</h3> <h3 style=\"margin:0; padding:10; float: left; \"> <a href=",
+        fname + "> ", filepath, "</a></h3></div>\n");
+    const std::string fileStatRed = StrCat(
         "<div style=\"overflow: hidden;\"> <h3 style=\"background-color: "
-        "#FF0000; margin:0; min-width: 110px; padding:10; float: left; \">" +
-        coverage +
-        "</h3> <h3 style=\"margin:0; padding:10; float: left; \"> <a href=" +
-        fname + "> " + filepath + "</a></h3></div>\n";
+        "#FF0000; margin:0; min-width: 110px; padding:10; float: left; \">",
+        coverage,
+        "</h3> <h3 style=\"margin:0; padding:10; float: left; \"> <a href=",
+        fname + "> ", filepath, "</a></h3></div>\n");
     const std::string fileStatWhite =
-        "<h3 style=\"margin:0; padding:0 \"> <a href=" + fname + ">" +
-        filepath + "</a> " + coverage + "</h3>\n";
+        StrCat("<h3 style=\"margin:0; padding:0 \"> <a href=" + fname + ">",
+               filepath, "</a> ", coverage, "</h3>\n");
 
     reportF << "<h3>" << filepath << coverage << "</h3>\n";
     bool uncovered = false;

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -459,8 +459,8 @@ void AnalyzeFile::analyze() {
           }
 
           if (splitted) {
-            content += sllineInfo;
-            content += packageDeclaration + "  " + importSection;
+            StrAppend(&content, sllineInfo, packageDeclaration, "  ",
+                      importSection);
             // content += "SLline " + std::to_string(fromLine - baseFromLine +
             // origFromLine + 1) + " \"" + origFile + "\" 1";
           } else {
@@ -479,12 +479,12 @@ void AnalyzeFile::analyze() {
             checkSLlineDirective_(line, l);
 
             bool inLineComment = false;
-            content += allLines[l];
+            StrAppend(&content, allLines[l]);
             if (l == fileChunks[i].m_fromLine) {
-              content += "  " + importSection;
+              StrAppend(&content, "  ", importSection);
             }
             if (l != (toLine - 1)) {
-              content += "\n";
+              StrAppend(&content, "\n");
             }
             linesWriten++;
 
@@ -520,10 +520,10 @@ void AnalyzeFile::analyze() {
             splitted = true;
             if ((chunkType == DesignElement::Package) &&
                 endPackageDetected == false)
-              content += "  endpackage  ";
+              StrAppend(&content, "  endpackage  ");
             if ((chunkType == DesignElement::Module) &&
                 endPackageDetected == false)
-              content += "  endmodule  ";
+              StrAppend(&content, "  endmodule  ");
           } else {
             splitted = false;
           }
@@ -537,9 +537,9 @@ void AnalyzeFile::analyze() {
             errors->printMessages();
             return;
           }
-          content += "  " + fileLevelImportSection;
+          StrAppend(&content, "  ", fileLevelImportSection);
 
-          PathId splitFileId =
+          const PathId splitFileId =
               fileSystem->getChunkFile(m_ppFileId, chunkNb, symbolTable);
           fileSystem->writeContent(splitFileId, content);
           m_splitFiles.emplace_back(splitFileId);
@@ -579,12 +579,12 @@ void AnalyzeFile::analyze() {
         }
         m_lineOffsets.push_back(linesWriten);
 
-        content += setSLlineDirective_(fromLine);
+        StrAppend(&content, setSLlineDirective_(fromLine));
         for (unsigned int l = fromLine; l < toLine; l++) {
           checkSLlineDirective_(allLines[l], l);
-          content += allLines[l];
+          StrAppend(&content, allLines[l]);
           if (l != (toLine - 1)) {
-            content += "\n";
+            StrAppend(&content, "\n");
           }
           linesWriten++;
         }
@@ -644,13 +644,13 @@ void AnalyzeFile::analyze() {
       }
       m_lineOffsets.push_back(linesWriten);
 
-      content += setSLlineDirective_(fromLine);
-      content += "  " + fileLevelImportSection;
+      StrAppend(&content, setSLlineDirective_(fromLine));
+      StrAppend(&content, "  ", fileLevelImportSection);
       for (unsigned int l = fromLine; l < toLine; l++) {
         checkSLlineDirective_(allLines[l], l);
-        content += allLines[l];
+        StrAppend(&content, allLines[l]);
         if (l != (toLine - 1)) {
-          content += "\n";
+          StrAppend(&content, "\n");
         }
         linesWriten++;
       }

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -314,7 +314,7 @@ void SV3_1aPpTreeShapeListener::enterInclude_directive(
                 ->getCommandLineParser()
                 ->lineOffsetsAsComments()) {
           post = StrCat("\n/* SLline ", info->m_startLine + startLineCol.first,
-                        " \"\"^\"", fileSystem->toPath(info->m_fileId),
+                        R"( ""^")", fileSystem->toPath(info->m_fileId),
                         "\" 0 */\n");
         } else {
           post = StrCat("\n`line ", info->m_startLine + startLineCol.first,
@@ -324,7 +324,7 @@ void SV3_1aPpTreeShapeListener::enterInclude_directive(
         if (m_pp->getCompileSourceFile()
                 ->getCommandLineParser()
                 ->lineOffsetsAsComments()) {
-          post = StrCat("\n/* SLline ", startLineCol.first + 1, " \"\"^\"",
+          post = StrCat("\n/* SLline ", startLineCol.first + 1, R"( ""^")",
                         fileSystem->toPath(m_pp->getFileId(startLineCol.first)),
                         "\" 2 */\n");
         } else {

--- a/src/hellouhdm.cpp
+++ b/src/hellouhdm.cpp
@@ -119,9 +119,9 @@ int main(int argc, const char** argv) {
       // ...
       // Iterate thru statements
       // ...
-      result += "+ module: " + defName + objectName +
-                ", file:" + std::string(vpi_get_str(vpiFile, obj_h)) +
-                ", line:" + std::to_string(vpi_get(vpiLineNo, obj_h));
+      SURELOG::StrAppend(&result, "+ module: ", defName, objectName,
+                         ", file:", vpi_get_str(vpiFile, obj_h),
+                         ", line:", vpi_get(vpiLineNo, obj_h));
       vpiHandle processItr = vpi_iterate(vpiProcess, obj_h);
       while (vpiHandle sub_h = vpi_scan(processItr)) {
         result += "\n    \\_ process stmt, file:" +
@@ -167,12 +167,12 @@ int main(int argc, const char** argv) {
             if (const char* s = vpi_get_str(vpiFile, obj_h)) {
               f = s;
             }
-            res += margin + "+ module: " + defName + objectName +
-                   ", file:" + f +
-                   ", line:" + std::to_string(vpi_get(vpiLineNo, obj_h)) + "\n";
+            SURELOG::StrAppend(&res, margin, "+ module: ", defName, objectName,
+                               ", file:", f,
+                               ", line:", vpi_get(vpiLineNo, obj_h), "\n");
 
             // Recursive tree traversal
-            margin = "  " + margin;
+            margin = SURELOG::StrCat("  ", margin);
             if (vpi_get(vpiType, obj_h) == vpiModule ||
                 vpi_get(vpiType, obj_h) == vpiGenScope) {
               vpiHandle subItr = vpi_iterate(vpiModule, obj_h);
@@ -201,7 +201,7 @@ int main(int argc, const char** argv) {
             }
             return res;
           };
-      result += inst_visit(obj_h, "");
+      SURELOG::StrAppend(&result, inst_visit(obj_h, ""));
     }
   }
   std::cout << result << std::endl;


### PR DESCRIPTION
Thus being able to switch on the performance-inefficient-string-concatenation clang tidy check.
While at it, improve readability by using a raw string for some complicated quoted strings.