### PR TITLE
Avoid cycles in VpiListener & in ElaboratorListener

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 # Version changes whenever some new features accumulated, or the
 # grammar or the cache format changes to make sure caches
 # are invalidated.
-project(SURELOG VERSION 1.66)
+project(SURELOG VERSION 1.67)
 
 # Detect build type, fallback to release and throw a warning if use didn't
 # specify any

--- a/tests/ArrayMethodIterator/ArrayMethodIterator.log
+++ b/tests/ArrayMethodIterator/ArrayMethodIterator.log
@@ -486,7 +486,7 @@ design: (work@top)
                 |vpiName:cb_
                 |vpiFullName:pkg::uvm_callbacks::get_all::callbacks_to_append::cb_
                 |vpiActual:
-                \_ref_obj: (pkg::uvm_callbacks::get_all::callbacks_to_append::cb_), line:19:60, endln:19:63
+                \_class_var: (pkg::uvm_callbacks::get_all::callbacks_to_append::cb_), line:15:6, endln:15:25
               |vpiName:unique
               |vpiWith:
               \_hier_path: (cb_.get_inst_id), line:19:73, endln:19:88
@@ -499,7 +499,7 @@ design: (work@top)
                   \_hier_path: (cb_.get_inst_id), line:19:73, endln:19:88
                   |vpiName:cb_
                   |vpiActual:
-                  \_ref_obj: (pkg::uvm_callbacks::get_all::callbacks_to_append::cb_), line:19:60, endln:19:63
+                  \_class_var: (pkg::uvm_callbacks::get_all::callbacks_to_append::cb_), line:15:6, endln:15:25
                 |vpiActual:
                 \_ref_obj: (pkg::uvm_callbacks::get_all::callbacks_to_append::get_inst_id), line:19:77, endln:19:88
                   |vpiParent:

--- a/tests/Assignments/Assignments.log
+++ b/tests/Assignments/Assignments.log
@@ -1238,7 +1238,7 @@ design: (work@dut)
                 \_hier_path: (cover_info.size), line:6:22, endln:6:39
                 |vpiName:cover_info
                 |vpiActual:
-                \_ref_obj: (cover_info), line:6:46, endln:6:56
+                \_logic_net: (work@dut.cover_info), line:6:5, endln:6:15
               |vpiActual:
               \_method_func_call: (size), line:6:33, endln:6:37
                 |vpiParent:
@@ -1258,7 +1258,7 @@ design: (work@dut)
             \_method_func_call: (new), line:6:18, endln:6:57
             |vpiName:cover_info
             |vpiActual:
-            \_ref_obj: (work@dut.uvm_packer::get_packed_bits.cover_info), line:6:46, endln:6:56
+            \_logic_net: (work@dut.cover_info), line:6:5, endln:6:15
           |vpiName:new
         |vpiLhs:
         \_ref_obj: (work@dut.uvm_packer::get_packed_bits.cover_info), line:6:5, endln:6:15
@@ -1282,7 +1282,7 @@ design: (work@dut)
             \_method_func_call: (new), line:7:21, endln:7:37
             |vpiName:m_pack_iter
             |vpiActual:
-            \_ref_obj: (work@dut.uvm_packer::get_packed_bits.m_pack_iter), line:7:25, endln:7:36
+            \_logic_net: (work@dut.m_pack_iter), line:7:25, endln:7:36
           |vpiName:new
         |vpiLhs:
         \_ref_obj: (work@dut.uvm_packer::get_packed_bits.stream), line:7:5, endln:7:11
@@ -1780,7 +1780,7 @@ design: (work@dut)
                 \_hier_path: (cover_info.size), line:6:22, endln:6:39
                 |vpiName:cover_info
                 |vpiActual:
-                \_ref_obj: (work@dut.uvm_packer::get_packed_bits.cover_info), line:6:46, endln:6:56
+                \_logic_net: (work@dut.cover_info), line:6:5, endln:6:15
               |vpiActual:
               \_method_func_call: (size), line:6:33, endln:6:37
                 |vpiParent:
@@ -1795,7 +1795,7 @@ design: (work@dut)
             |vpiName:cover_info
             |vpiFullName:work@dut.uvm_packer::get_packed_bits.cover_info
             |vpiActual:
-            \_ref_obj: (work@dut.uvm_packer::get_packed_bits.cover_info), line:6:46, endln:6:56
+            \_logic_net: (work@dut.cover_info), line:6:5, endln:6:15
           |vpiName:new
         |vpiLhs:
         \_ref_obj: (work@dut.uvm_packer::get_packed_bits.cover_info), line:6:5, endln:6:15
@@ -1822,7 +1822,7 @@ design: (work@dut)
             |vpiName:m_pack_iter
             |vpiFullName:work@dut.uvm_packer::get_packed_bits.m_pack_iter
             |vpiActual:
-            \_ref_obj: (work@dut.uvm_packer::get_packed_bits.m_pack_iter), line:7:25, endln:7:36
+            \_logic_net: (work@dut.m_pack_iter), line:7:25, endln:7:36
           |vpiName:new
         |vpiLhs:
         \_ref_obj: (work@dut.uvm_packer::get_packed_bits.stream), line:7:5, endln:7:11

--- a/tests/ClassFuncTask/ClassFuncTask.log
+++ b/tests/ClassFuncTask/ClassFuncTask.log
@@ -180,40 +180,30 @@ design: (unnamed)
           \_method_func_call: (super.new)
           |vpiName:name
           |vpiFullName:pack::C::new::name
-          |vpiActual:
-          \_ref_obj: (pack::C::new::name), line:16:15, endln:16:19
         |vpiArgument:
         \_ref_obj: (pack::C::new::parent), line:16:21, endln:16:27
           |vpiParent:
           \_method_func_call: (super.new)
           |vpiName:parent
           |vpiFullName:pack::C::new::parent
-          |vpiActual:
-          \_ref_obj: (pack::C::new::parent), line:16:21, endln:16:27
         |vpiArgument:
         \_ref_obj: (pack::C::new::UVM_PORT), line:16:29, endln:16:37
           |vpiParent:
           \_method_func_call: (super.new)
           |vpiName:UVM_PORT
           |vpiFullName:pack::C::new::UVM_PORT
-          |vpiActual:
-          \_ref_obj: (pack::C::new::UVM_PORT), line:16:29, endln:16:37
         |vpiArgument:
         \_ref_obj: (pack::C::new::min_size), line:16:39, endln:16:47
           |vpiParent:
           \_method_func_call: (super.new)
           |vpiName:min_size
           |vpiFullName:pack::C::new::min_size
-          |vpiActual:
-          \_ref_obj: (pack::C::new::min_size), line:16:39, endln:16:47
         |vpiArgument:
         \_ref_obj: (pack::C::new::max_size), line:16:49, endln:16:57
           |vpiParent:
           \_method_func_call: (super.new)
           |vpiName:max_size
           |vpiFullName:pack::C::new::max_size
-          |vpiActual:
-          \_ref_obj: (pack::C::new::max_size), line:16:49, endln:16:57
         |vpiName:super.new
     |vpiMethod:
     \_task: (pack::C::set), line:19:3, endln:21:10

--- a/tests/ClassMemberRef/ClassMemberRef.log
+++ b/tests/ClassMemberRef/ClassMemberRef.log
@@ -473,7 +473,7 @@ design: (work@top)
           |vpiName:en
           |vpiFullName:work@top.en
           |vpiActual:
-          \_ref_obj: (work@top.en), line:27:27, endln:27:29
+          \_logic_net: (work@top.en), line:27:27, endln:27:29
         |vpiName:set_name_enabled
         |vpiPrefix:
         \_ref_obj: (work@top.printer), line:27:1, endln:27:8
@@ -540,7 +540,7 @@ design: (work@top)
           |vpiName:en
           |vpiFullName:work@top.en
           |vpiActual:
-          \_ref_obj: (work@top.en), line:27:27, endln:27:29
+          \_logic_net: (work@top.en), line:27:27, endln:27:29
         |vpiName:set_name_enabled
         |vpiPrefix:
         \_ref_obj: (work@top.printer), line:27:1, endln:27:8

--- a/tests/ConstantWithElabUhdm/ConstantNoElabUhdm.log
+++ b/tests/ConstantWithElabUhdm/ConstantNoElabUhdm.log
@@ -2,7 +2,7 @@
 
 AST_DEBUG_BEGIN
 LIB:  work
-FILE: ${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv
+FILE: ${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv
 n<> u<0> t<_INVALID_> f<0> l<0:0>
 n<> u<1> t<Null_rule> p<75> s<74> l<2:1> el<1:2>
 n<> u<2> t<Struct_keyword> p<3> l<2:9> el<2:15>
@@ -80,15 +80,15 @@ n<> u<73> t<Description> p<74> c<72> l<3:1> el<8:16>
 n<> u<74> t<Source_text> p<75> c<28> l<2:1> el<8:16>
 n<> u<75> t<Top_level_rule> c<1> l<2:1> el<9:1>
 AST_DEBUG_END
-[WRN:PA0205] ${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv:3:1: No timescale set for "top".
+[WRN:PA0205] ${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv:3:1: No timescale set for "top".
 
 [INF:CP0300] Compilation...
 
-[INF:CP0303] ${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv:3:1: Compile module "work@top".
+[INF:CP0303] ${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv:3:1: Compile module "work@top".
 
 [INF:EL0526] Design Elaboration...
 
-[NTE:EL0503] ${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv:3:1: Top level module "work@top".
+[NTE:EL0503] ${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv:3:1: Top level module "work@top".
 
 [NTE:EL0508] Nb Top level modules: 1.
 
@@ -115,23 +115,6 @@ struct_net                                             1
 struct_typespec                                        1
 typespec_member                                        1
 === UHDM Object Stats End ===
-[INF:UH0707] Elaborating UHDM...
-
-=== UHDM Object Stats Begin (Elaborated Model) ===
-constant                                               5
-cont_assign                                            3
-design                                                 1
-logic_net                                              3
-logic_typespec                                         4
-module_inst                                            4
-operation                                              3
-port                                                   6
-range                                                  1
-ref_obj                                               12
-struct_net                                             1
-struct_typespec                                        1
-typespec_member                                        1
-=== UHDM Object Stats End ===
 [INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/ConstantNoElabUhdm/slpp_all/surelog.uhdm ...
 
 [INF:UH0709] Writing UHDM Html Coverage: ${SURELOG_DIR}/build/regression/ConstantNoElabUhdm/slpp_all/checker/surelog.chk.html ...
@@ -142,10 +125,9 @@ typespec_member                                        1
 
 ====== UHDM =======
 design: (work@top)
-|vpiElaborated:1
 |vpiName:work@top
 |uhdmallModules:
-\_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
+\_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv, line:3:1, endln:8:16
   |vpiParent:
   \_design: (work@top)
   |vpiFullName:work@top
@@ -153,20 +135,20 @@ design: (work@top)
   |vpiNet:
   \_logic_net: (work@top.out3), line:4:31, endln:4:35
     |vpiParent:
-    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv, line:3:1, endln:8:16
     |vpiName:out3
     |vpiFullName:work@top.out3
   |vpiNet:
   \_logic_net: (work@top.out4), line:5:17, endln:5:21
     |vpiParent:
-    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv, line:3:1, endln:8:16
     |vpiName:out4
     |vpiFullName:work@top.out4
     |vpiNetType:1
   |vpiPort:
   \_port: (out3), line:4:31, endln:4:35
     |vpiParent:
-    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv, line:3:1, endln:8:16
     |vpiName:out3
     |vpiDirection:2
     |vpiLowConn:
@@ -214,7 +196,7 @@ design: (work@top)
               |vpiSize:64
               |UINT:0
               |vpiConstType:9
-        |vpiRefFile:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv
+        |vpiRefFile:${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv
         |vpiRefLineNo:2
         |vpiRefColumnNo:24
         |vpiRefEndLineNo:2
@@ -222,7 +204,7 @@ design: (work@top)
   |vpiPort:
   \_port: (out4), line:5:17, endln:5:21
     |vpiParent:
-    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv, line:3:1, endln:8:16
     |vpiName:out4
     |vpiDirection:2
     |vpiLowConn:
@@ -238,7 +220,7 @@ design: (work@top)
   |vpiContAssign:
   \_cont_assign: , line:7:10, endln:7:32
     |vpiParent:
-    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv, line:3:1, endln:8:16
     |vpiRhs:
     \_operation: , line:7:21, endln:7:31
       |vpiParent:
@@ -271,14 +253,14 @@ design: (work@top)
 |vpiTypedef:
 \_struct_typespec: (my_struct_packed_t), line:2:9, endln:2:39
 |uhdmtopModules:
-\_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
+\_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv, line:3:1, endln:8:16
   |vpiName:work@top
   |vpiDefName:work@top
   |vpiTop:1
   |vpiNet:
   \_struct_net: (work@top.out3), line:4:31, endln:4:35
     |vpiParent:
-    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv, line:3:1, endln:8:16
     |vpiTypespec:
     \_struct_typespec: (my_struct_packed_t), line:2:9, endln:2:39
     |vpiName:out3
@@ -286,7 +268,7 @@ design: (work@top)
   |vpiNet:
   \_logic_net: (work@top.out4), line:5:17, endln:5:21
     |vpiParent:
-    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv, line:3:1, endln:8:16
     |vpiTypespec:
     \_logic_typespec: , line:5:12, endln:5:16
     |vpiName:out4
@@ -296,7 +278,7 @@ design: (work@top)
   |vpiPort:
   \_port: (out3), line:4:31, endln:4:35
     |vpiParent:
-    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv, line:3:1, endln:8:16
     |vpiName:out3
     |vpiDirection:2
     |vpiLowConn:
@@ -309,12 +291,10 @@ design: (work@top)
       \_struct_net: (work@top.out3), line:4:31, endln:4:35
     |vpiTypedef:
     \_struct_typespec: (my_struct_packed_t), line:2:9, endln:2:39
-    |vpiInstance:
-    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
   |vpiPort:
   \_port: (out4), line:5:17, endln:5:21
     |vpiParent:
-    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv, line:3:1, endln:8:16
     |vpiName:out4
     |vpiDirection:2
     |vpiLowConn:
@@ -327,12 +307,10 @@ design: (work@top)
       \_logic_net: (work@top.out4), line:5:17, endln:5:21
     |vpiTypedef:
     \_logic_typespec: , line:5:12, endln:5:16
-    |vpiInstance:
-    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
   |vpiContAssign:
   \_cont_assign: , line:7:10, endln:7:32
     |vpiParent:
-    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv, line:3:1, endln:8:16
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv, line:3:1, endln:8:16
     |vpiRhs:
     \_operation: , line:7:21, endln:7:31
       |vpiParent:
@@ -345,13 +323,15 @@ design: (work@top)
         |vpiName:out3
         |vpiFullName:work@top.out3
         |vpiActual:
-        \_struct_net: (work@top.out3), line:4:31, endln:4:35
+        \_logic_net: (work@top.out3), line:4:31, endln:4:35
       |vpiOperand:
       \_constant: , line:7:29, endln:7:31
-        |vpiDecompile:15
-        |vpiSize:4
-        |UINT:15
-        |vpiConstType:9
+        |vpiParent:
+        \_operation: , line:7:21, endln:7:31
+        |vpiDecompile:'1
+        |vpiSize:-1
+        |BIN:1
+        |vpiConstType:3
     |vpiLhs:
     \_ref_obj: (work@top.out4), line:7:10, endln:7:14
       |vpiParent:
@@ -368,4 +348,4 @@ design: (work@top)
 [   NOTE] : 5
 
 
-[roundtrip]: ${SURELOG_DIR}/tests/ConstantWithElabUhdm/dut.sv | ${SURELOG_DIR}/build/regression/ConstantNoElabUhdm/roundtrip/dut_000.sv | 7 | 8 |
+[roundtrip]: ${SURELOG_DIR}/tests/ConstantNoElabUhdm/dut.sv | ${SURELOG_DIR}/build/regression/ConstantNoElabUhdm/roundtrip/dut_000.sv | 7 | 8 |

--- a/tests/DoWhile/DoWhile.log
+++ b/tests/DoWhile/DoWhile.log
@@ -468,8 +468,6 @@ design: (unnamed)
             \_method_func_call: (next), line:10:27, endln:10:31
             |vpiName:key
             |vpiFullName:toto::uvm_default_factory::print::m_type_names.next::key
-            |vpiActual:
-            \_ref_obj: (toto::uvm_default_factory::print::m_type_names.next::key), line:10:32, endln:10:35
           |vpiName:next
       |vpiStmt:
       \_begin: (toto::uvm_default_factory::print), line:6:6, endln:10:7
@@ -612,8 +610,6 @@ design: (unnamed)
             \_method_func_call: (next), line:10:27, endln:10:31
             |vpiName:key
             |vpiFullName:toto::uvm_default_factory::print::m_type_names.next::key
-            |vpiActual:
-            \_ref_obj: (toto::uvm_default_factory::print::m_type_names.next::key), line:10:32, endln:10:35
           |vpiName:next
       |vpiStmt:
       \_begin: (toto::uvm_default_factory::print), line:6:6, endln:10:7

--- a/tests/DollarRoot/DollarRoot.log
+++ b/tests/DollarRoot/DollarRoot.log
@@ -12962,7 +12962,7 @@ design: (work@top)
             |vpiName:cmd
             |vpiFullName:work@test_program.save_command_master.cmd
             |vpiActual:
-            \_ref_obj: (work@test_program.save_command_master.cmd), line:637:61, endln:637:64
+            \_io_decl: (cmd), line:632:16, endln:632:19
           |vpiName:push_back
           |vpiPrefix:
           \_ref_obj: (work@test_program.save_command_master.write_command_queue_master), line:637:13, endln:637:39
@@ -12986,7 +12986,7 @@ design: (work@top)
             |vpiName:cmd
             |vpiFullName:work@test_program.save_command_master.cmd
             |vpiActual:
-            \_ref_obj: (work@test_program.save_command_master.cmd), line:639:60, endln:639:63
+            \_io_decl: (cmd), line:632:16, endln:632:19
           |vpiName:push_back
           |vpiPrefix:
           \_ref_obj: (work@test_program.save_command_master.read_command_queue_master), line:639:13, endln:639:38
@@ -13125,7 +13125,7 @@ design: (work@top)
               |vpiName:cmd
               |vpiFullName:work@test_program.save_command_slave.cmd
               |vpiActual:
-              \_ref_obj: (work@test_program.save_command_slave.cmd), line:651:56, endln:651:59
+              \_io_decl: (cmd), line:645:16, endln:645:19
             |vpiName:push_back
             |vpiPrefix:
             \_ref_obj: (work@test_program.save_command_slave.write_command_queue_slave), line:651:10, endln:651:35
@@ -13149,7 +13149,7 @@ design: (work@top)
               |vpiName:cmd
               |vpiFullName:work@test_program.save_command_slave.cmd
               |vpiActual:
-              \_ref_obj: (work@test_program.save_command_slave.cmd), line:653:55, endln:653:58
+              \_io_decl: (cmd), line:645:16, endln:645:19
             |vpiName:push_back
             |vpiPrefix:
             \_ref_obj: (work@test_program.save_command_slave.read_command_queue_slave), line:653:10, endln:653:34
@@ -13857,7 +13857,7 @@ design: (work@top)
                       |vpiName:i
                       |vpiFullName:work@test_program.get_expected_command_for_slave.i
                       |vpiActual:
-                      \_ref_obj: (work@test_program.get_expected_command_for_slave.i), line:694:59, endln:694:60
+                      \_logic_net: (work@test_program.i), line:692:59, endln:692:60
                     |vpiName:delete
                     |vpiPrefix:
                     \_ref_obj: (work@test_program.get_expected_command_for_slave.write_command_queue_slave), line:694:16, endln:694:41
@@ -14126,7 +14126,7 @@ design: (work@top)
                       |vpiName:i
                       |vpiFullName:work@test_program.get_expected_command_for_slave.i
                       |vpiActual:
-                      \_ref_obj: (work@test_program.get_expected_command_for_slave.i), line:706:58, endln:706:59
+                      \_logic_net: (work@test_program.i), line:692:59, endln:692:60
                     |vpiName:delete
                     |vpiPrefix:
                     \_ref_obj: (work@test_program.get_expected_command_for_slave.read_command_queue_slave), line:706:16, endln:706:40
@@ -16191,7 +16191,7 @@ design: (work@top)
                 |vpiName:rsp
                 |vpiFullName:work@test_program.rsp
                 |vpiActual:
-                \_ref_obj: (work@test_program.rsp), line:303:49, endln:303:52
+                \_struct_var: (work@test_program.rsp), line:285:19, endln:285:22
               |vpiName:push_back
               |vpiPrefix:
               \_ref_obj: (work@test_program.read_response_queue_slave), line:303:10, endln:303:35
@@ -16899,7 +16899,7 @@ design: (work@top)
                 |vpiName:rsp
                 |vpiFullName:work@test_program.rsp
                 |vpiActual:
-                \_ref_obj: (work@test_program.rsp), line:446:49, endln:446:52
+                \_struct_var: (work@test_program.rsp), line:428:19, endln:428:22
               |vpiName:push_back
               |vpiPrefix:
               \_ref_obj: (work@test_program.read_response_queue_slave), line:446:10, endln:446:35
@@ -22654,7 +22654,7 @@ design: (work@top)
             |vpiName:cmd
             |vpiFullName:work@test_program.save_command_master.cmd
             |vpiActual:
-            \_ref_obj: (work@test_program.save_command_master.cmd), line:637:61, endln:637:64
+            \_io_decl: (cmd), line:632:16, endln:632:19
           |vpiName:push_back
           |vpiPrefix:
           \_ref_obj: (work@test_program.save_command_master.write_command_queue_master), line:637:13, endln:637:39
@@ -22680,7 +22680,7 @@ design: (work@top)
             |vpiName:cmd
             |vpiFullName:work@test_program.save_command_master.cmd
             |vpiActual:
-            \_ref_obj: (work@test_program.save_command_master.cmd), line:639:60, endln:639:63
+            \_io_decl: (cmd), line:632:16, endln:632:19
           |vpiName:push_back
           |vpiPrefix:
           \_ref_obj: (work@test_program.save_command_master.read_command_queue_master), line:639:13, endln:639:38
@@ -22826,7 +22826,7 @@ design: (work@top)
               |vpiName:cmd
               |vpiFullName:work@test_program.save_command_slave.cmd
               |vpiActual:
-              \_ref_obj: (work@test_program.save_command_slave.cmd), line:651:56, endln:651:59
+              \_io_decl: (cmd), line:645:16, endln:645:19
             |vpiName:push_back
             |vpiPrefix:
             \_ref_obj: (work@test_program.save_command_slave.write_command_queue_slave), line:651:10, endln:651:35
@@ -22852,7 +22852,7 @@ design: (work@top)
               |vpiName:cmd
               |vpiFullName:work@test_program.save_command_slave.cmd
               |vpiActual:
-              \_ref_obj: (work@test_program.save_command_slave.cmd), line:653:55, endln:653:58
+              \_io_decl: (cmd), line:645:16, endln:645:19
             |vpiName:push_back
             |vpiPrefix:
             \_ref_obj: (work@test_program.save_command_slave.read_command_queue_slave), line:653:10, endln:653:34
@@ -23435,7 +23435,7 @@ design: (work@top)
                       |vpiName:i
                       |vpiFullName:work@test_program.get_expected_command_for_slave.i
                       |vpiActual:
-                      \_ref_obj: (work@test_program.get_expected_command_for_slave.i), line:694:59, endln:694:60
+                      \_ref_var: (work@test_program.get_expected_command_for_slave.i), line:691:54, endln:691:55
                     |vpiName:delete
                     |vpiPrefix:
                     \_ref_obj: (work@test_program.get_expected_command_for_slave.write_command_queue_slave), line:694:16, endln:694:41
@@ -23675,7 +23675,7 @@ design: (work@top)
                       |vpiName:i
                       |vpiFullName:work@test_program.get_expected_command_for_slave.i
                       |vpiActual:
-                      \_ref_obj: (work@test_program.get_expected_command_for_slave.i), line:706:58, endln:706:59
+                      \_ref_var: (work@test_program.get_expected_command_for_slave.i), line:703:53, endln:703:54
                     |vpiName:delete
                     |vpiPrefix:
                     \_ref_obj: (work@test_program.get_expected_command_for_slave.read_command_queue_slave), line:706:16, endln:706:40
@@ -25536,7 +25536,7 @@ design: (work@top)
                 |vpiName:rsp
                 |vpiFullName:work@test_program.rsp
                 |vpiActual:
-                \_ref_obj: (work@test_program.rsp), line:303:49, endln:303:52
+                \_struct_var: (work@test_program.rsp), line:285:19, endln:285:22
               |vpiName:push_back
               |vpiPrefix:
               \_ref_obj: (work@test_program.read_response_queue_slave), line:303:10, endln:303:35
@@ -26226,7 +26226,7 @@ design: (work@top)
                 |vpiName:rsp
                 |vpiFullName:work@test_program.rsp
                 |vpiActual:
-                \_ref_obj: (work@test_program.rsp), line:446:49, endln:446:52
+                \_struct_var: (work@test_program.rsp), line:428:19, endln:428:22
               |vpiName:push_back
               |vpiPrefix:
               \_ref_obj: (work@test_program.read_response_queue_slave), line:446:10, endln:446:35

--- a/tests/GenScopeFunc/GenScopeFunc.log
+++ b/tests/GenScopeFunc/GenScopeFunc.log
@@ -246,7 +246,7 @@ design: (work@top)
           |vpiName:counter
           |vpiFullName:work@mod.cscope.local_function.counter
           |vpiActual:
-          \_ref_obj: (work@mod.cscope.local_function.counter), line:11:38, endln:11:45
+          \_logic_net: (work@mod.counter), line:11:38, endln:11:45
         |vpiName:local_function
     |vpiLhs:
     \_ref_obj: (work@mod.foo), line:11:10, endln:11:13
@@ -408,7 +408,7 @@ design: (work@top)
             |vpiName:counter
             |vpiFullName:work@top.c.cscope.local_function.counter
             |vpiActual:
-            \_ref_obj: (work@top.c.cscope.local_function.counter), line:11:38, endln:11:45
+            \_gen_scope: (work@top.c.cscope), line:4:5, endln:8:8
           |vpiName:local_function
           |vpiFunction:
           \_function: (work@top.c.cscope.local_function), line:5:7, endln:7:18

--- a/tests/LibraryIntercon/LibraryIntercon.log
+++ b/tests/LibraryIntercon/LibraryIntercon.log
@@ -9,40 +9,40 @@ LIB: work
      ${SURELOG_DIR}/tests/LibraryIntercon/lib.map
 
 LIB: realLib
-     ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr
      ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr
+     ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr
 
 LIB: logicLib
-     ${SURELOG_DIR}/tests/LibraryIntercon/driver.sv
      ${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv
      ${SURELOG_DIR}/tests/LibraryIntercon/top.sv
+     ${SURELOG_DIR}/tests/LibraryIntercon/driver.sv
 
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/nets.pkg".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/lib.map".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.svr".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/top.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/nets.pkg".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/nets.pkg".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.svr".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/top.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.sv".
 
 [WRN:PA0205] ${SURELOG_DIR}/tests/LibraryIntercon/nets.pkg:1:1: No timescale set for "NetsPkg".
 

--- a/tests/OldLibrary/OldLibrary.log
+++ b/tests/OldLibrary/OldLibrary.log
@@ -2,27 +2,27 @@
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/OldLibrary/top.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL2.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL3.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL1.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL3.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL2.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/OldLibrary/top.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL2.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL3.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL1.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL3.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/OldLibrary/lib/CELL2.v".
 
 [WRN:PA0205] ${SURELOG_DIR}/tests/OldLibrary/top.v:1:1: No timescale set for "top".
 
-[WRN:PA0205] ${SURELOG_DIR}/tests/OldLibrary/lib/CELL2.v:1:1: No timescale set for "CELL2".
+[WRN:PA0205] ${SURELOG_DIR}/tests/OldLibrary/lib/CELL3.v:1:1: No timescale set for "CELL3".
 
 [WRN:PA0205] ${SURELOG_DIR}/tests/OldLibrary/lib/CELL1.v:1:1: No timescale set for "CELL1".
 
-[WRN:PA0205] ${SURELOG_DIR}/tests/OldLibrary/lib/CELL3.v:1:1: No timescale set for "CELL3".
+[WRN:PA0205] ${SURELOG_DIR}/tests/OldLibrary/lib/CELL2.v:1:1: No timescale set for "CELL2".
 
 [INF:CP0300] Compilation...
 

--- a/tests/PackageVar/PackageVar.log
+++ b/tests/PackageVar/PackageVar.log
@@ -426,8 +426,6 @@ design: (unnamed)
               \_method_func_call: (print_object), line:29:13, endln:29:25
               |vpiName:this
               |vpiFullName:pack::ovm_object::print::this
-              |vpiActual:
-              \_ref_obj: (pack::ovm_object::print::this), line:29:38, endln:29:42
             |vpiName:print_object
             |vpiPrefix:
             \_ref_obj: (pack::ovm_object::print::printer), line:29:5, endln:29:12
@@ -683,8 +681,6 @@ design: (unnamed)
                 \_method_func_call: (print_object), line:29:13, endln:29:25
                 |vpiName:this
                 |vpiFullName:pack::ovm_object::print::this
-                |vpiActual:
-                \_ref_obj: (pack::ovm_object::print::this), line:29:38, endln:29:42
               |vpiName:print_object
               |vpiPrefix:
               \_ref_obj: (pack::ovm_object::print::printer), line:29:5, endln:29:12

--- a/tests/TestSepComp/TestSepComp.log
+++ b/tests/TestSepComp/TestSepComp.log
@@ -27,14 +27,14 @@
 [   NOTE] : 0
 [INF:CM0023] Creating log file ${SURELOG_DIR}/tests/TestSepComp/slpp_all/surelog.log.
 
+PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/top.sv
 PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/pkg1.sv
 PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/pkg2.sv
-PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/top.sv
+[WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/top.sv:1:1: No timescale set for "top".
+
 [WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/pkg1.sv:1:1: No timescale set for "pkg1".
 
 [WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/pkg2.sv:1:1: No timescale set for "pkg2".
-
-[WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/top.sv:1:1: No timescale set for "top".
 
 [INF:CP0300] Compilation...
 

--- a/tests/UnitThisNew/UnitThisNew.log
+++ b/tests/UnitThisNew/UnitThisNew.log
@@ -842,8 +842,6 @@ design: (unnamed)
           \_method_func_call: (copy), line:11:11, endln:11:15
           |vpiName:this
           |vpiFullName:toto::uvm_object::clone::this
-          |vpiActual:
-          \_ref_obj: (toto::uvm_object::clone::this), line:11:16, endln:11:20
         |vpiName:copy
         |vpiPrefix:
         \_ref_obj: (toto::uvm_object::clone::tmp), line:11:7, endln:11:10
@@ -1346,8 +1344,6 @@ design: (unnamed)
           \_method_func_call: (copy), line:11:11, endln:11:15
           |vpiName:this
           |vpiFullName:toto::uvm_object::clone::this
-          |vpiActual:
-          \_ref_obj: (toto::uvm_object::clone::this), line:11:16, endln:11:20
         |vpiName:copy
         |vpiPrefix:
         \_ref_obj: (toto::uvm_object::clone::tmp), line:11:7, endln:11:10

--- a/third_party/tests/CoresSweRVMP/CoresSweRVMP.log
+++ b/third_party/tests/CoresSweRVMP/CoresSweRVMP.log
@@ -2,8 +2,8 @@
 
 [WRN:CM0010] Command line argument "-Wno-UNOPTFLAT" ignored.
 
-Running: cd ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser; cmake -G "Unix Makefiles" .; make -j 16
--- Configuring done (0.1s)
+Running: cd ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser; cmake -G "Unix Makefiles" .; make -j 2
+-- Configuring done (0.0s)
 -- Generating done (0.0s)
 -- Build files have been written to: ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser
 [100%] Generating preprocessing
@@ -114,26 +114,12 @@ PP CACHE USED FOR: ${SURELOG_DIR}/third_party/UVM/1800.2-2017-1.0/src/uvm_pkg.sv
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/CoresSweRVMP/design/lib/axi4_to_ahb.sv".
 
-Running: cd ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess; cmake -G "Unix Makefiles" .; make -j 16
--- Configuring done (0.1s)
+Running: cd ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess; cmake -G "Unix Makefiles" .; make -j 2
+-- Configuring done (0.0s)
 -- Generating done (0.0s)
 -- Build files have been written to: ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess
-[  6%] Generating 11_ifu_bp_ctl.sv
-[ 12%] Generating 12_beh_lib.sv
-[ 18%] Generating 10_lsu_bus_intf.sv
-[ 25%] Generating 13_ifu_mem_ctl.sv
-[ 31%] Generating 15_exu.sv
-[ 37%] Generating 14_mem_lib.sv
-[ 43%] Generating 16_dec_decode_ctl.sv
-[ 50%] Generating 1_lsu_stbuf.sv
-[ 56%] Generating 2_ahb_to_axi4.sv
-[ 62%] Generating 3_rvjtag_tap.sv
-[ 68%] Generating 4_dec_tlu_ctl.sv
-[ 75%] Generating 5_lsu_bus_buffer.sv
-[ 81%] Generating 7_axi4_to_ahb.sv
-[ 87%] Generating 6_dbg.sv
-[ 93%] Generating 8_ifu_aln_ctl.sv
-[100%] Generating 9_tb_top.sv
+[ 50%] Generating 1_axi4_to_ahb.sv
+[100%] Generating 2_mem_lib.sv
 [100%] Built target Parse
 Surelog parsing status: 0
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/UVM/1800.2-2017-1.0/src/uvm_pkg.sv".

--- a/third_party/tests/NyuziProcessor/NyuziProcessor.log
+++ b/third_party/tests/NyuziProcessor/NyuziProcessor.log
@@ -22,125 +22,125 @@
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/sim_sdram.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/oh_to_idx.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/reciprocal_rom.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/thread_select_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/rr_arbiter.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/synchronizer.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage1.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage4.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_2r1w.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_load_miss_queue.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_1r1w.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/performance_counters.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/writeback_stage.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/idx_to_oh.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_interconnect.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/reciprocal_rom.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/idx_to_oh.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/writeback_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/synchronizer.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage1.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage4.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_interconnect.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/performance_counters.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/oh_to_idx.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_2r1w.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/thread_select_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/rr_arbiter.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_load_miss_queue.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/int_execute_stage.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/async_fifo.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_1r1w.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_sram.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/spi_controller.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/logic_analyzer.sv".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart.sv".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_async_bridge.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_sequencer.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_controller.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_transmit.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/timer.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_receive.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/async_fifo.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_controller.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_interconnect.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_rom.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/timer.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_transmit.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv".
 
@@ -159,125 +159,125 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/sim_sdram.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/oh_to_idx.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/reciprocal_rom.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/thread_select_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/rr_arbiter.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/synchronizer.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage1.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage4.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_2r1w.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_load_miss_queue.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_1r1w.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/performance_counters.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/writeback_stage.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/idx_to_oh.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_interconnect.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/reciprocal_rom.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/idx_to_oh.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/writeback_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/synchronizer.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage1.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage4.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_interconnect.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/performance_counters.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/oh_to_idx.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_2r1w.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/thread_select_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/rr_arbiter.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_load_miss_queue.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/int_execute_stage.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/async_fifo.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_1r1w.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_sram.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/spi_controller.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/logic_analyzer.sv".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart.sv".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_async_bridge.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_sequencer.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_controller.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_transmit.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/timer.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_receive.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/async_fifo.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_controller.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_interconnect.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_rom.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/timer.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_transmit.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv".
 
 [INF:CM0029] Using global timescale: "10ps/10ps".
 
@@ -536,52 +536,25 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/trace_logger.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv:22:1: previous definition.
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv:22:1: previous definition.
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv:22:1: previous definition.
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv:22:1: previous definition.
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv:22:1: previous definition.
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/writeback_stage.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/thread_select_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv:22:1: previous definition.
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv:22:1: previous definition.
@@ -590,73 +563,106 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage1.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage4.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_load_miss_queue.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_1r1w.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/writeback_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_interconnect.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_interconnect.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/thread_select_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_load_miss_queue.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/int_execute_stage.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/async_fifo.sv:22:1: previous definition.
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv:22:1: previous definition.
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_1r1w.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_sram.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/spi_controller.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/async_fifo.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_controller.sv:22:1: previous definition.
@@ -666,12 +672,6 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_rom.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv:22:1: previous definition.
 
 [NTE:CP0309] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/async_fifo.sv:37:29: Implicit port type (wire) for "read_data".
 

--- a/third_party/tests/oh/BasicOh.log
+++ b/third_party/tests/oh/BasicOh.log
@@ -2,563 +2,563 @@
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_async.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrqn.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux9.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and3.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor3.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_sync.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor3.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa42.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao221.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux7.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mult.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffqn.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_datagate.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa31.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai311.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao22.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor4.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_parity.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux6.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsqn.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai22.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai222.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pll.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dsync.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa311.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa62.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_gray2bin.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux12.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_debouncer.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edge2pulse.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_arbiter.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobuflo.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rsync.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobufhi.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_tristate.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao222.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai21.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latnq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockgate.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pulse2pulse.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux9.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi211.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bitreverse.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_standby.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2onehot.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockor.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_stretcher.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai311.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oddr.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffq.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa211.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_header.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ser2par.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_dp.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao32.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi21.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao211.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa222.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffnq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi221.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa21.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_shift.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_cdc.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg0.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg1.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai32.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_add.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_inv.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao33.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockdiv.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux6.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fall2pulse.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buffer.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai22.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi33.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_iddr.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_delay.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_abs.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor3.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi222.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi3.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao21.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edgealign.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffqn.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux5.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and3.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2gray.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockor.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi4.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor2.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor2.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg0.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao31.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rise2pulse.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat1.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dsync.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa221.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ser2par.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat0.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa62.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrqn.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa33.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_sp.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buf.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi32.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_par2ser.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi31.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi22.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pll.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor4.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux8.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_delay.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai33.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_regfile.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa22.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao311.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pwr_buf.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_gray2bin.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi311.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao21.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai31.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai221.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa311.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa32.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_counter.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_7seg_decode.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai222.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsqn.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa32.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_parity.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pulse2pulse.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa92.v".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_abs.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mult.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buffer.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_regfile.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsqn.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao31.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edgealign.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux5.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_stretcher.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockgate.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_dp.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai33.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa42.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rise2pulse.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_datagate.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai31.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2onehot.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_shift.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pwr_buf.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi211.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi31.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux7.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa33.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_iddr.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobufhi.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bitreverse.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi33.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai21.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_add.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_sync.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fall2pulse.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg1.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffnq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_header.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat0.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_cdc.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edge2pulse.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobuflo.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockdiv.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buf.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi22.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao33.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrqn.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao221.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa221.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa21.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oddr.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_standby.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrqn.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao311.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi21.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa222.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi221.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_7seg_decode.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao222.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux8.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa31.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rsync.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2gray.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_inv.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_counter.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_arbiter.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat1.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_par2ser.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_sp.v".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffqn.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsqn.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latnq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai221.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_tristate.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi311.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao211.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa22.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_async.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrqn.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux9.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and3.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor3.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_sync.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor3.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa42.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao221.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux7.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mult.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffqn.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_datagate.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa31.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai311.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao22.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor4.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_parity.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux6.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai22.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai222.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pll.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dsync.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa311.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa62.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_gray2bin.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux12.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_debouncer.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edge2pulse.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_arbiter.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobuflo.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rsync.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobufhi.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_tristate.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao222.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai21.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latnq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockgate.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pulse2pulse.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux9.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi211.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bitreverse.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_standby.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2onehot.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockor.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_stretcher.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai311.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oddr.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffq.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa211.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_header.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ser2par.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_dp.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao32.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi21.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao211.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa222.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffnq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi221.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa21.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_shift.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_cdc.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg0.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg1.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai32.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_add.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_inv.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao33.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockdiv.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux6.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fall2pulse.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buffer.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai22.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi33.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_iddr.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_delay.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_abs.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor3.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi222.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi3.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao21.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edgealign.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffqn.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux5.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and3.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2gray.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockor.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi4.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor2.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor2.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg0.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao31.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rise2pulse.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat1.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dsync.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa221.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ser2par.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat0.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa62.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrqn.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa33.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_sp.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buf.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi32.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_par2ser.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi31.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi22.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pll.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor4.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux8.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_delay.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai33.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_regfile.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa22.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao311.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pwr_buf.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_gray2bin.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi311.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao21.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai31.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai221.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa311.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa32.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_counter.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_7seg_decode.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai222.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsqn.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa32.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_parity.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pulse2pulse.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa92.v".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_abs.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mult.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buffer.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_regfile.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao31.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edgealign.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux5.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_stretcher.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockgate.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_dp.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai33.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa42.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rise2pulse.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_datagate.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai31.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2onehot.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_shift.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pwr_buf.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi211.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi31.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux7.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa33.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_iddr.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobufhi.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bitreverse.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi33.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai21.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_add.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_sync.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fall2pulse.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg1.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffnq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_header.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat0.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_cdc.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edge2pulse.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobuflo.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockdiv.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buf.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi22.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao33.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao221.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa221.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa21.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oddr.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_standby.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao311.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi21.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa222.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi221.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_7seg_decode.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao222.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux8.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa31.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rsync.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2gray.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_inv.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_counter.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_arbiter.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat1.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_par2ser.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_sp.v".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffqn.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsqn.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latnq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai221.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_tristate.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi311.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao211.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa22.v".
 
 [INF:CM0029] Using global timescale: "1ns/1ns".
 


### PR DESCRIPTION
Avoid cycles in VpiListener & in ElaboratorListener

* A ref_obj shouldn't point to another ref_obj as its actual_group.
* listenDesign_ clears the visited container between iterating allXXX and topXXX. That removes the top level design as well (which was added by listenDesign) causing infinite loops.
  This is found in cases where "$root" is used and the corresponding ref_obj::actual_group points to a design.