### PR TITLE
pkg-config: provide right include base and add missing library.

### DIFF
--- a/cmake/configs/Surelog.pc.in
+++ b/cmake/configs/Surelog.pc.in
@@ -1,10 +1,12 @@
 prefix="@CMAKE_INSTALL_PREFIX@"
 exec_prefix="${prefix}"
 libdir="${prefix}/lib/surelog"
-includedir="${prefix}/include/Surelog"
+includedir="${prefix}/include"
 
 Name: @PROJECT_NAME@
 Description: @CMAKE_PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
+# Currently, Surelog and UHDM version numbers go in tandem
+Requires: UHDM >= @PROJECT_VERSION@
 Cflags: -I${includedir}
-Libs: -L${libdir} -lsurelog
+Libs: -L${libdir} -lsurelog -lantlr4-runtime


### PR DESCRIPTION
In all examples, we include <Surelog/SomeHeader.h>, which means the pkg-config needs to point to the directory where the Surelog/ directory is installed.

Also: add the antlr4 runtime library needed (TODO: if we use SURELOG_USE_HOST_ANTLR, would this need to be replaced with a 'Requires antlr4' ?)