### PR TITLE
Adapt shell.nix to make use of new SURELOG_USE_HOST_* flags.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -6,38 +6,41 @@
 pkgs.mkShell {
   buildInputs = with pkgs;
     [
-      stdenv
-
-      antlr4
-      cacert
       cmake
-      diffutils
-      git
-      gperftools
-      jdk11
-      lcov
-      libunwind
-      libuuid
-      pkg-config
+      diffutils   # Used in regression tests.
+      gperftools  # tcmalloc
+      jdk11       # to run antlr jar
+
+      # For generating code and make test/regression
       python310
       python310Packages.orderedmultidict
       python310Packages.psutil
-      swig
+
+      # Run regression scripts.
       tcl
-      time
-      zlib
+
+      # If Python API is built.
+      swig
 
       # Libraries for USE_HOST_* use
       flatbuffers
       capnproto
+      gtest
+      antlr4.runtime.cpp
 
       # Ease development
       ccache
       ninja
-      clang-tools
+      clang-tools   # clang-format, clang-tidy
+      lcov          # generate coverage
+      git cacert
     ];
-  shellHook =
-  ''
+  shellHook = ''
     export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+    export ADDITIONAL_CMAKE_OPTIONS="-DSURELOG_USE_HOST_GTEST=On"
+    export ADDITIONAL_CMAKE_OPTIONS="$ADDITIONAL_CMAKE_OPTIONS -DSURELOG_USE_HOST_FLATBUFFERS=On"
+
+    # The following does not work yet: can't find ANTLR_JAR_LOCATION
+    #export ADDITIONAL_CMAKE_OPTIONS="$ADDITIONAL_CMAKE_OPTIONS -DSURELOG_USE_HOST_ANTLR=On"
   '';
 }


### PR DESCRIPTION
USE_HOST_ANTLR does not work yet, need to figure out how to specify that we get the jar.