### PR TITLE
Don't use -DDEBUG to change layout of PathId.

### DIFF
--- a/include/Surelog/Common/PathId.h
+++ b/include/Surelog/Common/PathId.h
@@ -28,14 +28,6 @@
 #include <unordered_set>
 #include <vector>
 
-#if !defined(PATHID_DEBUG_ENABLED)
-#if defined(DEBUG) || defined(_DEBUG)
-#define PATHID_DEBUG_ENABLED 1
-#else
-#define PATHID_DEBUG_ENABLED 0
-#endif
-#endif
-
 namespace SURELOG {
 /**
  * class PathId


### PR DESCRIPTION
Since -DDEBUG is commonly used, it is dangerous to change the layout of an object just because of that - project using the Surelog library will now accidentally change the size that is not compatible anymore with the binary library. So, only do this if the very specific debugging option for this case is set.

Related: https://github.com/chipsalliance/UHDM/issues/872