### PR TITLE
Add missing cstdint includes

### DIFF
--- a/include/Surelog/ErrorReporting/Waiver.h
+++ b/include/Surelog/ErrorReporting/Waiver.h
@@ -30,6 +30,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <cstdint>
 #include <string_view>
 
 namespace SURELOG {

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <locale>
 #include <map>
 #include <regex>


### PR DESCRIPTION
GCC ``13.1.1`` fails to compile Surelog due to this missing includes:
```
Surelog/include/Surelog/ErrorReporting/Waiver.h:56:11: error: ‘uint32_t’ does not name a type
   56 |     const uint32_t m_line;
      |           ^~~~~~~~
Surelog/include/Surelog/ErrorReporting/Waiver.h:32:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   31 | #include <set>
  +++ |+#include <cstdint>
   32 | #include <string>
```
```
Surelog/src/Utils/StringUtils.cpp: In function ‘std::vector<std::basic_string_view<char> >& SURELOG::StringUtils::tokenizeBalanced(std::string_view, std::string_view, std::vector<std::basic_string_view<char> >&)’:
Surelog/src/Utils/StringUtils.cpp:126:9: error: ‘uint32_t’ does not name a type
126 |   const uint32_t stringSize = str.size(); 
    |         ^~~~~~~~
Surelog/src/Utils/StringUtils.cpp:31:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
 30 | #include <regex>
+++ |+#include <cstdint>
 31 | #include <sstream>
  ```