### PR TITLE
remove 'using namespace' directives; remove some superfluous `#includ…

### DIFF
--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -50,6 +50,7 @@ Checks: >
     clang-diagnostic-inconsistent-missing-override,
     clang-diagnostic-overloaded-virtual
     clang-diagnostic-unused-private-field,
+    google-build-using-namespace,
     modernize-loop-convert,
     modernize-raw-string-literal,
     modernize-use-override,

--- a/include/Surelog/API/PythonAPI.h
+++ b/include/Surelog/API/PythonAPI.h
@@ -25,8 +25,6 @@
 #define SURELOG_PYTHONAPI_H
 #pragma once
 
-#include <Surelog/Common/PathId.h>
-
 #include <filesystem>
 #include <string>
 #include <vector>

--- a/include/Surelog/Common/ClockingBlockHolder.h
+++ b/include/Surelog/Common/ClockingBlockHolder.h
@@ -32,8 +32,6 @@
 
 namespace SURELOG {
 
-class ClockingBlock;
-
 class ClockingBlockHolder {
  public:
   typedef std::multimap<SymbolId, ClockingBlock, SymbolIdLessThanComparer>

--- a/include/Surelog/Common/FileSystem.h
+++ b/include/Surelog/Common/FileSystem.h
@@ -30,7 +30,6 @@
 #include <cstdint>
 #include <filesystem>
 #include <istream>
-#include <ostream>
 #include <regex>
 #include <sstream>
 #include <string>
@@ -64,7 +63,7 @@ class SymbolTable;
  *   toPath returns a printable representation of the PathId. This doesn't
  *     necessarily have to be a resolve-able path. What the string represent
  *     is up to the interpretation of the FileSystem implementation itself.
- * 
+ *
  *   toPlatformAbsPath returns a std::filesystem::path representation of PathId.
  *     The path itself can be non-existant, in certain cases, however
  *     it does have to exist because it is to be used by external processes
@@ -74,7 +73,7 @@ class SymbolTable;
  *   NOTE:
  *     toPath(id) == toPath(toPathId(toPath(id))) but
  *     toPlatformAbsPath(id) <> toPlatformAbsPath(toPathId(toPlatformAbsPath(id)))
- * 
+ *
  *     i.e. string representation can be converted to id (and vice-versa)
  *     using toPathId & toPath but the same is not necessarily guaranteed
  *     between toPathId & toPlatformAbsPath (primarily because of potential
@@ -84,7 +83,7 @@ class SymbolTable;
  *   Mappings are basically replacement symbols to use in place of the
  *   original. These are/can be used to retarget PathId to point to a
  *   different target.
- * 
+ *
  */
 class FileSystem {
  public:

--- a/include/Surelog/Common/PathId.h
+++ b/include/Surelog/Common/PathId.h
@@ -22,7 +22,6 @@
 
 #include <cstdint>
 #include <istream>
-#include <ostream>
 #include <set>
 #include <string_view>
 #include <unordered_set>

--- a/include/Surelog/DesignCompile/CompileStep.h
+++ b/include/Surelog/DesignCompile/CompileStep.h
@@ -29,8 +29,7 @@
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
-#include <string>
-#include <unordered_set>
+#include <string_view>
 #include <vector>
 
 namespace SURELOG {

--- a/include/Surelog/ErrorReporting/Error.h
+++ b/include/Surelog/ErrorReporting/Error.h
@@ -28,7 +28,6 @@
 #include <Surelog/ErrorReporting/ErrorDefinition.h>
 #include <Surelog/ErrorReporting/Location.h>
 
-#include <string>
 #include <vector>
 
 namespace SURELOG {

--- a/include/Surelog/SourceCompile/SymbolTable.h
+++ b/include/Surelog/SourceCompile/SymbolTable.h
@@ -26,8 +26,6 @@
 #define SURELOG_SYMBOLTABLE_H
 #pragma once
 
-#include <Surelog/Common/SymbolId.h>
-
 #include <uhdm/SymbolFactory.h>
 
 namespace SURELOG {

--- a/include/Surelog/Testbench/Property.h
+++ b/include/Surelog/Testbench/Property.h
@@ -25,7 +25,6 @@
 #define SURELOG_PROPERTY_H
 #pragma once
 
-#include <Surelog/Common/SymbolId.h>
 #include <Surelog/Testbench/Variable.h>
 
 namespace SURELOG {

--- a/include/Surelog/Utils/StringUtils.h
+++ b/include/Surelog/Utils/StringUtils.h
@@ -25,9 +25,8 @@
 #define SURELOG_STRINGUTILS_H
 #pragma once
 
-#include <map>
-#include <sstream>
 #include <string>
+#include <sstream>
 #include <string_view>
 #include <vector>
 

--- a/src/API/PythonAPI.cpp
+++ b/src/API/PythonAPI.cpp
@@ -23,7 +23,6 @@
 
 #include <Surelog/API/PythonAPI.h>
 #include <Surelog/Common/FileSystem.h>
-#include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/Design.h>
 #include <Surelog/ErrorReporting/ErrorContainer.h>
 #include <Surelog/SourceCompile/SymbolTable.h>
@@ -42,6 +41,7 @@ typedef SURELOG::NodeId NodeId;
 #endif
 
 #include <cstring>
+#include <filesystem>
 #include <iostream>
 
 namespace SURELOG {

--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -21,7 +21,6 @@
  * Created on May 13, 2017, 4:42 PM
  */
 
-#include <Surelog/API/PythonAPI.h>
 #include <Surelog/API/SLAPI.h>
 
 #ifdef SURELOG_WITH_PYTHON

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -31,15 +31,10 @@
 
 #if defined(_MSC_VER)
 #include <direct.h>
-#define PATH_MAX _MAX_PATH
-#else
-#include <sys/param.h>
-#include <unistd.h>
 #endif
 
 #include <cstring>
 #include <iostream>
-#include <sstream>
 #include <thread>
 
 namespace SURELOG {

--- a/src/Common/FileSystem.cpp
+++ b/src/Common/FileSystem.cpp
@@ -33,7 +33,6 @@
 #include <unistd.h>
 #else
 #include <limits.h>
-#include <sys/param.h>
 #include <unistd.h>
 #endif
 

--- a/src/Common/PathId.cpp
+++ b/src/Common/PathId.cpp
@@ -23,7 +23,6 @@
 
 #include <Surelog/Common/FileSystem.h>
 #include <Surelog/Common/PathId.h>
-#include <Surelog/SourceCompile/SymbolTable.h>
 
 namespace SURELOG {
 std::ostream &operator<<(std::ostream &strm, const PathIdPP &id) {

--- a/src/Common/PathId_test.cpp
+++ b/src/Common/PathId_test.cpp
@@ -17,7 +17,6 @@
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/PlatformFileSystem.h>
 #include <Surelog/SourceCompile/SymbolTable.h>
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <filesystem>
@@ -25,7 +24,6 @@
 
 namespace SURELOG {
 
-using ::testing::ElementsAre;
 namespace fs = std::filesystem;
 
 namespace {

--- a/src/Common/PlatformFileSystem.cpp
+++ b/src/Common/PlatformFileSystem.cpp
@@ -25,8 +25,10 @@
 #include <Surelog/SourceCompile/SymbolTable.h>
 #include <Surelog/Utils/StringUtils.h>
 
+#include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <mutex>
 
 namespace SURELOG {
 static constexpr bool kEnableLogs = false;

--- a/src/Design/Struct.cpp
+++ b/src/Design/Struct.cpp
@@ -25,7 +25,8 @@
 #include <Surelog/Design/Struct.h>
 
 // UHDM
-#include <uhdm/uhdm.h>
+#include <uhdm/struct_typespec.h>
+#include <uhdm/typespec_member.h>
 
 namespace SURELOG {
 

--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -29,14 +29,9 @@
 #include <Surelog/ErrorReporting/LogListener.h>
 #include <Surelog/ErrorReporting/Waiver.h>
 #include <Surelog/SourceCompile/SymbolTable.h>
-#include <antlr4-runtime.h>
 #include <stdio.h>
 
 #include <iostream>
-#include <mutex>
-#if !(defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__))
-#include <unistd.h>
-#endif
 
 namespace SURELOG {
 ErrorContainer::ErrorContainer(SymbolTable* symbolTable,

--- a/src/ErrorReporting/ErrorDefinition.cpp
+++ b/src/ErrorReporting/ErrorDefinition.cpp
@@ -24,8 +24,6 @@
 #include <Surelog/Utils/NumUtils.h>
 #include <Surelog/Utils/StringUtils.h>
 
-#include <charconv>
-
 namespace SURELOG {
 
 ErrorDefinition::ErrorMap* ErrorDefinition::mutableGlobalErrorInfoMap() {

--- a/src/ErrorReporting/Report.cpp
+++ b/src/ErrorReporting/Report.cpp
@@ -33,12 +33,6 @@
 #include <regex>
 #include <thread>
 
-#if !(defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__))
-#include <unistd.h>
-#endif
-
-#include <Surelog/ErrorReporting/ErrorContainer.h>
-
 namespace SURELOG {
 
 namespace fs = std::filesystem;

--- a/src/ErrorReporting/Waiver.cpp
+++ b/src/ErrorReporting/Waiver.cpp
@@ -24,8 +24,6 @@
 #include <Surelog/ErrorReporting/ErrorDefinition.h>
 #include <Surelog/ErrorReporting/Waiver.h>
 
-#include <iostream>
-#include <sstream>
 #include <string>
 
 namespace SURELOG {

--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -39,8 +39,6 @@
 #include <strings.h>
 #endif
 
-#include <sstream>
-
 namespace SURELOG {
 
 Value* ExprBuilder::clone(Value* val) {

--- a/src/Expression/ExprBuilder_test.cpp
+++ b/src/Expression/ExprBuilder_test.cpp
@@ -17,17 +17,12 @@
 #include <Surelog/Design/FileContent.h>
 #include <Surelog/Expression/ExprBuilder.h>
 #include <Surelog/SourceCompile/ParserHarness.h>
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <memory>
-#include <string>
-#include <string_view>
 #include <vector>
 
 namespace SURELOG {
-
-using ::testing::ElementsAre;
 
 namespace {
 TEST(ExprBuilderTest, BasicValueOp) {

--- a/src/Library/AntlrLibParserErrorListener.cpp
+++ b/src/Library/AntlrLibParserErrorListener.cpp
@@ -25,7 +25,6 @@
 #include <Surelog/Library/AntlrLibParserErrorListener.h>
 #include <Surelog/Library/ParseLibraryDef.h>
 #include <Surelog/SourceCompile/SymbolTable.h>
-#include <antlr4-runtime.h>
 
 namespace SURELOG {
 

--- a/src/Library/Library.cpp
+++ b/src/Library/Library.cpp
@@ -21,7 +21,6 @@
  * Created on January 27, 2018, 5:25 PM
  */
 
-#include <Surelog/Common/FileSystem.h>
 #include <Surelog/Design/ModuleDefinition.h>
 #include <Surelog/Library/Library.h>
 #include <Surelog/SourceCompile/SymbolTable.h>

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -33,13 +33,10 @@
 #include <Surelog/Library/SVLibShapeListener.h>
 #include <Surelog/SourceCompile/SymbolTable.h>
 #include <Surelog/Utils/StringUtils.h>
-#include <antlr4-runtime.h>
 #include <parser/SV3_1aLexer.h>
 #include <parser/SV3_1aParser.h>
 
 namespace SURELOG {
-
-using namespace antlr4;
 
 ParseLibraryDef::ParseLibraryDef(CommandLineParser* commandLineParser,
                                  ErrorContainer* errors,
@@ -116,11 +113,11 @@ bool ParseLibraryDef::parseLibraryDefinition(PathId fileId, Library* lib) {
 
   AntlrLibParserErrorListener* errorListener =
       new AntlrLibParserErrorListener(this);
-  antlr4::ANTLRInputStream* inputStream = new ANTLRInputStream(stream);
+  antlr4::ANTLRInputStream* inputStream = new antlr4::ANTLRInputStream(stream);
   SV3_1aLexer* lexer = new SV3_1aLexer(inputStream);
   lexer->removeErrorListeners();
   lexer->addErrorListener(errorListener);
-  antlr4::CommonTokenStream* tokens = new CommonTokenStream(lexer);
+  antlr4::CommonTokenStream* tokens = new antlr4::CommonTokenStream(lexer);
   tokens->fill();
   SV3_1aParser* parser = new SV3_1aParser(tokens);
   parser->removeErrorListeners();
@@ -130,7 +127,7 @@ bool ParseLibraryDef::parseLibraryDefinition(PathId fileId, Library* lib) {
   SVLibShapeListener* listener = new SVLibShapeListener(this, tokens);
   m_fileContent = listener->getFileContent();
 
-  tree::ParseTreeWalker::DEFAULT.walk(listener, m_tree);
+  antlr4::tree::ParseTreeWalker::DEFAULT.walk(listener, m_tree);
 
   if (m_fileContent->getLibrary() == nullptr) {
     if (lib) {

--- a/src/SourceCompile/AntlrParserErrorListener.cpp
+++ b/src/SourceCompile/AntlrParserErrorListener.cpp
@@ -22,11 +22,9 @@
  */
 
 #include <Surelog/Common/FileSystem.h>
-#include <Surelog/ErrorReporting/ErrorContainer.h>
 #include <Surelog/SourceCompile/AntlrParserErrorListener.h>
 #include <Surelog/SourceCompile/CompileSourceFile.h>
 #include <Surelog/SourceCompile/ParseFile.h>
-#include <Surelog/SourceCompile/SymbolTable.h>
 #include <Surelog/Utils/StringUtils.h>
 
 namespace SURELOG {

--- a/src/SourceCompile/CheckCompile.cpp
+++ b/src/SourceCompile/CheckCompile.cpp
@@ -31,9 +31,6 @@
 #include <Surelog/SourceCompile/Compiler.h>
 #include <Surelog/SourceCompile/SymbolTable.h>
 
-#include <iostream>
-#include <set>
-
 namespace SURELOG {
 
 bool CheckCompile::check() {

--- a/src/SourceCompile/CommonListenerHelper.cpp
+++ b/src/SourceCompile/CommonListenerHelper.cpp
@@ -24,12 +24,11 @@
 #include <Surelog/Design/DesignElement.h>
 #include <Surelog/Design/FileContent.h>
 #include <Surelog/SourceCompile/CommonListenerHelper.h>
-#include <Surelog/SourceCompile/SymbolTable.h>
 #include <antlr4-runtime.h>
 
 namespace SURELOG {
 
-using namespace antlr4;
+using antlr4::ParserRuleContext;
 
 NodeId CommonListenerHelper::NodeIdFromContext(
     const antlr4::tree::ParseTree* ctx) const {
@@ -122,7 +121,7 @@ NodeId CommonListenerHelper::addVObject(ParserRuleContext* ctx,
 void CommonListenerHelper::addParentChildRelations(NodeId indexParent,
                                                    ParserRuleContext* ctx) {
   NodeId currentIndex = indexParent;
-  for (tree::ParseTree* child : ctx->children) {
+  for (antlr4::tree::ParseTree* child : ctx->children) {
     NodeId childIndex = NodeIdFromContext(child);
     if (childIndex) {
       MutableParent(childIndex) = UniqueId(indexParent);

--- a/src/SourceCompile/CompileSourceFile.cpp
+++ b/src/SourceCompile/CompileSourceFile.cpp
@@ -41,8 +41,6 @@
 
 namespace SURELOG {
 
-using namespace antlr4;
-
 CompileSourceFile::CompileSourceFile(PathId fileId, CommandLineParser* clp,
                                      ErrorContainer* errors, Compiler* compiler,
                                      SymbolTable* symbols,

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -43,15 +43,14 @@
 #include <Surelog/Utils/ContainerUtils.h>
 #include <Surelog/Utils/StringUtils.h>
 #include <Surelog/Utils/Timer.h>
-#include <antlr4-runtime.h>
 
+#include <climits>
 #include <filesystem>
 #include <thread>
 
 #if defined(_MSC_VER)
 #include <direct.h>
 #else
-#include <sys/param.h>
 #include <unistd.h>
 #endif
 

--- a/src/SourceCompile/ParseFile_test.cpp
+++ b/src/SourceCompile/ParseFile_test.cpp
@@ -15,14 +15,10 @@
 */
 
 #include <Surelog/Design/FileContent.h>
-#include <Surelog/SourceCompile/ParseFile.h>
 #include <Surelog/SourceCompile/ParserHarness.h>
-#include <Surelog/SourceCompile/SymbolTable.h>
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace SURELOG {
-using ::testing::ElementsAre;
 
 namespace {
 TEST(ParserTest, BasicParse) {

--- a/src/SourceCompile/ParserHarness.cpp
+++ b/src/SourceCompile/ParserHarness.cpp
@@ -22,7 +22,6 @@
  */
 
 #include <Surelog/CommandLine/CommandLineParser.h>
-#include <Surelog/Common/FileSystem.h>
 #include <Surelog/Design/FileContent.h>
 #include <Surelog/ErrorReporting/ErrorContainer.h>
 #include <Surelog/Library/Library.h>

--- a/src/SourceCompile/PreprocessFile_test.cpp
+++ b/src/SourceCompile/PreprocessFile_test.cpp
@@ -19,7 +19,6 @@
 #include <gtest/gtest.h>
 
 #include <string>
-#include <string_view>
 #include <vector>
 
 namespace SURELOG {

--- a/src/SourceCompile/SymbolTable_test.cpp
+++ b/src/SourceCompile/SymbolTable_test.cpp
@@ -14,6 +14,7 @@
  limitations under the License.
 */
 
+#include <Surelog/Common/SymbolId.h>
 #include <Surelog/SourceCompile/SymbolTable.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/src/Testbench/Program.cpp
+++ b/src/Testbench/Program.cpp
@@ -23,7 +23,6 @@
 
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Design/FileContent.h>
-#include <Surelog/SourceCompile/SymbolTable.h>
 #include <Surelog/Testbench/Program.h>
 
 #include <string_view>

--- a/src/Utils/NumUtils.cpp
+++ b/src/Utils/NumUtils.cpp
@@ -23,13 +23,8 @@
 
 #include <Surelog/Utils/NumUtils.h>
 
-#include <algorithm>
 #include <bitset>
 #include <cstring>
-#include <iostream>
-#include <locale>
-#include <regex>
-#include <sstream>
 
 namespace SURELOG {
 

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -25,8 +25,8 @@
 
 #include <algorithm>
 #include <array>
-#include <iostream>
 #include <locale>
+#include <map>
 #include <regex>
 #include <sstream>
 


### PR DESCRIPTION
…e`'s

Superfluous includes found with IWYU tool (it is somewhat overzealous, so I manually curated whatever it suggested).