### PR TITLE
Remove virtual class in package error

### DIFF
--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -106,8 +106,7 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
       VObjectType::slClass_declaration,
       VObjectType::slFunction_body_declaration,
       VObjectType::slTask_body_declaration,
-      VObjectType::slInterface_class_declaration
-  };
+      VObjectType::slInterface_class_declaration};
   m_helper.setDesign(m_compileDesign->getCompiler()->getDesign());
   for (unsigned int i = 0; i < m_package->m_fileContents.size(); i++) {
     const FileContent* fC = m_package->m_fileContents[i];

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -105,7 +105,9 @@ bool CompilePackage::collectObjects_(CollectType collectType, bool reduce) {
   std::vector<VObjectType> stopPoints = {
       VObjectType::slClass_declaration,
       VObjectType::slFunction_body_declaration,
-      VObjectType::slTask_body_declaration};
+      VObjectType::slTask_body_declaration,
+      VObjectType::slInterface_class_declaration
+  };
   m_helper.setDesign(m_compileDesign->getCompiler()->getDesign());
   for (unsigned int i = 0; i < m_package->m_fileContents.size(); i++) {
     const FileContent* fC = m_package->m_fileContents[i];

--- a/third_party/tests/Google/Google.log
+++ b/third_party/tests/Google/Google.log
@@ -6612,11 +6612,9 @@ Processing: -cd generic/class -I../../../../UVM/1800.2-2017-1.0/src/  -parse -no
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd generic/class -I../../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns class_test_27.sv -l class_test_27.sv.log
-[ERR:UH0700] Unsupported expression "<> ".
-
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 1
+[  ERROR] : 0
 [WARNING] : 0
 [   NOTE] : 0
 Processing: -cd generic/class -I../../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -noinfo -nouhdm -timescale=1ns/1ns class_test_8.sv -l class_test_8.sv.log
@@ -10787,6 +10785,6 @@ Processing: -cd chapter-25 -I../../../UVM/1800.2-2017-1.0/src/  -parse -nonote -
 Processed 1134 tests.
 [  FATAL] : 0
 [ SYNTAX] : 39
-[  ERROR] : 145
+[  ERROR] : 144
 [WARNING] : 1762
 [   NOTE] : 0


### PR DESCRIPTION
Remove message of the kind `[ERR:UH0700] Unsupported expression "<> ".` related to virtual class in package