### PR TITLE
Strip-down workflow to generate logs

### DIFF
--- a/.github/workflows/logs_on_demand.yml
+++ b/.github/workflows/logs_on_demand.yml
@@ -1,0 +1,285 @@
+name: 'logs_on_demand'
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+# Linux build, test, and publish
+  linux-install:
+    name: "Linux | Install | ${{ matrix.compiler }} | ${{ matrix.config }} | ${{ matrix.vendored_dependencies }}"
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+        - gcc
+        config:
+        - release
+        vendored_dependencies: [true]
+
+    env:
+      artifact-name: sl-${{ github.run_number }}-linux-${{ matrix.compiler }}-${{ matrix.config }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
+      if: ${{ matrix.vendored_dependencies }}
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+      if: ${{ !matrix.vendored_dependencies }}
+
+    # Fetch tags for CMakeLists version check
+    # https://github.com/actions/checkout/issues/701
+    - name: Git fetch tags
+      run: git fetch --tags origin
+
+    - uses: ./.github/linux-setup
+      with:
+        compiler: ${{ matrix.compiler }}
+        ccache-key: linux-install-${{ matrix.compiler }}-${{ matrix.config }}
+
+    - name: Install vendored dependencies
+      if: ${{ !matrix.vendored_dependencies }}
+      run: |
+        git clone https://github.com/google/flatbuffers.git
+        pushd flatbuffers
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DBUILD_SHARED_LIBS=ON . && cmake --build build && sudo cmake --install build
+        popd
+
+        git clone https://github.com/google/googletest.git
+        pushd googletest
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DBUILD_SHARED_LIBS=ON . && cmake --build build && sudo cmake --install build
+        popd
+
+        git clone https://github.com/capnproto/capnproto.git
+        pushd capnproto
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DCMAKE_POSITION_INDEPENDENT_CODE=ON . && cmake --build build && sudo cmake --install build
+        popd
+
+        git clone https://github.com/chipsalliance/UHDM.git
+        pushd UHDM
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DUHDM_USE_HOST_GTEST=ON -DUHDM_USE_HOST_CAPNP=ON . && cmake --build build && sudo cmake --install build
+        popd
+
+        sudo mkdir -p /usr/share/java
+        sudo wget https://www.antlr.org/download/antlr-4.12.0-complete.jar -P /usr/share/java
+        wget https://www.antlr.org/download/antlr4-cpp-runtime-4.12.0-source.zip && mkdir antlr4
+        pushd antlr4
+        unzip ../antlr4-cpp-runtime-4.12.0-source.zip && cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DBUILD_SHARED_LIBS=ON . && cmake --build build && sudo cmake --install build
+        popd
+
+    - name: Build, install & test
+      run: |
+        if [ "${{ matrix.config }}" == "debug" ]; then
+          export BUILD_TYPE=Debug
+          export CMAKE_ADDITIONAL_ARGS=-DSURELOG_WITH_TCMALLOC=Off
+        else
+          export BUILD_TYPE=Release
+          export CMAKE_ADDITIONAL_ARGS=
+        fi
+
+        export INSTALL_DIR=`pwd`/install
+
+        if [ "${{ matrix.vendored_dependencies }}" == "false" ]; then
+          # Ensure that vendored dependencies' shared libraries are available
+          # for any run checks, such as those in the `TestInstall` project
+          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+        fi
+
+        if [ "${{ matrix.vendored_dependencies }}" == "false" ]; then
+          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DBUILD_SHARED_LIBS=ON -DSURELOG_USE_HOST_FLATBUFFERS=ON -DSURELOG_USE_HOST_ANTLR=ON -DSURELOG_USE_HOST_UHDM=ON -DSURELOG_USE_HOST_GTEST=ON -DSURELOG_WITH_TCMALLOC=OFF -DCMAKE_MODULE_PATH="/usr/share/CMake/Modules;/usr/local/lib/cmake" -S . -B build
+        else
+          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR $CMAKE_ADDITIONAL_ARGS -S . -B build
+        fi
+
+        cmake --build build -j $(nproc)
+        cmake --install build
+
+        cmake --build build --target UnitTests -j $(nproc)
+        pushd build && ctest --output-on-failure && popd
+
+        rm -rf build      # make sure we only see installation artifacts
+        
+        # this shouldnt be necessary, and can't be reproduced outside CI
+        export CMAKE_PREFIX_PATH=$INSTALL_DIR
+
+        if [ "${{ matrix.vendored_dependencies }}" == "false" ]; then
+          cmake -DCMAKE_BUILD_TYPE=Release -DINSTALL_DIR=$INSTALL_DIR -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DBUILD_SHARED_LIBS=ON -DSURELOG_USE_HOST_FLATBUFFERS=ON -DSURELOG_USE_HOST_ANTLR=ON -DSURELOG_USE_HOST_UHDM=ON -DSURELOG_USE_HOST_GTEST=ON -S tests/TestInstall -B tests/TestInstall/build
+        else
+          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DINSTALL_DIR=$INSTALL_DIR -S tests/TestInstall -B tests/TestInstall/build
+        fi
+
+        cmake --build tests/TestInstall/build -j $(nproc)
+
+        echo "-- pkg-config content --"
+        cat $INSTALL_DIR/lib/pkgconfig/Surelog.pc
+        PREFIX=$INSTALL_DIR make test_install_pkgconfig
+
+    - name: Prepare build artifacts
+      run: |
+        mkdir artifacts
+        mv install ${{ env.artifact-name }}
+        tar czfp artifacts/${{ env.artifact-name }}.tar.gz ${{ env.artifact-name }}
+      if: ${{ matrix.vendored_dependencies }}
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.artifact-name }}
+        path: artifacts/${{ env.artifact-name }}.tar.gz
+      if: ${{ matrix.vendored_dependencies }}
+
+
+# Linux regression
+  linux-regression:
+    name: "Linux | Regression | ${{ matrix.compiler }} | ${{ matrix.config }} [${{ matrix.shard }}]"
+    runs-on: ubuntu-20.04
+    needs: linux-install
+    strategy:
+      fail-fast: false
+      matrix:
+        num_shards: [6]
+        shard: [0, 1, 2, 3, 4, 5]
+        compiler:
+        - gcc
+        config:
+        - release
+    env:
+      build-artifact-name: sl-${{ github.run_number }}-linux-${{ matrix.compiler }}-${{ matrix.config }}
+      regression-artifact-name: sl-${{ github.run_number }}-linux-${{ matrix.compiler }}-${{ matrix.config }}-regression-${{ matrix.shard }}
+
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update -qq &&
+        sudo apt install -y google-perftools libgoogle-perftools-dev
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+        architecture: x64
+
+    - name: Setup Python Packages
+      run: |
+        pip3 install orderedmultidict
+        pip3 install psutil
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Download artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ env.build-artifact-name }}
+
+    - name: Run regression ${{ matrix.shard }}/${{ matrix.num_shards }}
+      timeout-minutes: 120
+      run: |
+        tar xzfp ${{ env.build-artifact-name }}.tar.gz
+        mv ${{ env.build-artifact-name }} build
+        rm ${{ env.build-artifact-name }}.tar.gz
+
+        python3 scripts/regression.py run       \
+          --uhdm-dump-filepath bin/uhdm-dump    \
+          --jobs $(nproc)                       \
+          --show-diffs                          \
+          --num_shards=${{ matrix.num_shards }} \
+          --shard=${{ matrix.shard }}
+        git status
+
+    - name: Prepare regression artifacts
+      if: always()
+      run: |
+        cd build
+        mv regression ${{ env.regression-artifact-name }}
+        find ${{ env.regression-artifact-name }} -name "*.tar.gz" | tar czfp ${{ env.regression-artifact-name }}.tar.gz -T -
+
+    - name: Upload regression artifacts
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.regression-artifact-name }}
+        path: build/${{ env.regression-artifact-name }}.tar.gz
+
+
+# Code formatting
+  CodeFormatting:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get install clang-format
+        clang-format --version
+
+    - name: Run formatting style check
+      run: ./.github/bin/run-clang-format.sh
+
+
+# Code Tideness
+  ClangTidy:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update -qq
+        sudo apt -qq -y install clang-tidy-12 \
+                                g++-9 default-jre cmake \
+                                uuid-dev build-essential
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+        architecture: x64
+
+    - name: Setup Python Packages
+      run: |
+        pip3 install orderedmultidict
+        pip3 install psutil
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Use ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: clang-tidy-codegen
+
+    - name: Configure shell
+      run: |
+        echo 'PATH=/usr/lib/ccache:'"$PATH" >> $GITHUB_ENV
+
+    - name: Prepare source
+      run: |
+        make run-cmake-release
+        make -j2 -C build GenerateParser
+        make -j2 -C build GenerateListeners
+        make -j2 -C build GenerateSerializer
+        ln -sf build/compile_commands.json .
+
+    - name: Run clang tidy
+      run: |
+        ./.github/bin/run-clang-tidy.sh limited


### PR DESCRIPTION
Strip-down workflow to generate logs

A full build across all platforms takes over 90 mins to finish. This is a strip down version of the main workflow that works on demand to build minimal to generate logs. Note that this is on-demand workflow so it doesn't automatically trigger with every push or pull_request.