### PR TITLE
USE_HOST_UHDM: Get udhm-dump from path instead of third_party/

### DIFF
--- a/scripts/regression.py
+++ b/scripts/regression.py
@@ -1184,6 +1184,11 @@ def _main():
     args.uhdm_dump_filepath = os.path.join(args.build_dirpath, args.uhdm_dump_filepath)
   args.uhdm_dump_filepath = os.path.abspath(args.uhdm_dump_filepath)
 
+  # If there is no uhdm-dump in third_party/ (e.g. due to SURELOG_USE_HOST_UHDM)
+  # then get it from the path.
+  if not os.path.exists(args.uhdm_dump_filepath):
+    args.uhdm_dump_filepath = shutil.which(_default_uhdm_dump_filename)
+
   if not os.path.isabs(args.roundtrip_filepath):
     args.roundtrip_filepath = os.path.join(args.build_dirpath, args.roundtrip_filepath)
   args.roundtrip_filepath = os.path.abspath(args.roundtrip_filepath)


### PR DESCRIPTION
If the user chose SURELOG_USE_HOST_UHDM, there will be not uhdm-dump binary build in third_party/ but instead, it will be available in the users' environment.

So add this fallback: if the uhdm-dump binary is not found in the third_party/ location, take it from the PATH.

The change in the tcl file looks pretty big, but it is only three lines; the rest is fixing trailing whitespace.