### PR TITLE
Disable reduction for non-elaborated model

### DIFF
--- a/include/Surelog/Design/ModuleDefinition.h
+++ b/include/Surelog/Design/ModuleDefinition.h
@@ -84,7 +84,10 @@ class ModuleDefinition : public DesignComponent, public ClockingBlockHolder {
   }
   ClassDefinition* getClassDefinition(std::string_view name);
 
-  void setGenBlockId(NodeId id) { m_gen_block_id = id; }
+  void setGenBlockId(NodeId id) {
+    m_gen_block_id = id;
+    if (m_unelabModule) m_unelabModule->setGenBlockId(id);
+  }
   NodeId getGenBlockId() const { return m_gen_block_id; }
   UHDM::udp_defn* getUdpDefn() { return m_udpDefn; }
 
@@ -111,14 +114,17 @@ class ModuleDefinition : public DesignComponent, public ClockingBlockHolder {
   void setPrimitives(UHDM::VectorOfprimitive* primitives) { m_subPrimitives = primitives; }
   void setPrimitiveArrays(UHDM::VectorOfprimitive_array* primitives) { m_subPrimitiveArrays = primitives; }
   void setGenScpeArrays(UHDM::VectorOfgen_scope_array* gen_arrays) { m_subGenScopeArrays = gen_arrays; }
-  
+
+  ModuleDefinition* getUnelabMmodule() { return m_unelabModule; }
+
  private:
-  const std::string m_name;
+  std::string m_name;
   ModPortSignalMap m_modportSignalMap;
   ModPortClockingBlockMap m_modportClockingBlockMap;
   ClassNameClassDefinitionMultiMap m_classDefinitions;
   NodeId m_gen_block_id;
   UHDM::udp_defn* m_udpDefn;
+  ModuleDefinition* m_unelabModule;
 
   UHDM::VectorOfattribute* attributes_ = nullptr;
   std::vector<UHDM::module_array*>* m_moduleArrays = nullptr;

--- a/include/Surelog/DesignCompile/CompileHelper.h
+++ b/include/Surelog/DesignCompile/CompileHelper.h
@@ -581,7 +581,7 @@ class CompileHelper final {
 
   std::string decompileHelper(const UHDM::any* sel);
 
-  void setUnElabMode(bool on) { m_unElabMode = on; }
+  void setElabMode(bool on) { m_elabMode = on; }
 
  private:
   CompileHelper(const CompileHelper&) = delete;
@@ -608,7 +608,7 @@ class CompileHelper final {
   bool m_checkForLoops = false;
   int32_t m_stackLevel = 0;
   bool m_unwind = false;
-  bool m_unElabMode = false;
+  bool m_elabMode = true;
 };
 
 }  // namespace SURELOG

--- a/include/Surelog/DesignCompile/CompileHelper.h
+++ b/include/Surelog/DesignCompile/CompileHelper.h
@@ -582,6 +582,7 @@ class CompileHelper final {
   std::string decompileHelper(const UHDM::any* sel);
 
   void setElabMode(bool on) { m_elabMode = on; }
+  void setReduce(Reduce reduce) { m_reduce = reduce; }
 
  private:
   CompileHelper(const CompileHelper&) = delete;
@@ -609,6 +610,7 @@ class CompileHelper final {
   int32_t m_stackLevel = 0;
   bool m_unwind = false;
   bool m_elabMode = true;
+  Reduce m_reduce = Reduce::Yes;
 };
 
 }  // namespace SURELOG

--- a/include/Surelog/DesignCompile/CompileModule.h
+++ b/include/Surelog/DesignCompile/CompileModule.h
@@ -45,6 +45,26 @@ struct FunctorCompileModule {
         m_module(mdl),
         m_design(design),
         m_symbols(symbols),
+        m_errors(errors) {}
+  int32_t operator()() const;
+
+ private:
+  CompileDesign* const m_compileDesign;
+  ModuleDefinition* const m_module;
+  Design* const m_design;
+  SymbolTable* const m_symbols;
+  ErrorContainer* const m_errors;
+};
+
+struct FunctorGenerateModule {
+  FunctorGenerateModule(CompileDesign* compiler, ModuleDefinition* mdl,
+                         Design* design, SymbolTable* symbols,
+                         ErrorContainer* errors,
+                         ValuedComponentI* instance)
+      : m_compileDesign(compiler),
+        m_module(mdl),
+        m_design(design),
+        m_symbols(symbols),
         m_errors(errors),
         m_instance(instance) {}
   int32_t operator()() const;
@@ -72,7 +92,7 @@ class CompileModule final {
     m_helper.seterrorReporting(errors, symbols);
   }
 
-  bool compile();
+  bool compile(bool elabMode, Reduce reduce);
 
  private:
   CompileModule(const CompileModule&) = delete;

--- a/include/Surelog/DesignCompile/CompilePackage.h
+++ b/include/Surelog/DesignCompile/CompilePackage.h
@@ -66,7 +66,7 @@ class CompilePackage final {
     m_helper.seterrorReporting(errors, symbols);
   }
 
-  bool compile(Reduce reduce);
+  bool compile(bool elabMode);
 
  private:
   enum CollectType { FUNCTION, DEFINITION, OTHER };

--- a/src/Design/ModuleDefinition.cpp
+++ b/src/Design/ModuleDefinition.cpp
@@ -34,9 +34,16 @@ VObjectType ModuleDefinition::getType() const {
 
 ModuleDefinition::ModuleDefinition(const FileContent* fileContent,
                                    NodeId nodeId, const std::string_view name)
-    : DesignComponent(fileContent, nullptr), m_name(name), m_udpDefn(nullptr) {
+    : DesignComponent(fileContent, nullptr),
+      m_name(name),
+      m_udpDefn(nullptr),
+      m_unelabModule(nullptr) {
   if (fileContent) {
     addFileContent(fileContent, nodeId);
+    if (!name.empty()) {  // avoid loop
+      m_unelabModule = new ModuleDefinition(fileContent, nodeId, "");
+      m_unelabModule->m_name = name;
+    }
   }
 }
 

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -2327,9 +2327,7 @@ UHDM::any *CompileHelper::compileExpression(
             NodeId selectId = fC->Sibling(paramId);
             const std::string_view n = fC->SymName(paramId);
             name.assign(packageName).append("::").append(n);
-            if (m_unElabMode) {
-              // create ref_obj down below
-            } else {
+            if (m_elabMode) {
               Package *pack =
                   compileDesign->getCompiler()->getDesign()->getPackage(
                       packageName);
@@ -2365,6 +2363,8 @@ UHDM::any *CompileHelper::compileExpression(
                 }
                 if (result == nullptr) sval = pack->getValue(n);
               }
+            } else {
+              // create ref_obj down below
             }
           } else if (childType == VObjectType::slClass_type) {
             const std::string_view packageName = fC->SymName(fC->Child(child));
@@ -2377,9 +2377,7 @@ UHDM::any *CompileHelper::compileExpression(
             Package *pack =
                 compileDesign->getCompiler()->getDesign()->getPackage(
                     packageName);
-            if (m_unElabMode) {
-              // create ref_obj down below
-            } else {
+            if (m_elabMode) {
               if (pack) {
                 UHDM::VectorOfparam_assign *param_assigns =
                     pack->getParam_assigns();
@@ -2403,6 +2401,8 @@ UHDM::any *CompileHelper::compileExpression(
                 }
                 if (result == nullptr) sval = pack->getValue(n);
               }
+            } else {
+              // create ref_obj down below
             }
           } else {
             NodeId rhs;

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -643,7 +643,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
       UHDM::typespec* ts =
           compileTypespec(scope, fC, enum_base_type, compileDesign, reduce,
                           nullptr, nullptr, false);
-      if ((reduce == Reduce::Yes) && (valuedcomponenti_cast<Package*>(scope))) {
+      if (m_elabMode && (valuedcomponenti_cast<Package*>(scope))) {
         ts->Instance(scope->getUhdmInstance());
       }
       if (array_tps) {
@@ -668,7 +668,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
       UHDM::typespec* ts =
           compileTypespec(scope, fC, enum_base_type, compileDesign, reduce,
                           nullptr, nullptr, false);
-      if ((reduce == Reduce::Yes) && (valuedcomponenti_cast<Package*>(scope))) {
+      if (m_elabMode && (valuedcomponenti_cast<Package*>(scope))) {
         ts->Instance(scope->getUhdmInstance());
       }
       if (array_tps) {
@@ -734,7 +734,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
 
     // Enum basetype
     enum_t->Base_typespec(the_enum->getBaseTypespec());
-    if ((reduce == Reduce::Yes) && (valuedcomponenti_cast<Package*>(scope))) {
+    if (m_elabMode && (valuedcomponenti_cast<Package*>(scope))) {
       enum_t->Instance(scope->getUhdmInstance());
     }
     // Enum values
@@ -818,9 +818,9 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
       newTypeDef->setDefinition(dummy);
       // Don't create the typespec here, as it is most likely going to be
       // incomplete at compilation time, except for packages and FileContent
-      if ((reduce == Reduce::Yes) &&
-          ((valuedcomponenti_cast<Package*>(scope) ||
-            valuedcomponenti_cast<FileContent*>(scope)))) {
+      if ((m_reduce == Reduce::Yes) && (reduce == Reduce::Yes) &&
+          (valuedcomponenti_cast<Package*>(scope) ||
+           valuedcomponenti_cast<FileContent*>(scope))) {
         UHDM::typespec* ts = compileTypespec(scope, fC, stype, compileDesign,
                                              reduce, nullptr, nullptr, false);
         if (ts && (ts->UhdmType() != uhdmclass_typespec) &&
@@ -961,8 +961,7 @@ const DataType* CompileHelper::compileTypeDef(DesignComponent* scope,
           scope->needLateResolutionFunction(resolutionFunctionName, ts);
         }
 
-        if ((reduce == Reduce::Yes) &&
-            (valuedcomponenti_cast<Package*>(scope))) {
+        if (m_elabMode && (valuedcomponenti_cast<Package*>(scope))) {
           ts->Instance(scope->getUhdmInstance());
         }
         ts->VpiName(name);
@@ -3377,7 +3376,8 @@ bool CompileHelper::compileParameterDeclaration(
           adjustSize(ts, component, compileDesign, instance, c);
           Value* val = m_exprBuilder.fromVpiValue(c->VpiValue(), size);
           component->setValue(the_name, val, m_exprBuilder);
-        } else if ((reduce == Reduce::Yes) && (!isMultiDimension)) {
+        } else if ((m_reduce == Reduce::Yes) && (reduce == Reduce::Yes) &&
+                   (!isMultiDimension)) {
           UHDM::expr* the_expr = (UHDM::expr*)expr;
           if (the_expr->Typespec() == nullptr) the_expr->Typespec(ts);
           ExprEval expr_eval(the_expr, instance, fC->getFileId(),
@@ -3469,7 +3469,7 @@ bool CompileHelper::compileParameterDeclaration(
         expr* rhs = (expr*)compileExpression(
             component, fC, value, compileDesign,
             isMultiDimension ? Reduce::No : reduce, nullptr, instance);
-        if (reduce == Reduce::Yes) {
+        if ((m_reduce == Reduce::Yes) && (reduce == Reduce::Yes)) {
           rhs = (expr*)defaultPatternAssignment(ts, rhs, component,
                                                 compileDesign, instance);
         }

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -43,22 +43,23 @@ namespace SURELOG {
 int32_t FunctorCompilePackage::operator()() const {
   CompilePackage* instance = new CompilePackage(m_compileDesign, m_package,
                                                 m_design, m_symbols, m_errors);
-  instance->compile(Reduce::Yes);
+  instance->compile(true);
   delete instance;
 
   instance = new CompilePackage(m_compileDesign, m_package->getUnElabPackage(),
                                 m_design, m_symbols, m_errors);
-  instance->compile(Reduce::No);
+  instance->compile(false);
   delete instance;
 
   return 0;
 }
 
-bool CompilePackage::compile(Reduce reduce) {
+bool CompilePackage::compile(bool elabMode) {
   if (!m_package) return false;
   UHDM::Serializer& s = m_compileDesign->getSerializer();
   UHDM::package* pack = any_cast<UHDM::package*>(m_package->getUhdmInstance());
-  m_helper.setUnElabMode(reduce == Reduce::No);
+  m_helper.setElabMode(elabMode);
+  const Reduce reduce = elabMode ? Reduce::Yes : Reduce::No;
   if (pack == nullptr) {
     pack = s.MakePackage();
     pack->VpiName(m_package->getName());

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -1520,7 +1520,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
         byte_typespec* var = s.MakeByte_typespec();
         fC->populateCoreMembers(type, type, var);
         result = var;
-      } else if (reduce == Reduce::Yes) {
+      } else if ((m_reduce == Reduce::Yes) && (reduce == Reduce::Yes)) {
         if (any* cast_to =
                 getValue(typeName, component, compileDesign,
                          reduce == Reduce::Yes ? Reduce::No : Reduce::Yes,

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -872,7 +872,7 @@ void DesignElaboration::elaborateInstance_(
             if (DesignComponent* def = parent->getDefinition()) {
               // Compile generate block
               ((ModuleDefinition*)def)->setGenBlockId(Generate_block);
-              FunctorCompileModule funct(
+              FunctorGenerateModule funct(
                   m_compileDesign, (ModuleDefinition*)def, design,
                   m_compileDesign->getCompiler()->getSymbolTable(),
                   m_compileDesign->getCompiler()->getErrorContainer(), parent);
@@ -1066,7 +1066,7 @@ void DesignElaboration::elaborateInstance_(
 
             // Compile generate block
             ((ModuleDefinition*)def)->setGenBlockId(genBlock);
-            FunctorCompileModule funct(
+            FunctorGenerateModule funct(
                 m_compileDesign, (ModuleDefinition*)def, design,
                 m_compileDesign->getCompiler()->getSymbolTable(),
                 m_compileDesign->getCompiler()->getErrorContainer(), parent);
@@ -1389,7 +1389,7 @@ void DesignElaboration::elaborateInstance_(
 
         // Compile generate block
         ((ModuleDefinition*)def)->setGenBlockId(childId);
-        FunctorCompileModule funct(
+        FunctorGenerateModule funct(
             m_compileDesign, (ModuleDefinition*)def, design,
             m_compileDesign->getCompiler()->getSymbolTable(),
             m_compileDesign->getCompiler()->getErrorContainer(), parent);
@@ -1471,7 +1471,7 @@ void DesignElaboration::elaborateInstance_(
         } else {
           // Compile generate block
           ((ModuleDefinition*)def)->setGenBlockId(childId);
-          FunctorCompileModule funct(
+          FunctorGenerateModule funct(
               m_compileDesign, (ModuleDefinition*)def, design,
               m_compileDesign->getCompiler()->getSymbolTable(),
               m_compileDesign->getCompiler()->getErrorContainer(), parent);

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -107,6 +107,11 @@ bool ElaborationStep::bindTypedefs_() {
       TypeDef* typd = typed.second;
       defs.emplace_back(typd, mod);
     }
+    mod = mod->getUnelabMmodule();
+    for (const auto& typed : mod->getTypeDefMap()) {
+      TypeDef* typd = typed.second;
+      defs.emplace_back(typd, mod);
+    }
   }
 
   for (const auto& program_def : design->getProgramDefinitions()) {

--- a/src/DesignCompile/ResolveSymbols.cpp
+++ b/src/DesignCompile/ResolveSymbols.cpp
@@ -116,7 +116,7 @@ void ResolveSymbols::createFastLookup() {
                   new ClassDefinition(name, lib, pdef, m_fileData, subobject,
                                       nullptr, s.MakeClass_defn());
               m_fileData->addClassDefinition(fullSubName, def);
-              pdef->addClassDefinition(name, def);
+              pdef->getUnElabPackage()->addClassDefinition(name, def);
             }
           }
           break;
@@ -179,7 +179,7 @@ void ResolveSymbols::createFastLookup() {
                     new ClassDefinition(name, lib, mdef, m_fileData, subobject,
                                         nullptr, s.MakeClass_defn());
                 m_fileData->addClassDefinition(fullSubName, def);
-                mdef->addClassDefinition(name, def);
+                mdef->getUnelabMmodule()->addClassDefinition(name, def);
               } else {
                 ModuleDefinition* def =
                     new ModuleDefinition(m_fileData, subobject, fullSubName);
@@ -193,11 +193,12 @@ void ResolveSymbols::createFastLookup() {
         case VObjectType::slConfig_declaration:
         case VObjectType::slUdp_declaration:
         case VObjectType::slInterface_declaration:
-        default:
+        default: {
           ModuleDefinition* def =
               new ModuleDefinition(m_fileData, object, fullName);
           m_fileData->addModuleDefinition(fullName, def);
           break;
+        }
       }
     }
   }


### PR DESCRIPTION
Disable reduction for non-elaborated model

Generate independent ModuleDefinition for elaborated & non-elaborated
tree so reduction can be controlled independently. For non-elaborated
model, reduction is defaulted to OFF, whereas for the elaborated model,
reduction is ON.

The pattern follows similar implementation for packages.

Known Issue -
Logs show some binding differences (expected and correct). Nodes in
non-elaborated tree were binding incorrectly to nodes in elaborated
tree (like ref_obj::actual_group in elaborated model binding to xxx_var
which exist only in elaborated model).

To follow up with fixes to parenting and binding in non-elaborated
model.

No significant changes expected in the elaborated model.
