### PR TITLE
Enable clang-tidy in include files.

### DIFF
--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -50,8 +50,6 @@ Checks: >
     clang-diagnostic-inconsistent-missing-override,
     clang-diagnostic-overloaded-virtual
     clang-diagnostic-unused-private-field,
-    google-default-arguments,
-    google-explicit-constructor,
     modernize-loop-convert,
     modernize-raw-string-literal,
     modernize-use-override,
@@ -66,6 +64,7 @@ Checks: >
     readability-delete-null-pointer,
     readability-non-const-parameter,
     readability-redundant-member-init,
+    readability-redundant-smartptr-get,
     readability-redundant-string-cstr,
     readability-redundant-string-init,
     readability-static-accessed-through-instance,
@@ -92,7 +91,7 @@ if [ ! -r compile_commands.json ]; then
     exit 1
 fi
 
-find src/ -name "*.cpp" -or -name "*.h" \
+find src/ include/ -name "*.cpp" -or -name "*.h" \
     | grep -v Python | grep -v Constraint.h \
     | xargs -P$(nproc) -n 5 -- ${CLANG_TIDY} ${CLANG_TIDY_OPTS} 2>/dev/null \
             > ${TIDY_OUT}

--- a/include/Surelog/Design/DefParam.h
+++ b/include/Surelog/Design/DefParam.h
@@ -49,7 +49,7 @@ class DefParam final {
   Value* getValue() const { return m_value; }
   void setValue(Value* value) { m_value = value; }
 
-  void setChild(std::string name, DefParam* child) {
+  void setChild(const std::string& name, DefParam* child) {
     m_children.emplace(name, child);
   }
   std::map<std::string, DefParam*>& getChildren() { return m_children; }

--- a/include/Surelog/Design/Design.h
+++ b/include/Surelog/Design/Design.h
@@ -188,7 +188,7 @@ class Design final {
   void addClassDefinition(std::string_view className,
                           ClassDefinition* classDef);
 
-  void addProgramDefinition(const std::string programName, Program* program) {
+  void addProgramDefinition(const std::string& programName, Program* program) {
     m_programDefinitions.emplace(programName, program);
   }
 

--- a/include/Surelog/Design/Statement.h
+++ b/include/Surelog/Design/Statement.h
@@ -126,7 +126,7 @@ class SubRoutineCallStmt : public Statement {
 class ForLoopStmt : public Scope, public Statement {
   SURELOG_IMPLEMENT_RTTI_2_BASES(ForLoopStmt, Scope, Statement)
  public:
-  ForLoopStmt(std::string name, Scope* scope, Statement* parentStmt,
+  ForLoopStmt(const std::string& name, Scope* scope, Statement* parentStmt,
               const FileContent* fileContent, NodeId node, VObjectType type)
       : Scope(name, scope),
         Statement(scope, parentStmt, fileContent, node, type),
@@ -155,7 +155,7 @@ class ForLoopStmt : public Scope, public Statement {
 class ForeachLoopStmt : public Scope, public Statement {
   SURELOG_IMPLEMENT_RTTI_2_BASES(ForeachLoopStmt, Scope, Statement)
  public:
-  ForeachLoopStmt(std::string name, NodeId arrayId, Scope* scope,
+  ForeachLoopStmt(const std::string& name, NodeId arrayId, Scope* scope,
                   Statement* parentStmt, const FileContent* fileContent,
                   NodeId node, VObjectType type)
       : Scope(name, scope),

--- a/include/Surelog/DesignCompile/UhdmWriter.h
+++ b/include/Surelog/DesignCompile/UhdmWriter.h
@@ -25,6 +25,7 @@
 #define SURELOG_UHDMWRITER_H
 #pragma once
 
+#include <Surelog/Design/Netlist.h>
 #include <Surelog/DesignCompile/CompileHelper.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 

--- a/include/Surelog/ErrorReporting/LogListener.h
+++ b/include/Surelog/ErrorReporting/LogListener.h
@@ -30,6 +30,8 @@
 #include <ostream>
 #include <string>
 
+#include <Surelog/Common/PathId.h>
+
 namespace SURELOG {
 
 // A thread-safe log listener that flushes it contents to a named file on disk.

--- a/include/Surelog/Expression/Value.h
+++ b/include/Surelog/Expression/Value.h
@@ -441,7 +441,7 @@ class StValue final : public Value {
   friend LValue;
 
  public:
-  StValue() : m_type(Type::String), m_value(""), m_size(0), m_valid(false) {}
+  StValue() : m_type(Type::String),  m_size(0), m_valid(false) {}
   explicit StValue(std::string_view val)
       : m_type(Type::String), m_value(val), m_size(val.size()), m_valid(true) {}
   ~StValue() final;

--- a/include/Surelog/Library/LibrarySet.h
+++ b/include/Surelog/Library/LibrarySet.h
@@ -25,6 +25,7 @@
 #define SURELOG_LIBRARYSET_H
 #pragma once
 
+#include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>
 
 #include <ostream>

--- a/include/Surelog/SourceCompile/ParserHarness.h
+++ b/include/Surelog/SourceCompile/ParserHarness.h
@@ -28,6 +28,8 @@
 #include <memory>
 #include <string>
 
+#include <Surelog/Common/PathId.h>
+
 namespace SURELOG {
 
 class Compiler;

--- a/include/Surelog/Testbench/ClassObject.h
+++ b/include/Surelog/Testbench/ClassObject.h
@@ -39,7 +39,7 @@ class ClassObject final {
   typedef std::map<std::string, std::pair<Property*, Value*>, std::less<>>
       PropertyValueMap;
 
-  ClassObject(ClassDefinition* class_def) : m_class(class_def) {}
+  explicit ClassObject(ClassDefinition* class_def) : m_class(class_def) {}
   ClassDefinition* getClass() { return m_class; }
 
   const PropertyValueMap& getProperties() const { return m_properties; }

--- a/include/Surelog/Testbench/TaskMethod.h
+++ b/include/Surelog/Testbench/TaskMethod.h
@@ -25,6 +25,8 @@
 #define SURELOG_TASKMETHOD_H
 #pragma once
 
+#include <string_view>
+
 #include <Surelog/Design/Task.h>
 
 namespace SURELOG {
@@ -32,10 +34,10 @@ namespace SURELOG {
 class TaskMethod : public Task {
  public:
   TaskMethod(DesignComponent* parent, const FileContent* fC, NodeId id,
-             std::string name, bool is_extern)
+             std::string_view name, bool is_extern)
       : Task(parent, fC, id, name), m_extern(is_extern) {}
   ~TaskMethod() override = default;
-  bool isExtern() { return m_extern; }
+  bool isExtern() const { return m_extern; }
   bool compile(CompileHelper& compile_helper);
 
  private:

--- a/src/Common/PlatformFileSystem.cpp
+++ b/src/Common/PlatformFileSystem.cpp
@@ -43,14 +43,14 @@ PlatformFileSystem::~PlatformFileSystem() {
     std::scoped_lock<std::mutex> lock(m_inputStreamsMutex);
 
     while (!m_inputStreams.empty()) {
-      close(*m_inputStreams.begin()->get());
+      close(**m_inputStreams.begin());
     }
   }
   {
     std::scoped_lock<std::mutex> lock(m_outputStreamsMutex);
 
     while (!m_outputStreams.empty()) {
-      close(*m_outputStreams.begin()->get());
+      close(**m_outputStreams.begin());
     }
   }
 

--- a/src/Common/PlatformFileSystem_test.cpp
+++ b/src/Common/PlatformFileSystem_test.cpp
@@ -568,7 +568,7 @@ class InMemoryFileSystem : public TestFileSystem {
     std::pair<InputStreams::iterator, bool> it2 =
         m_inputStreams.emplace(new std::istringstream(it1->second));
 
-    return *it2.first->get();
+    return **it2.first;
   }
 
   bool close(std::istream &strm) override {
@@ -604,7 +604,7 @@ class InMemoryFileSystem : public TestFileSystem {
         m_outputStreams.emplace(new std::ostringstream(content, mode));
     m_openOutputFiles.emplace(it.first->get(), filepath);
 
-    return *it.first->get();
+    return **it.first;
   }
 
   bool saveContent(PathId fileId, const char *content, std::streamsize length,


### PR DESCRIPTION
This got lost when we moved the include files into a separate directory.

Fix a few obvious things, but the explicit constructors and default parameters neeed to be revisited, so removed for now from the minimial config.