### PR TITLE
Check if array_typespec have elem_typespec

### DIFF
--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -2778,9 +2778,11 @@ UHDM::any* CompileHelper::defaultPatternAssignment(const UHDM::typespec* tps,
               }
             } else if (ttps == uhdmarray_typespec) {
               array_typespec* lts = (array_typespec*)tps;
-              baseType = lts->Elem_typespec()->UhdmType();
-              if (lts->Ranges() && !lts->Ranges()->empty()) {
-                r = (*lts->Ranges())[0];
+              if (lts->Elem_typespec()) {
+                baseType = lts->Elem_typespec()->UhdmType();
+                if (lts->Ranges() && !lts->Ranges()->empty()) {
+                  r = (*lts->Ranges())[0];
+                }
               }
             } else if (ttps == uhdmpacked_array_typespec) {
               packed_array_typespec* lts = (packed_array_typespec*)tps;


### PR DESCRIPTION
Ref: https://github.com/chipsalliance/Surelog/issues/3480

This fixes segmentation fault when parsing ibex: https://github.com/antmicro/yosys-systemverilog/actions/runs/4280144816/jobs/7451781361#step:8:1705

It looks like ``array_typespec`` doesn't need to have ``elem_typespec``. I'm not sure if it is correct fix (e.g. maybe we need to set ``elem_typespec`` somewhere), but this fixes segmentation fault in case of ibex.