### PR TITLE
require any python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 # Python
 if (SURELOG_WITH_PYTHON)
   find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
-  find_package(SWIG 3.0 REQUIRED)
+  find_package(SWIG REQUIRED)
   message(STATUS "Python3_LIBRARIES = ${Python3_LIBRARIES}")
   message(STATUS "Python3_EXECUTABLE = ${Python3_EXECUTABLE}")
   message(STATUS "Python3_INCLUDE_DIRS = ${Python3_INCLUDE_DIRS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
 # Python
 if (SURELOG_WITH_PYTHON)
-  find_package(Python3 3.3 REQUIRED COMPONENTS Interpreter Development)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
   find_package(SWIG 3.0 REQUIRED)
   message(STATUS "Python3_LIBRARIES = ${Python3_LIBRARIES}")
   message(STATUS "Python3_EXECUTABLE = ${Python3_EXECUTABLE}")


### PR DESCRIPTION
This doesn't actually make a difference as you can override with any python3 version (as we do in CI), but brings it in line with UHDM and makes it easier if you don't specify python3 cmake variables. 