### PR TITLE
Assortment of small changes

### DIFF
--- a/include/Surelog/CommandLine/CommandLineParser.h
+++ b/include/Surelog/CommandLine/CommandLineParser.h
@@ -92,6 +92,7 @@ class CommandLineParser final {
   void setCacheAllowed(bool val) { m_cacheAllowed = val; }
   void setWriteCache(bool val) { m_writeCache = val; }
   void setPrecompiledCacheAllowed(bool val) { m_precompiledCacheAllowed = val; }
+  void setUsePPOutputFileLocation(bool val) { m_ppOutputFileLocation = val; }
   bool lineOffsetsAsComments() const { return m_lineOffsetsAsComments; }
   PathId getCacheDirId() const { return m_cacheDirId; }
   PathId getPrecompiledDirId() const { return m_precompiledDirId; }

--- a/include/Surelog/Common/FileSystem.h
+++ b/include/Surelog/Common/FileSystem.h
@@ -31,6 +31,7 @@
 #include <filesystem>
 #include <istream>
 #include <ostream>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -308,6 +309,9 @@ class FileSystem {
                                 PathIdVector &container) = 0;
   // Returns all files under the input 'dirId' that matches the input 'pattern'
   virtual PathIdVector &matching(PathId dirId, std::string_view pattern,
+                                 SymbolTable *symbolTable,
+                                 PathIdVector &container) = 0;
+  virtual PathIdVector &matching(PathId dirId, const std::regex &pattern,
                                  SymbolTable *symbolTable,
                                  PathIdVector &container) = 0;
 

--- a/include/Surelog/Common/NodeId.h
+++ b/include/Surelog/Common/NodeId.h
@@ -50,7 +50,7 @@ class NodeId final {
     return id;
   }
 
-  operator bool() const { return id != InvalidRawNodeId; }
+  explicit operator bool() const { return id != InvalidRawNodeId; }
 
   bool operator<(const NodeId &rhs) const { return id < rhs.id; }
   bool operator<=(const NodeId &rhs) const { return id <= rhs.id; }

--- a/include/Surelog/Common/PlatformFileSystem.h
+++ b/include/Surelog/Common/PlatformFileSystem.h
@@ -156,6 +156,9 @@ class PlatformFileSystem : public FileSystem {
   PathIdVector &matching(PathId dirId, std::string_view pattern,
                          SymbolTable *symbolTable,
                          PathIdVector &container) override;
+  PathIdVector &matching(PathId dirId, const std::regex &pattern,
+                         SymbolTable *symbolTable,
+                         PathIdVector &container) override;
 
   PathId getChild(PathId id, std::string_view name,
                   SymbolTable *symbolTable) override;

--- a/include/Surelog/SourceCompile/CommonListenerHelper.h
+++ b/include/Surelog/SourceCompile/CommonListenerHelper.h
@@ -35,6 +35,7 @@
 namespace antlr4 {
 class CommonTokenStream;
 class ParserRuleContext;
+class Token;
 namespace tree {
 class ParseTree;
 }
@@ -49,8 +50,12 @@ static constexpr char EscapeSequence[] = "#~@";
 
 class CommonListenerHelper {
  public:
-  virtual ~CommonListenerHelper();
+  virtual ~CommonListenerHelper() = default;
 
+ public:
+  FileContent* getFileContent() { return m_fileContent; }
+
+ protected:
   virtual SymbolId registerSymbol(std::string_view symbol) = 0;
 
   NodeId NodeIdFromContext(const antlr4::tree::ParseTree* ctx) const;
@@ -68,28 +73,25 @@ class CommonListenerHelper {
   unsigned short Column(NodeId index) const;
   unsigned int Line(NodeId index) const;
 
-  int addVObject(antlr4::ParserRuleContext* ctx, std::string_view name,
-                 VObjectType objtype);
+  NodeId addVObject(antlr4::ParserRuleContext* ctx, std::string_view name,
+                    VObjectType objtype);
 
-  int addVObject(antlr4::ParserRuleContext* ctx, VObjectType objtype);
+  NodeId addVObject(antlr4::ParserRuleContext* ctx, VObjectType objtype);
+  NodeId addVObject(antlr4::ParserRuleContext* ctx, SymbolId sym,
+                    VObjectType objtype);
 
   void addParentChildRelations(NodeId indexParent,
                                antlr4::ParserRuleContext* ctx);
 
   NodeId getObjectId(antlr4::ParserRuleContext* ctx) const;
 
-  FileContent* getFileContent() { return m_fileContent; }
+  virtual std::tuple<PathId, unsigned int, unsigned short, unsigned int,
+                     unsigned short>
+  getFileLine(antlr4::ParserRuleContext* ctx, antlr4::Token* token) const = 0;
 
-  virtual std::tuple<unsigned int, unsigned short, unsigned int, unsigned short>
-  getFileLine(antlr4::ParserRuleContext* ctx, PathId& fileId) = 0;
-
- private:
   NodeId& MutableChild(NodeId index);
   NodeId& MutableSibling(NodeId index);
   NodeId& MutableParent(NodeId index);
-
-  int addVObject(antlr4::ParserRuleContext* ctx, SymbolId sym,
-                 VObjectType objtype);
 
  protected:
   CommonListenerHelper(FileContent* file_content,

--- a/include/Surelog/SourceCompile/CompileSourceFile.h
+++ b/include/Surelog/SourceCompile/CompileSourceFile.h
@@ -76,6 +76,7 @@ class CompileSourceFile final {
   Library* getLibrary() const { return m_library; }
   void registerPP(PreprocessFile* pp) { m_ppIncludeVec.push_back(pp); }
   bool initParser();
+  void setParser(ParseFile* pf) { m_parser = pf; }
 
   const std::map<SymbolId, PreprocessFile::AntlrParserHandler*,
                  SymbolIdLessThanComparer>&

--- a/include/Surelog/SourceCompile/ParseFile.h
+++ b/include/Surelog/SourceCompile/ParseFile.h
@@ -38,6 +38,7 @@ class CompilationUnit;
 class ErrorContainer;
 class FileContent;
 class Library;
+class SV3_1aParserBaseListener;
 class SV3_1aPythonListener;
 class SV3_1aTreeShapeListener;
 class SymbolTable;
@@ -116,7 +117,7 @@ class ParseFile final {
   CompilationUnit* const m_compilationUnit;
   Library* m_library = nullptr;
   AntlrParserHandler* m_antlrParserHandler = nullptr;
-  SV3_1aTreeShapeListener* m_listener = nullptr;
+  SV3_1aParserBaseListener* m_listener = nullptr;
   std::vector<LineTranslationInfo> m_lineTranslationVec;
   bool m_usingCachedVersion;
   bool m_keepParserHandler;

--- a/include/Surelog/SourceCompile/PreprocessFile.h
+++ b/include/Surelog/SourceCompile/PreprocessFile.h
@@ -52,7 +52,7 @@ class Library;
 class MacroInfo;
 class SV3_1aPpLexer;
 class SV3_1aPpParser;
-class SV3_1aPpTreeShapeListener;
+class SV3_1aPpParserBaseListener;
 
 #define LINE1 1
 
@@ -272,7 +272,7 @@ class PreprocessFile final {
     antlr4::tree::ParseTree* m_pptree = nullptr;
     DescriptiveErrorListener* m_errorListener = nullptr;
   };
-  SV3_1aPpTreeShapeListener* m_listener = nullptr;
+  SV3_1aPpParserBaseListener* m_listener = nullptr;
 
  public:
   /* Options */

--- a/include/Surelog/SourceCompile/SV3_1aPpTreeListenerHelper.h
+++ b/include/Surelog/SourceCompile/SV3_1aPpTreeListenerHelper.h
@@ -39,6 +39,9 @@ namespace SURELOG {
 class SymbolTable;
 
 class SV3_1aPpTreeListenerHelper : public CommonListenerHelper {
+ public:
+  ~SV3_1aPpTreeListenerHelper() override = default;
+
  protected:
   PreprocessFile* m_pp;
   bool m_inActiveBranch;
@@ -49,21 +52,7 @@ class SV3_1aPpTreeListenerHelper : public CommonListenerHelper {
   antlr4::ParserRuleContext* m_append_paused_context;
   PreprocessFile::SpecialInstructions m_instructions;
 
- public:
-  SV3_1aPpTreeListenerHelper(PreprocessFile* pp,
-                             PreprocessFile::SpecialInstructions& instructions,
-                             antlr4::CommonTokenStream* tokens)
-      : CommonListenerHelper(nullptr, tokens),
-        m_pp(pp),
-        m_inActiveBranch(true),
-        m_inMacroDefinitionParsing(false),
-        m_inProtectedRegion(false),
-        m_filterProtectedRegions(false),
-        m_append_paused_context(nullptr),
-        m_instructions(instructions) {
-    init();
-  }
-
+ protected:
   // Helper function if-else
   void setCurrentBranchActivity(unsigned int currentLine);
   // Helper function if-else
@@ -85,10 +74,24 @@ class SV3_1aPpTreeListenerHelper : public CommonListenerHelper {
   SymbolTable* getSymbolTable() const;
   SymbolId registerSymbol(std::string_view symbol) final;
 
-  std::tuple<unsigned int, unsigned short, unsigned int, unsigned short>
-  getFileLine(antlr4::ParserRuleContext* ctx, PathId& fileId) override;
+  std::tuple<PathId, unsigned int, unsigned short, unsigned int, unsigned short>
+  getFileLine(antlr4::ParserRuleContext* ctx,
+              antlr4::Token* token) const override;
 
-  ~SV3_1aPpTreeListenerHelper() override = default;
+ protected:
+  SV3_1aPpTreeListenerHelper(PreprocessFile* pp,
+                             PreprocessFile::SpecialInstructions& instructions,
+                             antlr4::CommonTokenStream* tokens)
+      : CommonListenerHelper(nullptr, tokens),
+        m_pp(pp),
+        m_inActiveBranch(true),
+        m_inMacroDefinitionParsing(false),
+        m_inProtectedRegion(false),
+        m_filterProtectedRegions(false),
+        m_append_paused_context(nullptr),
+        m_instructions(instructions) {
+    init();
+  }
 };
 
 }  // namespace SURELOG

--- a/include/Surelog/SourceCompile/SV3_1aTreeShapeHelper.h
+++ b/include/Surelog/SourceCompile/SV3_1aTreeShapeHelper.h
@@ -49,12 +49,9 @@ class ParseLibraryDef;
 
 class SV3_1aTreeShapeHelper : public CommonListenerHelper {
  public:
-  SV3_1aTreeShapeHelper(ParseFile* pf, antlr4::CommonTokenStream* tokens,
-                        unsigned int lineOffset);
-  SV3_1aTreeShapeHelper(ParseLibraryDef* pf, antlr4::CommonTokenStream* tokens);
+  ~SV3_1aTreeShapeHelper() override = default;
 
-  ~SV3_1aTreeShapeHelper() override;
-
+ protected:
   void logError(ErrorDefinition::ErrorType error,
                 antlr4::ParserRuleContext* ctx, std::string_view object,
                 bool printColumn = false);
@@ -82,8 +79,14 @@ class SV3_1aTreeShapeHelper : public CommonListenerHelper {
   std::pair<double, TimeInfo::Unit> getTimeValue(
       SV3_1aParser::Time_literalContext* ctx);
 
-  std::tuple<unsigned int, unsigned short, unsigned int, unsigned short>
-  getFileLine(antlr4::ParserRuleContext* ctx, PathId& fileId) override;
+  std::tuple<PathId, unsigned int, unsigned short, unsigned int, unsigned short>
+  getFileLine(antlr4::ParserRuleContext* ctx,
+              antlr4::Token* token) const override;
+
+ protected:
+  SV3_1aTreeShapeHelper(ParseFile* pf, antlr4::CommonTokenStream* tokens,
+                        unsigned int lineOffset);
+  SV3_1aTreeShapeHelper(ParseLibraryDef* pf, antlr4::CommonTokenStream* tokens);
 
  protected:
   ParseFile* m_pf;

--- a/include/Surelog/Utils/ParseUtils.h
+++ b/include/Surelog/Utils/ParseUtils.h
@@ -34,15 +34,16 @@ using LineColumn = std::pair<int, int>;  // TODO: make <size_t, size_t> ?
 
 LineColumn getLineColumn(antlr4::CommonTokenStream* stream,
                          antlr4::ParserRuleContext* context);
-
 LineColumn getEndLineColumn(antlr4::CommonTokenStream* stream,
                             antlr4::ParserRuleContext* context);
 
-LineColumn getLineColumn(antlr4::tree::TerminalNode* node);
+LineColumn getLineColumn(antlr4::Token* token);
+LineColumn getEndLineColumn(antlr4::Token* token);
 
+LineColumn getLineColumn(antlr4::tree::TerminalNode* node);
 LineColumn getEndLineColumn(antlr4::tree::TerminalNode* node);
 
-std::vector<ParseTree*> getTopTokenList(ParseTree* tree);
+const std::vector<ParseTree*>& getTopTokenList(ParseTree* tree);
 void tokenizeAtComma(std::vector<std::string>& actualArgs,
                      const std::vector<ParseTree*>& tokens);
 

--- a/src/Common/PlatformFileSystem.cpp
+++ b/src/Common/PlatformFileSystem.cpp
@@ -27,7 +27,6 @@
 
 #include <fstream>
 #include <iostream>
-#include <regex>
 
 namespace SURELOG {
 static constexpr bool kEnableLogs = false;
@@ -895,6 +894,43 @@ PathIdVector &PlatformFileSystem::collect(PathId dirId,
 }
 
 PathIdVector &PlatformFileSystem::matching(PathId dirId,
+                                           const std::regex &pattern,
+                                           SymbolTable *symbolTable,
+                                           PathIdVector &container) {
+  std::filesystem::path prefix = toPath(dirId);
+  if (prefix.empty()) return container;
+
+  std::error_code ec;
+  const std::filesystem::directory_options options =
+      std::filesystem::directory_options::skip_permission_denied |
+      std::filesystem::directory_options::follow_directory_symlink;
+
+  for (const std::filesystem::directory_entry &entry :
+       std::filesystem::recursive_directory_iterator(prefix, options)) {
+    const std::filesystem::path &absolute = entry.path();
+    if (std::filesystem::is_regular_file(absolute, ec) && !ec) {
+      const std::string relative =
+          std::filesystem::relative(absolute, prefix, ec).string();
+      std::smatch match;
+      if (!ec && std::regex_match(relative, match, pattern)) {
+        if (std::filesystem::is_regular_file(absolute, ec) && !ec) {
+          container.emplace_back(toPathId(absolute.string(), symbolTable));
+        }
+      }
+    }
+  }
+
+  if (kEnableLogs) {
+    std::cerr << "matching: " << PathIdPP(dirId) << " => " << std::endl;
+    for (const PathId &fileId : container) {
+      std::cerr << "    " << PathIdPP(fileId) << std::endl;
+    }
+  }
+
+  return container;
+}
+
+PathIdVector &PlatformFileSystem::matching(PathId dirId,
                                            std::string_view pattern,
                                            SymbolTable *symbolTable,
                                            PathIdVector &container) {
@@ -954,35 +990,8 @@ PathIdVector &PlatformFileSystem::matching(PathId dirId,
   regexp = StringUtils::replaceAll(
       regexp, "*", StrCat("[^", escaped, "]*"));  // free for all
 
-  const std::regex regex(regexp);
-  const std::filesystem::directory_options options =
-      std::filesystem::directory_options::skip_permission_denied |
-      std::filesystem::directory_options::follow_directory_symlink;
-
-  for (const std::filesystem::directory_entry &entry :
-       std::filesystem::recursive_directory_iterator(prefix, options)) {
-    const std::filesystem::path &absolute = entry.path();
-    if (std::filesystem::is_regular_file(absolute, ec) && !ec) {
-      const std::string relative =
-          std::filesystem::relative(absolute, prefix, ec).string();
-      std::smatch match;
-      if (!ec && std::regex_match(relative, match, regex)) {
-        if (std::filesystem::is_regular_file(absolute, ec) && !ec) {
-          container.emplace_back(toPathId(absolute.string(), symbolTable));
-        }
-      }
-    }
-  }
-
-  if (kEnableLogs) {
-    std::cerr << "matching: " << PathIdPP(dirId) << ", " << pattern << " => "
-              << std::endl;
-    for (PathId fileId : container) {
-      std::cerr << "    " << PathIdPP(fileId) << std::endl;
-    }
-  }
-
-  return container;
+  const PathId prefixId = toPathId(prefix.string(), symbolTable);
+  return matching(prefixId, regexp, symbolTable, container);
 }
 
 PathId PlatformFileSystem::getChild(PathId id, std::string_view name,

--- a/src/Common/PlatformFileSystem.cpp
+++ b/src/Common/PlatformFileSystem.cpp
@@ -990,8 +990,9 @@ PathIdVector &PlatformFileSystem::matching(PathId dirId,
   regexp = StringUtils::replaceAll(
       regexp, "*", StrCat("[^", escaped, "]*"));  // free for all
 
+  const std::regex patregex(regexp);
   const PathId prefixId = toPathId(prefix.string(), symbolTable);
-  return matching(prefixId, regexp, symbolTable, container);
+  return matching(prefixId, patregex, symbolTable, container);
 }
 
 PathId PlatformFileSystem::getChild(PathId id, std::string_view name,

--- a/src/SourceCompile/CommonListenerHelper.cpp
+++ b/src/SourceCompile/CommonListenerHelper.cpp
@@ -31,11 +31,6 @@ namespace SURELOG {
 
 using namespace antlr4;
 
-CommonListenerHelper::~CommonListenerHelper() {
-  // TODO: ownership not clear
-  // delete m_fileContent;
-}
-
 NodeId CommonListenerHelper::NodeIdFromContext(
     const antlr4::tree::ParseTree* ctx) const {
   auto found = m_contextToObjectMap.find(ctx);
@@ -89,10 +84,9 @@ unsigned int CommonListenerHelper::Line(NodeId index) const {
   return m_fileContent->Line(index);
 }
 
-int CommonListenerHelper::addVObject(ParserRuleContext* ctx, SymbolId sym,
-                                     VObjectType objtype) {
-  PathId fileId;
-  auto [line, column, endLine, endColumn] = getFileLine(ctx, fileId);
+NodeId CommonListenerHelper::addVObject(ParserRuleContext* ctx, SymbolId sym,
+                                        VObjectType objtype) {
+  auto [fileId, line, column, endLine, endColumn] = getFileLine(ctx, nullptr);
 
   NodeId objectIndex = m_fileContent->addObject(sym, fileId, objtype, line,
                                                 column, endLine, endColumn);
@@ -114,14 +108,14 @@ int CommonListenerHelper::addVObject(ParserRuleContext* ctx, SymbolId sym,
   return objectIndex;
 }
 
-int CommonListenerHelper::addVObject(ParserRuleContext* ctx,
-                                     std::string_view name,
-                                     VObjectType objtype) {
+NodeId CommonListenerHelper::addVObject(ParserRuleContext* ctx,
+                                        std::string_view name,
+                                        VObjectType objtype) {
   return addVObject(ctx, registerSymbol(name), objtype);
 }
 
-int CommonListenerHelper::addVObject(ParserRuleContext* ctx,
-                                     VObjectType objtype) {
+NodeId CommonListenerHelper::addVObject(ParserRuleContext* ctx,
+                                        VObjectType objtype) {
   return addVObject(ctx, BadSymbolId, objtype);
 }
 

--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
@@ -39,17 +39,17 @@ SymbolId SV3_1aPpTreeListenerHelper::registerSymbol(std::string_view symbol) {
   return m_pp->getCompileSourceFile()->getSymbolTable()->registerSymbol(symbol);
 }
 
-std::tuple<unsigned int, unsigned short, unsigned int, unsigned short>
+std::tuple<PathId, unsigned int, unsigned short, unsigned int, unsigned short>
 SV3_1aPpTreeListenerHelper::getFileLine(antlr4::ParserRuleContext* ctx,
-                                        PathId& fileId) {
+                                        antlr4::Token* token) const {
   std::pair<int, int> lineCol = ParseUtils::getLineColumn(m_tokens, ctx);
   std::pair<int, int> endLineCol = ParseUtils::getEndLineColumn(m_tokens, ctx);
   unsigned int line = m_pp->getLineNb(lineCol.first);
   unsigned short column = lineCol.second;
   unsigned int endLine = m_pp->getLineNb(endLineCol.first);
   unsigned short endColumn = endLineCol.second;
-  fileId = m_pp->getFileId(lineCol.first);
-  return std::make_tuple(line, column, endLine, endColumn);
+  PathId fileId = m_pp->getFileId(lineCol.first);
+  return std::make_tuple(fileId, line, column, endLine, endColumn);
 }
 
 void SV3_1aPpTreeListenerHelper::init() {

--- a/src/Utils/ParseUtils.cpp
+++ b/src/Utils/ParseUtils.cpp
@@ -26,17 +26,13 @@
 
 namespace SURELOG {
 
-ParseUtils::LineColumn ParseUtils::getLineColumn(
-    antlr4::tree::TerminalNode* node) {
-  const antlr4::Token* token = node->getSymbol();
+ParseUtils::LineColumn ParseUtils::getLineColumn(antlr4::Token* token) {
   const size_t lineNb = token->getLine();
   const size_t columnNb = token->getCharPositionInLine() + 1;
   return std::make_pair(lineNb, columnNb);
 }
 
-ParseUtils::LineColumn ParseUtils::getEndLineColumn(
-    antlr4::tree::TerminalNode* node) {
-  const antlr4::Token* token = node->getSymbol();
+ParseUtils::LineColumn ParseUtils::getEndLineColumn(antlr4::Token* token) {
   const size_t lineNb = token->getLine();
   const size_t columnNb = token->getCharPositionInLine() +
                           token->getStopIndex() - token->getStartIndex() + 1 +
@@ -45,34 +41,32 @@ ParseUtils::LineColumn ParseUtils::getEndLineColumn(
 }
 
 ParseUtils::LineColumn ParseUtils::getLineColumn(
+    antlr4::tree::TerminalNode* node) {
+  return getLineColumn(node->getSymbol());
+}
+
+ParseUtils::LineColumn ParseUtils::getEndLineColumn(
+    antlr4::tree::TerminalNode* node) {
+  return getEndLineColumn(node->getSymbol());
+}
+
+ParseUtils::LineColumn ParseUtils::getLineColumn(
     antlr4::CommonTokenStream* stream, antlr4::ParserRuleContext* context) {
   const antlr4::misc::Interval sourceInterval = context->getSourceInterval();
   if (sourceInterval.a == -1) return std::make_pair(0, 0);
-  antlr4::Token* firstToken = stream->get(sourceInterval.a);
-  const size_t lineNb = firstToken->getLine();
-  const size_t columnNb = firstToken->getCharPositionInLine() + 1;
-  return std::make_pair(lineNb, columnNb);
+  return getLineColumn(stream->get(sourceInterval.a));
 }
 
 ParseUtils::LineColumn ParseUtils::getEndLineColumn(
     antlr4::CommonTokenStream* stream, antlr4::ParserRuleContext* context) {
   const antlr4::misc::Interval sourceInterval = context->getSourceInterval();
   if (sourceInterval.b == -1) return std::make_pair(0, 0);
-  antlr4::Token* firstToken = stream->get(sourceInterval.b);
-  const size_t lineNb = firstToken->getLine();
-  const size_t columnNb = firstToken->getCharPositionInLine() +
-                          firstToken->getStopIndex() -
-                          firstToken->getStartIndex() + 1 + 1;
-  return std::make_pair(lineNb, columnNb);
+  return getEndLineColumn(stream->get(sourceInterval.b));
 }
 
-std::vector<antlr4::tree::ParseTree*> ParseUtils::getTopTokenList(
+const std::vector<antlr4::tree::ParseTree*>& ParseUtils::getTopTokenList(
     antlr4::tree::ParseTree* tree) {
-  std::vector<antlr4::tree::ParseTree*> tokens;
-  for (antlr4::tree::ParseTree* child : tree->children) {
-    tokens.push_back(child);
-  }
-  return tokens;
+  return tree->children;
 }
 
 void ParseUtils::tokenizeAtComma(


### PR DESCRIPTION
Assortment of small changes

* Add a function to toggle 'usePreprocLoc'
* Make bool operator explicit to avoid implicit conversions
* Add a overload to support prebuilt regex for matching
* Add a function to set the parser externally - useful for unit testing
* Use base class pointer instead of concrete type to support different listener implementations
*  Option to use specific antlr::Token to compute line/column information
   * Option to be create VObject for whitespace and comments
   * Return PathId as function return value instead of the input reference
   * Fix return value of addVObject to NodeId to avoid implicit conversion to int/bool.