### PR TITLE
Derive the version number from the generated version header.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ option(
 option(SURELOG_BUILD_TESTS "Enable testing." ON)
 
 # Set the project and version
+# Version changes whenever some new features accumulated, or the
+# grammar or the cache format changes to make sure caches
+# are invalidated.
 project(SURELOG VERSION 1.48)
 
 # NOTE: Policy changes has to happen before adding any subprojects
@@ -90,7 +93,9 @@ endif()
 
 set(SURELOG_BUILD_TYPE ${CMAKE_BUILD_TYPE})
 message("Building version v${SURELOG_VERSION_MAJOR}.${SURELOG_VERSION_MINOR} [${SURELOG_VERSION_COMMIT_SHA}]")
-configure_file(${PROJECT_SOURCE_DIR}/include/Surelog/surelog-version.h.in ${GENDIR}/surelog-version.h)
+# TODO: should we also make install this header, or do we encourage to
+# use CommandLineParser::getVersionNumber() ?
+configure_file(${PROJECT_SOURCE_DIR}/include/Surelog/surelog-version.h.in ${GENDIR}/include/Surelog/surelog-version.h)
 
 
 if(WITH_LIBCXX)

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -27,6 +27,7 @@
 #include <Surelog/ErrorReporting/ErrorContainer.h>
 #include <Surelog/SourceCompile/SymbolTable.h>
 #include <Surelog/Utils/StringUtils.h>
+#include <Surelog/surelog-version.h>
 
 #if defined(_MSC_VER)
 #include <direct.h>
@@ -56,7 +57,11 @@ static std::unordered_map<std::string, std::string>
 //         Or when the cache schema changes
 //        This will render the cache invalid
 std::string_view CommandLineParser::getVersionNumber() {
-  static constexpr std::string_view kVersionNumber("1.48");
+#define VERSION_STRING(major, minor) #major "." #minor
+  // Defined in CMakeList.txt in project() call.
+  static constexpr std::string_view kVersionNumber(
+      VERSION_STRING(SURELOG_VERSION_MAJOR, SURELOG_VERSION_MINOR));
+#undef VERSION_STRING
   return kVersionNumber;
 }
 


### PR DESCRIPTION
That way, we have a single source where the version number is coming from: the CMake project.