### PR TITLE
Add CloneContext, CompareContext & ElaboratorContext

### DIFF
--- a/src/DesignCompile/CompileAssertion.cpp
+++ b/src/DesignCompile/CompileAssertion.cpp
@@ -77,13 +77,13 @@ UHDM::property_inst* createPropertyInst(DesignComponent* component,
     UHDM::func_call* call = (UHDM::func_call*)property_expr;
     UHDM::property_inst* real_property_expr = s.MakeProperty_inst();
     if (call->Tf_call_args()) {
-      UHDM::ElaboratorListener listener(&s, false, true);
+      UHDM::ElaboratorContext elaboratorContext(&s, false, true);
       UHDM::VectorOfany* args = s.MakeAnyVec();
       real_property_expr->VpiArguments(args);
       for (auto arg : *call->Tf_call_args()) {
         if (arg->UhdmType() == UHDM::uhdmref_obj) {
           UHDM::ref_obj* ref =
-              (UHDM::ref_obj*)UHDM::clone_tree(arg, s, &listener);
+              (UHDM::ref_obj*)UHDM::clone_tree(arg, &elaboratorContext);
           args->emplace_back(ref);
           ref->VpiParent(real_property_expr);
           component->needLateBinding(ref);

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -928,8 +928,9 @@ any *CompileHelper::getValue(std::string_view name, DesignComponent *component,
                     }
                   }
 
-                  ElaboratorListener listener(&s, false, true);
-                  result = UHDM::clone_tree((any *)param->Rhs(), s, &listener);
+                  ElaboratorContext elaboratorContext(&s, false, true);
+                  result =
+                      UHDM::clone_tree((any *)param->Rhs(), &elaboratorContext);
                   break;
                 }
               }
@@ -1027,8 +1028,9 @@ any *CompileHelper::getValue(std::string_view name, DesignComponent *component,
                 }
               }
 
-              ElaboratorListener listener(&s, false, true);
-              result = UHDM::clone_tree((any *)param->Rhs(), s, &listener);
+              ElaboratorContext elaboratorContext(&s, false, true);
+              result =
+                  UHDM::clone_tree((any *)param->Rhs(), &elaboratorContext);
               if (result != nullptr) result->VpiParent(param);
               break;
             }
@@ -2396,9 +2398,9 @@ UHDM::any *CompileHelper::compileExpression(
                       if (param_name == n) {
                         if (substituteAssignedValue(param->Rhs(),
                                                     compileDesign)) {
-                          ElaboratorListener listener(&s, false, true);
-                          result = UHDM::clone_tree((any *)param->Rhs(), s,
-                                                    &listener);
+                          ElaboratorContext elaboratorContext(&s, false, true);
+                          result = UHDM::clone_tree((any *)param->Rhs(),
+                                                    &elaboratorContext);
                           result->VpiParent(pexpr);
                           fC->populateCoreMembers(child, child, result);
                         }
@@ -2444,9 +2446,9 @@ UHDM::any *CompileHelper::compileExpression(
                       if (param_name == n) {
                         if (substituteAssignedValue(param->Rhs(),
                                                     compileDesign)) {
-                          ElaboratorListener listener(&s, false, true);
-                          result = UHDM::clone_tree((any *)param->Rhs(), s,
-                                                    &listener);
+                          ElaboratorContext elaboratorContext(&s, false, true);
+                          result = UHDM::clone_tree((any *)param->Rhs(),
+                                                    &elaboratorContext);
                           fC->populateCoreMembers(child, child, result);
                         }
                         break;
@@ -2551,9 +2553,10 @@ UHDM::any *CompileHelper::compileExpression(
                               (param_ass->Rhs()->UhdmType() == uhdmconstant)) {
                             if (substituteAssignedValue(param_ass->Rhs(),
                                                         compileDesign)) {
-                              ElaboratorListener listener(&s, false, true);
+                              ElaboratorContext elaboratorContext(&s, false,
+                                                                  true);
                               result = UHDM::clone_tree((any *)param_ass->Rhs(),
-                                                        s, &listener);
+                                                        &elaboratorContext);
                               result->VpiParent(
                                   const_cast<param_assign *>(param_ass));
                               fC->populateCoreMembers(child, child, result);
@@ -2609,9 +2612,10 @@ UHDM::any *CompileHelper::compileExpression(
                           if (complexValue) {
                             result = complexValue;
                           } else {
-                            ElaboratorListener listener(&s, false, true);
+                            ElaboratorContext elaboratorContext(&s, false,
+                                                                true);
                             result = UHDM::clone_tree((any *)param_ass->Rhs(),
-                                                      s, &listener);
+                                                      &elaboratorContext);
                             result->VpiParent(
                                 const_cast<param_assign *>(param_ass));
                             fC->populateCoreMembers(child, child, result);

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -532,9 +532,9 @@ const UHDM::typespec* bindTypespec(std::string_view name,
           type_parameter* tparam = any_cast<type_parameter*>(uparam);
           if (tparam) {
             result = tparam->Typespec();
-            ElaboratorListener listener(&s, false, true);
+            ElaboratorContext elaboratorContext(&s, false, true);
             result = any_cast<typespec*>(
-                UHDM::clone_tree((any*)result, s, &listener));
+                UHDM::clone_tree((any*)result, &elaboratorContext));
           }
         }
         break;
@@ -550,9 +550,9 @@ const UHDM::typespec* bindTypespec(std::string_view name,
             type_parameter* tparam = any_cast<type_parameter*>(uparam);
             if (tparam) {
               result = tparam->Typespec();
-              ElaboratorListener listener(&s, false, true);
+              ElaboratorContext elaboratorContext(&s, false, true);
               result = any_cast<typespec*>(
-                  UHDM::clone_tree((any*)result, s, &listener));
+                  UHDM::clone_tree((any*)result, &elaboratorContext));
             }
           }
         }
@@ -560,9 +560,9 @@ const UHDM::typespec* bindTypespec(std::string_view name,
         if (dt) {
           dt = dt->getActual();
           result = dt->getTypespec();
-          ElaboratorListener listener(&s, false, true);
-          result =
-              any_cast<typespec*>(UHDM::clone_tree((any*)result, s, &listener));
+          ElaboratorContext elaboratorContext(&s, false, true);
+          result = any_cast<typespec*>(
+              UHDM::clone_tree((any*)result, &elaboratorContext));
         }
       }
     }
@@ -728,9 +728,9 @@ typespec* CompileHelper::compileDatastructureTypespec(
       } else if (const SimpleType* sit = datatype_cast<const SimpleType*>(dt)) {
         result = sit->getTypespec();
         if (parent_tpd && result) {
-          ElaboratorListener listener(&s, false, true);
-          typespec* new_result =
-              any_cast<typespec*>(UHDM::clone_tree((any*)result, s, &listener));
+          ElaboratorContext elaboratorContext(&s, false, true);
+          typespec* new_result = any_cast<typespec*>(
+              UHDM::clone_tree((any*)result, &elaboratorContext));
           if (new_result) {
             new_result->Typedef_alias(result);
             result = new_result;
@@ -1932,9 +1932,9 @@ UHDM::typespec* CompileHelper::elabTypespec(DesignComponent* component,
       bit_typespec* tps = (bit_typespec*)spec;
       ranges = tps->Ranges();
       if (ranges) {
-        ElaboratorListener listener(&s, false, true);
-        bit_typespec* res =
-            any_cast<bit_typespec*>(UHDM::clone_tree((any*)spec, s, &listener));
+        ElaboratorContext elaboratorContext(&s, false, true);
+        bit_typespec* res = any_cast<bit_typespec*>(
+            UHDM::clone_tree((any*)spec, &elaboratorContext));
         ranges = res->Ranges();
         result = res;
       }
@@ -1944,9 +1944,9 @@ UHDM::typespec* CompileHelper::elabTypespec(DesignComponent* component,
       logic_typespec* tps = (logic_typespec*)spec;
       ranges = tps->Ranges();
       if (ranges) {
-        ElaboratorListener listener(&s, false, true);
+        ElaboratorContext elaboratorContext(&s, false, true);
         logic_typespec* res = any_cast<logic_typespec*>(
-            UHDM::clone_tree((any*)spec, s, &listener));
+            UHDM::clone_tree((any*)spec, &elaboratorContext));
         ranges = res->Ranges();
         result = res;
       }
@@ -1956,9 +1956,9 @@ UHDM::typespec* CompileHelper::elabTypespec(DesignComponent* component,
       array_typespec* tps = (array_typespec*)spec;
       ranges = tps->Ranges();
       if (ranges) {
-        ElaboratorListener listener(&s, false, true);
+        ElaboratorContext elaboratorContext(&s, false, true);
         array_typespec* res = any_cast<array_typespec*>(
-            UHDM::clone_tree((any*)spec, s, &listener));
+            UHDM::clone_tree((any*)spec, &elaboratorContext));
         ranges = res->Ranges();
         result = res;
       }
@@ -1968,9 +1968,9 @@ UHDM::typespec* CompileHelper::elabTypespec(DesignComponent* component,
       packed_array_typespec* tps = (packed_array_typespec*)spec;
       ranges = tps->Ranges();
       if (ranges) {
-        ElaboratorListener listener(&s, false, true);
+        ElaboratorContext elaboratorContext(&s, false, true);
         packed_array_typespec* res = any_cast<packed_array_typespec*>(
-            UHDM::clone_tree((any*)spec, s, &listener));
+            UHDM::clone_tree((any*)spec, &elaboratorContext));
         ranges = res->Ranges();
         result = res;
       }

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -43,14 +43,13 @@
 #include <Surelog/Testbench/Program.h>
 #include <Surelog/Utils/StringUtils.h>
 
-#include <cstring>
-
 // UHDM
 #include <uhdm/ElaboratorListener.h>
 #include <uhdm/ExprEval.h>
 #include <uhdm/clone_tree.h>
 #include <uhdm/uhdm.h>
 
+#include <cstring>
 #include <queue>
 #include <unordered_set>
 
@@ -663,8 +662,8 @@ const UHDM::any* resize(UHDM::Serializer& serializer, const UHDM::any* object,
   if (type == UHDM::uhdmconstant) {
     UHDM::constant* c = (UHDM::constant*)result;
     if (c->VpiSize() < maxsize) {
-      UHDM::ElaboratorListener listener(&serializer);
-      c = (UHDM::constant*)UHDM::clone_tree(c, serializer, &listener);
+      UHDM::ElaboratorContext elaboratorContext(&serializer);
+      c = (UHDM::constant*)UHDM::clone_tree(c, &elaboratorContext);
       int32_t constType = c->VpiConstType();
       const UHDM::typespec* tps = c->Typespec();
       bool is_signed = false;
@@ -1834,8 +1833,8 @@ std::vector<std::string_view> DesignElaboration::collectParams_(
         const std::string_view name = packageFile->SymName(ident);
         if (UHDM::expr* exp = def->getComplexValue(name)) {
           UHDM::Serializer& s = m_compileDesign->getSerializer();
-          UHDM::ElaboratorListener listener(&s, false, true);
-          UHDM::any* pclone = UHDM::clone_tree(exp, s, &listener);
+          UHDM::ElaboratorContext elaboratorContext(&s, false, true);
+          UHDM::any* pclone = UHDM::clone_tree(exp, &elaboratorContext);
           instance->setComplexValue(name, (UHDM::expr*)pclone);
         } else {
           Value* value = m_exprBuilder.clone(def->getValue(name));

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -169,14 +169,15 @@ bool ElaborationStep::bindTypedefs_() {
                 typd->getDefinitionNode(), m_compileDesign, Reduce::Yes,
                 nullptr, nullptr, false);
           } else if (typespec* tps = def->getTypespec()) {
-            ElaboratorListener listener(&s, false, true);
-            tpclone = (typespec*)UHDM::clone_tree((any*)tps, s, &listener);
+            ElaboratorContext elaboratorContext(&s, false, true);
+            tpclone =
+                (typespec*)UHDM::clone_tree((any*)tps, &elaboratorContext);
             tpclone->Typedef_alias(tps);
           }
           if (typespec* unpacked = prevDef->getUnpackedTypespec()) {
-            ElaboratorListener listener(&s, false, true);
-            array_typespec* unpacked_clone =
-                (array_typespec*)UHDM::clone_tree((any*)unpacked, s, &listener);
+            ElaboratorContext elaboratorContext(&s, false, true);
+            array_typespec* unpacked_clone = (array_typespec*)UHDM::clone_tree(
+                (any*)unpacked, &elaboratorContext);
             unpacked_clone->Elem_typespec(tpclone);
             tpclone = unpacked_clone;
           }

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -209,16 +209,16 @@ bool NetlistElaboration::elab_parameters_(ModuleInstance* instance,
           // Don't reduce these operations
           if (opType == vpiAssignmentPatternOp ||
               opType == vpiMultiAssignmentPatternOp) {
-            ElaboratorListener listener(&s, false, true);
+            ElaboratorContext elaboratorContext(&s, false, true);
             param_assign* pclone =
-                (param_assign*)UHDM::clone_tree(mod_assign, s, &listener);
+                (param_assign*)UHDM::clone_tree(mod_assign, &elaboratorContext);
             pclone->VpiParent((any*)mod_assign->VpiParent());
             pclone->VpiOverriden(instance->isOverridenParam(paramName));
             if (opType == vpiAssignmentPatternOp) {
               const any* lhs = pclone->Lhs();
               any* rhs = (any*)pclone->Rhs();
               if (complexVal) {
-                rhs = UHDM::clone_tree(complexVal, s, &listener);
+                rhs = UHDM::clone_tree(complexVal, &elaboratorContext);
                 rhs->VpiParent(pclone);
               }
               const typespec* ts = nullptr;

--- a/src/hellouhdm.cpp
+++ b/src/hellouhdm.cpp
@@ -69,10 +69,10 @@ int main(int argc, const char** argv) {
   if (the_design && (!vpi_get(vpiElaborated, the_design))) {
     std::cout << "UHDM Elaboration...\n";
     UHDM::Serializer serializer;
-    UHDM::ElaboratorListener* listener =
-        new UHDM::ElaboratorListener(&serializer, true);
-    listener->listenDesigns({the_design});
-    delete listener;
+    UHDM::ElaboratorContext* elaboratorContext =
+        new UHDM::ElaboratorContext(&serializer, true);
+    elaboratorContext->m_elaborator.listenDesigns({the_design});
+    delete elaboratorContext;
   }
 
   // Browse the UHDM Data Model using the IEEE VPI API.


### PR DESCRIPTION
Add CloneContext, CompareContext & ElaboratorContext

This is initial change for a larger goal to untie the tight coupling between cloning and elaboration. As it stands today, cloning doesn't work except for the specific case of elaboration.

* Context classes allows for adding additional args to the API without having to change the API itself.
* CompareContext returns the first failed comparison
* CloneContext has no concept of Elaboration to support cloning without elaboration or binding logic
* ElaboratorContext is a subclass of CloneContext that extends the cloning functionality with elaboration.
* uhdm-cmp now prints the first mismatch, if comparison fails.

Update Surelog to use ElaboratorContext in-place of ElaboratorListener in the context of cloning.