### PR TITLE
Be specific in inludes in hello*.cpp programs.

### DIFF
--- a/src/hellodesign.cpp
+++ b/src/hellodesign.cpp
@@ -25,7 +25,10 @@
 // cd tests/UnitElabBlock
 // hellodesign top.v -parse -mutestdout
 
-#include <Surelog/surelog.h>
+#include <Surelog/API/Surelog.h>
+#include <Surelog/CommandLine/CommandLineParser.h>
+#include <Surelog/ErrorReporting/ErrorContainer.h>
+#include <Surelog/SourceCompile/SymbolTable.h>
 
 #include <functional>
 #include <iostream>

--- a/src/hellosureworld.cpp
+++ b/src/hellosureworld.cpp
@@ -24,9 +24,13 @@
 // Example of usage:
 // cd tests/UnitElabBlock
 // hellouhdm top.v -parse -mutestdout
-
+#include <Surelog/API/Surelog.h>
+#include <Surelog/CommandLine/CommandLineParser.h>
 #include <Surelog/Common/FileSystem.h>
-#include <Surelog/surelog.h>
+#include <Surelog/Design/Design.h>
+#include <Surelog/Design/ModuleInstance.h>
+#include <Surelog/ErrorReporting/ErrorContainer.h>
+#include <Surelog/SourceCompile/SymbolTable.h>
 
 #include <functional>
 #include <iostream>

--- a/src/hellouhdm.cpp
+++ b/src/hellouhdm.cpp
@@ -25,7 +25,10 @@
 // cd tests/UnitElabBlock
 // hellouhdm top.v -parse -mutestdout
 
-#include <Surelog/surelog.h>
+#include <Surelog/API/Surelog.h>
+#include <Surelog/CommandLine/CommandLineParser.h>
+#include <Surelog/ErrorReporting/ErrorContainer.h>
+#include <Surelog/SourceCompile/SymbolTable.h>
 
 #include <functional>
 #include <iostream>


### PR DESCRIPTION
These are example programs, so we should be specific in what headers are needed.