### PR TITLE
Code Maintenance - Make reduce parameter non-optional

### DIFF
--- a/include/Surelog/DesignCompile/CompileHelper.h
+++ b/include/Surelog/DesignCompile/CompileHelper.h
@@ -66,6 +66,7 @@ class FScope : public ValuedComponentI {
 };
 
 typedef std::vector<FScope*> Scopes;
+enum class Reduce : bool { Yes = true, No = false };
 
 class CompileHelper final {
  public:
@@ -91,8 +92,7 @@ class CompileHelper final {
 
   const DataType* compileTypeDef(DesignComponent* scope, const FileContent* fC,
                                  NodeId id, CompileDesign* compileDesign,
-                                 UHDM::any* pstmt = nullptr,
-                                 bool reduce = false);
+                                 Reduce reduce, UHDM::any* pstmt = nullptr);
 
   bool compileScopeBody(Scope* parent, Statement* parentStmt,
                         const FileContent* fC, NodeId id);
@@ -138,7 +138,7 @@ class CompileHelper final {
 
   bool compileDataDeclaration(DesignComponent* component, const FileContent* fC,
                               NodeId id, bool interface,
-                              CompileDesign* compileDesign, bool reduce,
+                              CompileDesign* compileDesign, Reduce reduce,
                               UHDM::VectorOfattribute* attributes);
 
   // ------------------------------------------------------------------------------------------
@@ -158,8 +158,8 @@ class CompileHelper final {
 
   UHDM::VectorOfany* compileTfCallArguments(
       DesignComponent* component, const FileContent* fC, NodeId Arg_list_node,
-      CompileDesign* compileDesign, UHDM::any* call, ValuedComponentI* instance,
-      bool reduce, bool muteErrors);
+      CompileDesign* compileDesign, Reduce reduce, UHDM::any* call,
+      ValuedComponentI* instance, bool muteErrors);
 
   UHDM::assignment* compileBlockingAssignment(
       DesignComponent* component, const FileContent* fC, NodeId nodeId,
@@ -183,24 +183,22 @@ class CompileHelper final {
 
   bool compileParameterDeclaration(DesignComponent* component,
                                    const FileContent* fC, NodeId nodeId,
-                                   CompileDesign* compileDesign,
+                                   CompileDesign* compileDesign, Reduce reduce,
                                    bool localParam,
                                    ValuedComponentI* m_instance,
-                                   bool port_param, bool reduce,
-                                   bool muteErrors);
+                                   bool port_param, bool muteErrors);
 
   NodeId setFuncTaskQualifiers(const FileContent* fC, NodeId nodeId,
                                UHDM::task_func* func);
 
   bool compileTask(DesignComponent* component, const FileContent* fC,
-                   NodeId nodeId, CompileDesign* compileDesign,
-                   ValuedComponentI* instance, bool isMethod = false,
-                   bool reduce = false);
+                   NodeId nodeId, CompileDesign* compileDesign, Reduce reduce,
+                   ValuedComponentI* instance, bool isMethod);
 
   bool compileFunction(DesignComponent* component, const FileContent* fC,
                        NodeId nodeId, CompileDesign* compileDesign,
-                       ValuedComponentI* instance, bool isMethod = false,
-                       bool reduce = false);
+                       Reduce reduce, ValuedComponentI* instance,
+                       bool isMethod);
 
   bool compileAssertionItem(DesignComponent* component, const FileContent* fC,
                             NodeId nodeId, CompileDesign* compileDesign);
@@ -229,21 +227,20 @@ class CompileHelper final {
 
   UHDM::VectorOfany* compileStmt(DesignComponent* component,
                                  const FileContent* fC, NodeId nodeId,
-                                 CompileDesign* compileDesign,
+                                 CompileDesign* compileDesign, Reduce reduce,
                                  UHDM::any* pstmt = nullptr,
-                                 ValuedComponentI* instance = nullptr,
-                                 bool reduce = false);
+                                 ValuedComponentI* instance = nullptr);
 
   UHDM::any* compileVariable(DesignComponent* component, const FileContent* fC,
                              NodeId nodeId, CompileDesign* compileDesign,
-                             UHDM::any* pstmt, ValuedComponentI* instance,
-                             bool reduce, bool muteErrors);
+                             Reduce reduce, UHDM::any* pstmt,
+                             ValuedComponentI* instance, bool muteErrors);
 
   UHDM::typespec* compileTypespec(DesignComponent* component,
                                   const FileContent* fC, NodeId nodeId,
-                                  CompileDesign* compileDesign,
+                                  CompileDesign* compileDesign, Reduce reduce,
                                   UHDM::any* pstmt, ValuedComponentI* instance,
-                                  bool reduce, bool isVariable = false);
+                                  bool isVariable);
 
   UHDM::typespec* compileBuiltinTypespec(DesignComponent* component,
                                          const FileContent* fC, NodeId type,
@@ -253,8 +250,8 @@ class CompileHelper final {
 
   UHDM::typespec* compileDatastructureTypespec(
       DesignComponent* component, const FileContent* fC, NodeId type,
-      CompileDesign* compileDesign, SURELOG::ValuedComponentI* instance,
-      bool reduce, std::string_view suffixname = "",
+      CompileDesign* compileDesign, Reduce reduce,
+      SURELOG::ValuedComponentI* instance, std::string_view suffixname = "",
       std::string_view typeName = "");
 
   UHDM::any* compileCheckerInstantiation(DesignComponent* component,
@@ -297,27 +294,30 @@ class CompileHelper final {
 
   UHDM::any* compileExpression(DesignComponent* component,
                                const FileContent* fC, NodeId nodeId,
-                               CompileDesign* compileDesign,
+                               CompileDesign* compileDesign, Reduce reduce,
                                UHDM::any* pexpr = nullptr,
                                ValuedComponentI* instance = nullptr,
-                               bool reduce = false, bool muteErrors = false);
+                               bool muteErrors = false);
 
   UHDM::any* compilePartSelectRange(
       DesignComponent* component, const FileContent* fC, NodeId Constant_range,
-      std::string_view name, CompileDesign* compileDesign, UHDM::any* pexpr,
-      ValuedComponentI* instance, bool reduce, bool muteErrors);
+      std::string_view name, CompileDesign* compileDesign, Reduce reduce,
+      UHDM::any* pexpr, ValuedComponentI* instance, bool muteErrors);
 
-  std::vector<UHDM::range*>* compileRanges(
-      DesignComponent* component, const FileContent* fC,
-      NodeId Packed_dimension, CompileDesign* compileDesign, UHDM::any* pexpr,
-      ValuedComponentI* instance, bool reduce, int32_t& size, bool muteErrors);
+  std::vector<UHDM::range*>* compileRanges(DesignComponent* component,
+                                           const FileContent* fC,
+                                           NodeId Packed_dimension,
+                                           CompileDesign* compileDesign,
+                                           Reduce reduce, UHDM::any* pexpr,
+                                           ValuedComponentI* instance,
+                                           int32_t& size, bool muteErrors);
 
   UHDM::any* compileAssignmentPattern(DesignComponent* component,
                                       const FileContent* fC,
                                       NodeId Assignment_pattern,
                                       CompileDesign* compileDesign,
-                                      UHDM::any* pexpr,
-                                      ValuedComponentI* instance, bool reduce);
+                                      Reduce reduce, UHDM::any* pexpr,
+                                      ValuedComponentI* instance);
 
   UHDM::array_var* compileArrayVar(DesignComponent* component,
                                    const FileContent* fC, NodeId varId,
@@ -332,47 +332,49 @@ class CompileHelper final {
 
   UHDM::VectorOfany* compileDataDeclaration(
       DesignComponent* component, const FileContent* fC, NodeId nodeId,
-      CompileDesign* compileDesign, UHDM::any* pstmt = nullptr,
-      ValuedComponentI* instance = nullptr, bool reduce = false);
+      CompileDesign* compileDesign, Reduce reduce, UHDM::any* pstmt = nullptr,
+      ValuedComponentI* instance = nullptr);
 
   UHDM::any* compileForLoop(DesignComponent* component, const FileContent* fC,
                             NodeId nodeId, CompileDesign* compileDesign);
 
   UHDM::any* compileSelectExpression(
       DesignComponent* component, const FileContent* fC, NodeId Bit_select,
-      std::string_view name, CompileDesign* compileDesign, UHDM::any* pexpr,
-      ValuedComponentI* instance, bool reduce, bool muteErrors);
+      std::string_view name, CompileDesign* compileDesign, Reduce reduce,
+      UHDM::any* pexpr, ValuedComponentI* instance, bool muteErrors);
 
   UHDM::any* compileBits(DesignComponent* component, const FileContent* fC,
                          NodeId Expression, CompileDesign* compileDesign,
-                         UHDM::any* pexpr, ValuedComponentI* instance,
-                         bool reduce, bool sizeMode, bool muteErrors);
+                         Reduce reduce, UHDM::any* pexpr,
+                         ValuedComponentI* instance, bool sizeMode,
+                         bool muteErrors);
 
   UHDM::any* compileClog2(DesignComponent* component, const FileContent* fC,
                           NodeId Expression, CompileDesign* compileDesign,
-                          UHDM::any* pexpr, ValuedComponentI* instance,
-                          bool reduce, bool muteErrors);
+                          Reduce reduce, UHDM::any* pexpr,
+                          ValuedComponentI* instance, bool muteErrors);
 
   UHDM::any* compileBound(DesignComponent* component, const FileContent* fC,
                           NodeId Expression, CompileDesign* compileDesign,
-                          UHDM::any* pexpr, ValuedComponentI* instance,
-                          bool reduce, bool muteErrors, std::string_view name);
+                          Reduce reduce, UHDM::any* pexpr,
+                          ValuedComponentI* instance, bool muteErrors,
+                          std::string_view name);
 
   UHDM::any* compileTypename(DesignComponent* component, const FileContent* fC,
                              NodeId Expression, CompileDesign* compileDesign,
-                             UHDM::any* pexpr, ValuedComponentI* instance,
-                             bool reduce);
+                             Reduce reduce, UHDM::any* pexpr,
+                             ValuedComponentI* instance);
 
   const UHDM::typespec* getTypespec(DesignComponent* component,
                                     const FileContent* fC, NodeId id,
-                                    CompileDesign* compileDesign,
-                                    ValuedComponentI* instance, bool reduce);
+                                    CompileDesign* compileDesign, Reduce reduce,
+                                    ValuedComponentI* instance);
 
   UHDM::any* compileComplexFuncCall(DesignComponent* component,
                                     const FileContent* fC, NodeId nodeId,
-                                    CompileDesign* compileDesign,
+                                    CompileDesign* compileDesign, Reduce reduce,
                                     UHDM::any* pexpr,
-                                    ValuedComponentI* instance, bool reduce,
+                                    ValuedComponentI* instance,
                                     bool muteErrors);
 
   std::vector<UHDM::attribute*>* compileAttributes(
@@ -438,8 +440,8 @@ class CompileHelper final {
                             CompileDesign* compileDesign, NodeId id,
                             ValuedComponentI* instance);
   void compileGateInstantiation(ModuleDefinition* mod, const FileContent* fC,
-                            CompileDesign* compileDesign, NodeId id,
-                            ValuedComponentI* instance);
+                                CompileDesign* compileDesign, NodeId id,
+                                ValuedComponentI* instance);
   void compileHighConn(ModuleDefinition* component, const FileContent* fC,
                        CompileDesign* compileDesign, NodeId id,
                        UHDM::VectorOfport* ports);
@@ -478,8 +480,8 @@ class CompileHelper final {
 
   uint64_t Bits(const UHDM::any* typespec, bool& invalidValue,
                 DesignComponent* component, CompileDesign* compileDesign,
-                ValuedComponentI* instance, PathId fileId, uint32_t lineNumber,
-                bool reduce, bool sizeMode);
+                Reduce reduce, ValuedComponentI* instance, PathId fileId,
+                uint32_t lineNumber, bool sizeMode);
 
   UHDM::variables* getSimpleVarFromTypespec(
       UHDM::typespec* spec, std::vector<UHDM::range*>* packedDimensions,
@@ -503,17 +505,18 @@ class CompileHelper final {
                     CompileDesign* compileDesign, ValuedComponentI* instance);
 
   UHDM::any* getValue(std::string_view name, DesignComponent* component,
-                      CompileDesign* compileDesign, ValuedComponentI* instance,
-                      PathId fileId, uint32_t lineNumber, UHDM::any* pexpr,
-                      bool reduce, bool muteErrors = false);
+                      CompileDesign* compileDesign, Reduce reduce,
+                      ValuedComponentI* instance, PathId fileId,
+                      uint32_t lineNumber, UHDM::any* pexpr,
+                      bool muteErrors = false);
 
   // Parse numeric UHDM constant into int64_t. Returns if successful.
   bool parseConstant(const UHDM::constant& constant, int64_t* value);
 
   int64_t getValue(bool& validValue, DesignComponent* component,
                    const FileContent* fC, NodeId nodeId,
-                   CompileDesign* compileDesign, UHDM::any* pexpr,
-                   ValuedComponentI* instance, bool reduce,
+                   CompileDesign* compileDesign, Reduce reduce,
+                   UHDM::any* pexpr, ValuedComponentI* instance,
                    bool muteErrors = false);
 
   UHDM::typespec* elabTypespec(DesignComponent* component, UHDM::typespec* spec,
@@ -546,9 +549,9 @@ class CompileHelper final {
 
   UHDM::any* decodeHierPath(UHDM::hier_path* path, bool& invalidValue,
                             DesignComponent* component,
-                            CompileDesign* compileDesign,
+                            CompileDesign* compileDesign, Reduce reduce,
                             ValuedComponentI* instance, PathId fileName,
-                            uint32_t lineNumber, UHDM::any* pexpr, bool reduce,
+                            uint32_t lineNumber, UHDM::any* pexpr,
                             bool muteErrors, bool returnTypespec);
 
   bool valueRange(Value* val, UHDM::typespec* tps, DesignComponent* component,

--- a/include/Surelog/DesignCompile/CompilePackage.h
+++ b/include/Surelog/DesignCompile/CompilePackage.h
@@ -66,11 +66,11 @@ class CompilePackage final {
     m_helper.seterrorReporting(errors, symbols);
   }
 
-  bool compile(bool reduce);
+  bool compile(Reduce reduce);
 
  private:
   enum CollectType { FUNCTION, DEFINITION, OTHER };
-  bool collectObjects_(CollectType collectType, bool reduce);
+  bool collectObjects_(CollectType collectType, Reduce reduce);
 
   CompileDesign* const m_compileDesign;
   Package* const m_package;

--- a/src/DesignCompile/CompileAssertion.cpp
+++ b/src/DesignCompile/CompileAssertion.cpp
@@ -41,8 +41,9 @@ bool CompileHelper::compileAssertionItem(DesignComponent* component,
   NodeId item = fC->Child(nodeId);
   if (fC->Type(item) == VObjectType::slConcurrent_assertion_item) {
     NodeId Concurrent_assertion_statement = fC->Child(item);
-    UHDM::VectorOfany* stmts = compileStmt(
-        component, fC, Concurrent_assertion_statement, compileDesign, nullptr);
+    UHDM::VectorOfany* stmts =
+        compileStmt(component, fC, Concurrent_assertion_statement,
+                    compileDesign, Reduce::No, nullptr);
     UHDM::VectorOfany* assertions = component->getAssertions();
     if (assertions == nullptr) {
       component->setAssertions(s.MakeAnyVec());
@@ -108,12 +109,13 @@ UHDM::any* CompileHelper::compileConcurrentAssertion(
     }
     UHDM::VectorOfany* if_stmts = nullptr;
     if (if_stmt_id)
-      if_stmts = compileStmt(component, fC, if_stmt_id, compileDesign, pstmt);
+      if_stmts = compileStmt(component, fC, if_stmt_id, compileDesign,
+                             Reduce::No, pstmt);
     if (if_stmts) if_stmt = (*if_stmts)[0];
     UHDM::VectorOfany* else_stmts = nullptr;
     if (else_stmt_id)
-      else_stmts =
-          compileStmt(component, fC, else_stmt_id, compileDesign, pstmt);
+      else_stmts = compileStmt(component, fC, else_stmt_id, compileDesign,
+                               Reduce::No, pstmt);
     if (else_stmts) else_stmt = (*else_stmts)[0];
   }
 
@@ -123,8 +125,9 @@ UHDM::any* CompileHelper::compileConcurrentAssertion(
       NodeId Property_expr = fC->Child(Property_spec);
       UHDM::assert_stmt* assert_stmt = s.MakeAssert_stmt();
       UHDM::property_spec* prop_spec = s.MakeProperty_spec();
-      UHDM::any* property_expr = compileExpression(
-          component, fC, Property_expr, compileDesign, pstmt, instance, false);
+      UHDM::any* property_expr =
+          compileExpression(component, fC, Property_expr, compileDesign,
+                            Reduce::No, pstmt, instance);
       property_expr = createPropertyInst(property_expr, s);
       prop_spec->VpiPropertyExpr(property_expr);
       fC->populateCoreMembers(Property_spec, Property_spec, prop_spec);
@@ -139,14 +142,15 @@ UHDM::any* CompileHelper::compileConcurrentAssertion(
       UHDM::expr* clocking_event = nullptr;
       if (fC->Type(Property_expr) == VObjectType::slClocking_event) {
         clocking_event = (UHDM::expr*)compileExpression(
-            component, fC, Property_expr, compileDesign, pstmt, instance,
-            false);
+            component, fC, Property_expr, compileDesign, Reduce::No, pstmt,
+            instance);
         Property_expr = fC->Sibling(Property_expr);
       }
       UHDM::assume* assume_stmt = s.MakeAssume();
       UHDM::property_spec* prop_spec = s.MakeProperty_spec();
-      UHDM::any* property_expr = compileExpression(
-          component, fC, Property_expr, compileDesign, pstmt, instance, false);
+      UHDM::any* property_expr =
+          compileExpression(component, fC, Property_expr, compileDesign,
+                            Reduce::No, pstmt, instance);
       property_expr = createPropertyInst(property_expr, s);
       prop_spec->VpiClockingEvent(clocking_event);
       prop_spec->VpiPropertyExpr(property_expr);
@@ -163,8 +167,9 @@ UHDM::any* CompileHelper::compileConcurrentAssertion(
       NodeId Property_expr = fC->Child(Property_spec);
       UHDM::cover* cover_stmt = s.MakeCover();
       UHDM::property_spec* prop_spec = s.MakeProperty_spec();
-      UHDM::any* property_expr = compileExpression(
-          component, fC, Property_expr, compileDesign, pstmt, instance, false);
+      UHDM::any* property_expr =
+          compileExpression(component, fC, Property_expr, compileDesign,
+                            Reduce::No, pstmt, instance);
       property_expr = createPropertyInst(property_expr, s);
       prop_spec->VpiPropertyExpr(property_expr);
       fC->populateCoreMembers(Property_spec, Property_spec, prop_spec);
@@ -178,8 +183,9 @@ UHDM::any* CompileHelper::compileConcurrentAssertion(
       UHDM::cover* cover_stmt = s.MakeCover();
       cover_stmt->VpiIsCoverSequence();
       UHDM::property_spec* prop_spec = s.MakeProperty_spec();
-      UHDM::any* property_expr = compileExpression(
-          component, fC, Property_expr, compileDesign, pstmt, instance, false);
+      UHDM::any* property_expr =
+          compileExpression(component, fC, Property_expr, compileDesign,
+                            Reduce::No, pstmt, instance);
       property_expr = createPropertyInst(property_expr, s);
       prop_spec->VpiPropertyExpr(property_expr);
       fC->populateCoreMembers(Property_expr, Property_expr, prop_spec);
@@ -192,8 +198,9 @@ UHDM::any* CompileHelper::compileConcurrentAssertion(
       NodeId Property_expr = fC->Child(Property_spec);
       UHDM::restrict* restrict_stmt = s.MakeRestrict();
       UHDM::property_spec* prop_spec = s.MakeProperty_spec();
-      UHDM::any* property_expr = compileExpression(
-          component, fC, Property_expr, compileDesign, pstmt, instance, false);
+      UHDM::any* property_expr =
+          compileExpression(component, fC, Property_expr, compileDesign,
+                            Reduce::No, pstmt, instance);
       property_expr = createPropertyInst(property_expr, s);
       prop_spec->VpiPropertyExpr(property_expr);
       fC->populateCoreMembers(Property_spec, Property_spec, prop_spec);
@@ -226,15 +233,17 @@ UHDM::any* CompileHelper::compileSimpleImmediateAssertion(
     if (else_keyword) else_stmt_id = fC->Sibling(else_keyword);
   }
   UHDM::any* expr = compileExpression(component, fC, Expression, compileDesign,
-                                      pstmt, instance, false);
+                                      Reduce::No, pstmt, instance);
   UHDM::VectorOfany* if_stmts = nullptr;
   if (if_stmt_id)
-    if_stmts = compileStmt(component, fC, if_stmt_id, compileDesign, pstmt);
+    if_stmts = compileStmt(component, fC, if_stmt_id, compileDesign, Reduce::No,
+                           pstmt);
   UHDM::any* if_stmt = nullptr;
   if (if_stmts) if_stmt = (*if_stmts)[0];
   UHDM::VectorOfany* else_stmts = nullptr;
   if (else_stmt_id)
-    else_stmts = compileStmt(component, fC, else_stmt_id, compileDesign, pstmt);
+    else_stmts = compileStmt(component, fC, else_stmt_id, compileDesign,
+                             Reduce::No, pstmt);
   UHDM::any* else_stmt = nullptr;
   if (else_stmts) else_stmt = (*else_stmts)[0];
   UHDM::any* stmt = nullptr;
@@ -315,15 +324,17 @@ UHDM::any* CompileHelper::compileDeferredImmediateAssertion(
     if (else_keyword) else_stmt_id = fC->Sibling(else_keyword);
   }
   UHDM::any* expr = compileExpression(component, fC, Expression, compileDesign,
-                                      pstmt, instance, false);
+                                      Reduce::No, pstmt, instance);
   UHDM::VectorOfany* if_stmts = nullptr;
   if (if_stmt_id)
-    if_stmts = compileStmt(component, fC, if_stmt_id, compileDesign, pstmt);
+    if_stmts = compileStmt(component, fC, if_stmt_id, compileDesign, Reduce::No,
+                           pstmt);
   UHDM::any* if_stmt = nullptr;
   if (if_stmts) if_stmt = (*if_stmts)[0];
   UHDM::VectorOfany* else_stmts = nullptr;
   if (else_stmt_id)
-    else_stmts = compileStmt(component, fC, else_stmt_id, compileDesign, pstmt);
+    else_stmts = compileStmt(component, fC, else_stmt_id, compileDesign,
+                             Reduce::No, pstmt);
   UHDM::any* else_stmt = nullptr;
   if (else_stmts) else_stmt = (*else_stmts)[0];
   UHDM::any* stmt = nullptr;

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -270,7 +270,7 @@ bool CompileClass::compile() {
 bool CompileClass::compile_class_property_(const FileContent* fC, NodeId id) {
   NodeId data_declaration = fC->Child(id);
   m_helper.compileDataDeclaration(m_class, fC, data_declaration, false,
-                                  m_compileDesign, false, m_attributes);
+                                  m_compileDesign, Reduce::No, m_attributes);
 
   NodeId var_decl = fC->Child(data_declaration);
   VObjectType type = fC->Type(data_declaration);
@@ -465,9 +465,9 @@ bool CompileClass::compile_class_method_(const FileContent* fC, NodeId id) {
       }
     }
     m_helper.compileFunction(m_class, fC, fC->Child(id), m_compileDesign,
-                             nullptr, true);
+                             Reduce::No, nullptr, true);
     m_helper.compileFunction(m_class, fC, fC->Child(id), m_compileDesign,
-                             nullptr, true);
+                             Reduce::No, nullptr, true);
 
   } else if (func_type == VObjectType::slTask_declaration) {
     /*
@@ -496,10 +496,10 @@ bool CompileClass::compile_class_method_(const FileContent* fC, NodeId id) {
           .append(fC->SymName(fC->Sibling(task_name)));
     }
 
-    m_helper.compileTask(m_class, fC, fC->Child(id), m_compileDesign, nullptr,
-                         true);
-    m_helper.compileTask(m_class, fC, fC->Child(id), m_compileDesign, nullptr,
-                         true);
+    m_helper.compileTask(m_class, fC, fC->Child(id), m_compileDesign,
+                         Reduce::No, nullptr, true);
+    m_helper.compileTask(m_class, fC, fC->Child(id), m_compileDesign,
+                         Reduce::No, nullptr, true);
 
   } else if (func_type == VObjectType::slMethod_prototype) {
     /*
@@ -530,10 +530,10 @@ bool CompileClass::compile_class_method_(const FileContent* fC, NodeId id) {
             .append(fC->SymName(fC->Sibling(task_name)));
       }
 
-      m_helper.compileTask(m_class, fC, fC->Child(id), m_compileDesign, nullptr,
-                           true);
-      m_helper.compileTask(m_class, fC, fC->Child(id), m_compileDesign, nullptr,
-                           true);
+      m_helper.compileTask(m_class, fC, fC->Child(id), m_compileDesign,
+                           Reduce::No, nullptr, true);
+      m_helper.compileTask(m_class, fC, fC->Child(id), m_compileDesign,
+                           Reduce::No, nullptr, true);
 
     } else {
       NodeId function_data_type = fC->Child(func_prototype);
@@ -551,9 +551,9 @@ bool CompileClass::compile_class_method_(const FileContent* fC, NodeId id) {
       funcName = fC->SymName(function_name);
 
       m_helper.compileFunction(m_class, fC, fC->Child(id), m_compileDesign,
-                               nullptr, true);
+                               Reduce::No, nullptr, true);
       m_helper.compileFunction(m_class, fC, fC->Child(id), m_compileDesign,
-                               nullptr, true);
+                               Reduce::No, nullptr, true);
     }
     is_extern = true;
   } else if (func_type == VObjectType::slClass_constructor_declaration) {
@@ -567,9 +567,9 @@ bool CompileClass::compile_class_method_(const FileContent* fC, NodeId id) {
     funcName = "new";
 
     m_helper.compileFunction(m_class, fC, fC->Child(id), m_compileDesign,
-                             nullptr, true);
+                             Reduce::No, nullptr, true);
     m_helper.compileFunction(m_class, fC, fC->Child(id), m_compileDesign,
-                             nullptr, true);
+                             Reduce::No, nullptr, true);
 
   } else {
     funcName = "UNRECOGNIZED_METHOD_TYPE";
@@ -735,12 +735,13 @@ bool CompileClass::compile_local_parameter_declaration_(const FileContent* fC,
       fC->Type(list_of_type_assignments) == VObjectType::slType) {
     // Type param
     m_helper.compileParameterDeclaration(m_class, fC, list_of_type_assignments,
-                                         m_compileDesign, true, nullptr, false,
-                                         false, false);
+                                         m_compileDesign, Reduce::No, true,
+                                         nullptr, false, false);
 
   } else {
-    m_helper.compileParameterDeclaration(m_class, fC, id, m_compileDesign, true,
-                                         nullptr, false, false, false);
+    m_helper.compileParameterDeclaration(m_class, fC, id, m_compileDesign,
+                                         Reduce::No, true, nullptr, false,
+                                         false);
   }
   NodeId data_type_or_implicit = fC->Child(id);
   NodeId list_of_param_assignments = fC->Sibling(data_type_or_implicit);
@@ -779,12 +780,13 @@ bool CompileClass::compile_parameter_declaration_(const FileContent* fC,
       fC->Type(list_of_type_assignments) == VObjectType::slType) {
     // Type param
     m_helper.compileParameterDeclaration(m_class, fC, list_of_type_assignments,
-                                         m_compileDesign, false, nullptr, false,
-                                         false, false);
+                                         m_compileDesign, Reduce::No, false,
+                                         nullptr, false, false);
 
   } else {
     m_helper.compileParameterDeclaration(m_class, fC, id, m_compileDesign,
-                                         false, nullptr, false, false, false);
+                                         Reduce::No, false, nullptr, false,
+                                         false);
   }
 
   NodeId data_type_or_implicit = fC->Child(id);
@@ -883,15 +885,15 @@ bool CompileClass::compile_class_parameters_(const FileContent* fC, NodeId id) {
           fC->Type(list_of_type_assignments) == VObjectType::slType) {
         // Type param
         m_helper.compileParameterDeclaration(
-            m_class, fC, list_of_type_assignments, m_compileDesign, false,
-            nullptr, false, false, false);
+            m_class, fC, list_of_type_assignments, m_compileDesign, Reduce::No,
+            false, nullptr, false, false);
       } else if (fC->Type(type) == VObjectType::slType) {
         // Handled in compile_parameter_declaration_
       } else {
         // Regular param
         m_helper.compileParameterDeclaration(
-            m_class, fC, parameter_port_declaration, m_compileDesign, false,
-            nullptr, false, false, false);
+            m_class, fC, parameter_port_declaration, m_compileDesign,
+            Reduce::No, false, nullptr, false, false);
       }
       parameter_port_declaration = fC->Sibling(parameter_port_declaration);
     }

--- a/src/DesignCompile/CompileExpression_test.cpp
+++ b/src/DesignCompile/CompileExpression_test.cpp
@@ -57,8 +57,8 @@ TEST(CompileExpression, ExprFromParseTree1) {
     NodeId param = fC->Child(param_assign);
     NodeId rhs = fC->Sibling(param);
     const UHDM::expr *exp = (UHDM::expr *)helper.compileExpression(
-        nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, true,
-        true);
+        nullptr, fC.get(), rhs, compileDesign.get(), Reduce::Yes, nullptr,
+        nullptr, true);
     EXPECT_EQ(exp->UhdmType(), UHDM::uhdmconstant);
     bool invalidValue = false;
     UHDM::ExprEval eval;
@@ -87,8 +87,8 @@ TEST(CompileExpression, ExprFromParseTree2) {
     NodeId param = fC->Child(param_assign);
     NodeId rhs = fC->Sibling(param);
     const UHDM::expr *exp = (UHDM::expr *)helper.compileExpression(
-        nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, true,
-        true);
+        nullptr, fC.get(), rhs, compileDesign.get(), Reduce::Yes, nullptr,
+        nullptr, true);
     EXPECT_EQ(exp->UhdmType(), UHDM::uhdmconstant);
     bool invalidValue = false;
     UHDM::ExprEval eval;
@@ -116,12 +116,12 @@ TEST(CompileExpression, ExprFromParseTree3) {
     const std::string_view name = fC->SymName(param);
     NodeId rhs = fC->Sibling(param);
     const UHDM::expr *exp1 = (UHDM::expr *)helper.compileExpression(
-        nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, false,
-        true);
+        nullptr, fC.get(), rhs, compileDesign.get(), Reduce::No, nullptr,
+        nullptr, true);
     EXPECT_EQ(exp1->UhdmType(), UHDM::uhdmoperation);
     const UHDM::expr *exp2 = (UHDM::expr *)helper.compileExpression(
-        nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, true,
-        true);
+        nullptr, fC.get(), rhs, compileDesign.get(), Reduce::Yes, nullptr,
+        nullptr, true);
     if (name == "p1") {
       EXPECT_EQ(exp2->UhdmType(), UHDM::uhdmconstant);
       bool invalidValue = false;
@@ -157,12 +157,12 @@ TEST(CompileExpression, ExprFromPpTree) {
     const std::string_view name = fC->SymName(param);
     NodeId rhs = fC->Sibling(param);
     const UHDM::expr *exp1 = (UHDM::expr *)helper.compileExpression(
-        nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, false,
-        true);
+        nullptr, fC.get(), rhs, compileDesign.get(), Reduce::No, nullptr,
+        nullptr, true);
     EXPECT_EQ(exp1->UhdmType(), UHDM::uhdmoperation);
     const UHDM::expr *exp2 = (UHDM::expr *)helper.compileExpression(
-        nullptr, fC.get(), rhs, compileDesign.get(), nullptr, nullptr, true,
-        true);
+        nullptr, fC.get(), rhs, compileDesign.get(), Reduce::Yes, nullptr,
+        nullptr, true);
     if (name == "p1") {
       EXPECT_EQ(exp2->UhdmType(), UHDM::uhdmconstant);
       bool invalidValue = false;

--- a/src/DesignCompile/CompileFileContent.cpp
+++ b/src/DesignCompile/CompileFileContent.cpp
@@ -70,14 +70,14 @@ bool CompileFileContent::collectObjects_() {
       }
       case VObjectType::slFunction_declaration: {
         m_helper.compileFunction(m_fileContent, fC, id, m_compileDesign,
-                                 nullptr, true);
+                                 Reduce::No, nullptr, true);
         m_helper.compileFunction(m_fileContent, fC, id, m_compileDesign,
-                                 nullptr, true);
+                                 Reduce::No, nullptr, true);
         break;
       }
       case VObjectType::slData_declaration: {
         m_helper.compileDataDeclaration(m_fileContent, fC, id, false,
-                                        m_compileDesign, true, nullptr);
+                                        m_compileDesign, Reduce::Yes, nullptr);
         break;
       }
       case VObjectType::slParameter_declaration: {
@@ -88,12 +88,12 @@ bool CompileFileContent::collectObjects_() {
           // Type param
           m_helper.compileParameterDeclaration(
               m_fileContent, fC, list_of_type_assignments, m_compileDesign,
-              false, nullptr, false, true, false);
+              Reduce::Yes, false, nullptr, false, false);
 
         } else {
           m_helper.compileParameterDeclaration(m_fileContent, fC, id,
-                                               m_compileDesign, false, nullptr,
-                                               false, true, false);
+                                               m_compileDesign, Reduce::Yes,
+                                               false, nullptr, false, false);
         }
         break;
       }
@@ -109,12 +109,12 @@ bool CompileFileContent::collectObjects_() {
           // Type param
           m_helper.compileParameterDeclaration(
               m_fileContent, fC, list_of_type_assignments, m_compileDesign,
-              true, nullptr, false, true, false);
+              Reduce::Yes, true, nullptr, false, false);
 
         } else {
           m_helper.compileParameterDeclaration(m_fileContent, fC, id,
-                                               m_compileDesign, true, nullptr,
-                                               false, true, false);
+                                               m_compileDesign, Reduce::Yes,
+                                               true, nullptr, false, false);
         }
         break;
       }

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -614,7 +614,8 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
         case VObjectType::slData_declaration: {
           if (collectType != CollectType::DEFINITION) break;
           m_helper.compileDataDeclaration(m_module, fC, id, false,
-                                          m_compileDesign, false, m_attributes);
+                                          m_compileDesign, Reduce::No,
+                                          m_attributes);
           m_attributes = nullptr;
           break;
         }
@@ -649,8 +650,9 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
           NodeId list_of_param_assignments = fC->Child(id);
           while (list_of_param_assignments) {
             m_helper.compileParameterDeclaration(
-                m_module, fC, list_of_param_assignments, m_compileDesign, false,
-                m_instance, false, m_instance != nullptr, false);
+                m_module, fC, list_of_param_assignments, m_compileDesign,
+                m_instance != nullptr ? Reduce::Yes : Reduce::No, false,
+                m_instance, false, false);
             list_of_param_assignments = fC->Sibling(list_of_param_assignments);
           }
           break;
@@ -664,13 +666,15 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
               fC->Type(list_of_type_assignments) == VObjectType::slType) {
             // Type param
             m_helper.compileParameterDeclaration(
-                m_module, fC, list_of_type_assignments, m_compileDesign, false,
-                m_instance, ParameterPortListId, m_instance != nullptr, false);
+                m_module, fC, list_of_type_assignments, m_compileDesign,
+                m_instance != nullptr ? Reduce::Yes : Reduce::No, false,
+                m_instance, ParameterPortListId, false);
 
           } else {
             m_helper.compileParameterDeclaration(
-                m_module, fC, id, m_compileDesign, false, m_instance,
-                ParameterPortListId, m_instance != nullptr, false);
+                m_module, fC, id, m_compileDesign,
+                m_instance != nullptr ? Reduce::Yes : Reduce::No, false,
+                m_instance, ParameterPortListId, false);
           }
           break;
         }
@@ -682,27 +686,30 @@ bool CompileModule::collectModuleObjects_(CollectType collectType) {
               fC->Type(list_of_type_assignments) == VObjectType::slType) {
             // Type param
             m_helper.compileParameterDeclaration(
-                m_module, fC, list_of_type_assignments, m_compileDesign, true,
-                m_instance, ParameterPortListId, m_instance != nullptr, false);
+                m_module, fC, list_of_type_assignments, m_compileDesign,
+                m_instance != nullptr ? Reduce::Yes : Reduce::No, true,
+                m_instance, ParameterPortListId, false);
 
           } else {
             m_helper.compileParameterDeclaration(
-                m_module, fC, id, m_compileDesign, true, m_instance,
-                ParameterPortListId, m_instance != nullptr, false);
+                m_module, fC, id, m_compileDesign,
+                m_instance != nullptr ? Reduce::Yes : Reduce::No, true,
+                m_instance, ParameterPortListId, false);
           }
           break;
         }
         case VObjectType::slTask_declaration: {
           // Called twice, placeholder first, then definition
           if (collectType == CollectType::OTHER) break;
-          m_helper.compileTask(m_module, fC, id, m_compileDesign, m_instance);
+          m_helper.compileTask(m_module, fC, id, m_compileDesign, Reduce::No,
+                               m_instance, false);
           break;
         }
         case VObjectType::slFunction_declaration: {
           // Called twice, placeholder first, then definition
           if (collectType == CollectType::OTHER) break;
           m_helper.compileFunction(m_module, fC, id, m_compileDesign,
-                                   m_instance);
+                                   Reduce::No, m_instance, false);
           break;
         }
         case VObjectType::slDpi_import_export: {
@@ -941,8 +948,9 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
           NodeId list_of_param_assignments = fC->Child(id);
           while (list_of_param_assignments) {
             m_helper.compileParameterDeclaration(
-                m_module, fC, list_of_param_assignments, m_compileDesign, false,
-                m_instance, false, m_instance != nullptr, false);
+                m_module, fC, list_of_param_assignments, m_compileDesign,
+                m_instance != nullptr ? Reduce::Yes : Reduce::No, false,
+                m_instance, false, false);
             list_of_param_assignments = fC->Sibling(list_of_param_assignments);
           }
           break;
@@ -970,7 +978,8 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
         case VObjectType::slData_declaration: {
           if (collectType != CollectType::DEFINITION) break;
           m_helper.compileDataDeclaration(m_module, fC, id, true,
-                                          m_compileDesign, false, m_attributes);
+                                          m_compileDesign, Reduce::No,
+                                          m_attributes);
           m_attributes = nullptr;
           break;
         }
@@ -994,13 +1003,14 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
         }
         case VObjectType::slTask_declaration: {
           if (collectType != CollectType::FUNCTION) break;
-          m_helper.compileTask(m_module, fC, id, m_compileDesign, m_instance);
+          m_helper.compileTask(m_module, fC, id, m_compileDesign, Reduce::No,
+                               m_instance, false);
           break;
         }
         case VObjectType::slFunction_declaration: {
           if (collectType != CollectType::FUNCTION) break;
           m_helper.compileFunction(m_module, fC, id, m_compileDesign,
-                                   m_instance);
+                                   Reduce::No, m_instance, false);
           break;
         }
         case VObjectType::slDpi_import_export: {
@@ -1154,13 +1164,15 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
               fC->Type(list_of_type_assignments) == VObjectType::slType) {
             // Type param
             m_helper.compileParameterDeclaration(
-                m_module, fC, list_of_type_assignments, m_compileDesign, false,
-                m_instance, ParameterPortListId, m_instance != nullptr, false);
+                m_module, fC, list_of_type_assignments, m_compileDesign,
+                m_instance != nullptr ? Reduce::Yes : Reduce::No, false,
+                m_instance, ParameterPortListId, false);
 
           } else {
             m_helper.compileParameterDeclaration(
-                m_module, fC, id, m_compileDesign, false, m_instance,
-                ParameterPortListId, m_instance != nullptr, false);
+                m_module, fC, id, m_compileDesign,
+                m_instance != nullptr ? Reduce::Yes : Reduce::No, false,
+                m_instance, ParameterPortListId, false);
           }
           break;
         }
@@ -1172,13 +1184,15 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
               fC->Type(list_of_type_assignments) == VObjectType::slType) {
             // Type param
             m_helper.compileParameterDeclaration(
-                m_module, fC, list_of_type_assignments, m_compileDesign, true,
-                m_instance, ParameterPortListId, m_instance != nullptr, false);
+                m_module, fC, list_of_type_assignments, m_compileDesign,
+                m_instance != nullptr ? Reduce::Yes : Reduce::No, true,
+                m_instance, ParameterPortListId, false);
 
           } else {
             m_helper.compileParameterDeclaration(
-                m_module, fC, id, m_compileDesign, true, m_instance,
-                ParameterPortListId, m_instance != nullptr, false);
+                m_module, fC, id, m_compileDesign,
+                m_instance != nullptr ? Reduce::Yes : Reduce::No, true,
+                m_instance, ParameterPortListId, false);
           }
           break;
         }

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -139,8 +139,8 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
         NodeId list_of_param_assignments = fC->Child(id);
         if (list_of_param_assignments)
           m_helper.compileParameterDeclaration(
-              m_program, fC, list_of_param_assignments, m_compileDesign, false,
-              nullptr, false, false, false);
+              m_program, fC, list_of_param_assignments, m_compileDesign,
+              Reduce::No, false, nullptr, false, false);
         break;
       }
       case VObjectType::slAnsi_port_declaration: {
@@ -162,13 +162,15 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
       case VObjectType::slTask_declaration: {
         // Called twice, placeholder first, then definition
         if (collectType == CollectType::OTHER) break;
-        m_helper.compileTask(m_program, fC, id, m_compileDesign, nullptr);
+        m_helper.compileTask(m_program, fC, id, m_compileDesign, Reduce::No,
+                             nullptr, false);
         break;
       }
       case VObjectType::slFunction_declaration: {
         // Called twice, placeholder first, then definition
         if (collectType == CollectType::OTHER) break;
-        m_helper.compileFunction(m_program, fC, id, m_compileDesign, nullptr);
+        m_helper.compileFunction(m_program, fC, id, m_compileDesign, Reduce::No,
+                                 nullptr, false);
         break;
       }
       case VObjectType::slLet_declaration: {
@@ -209,13 +211,13 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
             fC->Type(list_of_type_assignments) == VObjectType::slType) {
           // Type param
           m_helper.compileParameterDeclaration(
-              m_program, fC, list_of_type_assignments, m_compileDesign, false,
-              nullptr, ParameterPortListId, false, false);
+              m_program, fC, list_of_type_assignments, m_compileDesign,
+              Reduce::No, false, nullptr, ParameterPortListId, false);
 
         } else {
           m_helper.compileParameterDeclaration(
-              m_program, fC, id, m_compileDesign, false, nullptr,
-              ParameterPortListId, false, false);
+              m_program, fC, id, m_compileDesign, Reduce::No, false, nullptr,
+              ParameterPortListId, false);
         }
         break;
       }
@@ -227,13 +229,13 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
             fC->Type(list_of_type_assignments) == VObjectType::slType) {
           // Type param
           m_helper.compileParameterDeclaration(
-              m_program, fC, list_of_type_assignments, m_compileDesign, true,
-              nullptr, ParameterPortListId, false, false);
+              m_program, fC, list_of_type_assignments, m_compileDesign,
+              Reduce::No, true, nullptr, ParameterPortListId, false);
 
         } else {
           m_helper.compileParameterDeclaration(
-              m_program, fC, id, m_compileDesign, true, nullptr,
-              ParameterPortListId, false, false);
+              m_program, fC, id, m_compileDesign, Reduce::No, true, nullptr,
+              ParameterPortListId, false);
         }
         break;
       }
@@ -264,7 +266,8 @@ bool CompileProgram::collectObjects_(CollectType collectType) {
       case VObjectType::slData_declaration: {
         if (collectType != CollectType::DEFINITION) break;
         m_helper.compileDataDeclaration(m_program, fC, id, false,
-                                        m_compileDesign, false, m_attributes);
+                                        m_compileDesign, Reduce::No,
+                                        m_attributes);
         m_attributes = nullptr;
         break;
       }

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -1014,8 +1014,8 @@ void DesignElaboration::elaborateInstance_(
           bool validValue;
           m_helper.checkForLoops(true);
           uint64_t initVal = (uint64_t)m_helper.getValue(
-              validValue, parentDef, fC, constExpr, m_compileDesign, nullptr,
-              parent, true, false);
+              validValue, parentDef, fC, constExpr, m_compileDesign,
+              Reduce::Yes, nullptr, parent, false);
           m_helper.checkForLoops(false);
           Value* initValue = m_exprBuilder.getValueFactory().newLValue();
           initValue->set(initVal);
@@ -1040,9 +1040,9 @@ void DesignElaboration::elaborateInstance_(
           // Generate block
           NodeId genBlock = fC->Sibling(iteration);
           m_helper.checkForLoops(true);
-          int64_t condVal =
-              m_helper.getValue(validValue, parentDef, fC, endLoopTest,
-                                m_compileDesign, nullptr, parent, true, false);
+          int64_t condVal = m_helper.getValue(
+              validValue, parentDef, fC, endLoopTest, m_compileDesign,
+              Reduce::Yes, nullptr, parent, false);
           m_helper.checkForLoops(false);
           bool cont = (validValue && (condVal > 0));
 
@@ -1085,8 +1085,8 @@ void DesignElaboration::elaborateInstance_(
             parent->setValue(name, newVal, m_exprBuilder, fC->Line(varId));
             m_helper.checkForLoops(true);
             condVal = m_helper.getValue(validValue, parentDef, fC, endLoopTest,
-                                        m_compileDesign, nullptr, parent, true,
-                                        false);
+                                        m_compileDesign, Reduce::Yes, nullptr,
+                                        parent, false);
             m_helper.checkForLoops(false);
             cont = (validValue && (condVal > 0));
 
@@ -1103,9 +1103,9 @@ void DesignElaboration::elaborateInstance_(
           }
           bool validValue;
           m_helper.checkForLoops(true);
-          int64_t condVal =
-              m_helper.getValue(validValue, parentDef, fC, conditionId,
-                                m_compileDesign, nullptr, parent, true, false);
+          int64_t condVal = m_helper.getValue(
+              validValue, parentDef, fC, conditionId, m_compileDesign,
+              Reduce::Yes, nullptr, parent, false);
           m_helper.checkForLoops(false);
           NodeId tmp = fC->Sibling(conditionId);
 
@@ -1133,8 +1133,8 @@ void DesignElaboration::elaborateInstance_(
               for (NodeId id : checkIds) {
                 m_helper.checkForLoops(true);
                 UHDM::any* tmpExp = m_helper.compileExpression(
-                    parentDef, fC, id, m_compileDesign, nullptr, parent, true,
-                    false);
+                    parentDef, fC, id, m_compileDesign, Reduce::Yes, nullptr,
+                    parent, false);
                 m_helper.checkForLoops(false);
                 if (tmpExp && (tmpExp->UhdmType() == UHDM::uhdmconstant)) {
                   UHDM::constant* c = (UHDM::constant*)tmpExp;
@@ -1157,8 +1157,8 @@ void DesignElaboration::elaborateInstance_(
             }
             m_helper.checkForLoops(true);
             const UHDM::any* condExpr = m_helper.compileExpression(
-                parentDef, fC, conditionId, m_compileDesign, nullptr, parent,
-                true, false);
+                parentDef, fC, conditionId, m_compileDesign, Reduce::Yes,
+                nullptr, parent, false);
             m_helper.checkForLoops(false);
             condExpr = resize(m_compileDesign->getSerializer(), condExpr,
                               maxsize, is_overall_unsigned);
@@ -1185,8 +1185,8 @@ void DesignElaboration::elaborateInstance_(
                 if (fC->Type(exprItem) == VObjectType::slConstant_expression) {
                   m_helper.checkForLoops(true);
                   const UHDM::any* caseExpr = m_helper.compileExpression(
-                      parentDef, fC, exprItem, m_compileDesign, nullptr, parent,
-                      true, false);
+                      parentDef, fC, exprItem, m_compileDesign, Reduce::Yes,
+                      nullptr, parent, false);
                   m_helper.checkForLoops(false);
                   caseExpr = resize(m_compileDesign->getSerializer(), caseExpr,
                                     maxsize, is_overall_unsigned);
@@ -1260,9 +1260,9 @@ void DesignElaboration::elaborateInstance_(
                     if (fC->Type(Cond) == VObjectType::slConstant_expression) {
                       bool validValue;
                       m_helper.checkForLoops(true);
-                      condVal = m_helper.getValue(validValue, parentDef, fC,
-                                                  Cond, m_compileDesign,
-                                                  nullptr, parent, true, false);
+                      condVal = m_helper.getValue(
+                          validValue, parentDef, fC, Cond, m_compileDesign,
+                          Reduce::Yes, nullptr, parent, false);
                       m_helper.checkForLoops(false);
                     } else {
                       // It is not an else-if
@@ -1278,9 +1278,9 @@ void DesignElaboration::elaborateInstance_(
                     if (fC->Type(Cond) == VObjectType::slConstant_expression) {
                       bool validValue;
                       m_helper.checkForLoops(true);
-                      condVal = m_helper.getValue(validValue, parentDef, fC,
-                                                  Cond, m_compileDesign,
-                                                  nullptr, parent, true, false);
+                      condVal = m_helper.getValue(
+                          validValue, parentDef, fC, Cond, m_compileDesign,
+                          Reduce::Yes, nullptr, parent, false);
                       m_helper.checkForLoops(false);
                     } else {
                       // It is not an else-if
@@ -1586,14 +1586,14 @@ void DesignElaboration::elaborateInstance_(
                 break;
               }
               case UseClause::UseLib: {
-                for (const auto& lib : use.getLibs()) {
+                const auto& libs = use.getLibs();
+                if (!libs.empty()) {
+                  const auto& lib = libs.front();
                   modName = StrCat(lib, "@", mname);
                   def = design->getComponentDefinition(modName);
                   if (def) {
                     use.setUsed();
-                    break;
                   }
-                  break;
                 }
                 break;
               }
@@ -1647,17 +1647,17 @@ void DesignElaboration::elaborateInstance_(
                 NodeId rightNode = fC->Sibling(leftNode);
                 bool validValue;
                 m_helper.checkForLoops(true);
-                int64_t left = m_helper.getValue(validValue, parentDef, fC,
-                                                 leftNode, m_compileDesign,
-                                                 nullptr, parent, true, false);
+                int64_t left = m_helper.getValue(
+                    validValue, parentDef, fC, leftNode, m_compileDesign,
+                    Reduce::Yes, nullptr, parent, false);
                 m_helper.checkForLoops(false);
                 int64_t right = 0;
                 if (rightNode && (fC->Type(rightNode) ==
                                   VObjectType::slConstant_expression)) {
                   m_helper.checkForLoops(true);
-                  right = m_helper.getValue(validValue, parentDef, fC,
-                                            rightNode, m_compileDesign, nullptr,
-                                            parent, true, false);
+                  right = m_helper.getValue(
+                      validValue, parentDef, fC, rightNode, m_compileDesign,
+                      Reduce::Yes, nullptr, parent, false);
                   m_helper.checkForLoops(false);
                 }
                 if (left < right) {
@@ -1686,9 +1686,9 @@ void DesignElaboration::elaborateInstance_(
               int32_t unpackedSize = 0;
               unpackedDimId = fC->Sibling(identifierId);
               if (std::vector<UHDM::range*>* unpackedDimensions =
-                      m_helper.compileRanges(def, fC, unpackedDimId,
-                                             m_compileDesign, nullptr, parent,
-                                             false, unpackedSize, false)) {
+                      m_helper.compileRanges(
+                          def, fC, unpackedDimId, m_compileDesign, Reduce::No,
+                          nullptr, parent, unpackedSize, false)) {
                 UHDM::Serializer& s = m_compileDesign->getSerializer();
                 UHDM::module_array* mod_array = s.MakeModule_array();
                 mod_array->Ranges(unpackedDimensions);
@@ -1919,8 +1919,8 @@ std::vector<std::string_view> DesignElaboration::collectParams_(
         }
         m_helper.checkForLoops(true);
         UHDM::expr* complexV = (UHDM::expr*)m_helper.compileExpression(
-            parentDefinition, parentFile, expr, m_compileDesign, nullptr,
-            parentInstance, true, false);
+            parentDefinition, parentFile, expr, m_compileDesign, Reduce::Yes,
+            nullptr, parentInstance, false);
         m_helper.checkForLoops(false);
         Value* value = nullptr;
         bool complex = false;
@@ -1935,8 +1935,8 @@ std::vector<std::string_view> DesignElaboration::collectParams_(
               // GDB: p replay=true
               if (replay) {
                 m_helper.compileExpression(parentDefinition, parentFile, expr,
-                                           m_compileDesign, nullptr,
-                                           parentInstance, true, false);
+                                           m_compileDesign, Reduce::Yes,
+                                           nullptr, parentInstance, false);
 
                 m_exprBuilder.evalExpr(parentFile, expr, parentInstance, true);
               }
@@ -1957,7 +1957,7 @@ std::vector<std::string_view> DesignElaboration::collectParams_(
                 m_helper.checkForLoops(true);
                 complexV = (UHDM::expr*)m_helper.compileExpression(
                     parentDefinition, parentFile, expr, m_compileDesign,
-                    nullptr, parentInstance, false, false);
+                    Reduce::No, nullptr, parentInstance, false);
                 m_helper.checkForLoops(false);
                 if (complexV->UhdmType() == UHDM::uhdmref_obj) {
                   UHDM::ref_obj* ref = (UHDM::ref_obj*)complexV;
@@ -2048,8 +2048,8 @@ std::vector<std::string_view> DesignElaboration::collectParams_(
             // GDB: p replay=true
             if (replay) {
               m_helper.compileExpression(parentDefinition, parentFile, expr,
-                                         m_compileDesign, nullptr,
-                                         parentInstance, true, false);
+                                         m_compileDesign, Reduce::Yes, nullptr,
+                                         parentInstance, false);
             }
 
             const std::string_view pname = parentFile->SymName(child);
@@ -2082,8 +2082,8 @@ std::vector<std::string_view> DesignElaboration::collectParams_(
         }
         m_helper.checkForLoops(true);
         UHDM::expr* complexV = (UHDM::expr*)m_helper.compileExpression(
-            parentDefinition, parentFile, expr, m_compileDesign, nullptr,
-            parentInstance, true, false);
+            parentDefinition, parentFile, expr, m_compileDesign, Reduce::Yes,
+            nullptr, parentInstance, false);
         m_helper.checkForLoops(false);
         Value* value = nullptr;
         bool complex = false;
@@ -2252,7 +2252,8 @@ std::vector<std::string_view> DesignElaboration::collectParams_(
             m_helper.checkForLoops(true);
             UHDM::expr* expr = (UHDM::expr*)m_helper.compileExpression(
                 instance->getDefinition(), param.fC, exprId, m_compileDesign,
-                nullptr, instance, !isMultidimension, false);
+                isMultidimension ? Reduce::No : Reduce::Yes, nullptr, instance,
+                false);
             m_helper.checkForLoops(false);
             Value* value = nullptr;
             bool complex = false;

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -166,8 +166,8 @@ bool ElaborationStep::bindTypedefs_() {
               fC->Type(Packed_dimension) == VObjectType::slPacked_dimension) {
             tpclone = m_helper.compileTypespec(
                 defTuple.second, typd->getFileContent(),
-                typd->getDefinitionNode(), m_compileDesign, nullptr, nullptr,
-                true);
+                typd->getDefinitionNode(), m_compileDesign, Reduce::Yes,
+                nullptr, nullptr, false);
           } else if (typespec* tps = def->getTypespec()) {
             ElaboratorListener listener(&s, false, true);
             tpclone = (typespec*)UHDM::clone_tree((any*)tps, s, &listener);
@@ -195,9 +195,9 @@ bool ElaborationStep::bindTypedefs_() {
       if (typd->getTypespec() == nullptr) {
         const FileContent* typeF = typd->getFileContent();
         NodeId typeId = typd->getDefinitionNode();
-        UHDM::typespec* ts =
-            m_helper.compileTypespec(defTuple.second, typeF, typeId,
-                                     m_compileDesign, nullptr, nullptr, true);
+        UHDM::typespec* ts = m_helper.compileTypespec(
+            defTuple.second, typeF, typeId, m_compileDesign, Reduce::Yes,
+            nullptr, nullptr, false);
         if (ts) {
           ts->VpiName(typd->getName());
           std::string name;
@@ -240,7 +240,7 @@ bool ElaborationStep::bindTypedefs_() {
         typd->setTypespec(nullptr);
         UHDM::typespec* ts = m_helper.compileTypespec(
             defTuple.second, typd->getFileContent(), typd->getDefinitionNode(),
-            m_compileDesign, nullptr, nullptr, true);
+            m_compileDesign, Reduce::Yes, nullptr, nullptr, false);
         if (ts) {
           specs.emplace(typd->getName(), ts);
           ts->VpiName(typd->getName());
@@ -1320,7 +1320,8 @@ UHDM::expr* ElaborationStep::exprFromAssign_(DesignComponent* component,
   expr* exp = nullptr;
   if (expression) {
     exp = (expr*)m_helper.compileExpression(component, fC, expression,
-                                            m_compileDesign, nullptr, instance);
+                                            m_compileDesign, Reduce::No,
+                                            nullptr, instance);
   }
   return exp;
 }
@@ -1368,7 +1369,7 @@ UHDM::typespec* ElaborationStep::elabTypeParameter_(DesignComponent* component,
         if (ModuleInstance* pinst = instance->getParent()) parent = pinst;
         override_spec = m_helper.compileTypespec(
             component, param->getFileContent(), param->getNodeType(),
-            m_compileDesign, nullptr, parent, true);
+            m_compileDesign, Reduce::Yes, nullptr, parent, false);
       }
 
       if (override_spec) {
@@ -1423,7 +1424,7 @@ any* ElaborationStep::makeVar_(DesignComponent* component, Signal* sig,
       if (tps == nullptr) {
         tps = m_helper.compileTypespec(component, un->getFileContent(),
                                        un->getNodeId(), m_compileDesign,
-                                       nullptr, instance, true, true);
+                                       Reduce::Yes, nullptr, instance, true);
         ((DummyType*)un)->setTypespec(tps);
       }
       variables* var = nullptr;

--- a/src/DesignCompile/Elaboration_test.cpp
+++ b/src/DesignCompile/Elaboration_test.cpp
@@ -85,11 +85,11 @@ TEST(Elaboration, ExprFromPpTree) {
     NodeId rhs = fC->Sibling(param);
     // Not reduced
     UHDM::expr* exp1 = (UHDM::expr*)helper.compileExpression(
-        component, fC, rhs, compileDesign, nullptr, top, false, true);
+        component, fC, rhs, compileDesign, Reduce::No, nullptr, top, true);
     EXPECT_EQ(exp1->UhdmType(), UHDM::uhdmoperation);
     // Reduced
     UHDM::expr* exp2 = (UHDM::expr*)helper.compileExpression(
-        component, fC, rhs, compileDesign, nullptr, top, true, true);
+        component, fC, rhs, compileDesign, Reduce::Yes, nullptr, top, true);
     if (name == "p1") {
       EXPECT_EQ(exp2->UhdmType(), UHDM::uhdmconstant);
       bool invalidValue = false;
@@ -132,7 +132,7 @@ TEST(Elaboration, ExprFromText) {
     NodeId rhs = fC->Sibling(param);
     // Reduced
     UHDM::expr* exp = (UHDM::expr*)helper.compileExpression(
-        component, fC, rhs, compileDesign, nullptr, top, true, true);
+        component, fC, rhs, compileDesign, Reduce::Yes, nullptr, top, true);
     EXPECT_EQ(exp->UhdmType(), UHDM::uhdmconstant);
     bool invalidValue = false;
     UHDM::ExprEval eval;
@@ -180,7 +180,7 @@ TEST(Elaboration, ExprUsePackage) {
     NodeId rhs = fC->Sibling(param);
     // Reduced
     UHDM::expr* exp = (UHDM::expr*)helper.compileExpression(
-        component, fC, rhs, compileDesign, nullptr, top, true, true);
+        component, fC, rhs, compileDesign, Reduce::Yes, nullptr, top, true);
     EXPECT_EQ(exp->UhdmType(), UHDM::uhdmconstant);
     bool invalidValue = false;
     UHDM::ExprEval eval;

--- a/src/DesignCompile/EvalFunc.cpp
+++ b/src/DesignCompile/EvalFunc.cpp
@@ -55,8 +55,8 @@ expr* CompileHelper::EvalFunc(UHDM::function* func, std::vector<any*>* args,
   UHDM::GetObjectFunctor getValueFunctor = [&](std::string_view name,
                                                const any* inst,
                                                const any* pexpr) -> UHDM::any* {
-    return (expr*)getValue(name, component, compileDesign, instance, fileId,
-                           lineNumber, (any*)pexpr, true, false);
+    return (expr*)getValue(name, component, compileDesign, Reduce::Yes,
+                           instance, fileId, lineNumber, (any*)pexpr, false);
   };
   UHDM::GetTaskFuncFunctor getTaskFuncFunctor =
       [&](std::string_view name, const any* inst) -> UHDM::task_func* {

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -286,16 +286,18 @@ bool NetlistElaboration::elab_parameters_(ModuleInstance* instance,
           m_helper.checkForLoops(true);
           expr* rhs = (expr*)m_helper.compileExpression(
               pmod, tpm->getFileContent(), tpm->getNodeId(), m_compileDesign,
-              nullptr, pinst, !isMultidimensional);
+              isMultidimensional ? Reduce::No : Reduce::Yes, nullptr, pinst);
           m_helper.checkForLoops(false);
           if (en_replay && m_helper.errorOnNegativeConstant(
                                pmod, rhs, m_compileDesign, pinst)) {
             bool replay = false;
             // GDB: p replay=true
             if (replay) {
-              m_helper.compileExpression(pmod, tpm->getFileContent(),
-                                         tpm->getNodeId(), m_compileDesign,
-                                         nullptr, pinst, !isMultidimensional);
+              m_helper.compileExpression(
+                  pmod, tpm->getFileContent(), tpm->getNodeId(),
+                  m_compileDesign,
+                  isMultidimensional ? Reduce::No : Reduce::Yes, nullptr,
+                  pinst);
             }
           }
 
@@ -306,7 +308,7 @@ bool NetlistElaboration::elab_parameters_(ModuleInstance* instance,
             m_helper.checkForLoops(true);
             expr* crhs = (expr*)m_helper.compileExpression(
                 mod, assign->getFileContent(), assign->getAssignId(),
-                m_compileDesign, nullptr, instance, true);
+                m_compileDesign, Reduce::Yes, nullptr, instance);
             m_helper.checkForLoops(false);
             if (crhs && crhs->UhdmType() == uhdmconstant) {
               if (en_replay && m_helper.errorOnNegativeConstant(
@@ -316,7 +318,7 @@ bool NetlistElaboration::elab_parameters_(ModuleInstance* instance,
                 if (replay) {
                   m_helper.compileExpression(
                       mod, assign->getFileContent(), assign->getAssignId(),
-                      m_compileDesign, nullptr, instance, true);
+                      m_compileDesign, Reduce::Yes, nullptr, instance);
                 }
               }
 
@@ -433,7 +435,8 @@ bool NetlistElaboration::elab_parameters_(ModuleInstance* instance,
         m_helper.checkForLoops(true);
         expr* rhs = (expr*)m_helper.compileExpression(
             mod, assign->getFileContent(), assign->getAssignId(),
-            m_compileDesign, nullptr, instance, !isMultidimensional);
+            m_compileDesign, isMultidimensional ? Reduce::No : Reduce::Yes,
+            nullptr, instance);
         m_helper.checkForLoops(false);
         inst_assign->Rhs(rhs);
       }
@@ -806,8 +809,8 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
                fC->Type(Udp_instance) == VObjectType::slDelay3) {
       m_helper.checkForLoops(true);
       expr* delay_expr = (expr*)m_helper.compileExpression(
-          parent_comp, fC, Udp_instance, m_compileDesign, nullptr, parent,
-          true);
+          parent_comp, fC, Udp_instance, m_compileDesign, Reduce::Yes, nullptr,
+          parent);
       m_helper.checkForLoops(false);
       VectorOfexpr* delays = s.MakeExprVec();
       netlist->delays(delays);
@@ -824,8 +827,8 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
         int32_t size;
         m_helper.checkForLoops(true);
         VectorOfrange* ranges = m_helper.compileRanges(
-            comp, fC, Unpacked_dimension, m_compileDesign, nullptr, parent,
-            true, size, false);
+            comp, fC, Unpacked_dimension, m_compileDesign, Reduce::Yes, nullptr,
+            parent, size, false);
         m_helper.checkForLoops(false);
         netlist->ranges(ranges);
       }
@@ -932,13 +935,13 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
                 m_helper.checkForLoops(true);
                 exp = m_helper.compileExpression(
                     parent_comp, fC, Hierarchical_identifier, m_compileDesign,
-                    nullptr, parent, true);
+                    Reduce::Yes, nullptr, parent);
                 m_helper.checkForLoops(false);
               } else {
                 m_helper.checkForLoops(true);
                 exp = m_helper.compileExpression(parent_comp, fC, Net_lvalue,
-                                                 m_compileDesign, nullptr,
-                                                 parent, true);
+                                                 m_compileDesign, Reduce::Yes,
+                                                 nullptr, parent);
                 m_helper.checkForLoops(false);
               }
               p->High_conn(exp);
@@ -984,7 +987,7 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
             m_helper.checkForLoops(true);
             any* exp = m_helper.compileExpression(
                 parent_comp, fC, Hierarchical_identifier, m_compileDesign,
-                nullptr, parent, true);
+                Reduce::Yes, nullptr, parent);
             m_helper.checkForLoops(false);
             p->High_conn(exp);
             if (exp->UhdmType() == uhdmref_obj) {
@@ -1134,9 +1137,9 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
         }
         if (Expression) {
           m_helper.checkForLoops(true);
-          hexpr = (expr*)m_helper.compileExpression(parent_comp, fC, Expression,
-                                                    m_compileDesign, nullptr,
-                                                    parent, true);
+          hexpr = (expr*)m_helper.compileExpression(
+              parent_comp, fC, Expression, m_compileDesign, Reduce::Yes,
+              nullptr, parent);
           m_helper.checkForLoops(false);
           NodeId Primary = fC->Child(Expression);
           NodeId Primary_literal = fC->Child(Primary);
@@ -1401,8 +1404,8 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
                 if (NodeId defaultId = pair.second->getDefaultValue()) {
                   m_helper.checkForLoops(true);
                   expr* exp = (expr*)m_helper.compileExpression(
-                      comp, fC, defaultId, m_compileDesign, nullptr, instance,
-                      true);
+                      comp, fC, defaultId, m_compileDesign, Reduce::Yes,
+                      nullptr, instance);
                   m_helper.checkForLoops(false);
                   p->High_conn(exp);
                 }
@@ -1430,7 +1433,8 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
       if (NodeId defaultId = (*found).second->getDefaultValue()) {
         m_helper.checkForLoops(true);
         expr* exp = (expr*)m_helper.compileExpression(
-            comp, fC, defaultId, m_compileDesign, nullptr, instance, true);
+            comp, fC, defaultId, m_compileDesign, Reduce::Yes, nullptr,
+            instance);
         m_helper.checkForLoops(false);
         p->High_conn(exp);
       }
@@ -1696,7 +1700,7 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
     if (itr == tscache.end()) {
       m_helper.checkForLoops(true);
       tps = m_helper.compileTypespec(comp, fC, typeSpecId, m_compileDesign,
-                                     nullptr, child, true, true);
+                                     Reduce::Yes, nullptr, child, true);
       m_helper.checkForLoops(false);
       tscache.emplace(typeSpecId, tps);
     } else {
@@ -1709,8 +1713,8 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
       if (itr == tscache.end()) {
         m_helper.checkForLoops(true);
         tps = m_helper.compileTypespec(comp, fC, sig->getInterfaceTypeNameId(),
-                                       m_compileDesign, nullptr, child, true,
-                                       true);
+                                       m_compileDesign, Reduce::Yes, nullptr,
+                                       child, true);
         m_helper.checkForLoops(false);
         tscache.emplace(sig->getInterfaceTypeNameId(), tps);
       } else {
@@ -1779,12 +1783,12 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
   m_helper.checkForLoops(true);
   std::vector<UHDM::range*>* packedDimensions =
       m_helper.compileRanges(comp, fC, packedDimension, m_compileDesign,
-                             nullptr, child, true, packedSize, false);
+                             Reduce::Yes, nullptr, child, packedSize, false);
   m_helper.checkForLoops(false);
   m_helper.checkForLoops(true);
   std::vector<UHDM::range*>* unpackedDimensions =
       m_helper.compileRanges(comp, fC, unpackedDimension, m_compileDesign,
-                             nullptr, child, true, unpackedSize, false);
+                             Reduce::Yes, nullptr, child, unpackedSize, false);
   m_helper.checkForLoops(false);
   any* obj = nullptr;
 
@@ -1793,8 +1797,8 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
   if ((exp == nullptr) && sig->getDefaultValue()) {
     m_helper.checkForLoops(true);
     exp = (expr*)m_helper.compileExpression(comp, fC, sig->getDefaultValue(),
-                                            m_compileDesign, nullptr, child,
-                                            true);
+                                            m_compileDesign, Reduce::Yes,
+                                            nullptr, child);
     m_helper.checkForLoops(false);
   }
   if (isNet) {
@@ -2124,7 +2128,8 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
       if (sig->getDelay()) {
         m_helper.checkForLoops(true);
         expr* delay_expr = (expr*)m_helper.compileExpression(
-            comp, fC, sig->getDelay(), m_compileDesign, nullptr, child, true);
+            comp, fC, sig->getDelay(), m_compileDesign, Reduce::Yes, nullptr,
+            child);
         m_helper.checkForLoops(false);
         assign->Delay(delay_expr);
       }
@@ -2227,7 +2232,7 @@ bool NetlistElaboration::elab_ports_nets_(
           if (fC->Type(Port_expr) == VObjectType::slPort_expression) {
             any* exp =
                 m_helper.compileExpression(comp, fC, Port_expr, m_compileDesign,
-                                           nullptr, child, true, false);
+                                           Reduce::Yes, nullptr, child, false);
             dest_port->Low_conn(exp);
           }
         }
@@ -2241,9 +2246,9 @@ bool NetlistElaboration::elab_ports_nets_(
         NodeId unpackedDimension = sig->getUnpackedDimension();
         int32_t unpackedSize;
         m_helper.checkForLoops(true);
-        std::vector<UHDM::range*>* unpackedDimensions =
-            m_helper.compileRanges(comp, fC, unpackedDimension, m_compileDesign,
-                                   nullptr, child, true, unpackedSize, false);
+        std::vector<UHDM::range*>* unpackedDimensions = m_helper.compileRanges(
+            comp, fC, unpackedDimension, m_compileDesign, Reduce::Yes, nullptr,
+            child, unpackedSize, false);
         m_helper.checkForLoops(false);
         NodeId typeSpecId = sig->getTypeSpecId();
         if (typeSpecId) {
@@ -2251,9 +2256,9 @@ bool NetlistElaboration::elab_ports_nets_(
           auto itr = tscache.find(typeSpecId);
           if (itr == tscache.end()) {
             m_helper.checkForLoops(true);
-            tps =
-                m_helper.compileTypespec(comp, fC, typeSpecId, m_compileDesign,
-                                         dest_port, instance, true, true);
+            tps = m_helper.compileTypespec(comp, fC, typeSpecId,
+                                           m_compileDesign, Reduce::Yes,
+                                           dest_port, instance, true);
             m_helper.checkForLoops(false);
             tscache.emplace(typeSpecId, tps);
           } else {
@@ -2530,8 +2535,9 @@ UHDM::any* NetlistElaboration::bind_net_(const FileContent* origfC, NodeId id,
       }
     }
     m_helper.checkForLoops(true);
-    result = m_helper.getValue(name, instance->getDefinition(), m_compileDesign,
-                               instance, BadPathId, 0, nullptr, true, true);
+    result =
+        m_helper.getValue(name, instance->getDefinition(), m_compileDesign,
+                          Reduce::Yes, instance, BadPathId, 0, nullptr, true);
     m_helper.checkForLoops(false);
   }
   if ((instance != nullptr) && (result == nullptr)) {

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -712,26 +712,27 @@ bool TestbenchElaboration::bindProperties_() {
       int32_t packedSize = 0;
       int32_t unpackedSize = 0;
       std::vector<UHDM::range*>* packedDimensions = m_helper.compileRanges(
-          classDefinition, fC, packedDimension, m_compileDesign, nullptr,
-          nullptr, true, packedSize, false);
+          classDefinition, fC, packedDimension, m_compileDesign, Reduce::Yes,
+          nullptr, nullptr, packedSize, false);
       std::vector<UHDM::range*>* unpackedDimensions = nullptr;
       if (fC->Type(unpackedDimension) == VObjectType::slClass_new) {
       } else {
         unpackedDimensions = m_helper.compileRanges(
-            classDefinition, fC, unpackedDimension, m_compileDesign, nullptr,
-            nullptr, true, unpackedSize, false);
+            classDefinition, fC, unpackedDimension, m_compileDesign,
+            Reduce::Yes, nullptr, nullptr, unpackedSize, false);
       }
       UHDM::typespec* tps = nullptr;
       NodeId typeSpecId = sig->getTypeSpecId();
       if (typeSpecId) {
         tps = m_helper.compileTypespec(classDefinition, fC, typeSpecId,
-                                       m_compileDesign, nullptr, nullptr, true);
+                                       m_compileDesign, Reduce::Yes, nullptr,
+                                       nullptr, false);
       }
       if (tps == nullptr) {
         if (sig->getInterfaceTypeNameId()) {
           tps = m_helper.compileTypespec(
               classDefinition, fC, sig->getInterfaceTypeNameId(),
-              m_compileDesign, nullptr, nullptr, true);
+              m_compileDesign, Reduce::Yes, nullptr, nullptr, false);
         }
       }
 


### PR DESCRIPTION
Code Maintenance - Make reduce parameter non-optional

Use enum for reduce (instead of bool) to be explicit. Helps code readability when function takes 2 or more boolean arguments and some of those happen to be default. Also, reorder some of the parameters to be consistent across functions in the class.