### PR TITLE
Fix string constant vpiDecompile

### DIFF
--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -708,7 +708,7 @@ constant *compileConst(const FileContent *fC, NodeId child, Serializer &s) {
     case VObjectType::slStringLiteral: {
       UHDM::constant *c = s.MakeConstant();
       std::string_view value = StringUtils::unquoted(fC->SymName(child));
-      c->VpiDecompile(value);
+      c->VpiDecompile(fC->SymName(child));
       c->VpiSize(value.length() * 8);
       c->VpiValue(StrCat("STRING:", value));
       c->VpiConstType(vpiStringConst);

--- a/tests/BadLabel/BadLabel.log
+++ b/tests/BadLabel/BadLabel.log
@@ -568,7 +568,7 @@ design: (work@test)
           \_constant: , line:31:26, endln:31:34
             |vpiParent:
             \_sys_func_call: ($display), line:31:17, endln:31:35
-            |vpiDecompile:PASSED
+            |vpiDecompile:"PASSED"
             |vpiSize:48
             |STRING:PASSED
             |vpiConstType:6
@@ -596,6 +596,7 @@ design: (work@test)
           \_constant: , line:43:12, endln:43:14
             |vpiParent:
             \_func_call: (print), line:43:6, endln:43:15
+            |vpiDecompile:""
             |STRING:
             |vpiConstType:6
           |vpiName:print
@@ -612,6 +613,7 @@ design: (work@test)
           \_constant: , line:47:12, endln:47:14
             |vpiParent:
             \_func_call: (print), line:47:6, endln:47:15
+            |vpiDecompile:""
             |STRING:
             |vpiConstType:6
           |vpiName:print
@@ -629,6 +631,7 @@ design: (work@test)
           \_constant: , line:51:11, endln:51:13
             |vpiParent:
             \_func_call: (print), line:51:5, endln:51:14
+            |vpiDecompile:""
             |STRING:
             |vpiConstType:6
           |vpiName:print

--- a/tests/PackageVar/PackageVar.log
+++ b/tests/PackageVar/PackageVar.log
@@ -496,6 +496,7 @@ design: (unnamed)
             \_constant: , line:35:41, endln:35:43
               |vpiParent:
               \_func_call: (m_field_automation), line:35:5, endln:35:44
+              |vpiDecompile:""
               |STRING:
               |vpiConstType:6
             |vpiName:m_field_automation
@@ -753,6 +754,7 @@ design: (unnamed)
               \_constant: , line:35:41, endln:35:43
                 |vpiParent:
                 \_func_call: (m_field_automation), line:35:5, endln:35:44
+                |vpiDecompile:""
                 |STRING:
                 |vpiConstType:6
               |vpiName:m_field_automation

--- a/tests/ParamFile/ParamFile.log
+++ b/tests/ParamFile/ParamFile.log
@@ -281,6 +281,7 @@ design: (work@dut)
     \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/ParamFile/dut.sv, line:3:1, endln:10:10
     |vpiRhs:
     \_constant: , line:4:29, endln:4:31
+      |vpiDecompile:""
       |STRING:
       |vpiTypespec:
       \_string_typespec: 
@@ -327,6 +328,7 @@ design: (work@dut)
     \_module_inst: work@ram_1p (work@ram_1p), file:${SURELOG_DIR}/tests/ParamFile/dut.sv, line:12:1, endln:30:10
     |vpiRhs:
     \_constant: , line:13:37, endln:13:39
+      |vpiDecompile:""
       |STRING:
       |vpiTypespec:
       \_string_typespec: 
@@ -381,6 +383,7 @@ design: (work@dut)
           \_constant: , line:19:22, endln:19:24
             |vpiParent:
             \_operation: , line:19:7, endln:19:24
+            |vpiDecompile:""
             |STRING:
             |vpiConstType:6
         |vpiStmt:
@@ -397,7 +400,7 @@ design: (work@dut)
             \_constant: , line:20:16, endln:20:56
               |vpiParent:
               \_sys_func_call: ($display), line:20:7, endln:20:70
-              |vpiDecompile:Initializing memory %m from file '%s'.
+              |vpiDecompile:"Initializing memory %m from file '%s'."
               |vpiSize:304
               |STRING:Initializing memory %m from file '%s'.
               |vpiConstType:6
@@ -447,6 +450,7 @@ design: (work@dut)
           \_constant: , line:24:22, endln:24:24
             |vpiParent:
             \_operation: , line:24:7, endln:24:24
+            |vpiDecompile:""
             |STRING:
             |vpiConstType:6
         |vpiStmt:
@@ -463,7 +467,7 @@ design: (work@dut)
             \_constant: , line:25:16, endln:25:52
               |vpiParent:
               \_sys_func_call: ($display), line:25:7, endln:25:53
-              |vpiDecompile:Initializing memory file is empty.
+              |vpiDecompile:"Initializing memory file is empty."
               |vpiSize:272
               |STRING:Initializing memory file is empty.
               |vpiConstType:6

--- a/tests/ParamFile/ParamFileNoTop.log
+++ b/tests/ParamFile/ParamFileNoTop.log
@@ -285,6 +285,7 @@ design: (unnamed)
     \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/ParamFile/dut.sv, line:3:1, endln:10:10
     |vpiRhs:
     \_constant: , line:4:29, endln:4:31
+      |vpiDecompile:""
       |STRING:
       |vpiTypespec:
       \_string_typespec: 
@@ -331,6 +332,7 @@ design: (unnamed)
     \_module_inst: work@ram_1p (work@ram_1p), file:${SURELOG_DIR}/tests/ParamFile/dut.sv, line:12:1, endln:30:10
     |vpiRhs:
     \_constant: , line:13:37, endln:13:39
+      |vpiDecompile:""
       |STRING:
       |vpiTypespec:
       \_string_typespec: 
@@ -385,6 +387,7 @@ design: (unnamed)
           \_constant: , line:19:22, endln:19:24
             |vpiParent:
             \_operation: , line:19:7, endln:19:24
+            |vpiDecompile:""
             |STRING:
             |vpiConstType:6
         |vpiStmt:
@@ -401,7 +404,7 @@ design: (unnamed)
             \_constant: , line:20:16, endln:20:56
               |vpiParent:
               \_sys_func_call: ($display), line:20:7, endln:20:70
-              |vpiDecompile:Initializing memory %m from file '%s'.
+              |vpiDecompile:"Initializing memory %m from file '%s'."
               |vpiSize:304
               |STRING:Initializing memory %m from file '%s'.
               |vpiConstType:6
@@ -449,6 +452,7 @@ design: (unnamed)
           \_constant: , line:24:22, endln:24:24
             |vpiParent:
             \_operation: , line:24:7, endln:24:24
+            |vpiDecompile:""
             |STRING:
             |vpiConstType:6
         |vpiStmt:
@@ -465,7 +469,7 @@ design: (unnamed)
             \_constant: , line:25:16, endln:25:52
               |vpiParent:
               \_sys_func_call: ($display), line:25:7, endln:25:53
-              |vpiDecompile:Initializing memory file is empty.
+              |vpiDecompile:"Initializing memory file is empty."
               |vpiSize:272
               |STRING:Initializing memory file is empty.
               |vpiConstType:6

--- a/tests/ParamFile/ParamFileOverr.log
+++ b/tests/ParamFile/ParamFileOverr.log
@@ -279,6 +279,7 @@ design: (work@dut)
     \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/ParamFile/dut.sv, line:3:1, endln:10:10
     |vpiRhs:
     \_constant: , line:4:29, endln:4:31
+      |vpiDecompile:""
       |STRING:
       |vpiTypespec:
       \_string_typespec: 
@@ -325,6 +326,7 @@ design: (work@dut)
     \_module_inst: work@ram_1p (work@ram_1p), file:${SURELOG_DIR}/tests/ParamFile/dut.sv, line:12:1, endln:30:10
     |vpiRhs:
     \_constant: , line:13:37, endln:13:39
+      |vpiDecompile:""
       |STRING:
       |vpiTypespec:
       \_string_typespec: 
@@ -379,6 +381,7 @@ design: (work@dut)
           \_constant: , line:19:22, endln:19:24
             |vpiParent:
             \_operation: , line:19:7, endln:19:24
+            |vpiDecompile:""
             |STRING:
             |vpiConstType:6
         |vpiStmt:
@@ -395,7 +398,7 @@ design: (work@dut)
             \_constant: , line:20:16, endln:20:56
               |vpiParent:
               \_sys_func_call: ($display), line:20:7, endln:20:70
-              |vpiDecompile:Initializing memory %m from file '%s'.
+              |vpiDecompile:"Initializing memory %m from file '%s'."
               |vpiSize:304
               |STRING:Initializing memory %m from file '%s'.
               |vpiConstType:6
@@ -445,6 +448,7 @@ design: (work@dut)
           \_constant: , line:24:22, endln:24:24
             |vpiParent:
             \_operation: , line:24:7, endln:24:24
+            |vpiDecompile:""
             |STRING:
             |vpiConstType:6
         |vpiStmt:
@@ -461,7 +465,7 @@ design: (work@dut)
             \_constant: , line:25:16, endln:25:52
               |vpiParent:
               \_sys_func_call: ($display), line:25:7, endln:25:53
-              |vpiDecompile:Initializing memory file is empty.
+              |vpiDecompile:"Initializing memory file is empty."
               |vpiSize:272
               |STRING:Initializing memory file is empty.
               |vpiConstType:6


### PR DESCRIPTION
Follow-up of https://github.com/chipsalliance/Surelog/issues/3465#issuecomment-1435907623
vpiDecompile string constant is feed with double-quote 