### PR TITLE
Implement GC

### DIFF
--- a/include/Surelog/CommandLine/CommandLineParser.h
+++ b/include/Surelog/CommandLine/CommandLineParser.h
@@ -149,6 +149,7 @@ class CommandLineParser final {
   bool writeUhdm() const { return m_writeUhdm; }
   bool sepComp() const { return m_sepComp; }
   bool link() const { return m_link; }
+  bool gc() const { return m_gc; }
   void setParse(bool val) { m_parse = val; }
   void setParseOnly(bool val) { m_parseOnly = val; }
   void setLowMem(bool val) { m_lowMem = val; }
@@ -178,6 +179,7 @@ class CommandLineParser final {
   void setDebugUhdm(bool val) { m_dumpUhdm = val; }
   void setCoverUhdm(bool val) { m_coverUhdm = val; }
   void setWriteUhdm(bool val) { m_writeUhdm = val; }
+  void setGC(bool val) { m_gc = val; }
   void showVpiIds(bool val) { m_showVpiIDs = val; }
   void setDebugAstModel(bool val) { m_debugAstModel = val; }
   void setParametersSubstitution(bool val) { m_parametersubstitution = val; }
@@ -361,6 +363,7 @@ class CommandLineParser final {
   bool m_noCacheHash;
   bool m_sepComp;
   bool m_link;
+  bool m_gc;
 };
 
 }  // namespace SURELOG

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -249,6 +249,7 @@ static const std::initializer_list<std::string_view> helpText = {
     "                        <with> are expected to be absolute paths.",
     "  -exe <command>        Post execute a system call <command>, passes it",
     "                        the preprocessor file list.",
+    "  -nogc                 Disable garbage collection during save.",
     "  --help                This help",
     "  --version             Surelog version",
     "",
@@ -402,7 +403,8 @@ CommandLineParser::CommandLineParser(ErrorContainer* errors,
       m_nonSynthesizableWithFormal(false),
       m_noCacheHash(false),
       m_sepComp(false),
-      m_link(false) {
+      m_link(false),
+      m_gc(false) {
   if (FileSystem::getInstance() == nullptr) {
     // Ensures that instance gets created early!
     FileSystem::setInstance(new PlatformFileSystem(fs::current_path()));
@@ -1020,6 +1022,8 @@ bool CommandLineParser::parseCommandLine(int32_t argc, const char** argv) {
       }
       std::error_code ec;
       m_exeCommand = fs::weakly_canonical(exeCommand, ec).string();
+    } else if (all_arguments[i] == "-nogc") {
+      m_gc = false;
     }
 // No multiprocess on Windows platform, only multithreads
 #if defined(_MSC_VER) || defined(__MINGW32__) || defined(__CYGWIN__)

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -1990,7 +1990,7 @@ bool CompileHelper::compileTask(DesignComponent* component,
                   stmts->push_back(st);
                 } else {
                   any_cast<variables*>((expr*)stmt->Lhs())->VpiParent(begin);
-                  s.assign_stmtMaker.Erase(stmt);
+                  // s.Erase(stmt);
                 }
               } else {
                 stmts->push_back(st);
@@ -2036,7 +2036,7 @@ bool CompileHelper::compileTask(DesignComponent* component,
                 task->Stmt(st);
               } else {
                 any_cast<variables*>((expr*)stmt->Lhs())->VpiParent(task);
-                s.assign_stmtMaker.Erase(stmt);
+                // s.Erase(stmt);
               }
             } else {
               task->Stmt(st);
@@ -2405,7 +2405,7 @@ bool CompileHelper::compileFunction(DesignComponent* component,
                   stmts->push_back(st);
                 } else {
                   any_cast<variables*>((expr*)stmt->Lhs())->VpiParent(begin);
-                  s.assign_stmtMaker.Erase(stmt);
+                  // s.Erase(stmt);
                 }
               } else {
                 stmts->push_back(st);
@@ -2451,7 +2451,7 @@ bool CompileHelper::compileFunction(DesignComponent* component,
               func->Stmt(st);
             } else {
               any_cast<variables*>((expr*)stmt->Lhs())->VpiParent(func);
-              s.assign_stmtMaker.Erase(stmt);
+              // s.Erase(stmt);
             }
           } else {
             func->Stmt(st);

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -285,7 +285,7 @@ bool ElaborationStep::bindTypedefs_() {
         if (orig && (orig->UhdmType() == uhdmunsupported_typespec)) {
           const std::string_view need = orig->VpiName();
           if (need == tps->VpiName()) {
-            s.unsupported_typespecMaker.Erase((unsupported_typespec*)orig);
+            // s.Erase(orig);
             if (expr* ex = any_cast<expr*>(var)) {
               ex->Typespec(tps);
             } else if (typespec_member* ex = any_cast<typespec_member*>(var)) {
@@ -326,7 +326,7 @@ bool ElaborationStep::bindTypedefs_() {
           std::map<std::string, typespec*>::iterator itr = specs.find(need);
           if (itr != specs.end()) {
             typespec* tps = (*itr).second;
-            s.unsupported_typespecMaker.Erase((unsupported_typespec*)orig);
+            // s.Erase(orig);
             if (expr* ex = any_cast<expr*>(var)) {
               ex->Typespec(tps);
             } else if (typespec_member* ex = any_cast<typespec_member*>(var)) {
@@ -364,7 +364,7 @@ bool ElaborationStep::bindTypedefs_() {
 
         if (itr != specs.end()) {
           typespec* tps = (*itr).second;
-          s.unsupported_typespecMaker.Erase((unsupported_typespec*)orig);
+          // s.Erase(orig);
           if (expr* ex = any_cast<expr*>(var)) {
             ex->Typespec(tps);
           } else if (typespec_member* ex = any_cast<typespec_member*>(var)) {
@@ -400,7 +400,7 @@ bool ElaborationStep::bindTypedefs_() {
         std::map<std::string, typespec*>::iterator itr = specs.find(need);
         if (itr != specs.end()) {
           typespec* tps = (*itr).second;
-          s.unsupported_typespecMaker.Erase((unsupported_typespec*)orig);
+          // s.Erase(orig);
           if (expr* ex = any_cast<expr*>(var)) {
             ex->Typespec(tps);
           } else if (typespec_member* ex = any_cast<typespec_member*>(var)) {

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -4459,6 +4459,8 @@ vpiHandle UhdmWriter::write(PathId uhdmFileId) {
     m_compileDesign->getCompiler()->getErrorContainer()->addError(err);
     m_compileDesign->getCompiler()->getErrorContainer()->printMessages(
         m_compileDesign->getCompiler()->getCommandLineParser()->muteStdout());
+    s.SetGCEnabled(
+        m_compileDesign->getCompiler()->getCommandLineParser()->gc());
     s.Save(uhdmFile);
   }
 

--- a/tests/ArrayMethodIterator/ArrayMethodIterator.log
+++ b/tests/ArrayMethodIterator/ArrayMethodIterator.log
@@ -184,6 +184,7 @@ AST_DEBUG_END
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                         2
 array_var                                              2
+assign_stmt                                            3
 assignment                                             1
 begin                                                  1
 class_defn                                             3
@@ -208,6 +209,7 @@ type_parameter                                         2
 === UHDM Object Stats Begin (Elaborated Model) ===
 array_typespec                                         2
 array_var                                              6
+assign_stmt                                            3
 assignment                                             2
 begin                                                  2
 class_defn                                             3

--- a/tests/BindMethod/BindMethod.log
+++ b/tests/BindMethod/BindMethod.log
@@ -120,6 +120,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
+assign_stmt                                            2
 assignment                                             2
 begin                                                  2
 class_defn                                             4
@@ -139,6 +140,7 @@ task                                                   3
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
+assign_stmt                                            2
 assignment                                             4
 begin                                                  4
 class_defn                                             4

--- a/tests/Bindings/Bindings.log
+++ b/tests/Bindings/Bindings.log
@@ -1390,7 +1390,7 @@ ref_obj                                               69
 string_typespec                                        3
 sys_func_call                                          3
 task                                                   9
-unsupported_typespec                                   5
+unsupported_typespec                                   7
 === UHDM Object Stats End ===
 [INF:UH0707] Elaborating UHDM...
 
@@ -1436,7 +1436,7 @@ ref_obj                                               97
 string_typespec                                        3
 sys_func_call                                          3
 task                                                  18
-unsupported_typespec                                   5
+unsupported_typespec                                   7
 === UHDM Object Stats End ===
 [ERR:UH0718] ${SURELOG_DIR}/tests/Bindings/dut.sv:75:11: Illegal lhs of type wire "data_r".
 

--- a/tests/BlackBePipeInt/BlackBePipeInt.log
+++ b/tests/BlackBePipeInt/BlackBePipeInt.log
@@ -66,6 +66,7 @@ sys_func_call                                         25
 tagged_pattern                                     55611
 typespec_member                                    96306
 union_typespec                                         6
+unsupported_typespec                                   1
 === UHDM Object Stats End ===
 [INF:UH0707] Elaborating UHDM...
 
@@ -107,6 +108,7 @@ sys_func_call                                         31
 tagged_pattern                                     55611
 typespec_member                                    96306
 union_typespec                                         6
+unsupported_typespec                                   1
 === UHDM Object Stats End ===
 [INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/BlackBePipeInt/slpp_all/surelog.uhdm ...
 

--- a/tests/ClassFuncProto/ClassFuncProto.log
+++ b/tests/ClassFuncProto/ClassFuncProto.log
@@ -509,6 +509,7 @@ Instance tree:
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
+assign_stmt                                            1
 bit_typespec                                           1
 class_defn                                            13
 class_typespec                                         7
@@ -530,11 +531,12 @@ package                                                2
 range                                                  3
 ref_var                                                2
 task                                                  10
-unsupported_typespec                                   5
+unsupported_typespec                                   6
 === UHDM Object Stats End ===
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
+assign_stmt                                            1
 bit_typespec                                           7
 class_defn                                            16
 class_typespec                                        20
@@ -556,7 +558,7 @@ package                                                2
 range                                                 23
 ref_var                                               16
 task                                                  26
-unsupported_typespec                                   5
+unsupported_typespec                                   6
 === UHDM Object Stats End ===
 [INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/ClassFuncProto/slpp_all/surelog.uhdm ...
 

--- a/tests/ClassMemberFunc/ClassMemberFunc.log
+++ b/tests/ClassMemberFunc/ClassMemberFunc.log
@@ -104,7 +104,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
-assign_stmt                                            2
+assign_stmt                                            4
 begin                                                  2
 class_defn                                             2
 class_typespec                                         1
@@ -116,12 +116,12 @@ method_func_call                                       2
 package                                                2
 ref_obj                                                4
 ref_var                                                2
-unsupported_typespec                                   4
+unsupported_typespec                                   6
 === UHDM Object Stats End ===
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
-assign_stmt                                            4
+assign_stmt                                            6
 begin                                                  4
 class_defn                                             2
 class_typespec                                         2
@@ -133,7 +133,7 @@ method_func_call                                       4
 package                                                2
 ref_obj                                                8
 ref_var                                                8
-unsupported_typespec                                   4
+unsupported_typespec                                   6
 === UHDM Object Stats End ===
 [INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/ClassMemberFunc/slpp_all/surelog.uhdm ...
 

--- a/tests/ClassVar/ClassVar.log
+++ b/tests/ClassVar/ClassVar.log
@@ -150,7 +150,7 @@ AST_DEBUG_END
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                         2
 array_var                                              2
-assign_stmt                                            2
+assign_stmt                                            3
 begin                                                  2
 bit_select                                             2
 class_defn                                             2
@@ -177,7 +177,7 @@ unsupported_typespec                                   2
 === UHDM Object Stats Begin (Elaborated Model) ===
 array_typespec                                         2
 array_var                                              5
-assign_stmt                                            4
+assign_stmt                                            5
 begin                                                  4
 bit_select                                             4
 class_defn                                             2

--- a/tests/DollarRoot/DollarRoot.log
+++ b/tests/DollarRoot/DollarRoot.log
@@ -6758,7 +6758,7 @@ AST_DEBUG_END
 always                                                 9
 array_typespec                                        10
 array_var                                              5
-assign_stmt                                           32
+assign_stmt                                           53
 assignment                                            65
 begin                                                 84
 bit_select                                            42
@@ -6823,7 +6823,7 @@ wait_stmt                                              1
 always                                                18
 array_typespec                                        10
 array_var                                              5
-assign_stmt                                           50
+assign_stmt                                           71
 assignment                                           130
 begin                                                168
 bit_select                                            84

--- a/tests/EvalFunc/EvalFunc.log
+++ b/tests/EvalFunc/EvalFunc.log
@@ -748,7 +748,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
-assign_stmt                                            3
+assign_stmt                                            5
 assignment                                            15
 begin                                                  8
 constant                                             104
@@ -778,7 +778,7 @@ sys_func_call                                          1
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
-assign_stmt                                            6
+assign_stmt                                            8
 assignment                                            30
 begin                                                 16
 constant                                             104

--- a/tests/EvalFuncPack/EvalFuncPack.log
+++ b/tests/EvalFuncPack/EvalFuncPack.log
@@ -761,7 +761,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
-assign_stmt                                            6
+assign_stmt                                            8
 assignment                                             8
 begin                                                 10
 bit_select                                             4
@@ -800,7 +800,7 @@ task                                                   9
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
-assign_stmt                                           14
+assign_stmt                                           16
 assignment                                            17
 begin                                                 23
 bit_select                                            10

--- a/tests/ForLoopBind/ForLoopBind.log
+++ b/tests/ForLoopBind/ForLoopBind.log
@@ -498,7 +498,7 @@ AST_DEBUG_END
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                         2
 array_var                                              2
-assign_stmt                                            4
+assign_stmt                                            6
 assignment                                             4
 begin                                                  6
 class_defn                                            13
@@ -531,7 +531,7 @@ unsupported_typespec                                   4
 === UHDM Object Stats Begin (Elaborated Model) ===
 array_typespec                                         2
 array_var                                              4
-assign_stmt                                            6
+assign_stmt                                            8
 assignment                                             8
 begin                                                 12
 class_defn                                            13

--- a/tests/ForeachClass/ForeachClass.log
+++ b/tests/ForeachClass/ForeachClass.log
@@ -139,6 +139,7 @@ AST_DEBUG_END
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                         2
 array_var                                              2
+assign_stmt                                            2
 begin                                                  6
 bit_select                                             4
 class_defn                                             1
@@ -165,6 +166,7 @@ unsupported_typespec                                   2
 === UHDM Object Stats Begin (Elaborated Model) ===
 array_typespec                                         2
 array_var                                              4
+assign_stmt                                            2
 begin                                                 12
 bit_select                                             8
 class_defn                                             1

--- a/tests/ForeachForeach/ForeachForeach.log
+++ b/tests/ForeachForeach/ForeachForeach.log
@@ -128,6 +128,7 @@ AST_DEBUG_END
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                         3
 array_var                                              3
+assign_stmt                                            2
 assignment                                             2
 begin                                                  6
 bit_select                                             2
@@ -153,6 +154,7 @@ unsupported_typespec                                   6
 === UHDM Object Stats Begin (Elaborated Model) ===
 array_typespec                                         3
 array_var                                              8
+assign_stmt                                            2
 assignment                                             4
 begin                                                 12
 bit_select                                             4

--- a/tests/ForeachFunction/ForeachFunction.log
+++ b/tests/ForeachFunction/ForeachFunction.log
@@ -86,6 +86,7 @@ AST_DEBUG_END
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                         2
 array_var                                              2
+assign_stmt                                            1
 begin                                                  2
 constant                                               3
 design                                                 1
@@ -107,6 +108,7 @@ unsupported_typespec                                   3
 === UHDM Object Stats Begin (Elaborated Model) ===
 array_typespec                                         2
 array_var                                              5
+assign_stmt                                            1
 begin                                                  4
 constant                                               3
 design                                                 1

--- a/tests/FuncArgDirection/FuncArgDirection.log
+++ b/tests/FuncArgDirection/FuncArgDirection.log
@@ -496,7 +496,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
-assign_stmt                                            1
+assign_stmt                                            2
 assignment                                             1
 begin                                                  2
 bit_select                                             2
@@ -531,7 +531,7 @@ task                                                   9
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
-assign_stmt                                            2
+assign_stmt                                            3
 assignment                                             2
 begin                                                  4
 bit_select                                             4

--- a/tests/FuncDef2/FuncDef2.log
+++ b/tests/FuncDef2/FuncDef2.log
@@ -3651,7 +3651,7 @@ AST_DEBUG_END
 always                                                 7
 array_net                                              1
 array_typespec                                         1
-assign_stmt                                            3
+assign_stmt                                           37
 assignment                                           115
 begin                                                 97
 bit_select                                            39
@@ -3704,7 +3704,7 @@ unsupported_typespec                                  10
 always                                                11
 array_net                                              1
 array_typespec                                         1
-assign_stmt                                            6
+assign_stmt                                           40
 assignment                                           276
 begin                                                236
 bit_select                                            76

--- a/tests/FuncParam/FuncParam.log
+++ b/tests/FuncParam/FuncParam.log
@@ -37,6 +37,7 @@
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
+assign_stmt                                            1
 begin                                                  1
 class_defn                                             8
 class_typespec                                         4
@@ -66,6 +67,7 @@ task                                                   9
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
+assign_stmt                                            1
 begin                                                  3
 class_defn                                             8
 class_typespec                                         4

--- a/tests/FuncStruct/FuncStruct.log
+++ b/tests/FuncStruct/FuncStruct.log
@@ -256,6 +256,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
+assign_stmt                                            2
 assignment                                             4
 begin                                                  2
 bit_select                                             5
@@ -280,6 +281,7 @@ ref_obj                                                6
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
+assign_stmt                                            2
 assignment                                            10
 begin                                                  5
 bit_select                                            10

--- a/tests/IOClassStruct/IOClassStruct.log
+++ b/tests/IOClassStruct/IOClassStruct.log
@@ -128,6 +128,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
+assign_stmt                                            1
 assignment                                             1
 begin                                                  1
 class_defn                                             2
@@ -143,11 +144,12 @@ package                                                2
 ref_obj                                                4
 struct_typespec                                        1
 typespec_member                                        1
-unsupported_typespec                                   1
+unsupported_typespec                                   3
 === UHDM Object Stats End ===
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
+assign_stmt                                            1
 assignment                                             2
 begin                                                  2
 class_defn                                             2
@@ -163,7 +165,7 @@ package                                                2
 ref_obj                                                8
 struct_typespec                                        2
 typespec_member                                        2
-unsupported_typespec                                   1
+unsupported_typespec                                   3
 === UHDM Object Stats End ===
 [INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/IOClassStruct/slpp_all/surelog.uhdm ...
 

--- a/tests/Implicit/Implicit.log
+++ b/tests/Implicit/Implicit.log
@@ -132,270 +132,270 @@ ref_obj                                               14
 [INF:UH0711] Decompiling UHDM...
 
 ====== UHDM =======
-design: (work@dff_from_nand), id:28
+design: (work@dff_from_nand), id:29
 |vpiElaborated:1
 |vpiName:work@dff_from_nand
 |uhdmallModules:
-\_module_inst: work@dff_from_nand (work@dff_from_nand), id:29, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+\_module_inst: work@dff_from_nand (work@dff_from_nand), id:30, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
   |vpiParent:
-  \_design: (work@dff_from_nand), id:28
+  \_design: (work@dff_from_nand), id:29
   |vpiFullName:work@dff_from_nand
   |vpiDefName:work@dff_from_nand
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.Q), id:30, line:3:6, endln:3:7
+  \_logic_net: (work@dff_from_nand.Q), id:31, line:3:6, endln:3:7
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:29, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:30, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiTypespec:
-    \_logic_typespec: , id:31, line:3:1, endln:3:5
+    \_logic_typespec: , id:32, line:3:1, endln:3:5
     |vpiName:Q
     |vpiFullName:work@dff_from_nand.Q
     |vpiNetType:1
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.Q_BAR), id:32, line:3:8, endln:3:13
+  \_logic_net: (work@dff_from_nand.Q_BAR), id:33, line:3:8, endln:3:13
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:29, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:30, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiTypespec:
-    \_logic_typespec: , id:33, line:3:1, endln:3:5
+    \_logic_typespec: , id:34, line:3:1, endln:3:5
     |vpiName:Q_BAR
     |vpiFullName:work@dff_from_nand.Q_BAR
     |vpiNetType:1
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.D), id:34, line:4:6, endln:4:7
+  \_logic_net: (work@dff_from_nand.D), id:35, line:4:6, endln:4:7
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:29, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:30, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiTypespec:
-    \_logic_typespec: , id:35, line:4:1, endln:4:4
+    \_logic_typespec: , id:36, line:4:1, endln:4:4
     |vpiName:D
     |vpiFullName:work@dff_from_nand.D
     |vpiNetType:48
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.CLK), id:36, line:4:8, endln:4:11
+  \_logic_net: (work@dff_from_nand.CLK), id:37, line:4:8, endln:4:11
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:29, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:30, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiTypespec:
-    \_logic_typespec: , id:37, line:4:1, endln:4:4
+    \_logic_typespec: , id:38, line:4:1, endln:4:4
     |vpiName:CLK
     |vpiFullName:work@dff_from_nand.CLK
     |vpiNetType:48
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.X), id:38, line:6:10, endln:6:11
+  \_logic_net: (work@dff_from_nand.X), id:39, line:6:10, endln:6:11
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:29, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:30, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiName:X
     |vpiFullName:work@dff_from_nand.X
     |vpiNetType:1
   |vpiPrimitive:
-  \_gate: work@nand (work@dff_from_nand.U1), id:0, line:6:6, endln:6:18
+  \_gate: work@nand (work@dff_from_nand.U1), id:1, line:6:6, endln:6:18
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:29, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:30, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiDefName:work@nand
     |vpiName:U1
     |vpiFullName:work@dff_from_nand.U1
     |vpiPrimType:2
     |vpiPrimTerm:
-    \_prim_term: , id:1, line:6:10, endln:6:11
+    \_prim_term: , id:2, line:6:10, endln:6:11
       |vpiParent:
-      \_gate: work@nand (work@dff_from_nand.U1), id:0, line:6:6, endln:6:18
+      \_gate: work@nand (work@dff_from_nand.U1), id:1, line:6:6, endln:6:18
       |vpiDirection:2
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.U1.X), id:2, line:6:10, endln:6:11
+      \_ref_obj: (work@dff_from_nand.U1.X), id:3, line:6:10, endln:6:11
         |vpiParent:
-        \_gate: work@nand (work@dff_from_nand.U1), id:0, line:6:6, endln:6:18
+        \_gate: work@nand (work@dff_from_nand.U1), id:1, line:6:6, endln:6:18
         |vpiName:X
         |vpiFullName:work@dff_from_nand.U1.X
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.X), id:38, line:6:10, endln:6:11
+        \_logic_net: (work@dff_from_nand.X), id:39, line:6:10, endln:6:11
     |vpiPrimTerm:
-    \_prim_term: , id:3, line:6:12, endln:6:13
+    \_prim_term: , id:4, line:6:12, endln:6:13
       |vpiParent:
-      \_gate: work@nand (work@dff_from_nand.U1), id:0, line:6:6, endln:6:18
+      \_gate: work@nand (work@dff_from_nand.U1), id:1, line:6:6, endln:6:18
       |vpiDirection:1
       |vpiTermIndex:1
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.U1.D), id:4, line:6:12, endln:6:13
+      \_ref_obj: (work@dff_from_nand.U1.D), id:5, line:6:12, endln:6:13
         |vpiParent:
-        \_gate: work@nand (work@dff_from_nand.U1), id:0, line:6:6, endln:6:18
+        \_gate: work@nand (work@dff_from_nand.U1), id:1, line:6:6, endln:6:18
         |vpiName:D
         |vpiFullName:work@dff_from_nand.U1.D
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.D), id:34, line:4:6, endln:4:7
+        \_logic_net: (work@dff_from_nand.D), id:35, line:4:6, endln:4:7
     |vpiPrimTerm:
-    \_prim_term: , id:5, line:6:14, endln:6:17
+    \_prim_term: , id:6, line:6:14, endln:6:17
       |vpiParent:
-      \_gate: work@nand (work@dff_from_nand.U1), id:0, line:6:6, endln:6:18
+      \_gate: work@nand (work@dff_from_nand.U1), id:1, line:6:6, endln:6:18
       |vpiDirection:1
       |vpiTermIndex:2
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.U1.CLK), id:6, line:6:14, endln:6:17
+      \_ref_obj: (work@dff_from_nand.U1.CLK), id:7, line:6:14, endln:6:17
         |vpiParent:
-        \_gate: work@nand (work@dff_from_nand.U1), id:0, line:6:6, endln:6:18
+        \_gate: work@nand (work@dff_from_nand.U1), id:1, line:6:6, endln:6:18
         |vpiName:CLK
         |vpiFullName:work@dff_from_nand.U1.CLK
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.CLK), id:36, line:4:8, endln:4:11
+        \_logic_net: (work@dff_from_nand.CLK), id:37, line:4:8, endln:4:11
   |vpiPrimitive:
-  \_gate: work@not (work@dff_from_nand.work@not), id:7, line:7:5, endln:7:15
+  \_gate: work@not (work@dff_from_nand.work@not), id:8, line:7:5, endln:7:15
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:29, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:30, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiDefName:work@not
     |vpiFullName:work@dff_from_nand.work@not
     |vpiPrimType:8
     |vpiPrimTerm:
-    \_prim_term: , id:8, line:7:13, endln:7:14
+    \_prim_term: , id:9, line:7:13, endln:7:14
       |vpiParent:
-      \_gate: work@not (work@dff_from_nand.work@not), id:7, line:7:5, endln:7:15
+      \_gate: work@not (work@dff_from_nand.work@not), id:8, line:7:5, endln:7:15
       |vpiDirection:2
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.work@not.X), id:9, line:7:13, endln:7:14
+      \_ref_obj: (work@dff_from_nand.work@not.X), id:10, line:7:13, endln:7:14
         |vpiParent:
-        \_gate: work@not (work@dff_from_nand.work@not), id:7, line:7:5, endln:7:15
+        \_gate: work@not (work@dff_from_nand.work@not), id:8, line:7:5, endln:7:15
         |vpiName:X
         |vpiFullName:work@dff_from_nand.work@not.X
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.X), id:38, line:6:10, endln:6:11
+        \_logic_net: (work@dff_from_nand.X), id:39, line:6:10, endln:6:11
 |uhdmtopModules:
-\_module_inst: work@dff_from_nand (work@dff_from_nand), id:39, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+\_module_inst: work@dff_from_nand (work@dff_from_nand), id:40, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
   |vpiName:work@dff_from_nand
   |vpiDefName:work@dff_from_nand
   |vpiTop:1
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.Q), id:11, line:3:6, endln:3:7
+  \_logic_net: (work@dff_from_nand.Q), id:12, line:3:6, endln:3:7
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:39, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:40, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiTypespec:
-    \_logic_typespec: , id:10, line:3:1, endln:3:5
+    \_logic_typespec: , id:11, line:3:1, endln:3:5
       |vpiParent:
-      \_logic_net: (work@dff_from_nand.Q_BAR), id:12, line:3:8, endln:3:13
+      \_logic_net: (work@dff_from_nand.Q_BAR), id:13, line:3:8, endln:3:13
     |vpiName:Q
     |vpiFullName:work@dff_from_nand.Q
     |vpiNetType:1
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.Q_BAR), id:12, line:3:8, endln:3:13
+  \_logic_net: (work@dff_from_nand.Q_BAR), id:13, line:3:8, endln:3:13
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:39, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:40, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiTypespec:
-    \_logic_typespec: , id:10, line:3:1, endln:3:5
+    \_logic_typespec: , id:11, line:3:1, endln:3:5
     |vpiName:Q_BAR
     |vpiFullName:work@dff_from_nand.Q_BAR
     |vpiNetType:1
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.D), id:14, line:4:6, endln:4:7
+  \_logic_net: (work@dff_from_nand.D), id:15, line:4:6, endln:4:7
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:39, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:40, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiTypespec:
-    \_logic_typespec: , id:13, line:4:1, endln:4:4
+    \_logic_typespec: , id:14, line:4:1, endln:4:4
       |vpiParent:
-      \_logic_net: (work@dff_from_nand.CLK), id:15, line:4:8, endln:4:11
+      \_logic_net: (work@dff_from_nand.CLK), id:16, line:4:8, endln:4:11
     |vpiName:D
     |vpiFullName:work@dff_from_nand.D
     |vpiNetType:48
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.CLK), id:15, line:4:8, endln:4:11
+  \_logic_net: (work@dff_from_nand.CLK), id:16, line:4:8, endln:4:11
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:39, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:40, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiTypespec:
-    \_logic_typespec: , id:13, line:4:1, endln:4:4
+    \_logic_typespec: , id:14, line:4:1, endln:4:4
     |vpiName:CLK
     |vpiFullName:work@dff_from_nand.CLK
     |vpiNetType:48
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.X), id:18, line:6:10, endln:6:11
+  \_logic_net: (work@dff_from_nand.X), id:19, line:6:10, endln:6:11
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:39, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:40, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiName:X
     |vpiFullName:work@dff_from_nand.X
     |vpiNetType:1
   |vpiNet:
-  \_logic_net: (work@dff_from_nand.X_BAR), id:25, line:7:6, endln:7:11
+  \_logic_net: (work@dff_from_nand.X_BAR), id:26, line:7:6, endln:7:11
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:39, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:40, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiName:X_BAR
     |vpiFullName:work@dff_from_nand.X_BAR
     |vpiNetType:1
   |vpiTopModule:1
   |vpiPrimitive:
-  \_gate: work@nand (work@dff_from_nand.U1), id:47, line:6:6, endln:6:18
+  \_gate: work@nand (work@dff_from_nand.U1), id:48, line:6:6, endln:6:18
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:39, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:40, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiDefName:work@nand
     |vpiName:U1
     |vpiFullName:work@dff_from_nand.U1
     |vpiPrimType:2
     |vpiPrimTerm:
-    \_prim_term: , id:48, line:6:10, endln:6:11
+    \_prim_term: , id:49, line:6:10, endln:6:11
       |vpiParent:
-      \_gate: work@nand (work@dff_from_nand.U1), id:47, line:6:6, endln:6:18
+      \_gate: work@nand (work@dff_from_nand.U1), id:48, line:6:6, endln:6:18
       |vpiDirection:2
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.X), id:49, line:6:10, endln:6:11
+      \_ref_obj: (work@dff_from_nand.X), id:50, line:6:10, endln:6:11
         |vpiParent:
-        \_prim_term: , id:48, line:6:10, endln:6:11
+        \_prim_term: , id:49, line:6:10, endln:6:11
         |vpiName:X
         |vpiFullName:work@dff_from_nand.X
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.X), id:18, line:6:10, endln:6:11
+        \_logic_net: (work@dff_from_nand.X), id:19, line:6:10, endln:6:11
     |vpiPrimTerm:
-    \_prim_term: , id:50, line:6:12, endln:6:13
+    \_prim_term: , id:51, line:6:12, endln:6:13
       |vpiParent:
-      \_gate: work@nand (work@dff_from_nand.U1), id:47, line:6:6, endln:6:18
+      \_gate: work@nand (work@dff_from_nand.U1), id:48, line:6:6, endln:6:18
       |vpiDirection:1
       |vpiTermIndex:1
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.D), id:51, line:6:12, endln:6:13
+      \_ref_obj: (work@dff_from_nand.D), id:52, line:6:12, endln:6:13
         |vpiParent:
-        \_prim_term: , id:50, line:6:12, endln:6:13
+        \_prim_term: , id:51, line:6:12, endln:6:13
         |vpiName:D
         |vpiFullName:work@dff_from_nand.D
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.D), id:14, line:4:6, endln:4:7
+        \_logic_net: (work@dff_from_nand.D), id:15, line:4:6, endln:4:7
     |vpiPrimTerm:
-    \_prim_term: , id:52, line:6:14, endln:6:17
+    \_prim_term: , id:53, line:6:14, endln:6:17
       |vpiParent:
-      \_gate: work@nand (work@dff_from_nand.U1), id:47, line:6:6, endln:6:18
+      \_gate: work@nand (work@dff_from_nand.U1), id:48, line:6:6, endln:6:18
       |vpiDirection:1
       |vpiTermIndex:2
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.CLK), id:53, line:6:14, endln:6:17
+      \_ref_obj: (work@dff_from_nand.CLK), id:54, line:6:14, endln:6:17
         |vpiParent:
-        \_prim_term: , id:52, line:6:14, endln:6:17
+        \_prim_term: , id:53, line:6:14, endln:6:17
         |vpiName:CLK
         |vpiFullName:work@dff_from_nand.CLK
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.CLK), id:15, line:4:8, endln:4:11
+        \_logic_net: (work@dff_from_nand.CLK), id:16, line:4:8, endln:4:11
   |vpiPrimitive:
-  \_gate: work@not (work@dff_from_nand.), id:54, line:7:5, endln:7:15
+  \_gate: work@not (work@dff_from_nand.), id:55, line:7:5, endln:7:15
     |vpiParent:
-    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:39, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
+    \_module_inst: work@dff_from_nand (work@dff_from_nand), id:40, file:${SURELOG_DIR}/tests/Implicit/dut.sv, line:2:1, endln:8:10
     |vpiDefName:work@not
     |vpiFullName:work@dff_from_nand.
     |vpiPrimType:8
     |vpiPrimTerm:
-    \_prim_term: , id:55, line:7:6, endln:7:11
+    \_prim_term: , id:56, line:7:6, endln:7:11
       |vpiParent:
-      \_gate: work@not (work@dff_from_nand.), id:54, line:7:5, endln:7:15
+      \_gate: work@not (work@dff_from_nand.), id:55, line:7:5, endln:7:15
       |vpiDirection:2
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.X_BAR), id:56, line:7:6, endln:7:11
+      \_ref_obj: (work@dff_from_nand.X_BAR), id:57, line:7:6, endln:7:11
         |vpiParent:
-        \_prim_term: , id:55, line:7:6, endln:7:11
+        \_prim_term: , id:56, line:7:6, endln:7:11
         |vpiName:X_BAR
         |vpiFullName:work@dff_from_nand.X_BAR
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.X_BAR), id:25, line:7:6, endln:7:11
+        \_logic_net: (work@dff_from_nand.X_BAR), id:26, line:7:6, endln:7:11
     |vpiPrimTerm:
-    \_prim_term: , id:57, line:7:13, endln:7:14
+    \_prim_term: , id:58, line:7:13, endln:7:14
       |vpiParent:
-      \_gate: work@not (work@dff_from_nand.), id:54, line:7:5, endln:7:15
+      \_gate: work@not (work@dff_from_nand.), id:55, line:7:5, endln:7:15
       |vpiDirection:1
       |vpiTermIndex:1
       |vpiExpr:
-      \_ref_obj: (work@dff_from_nand.X), id:58, line:7:13, endln:7:14
+      \_ref_obj: (work@dff_from_nand.X), id:59, line:7:13, endln:7:14
         |vpiParent:
-        \_prim_term: , id:57, line:7:13, endln:7:14
+        \_prim_term: , id:58, line:7:13, endln:7:14
         |vpiName:X
         |vpiFullName:work@dff_from_nand.X
         |vpiActual:
-        \_logic_net: (work@dff_from_nand.X), id:18, line:6:10, endln:6:11
+        \_logic_net: (work@dff_from_nand.X), id:19, line:6:10, endln:6:11
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/ImportBinding/ImportBinding.log
+++ b/tests/ImportBinding/ImportBinding.log
@@ -143,7 +143,7 @@ param_assign                                          12
 parameter                                             14
 range                                                 13
 ref_obj                                                7
-unsupported_typespec                                   1
+unsupported_typespec                                   2
 === UHDM Object Stats End ===
 [INF:UH0707] Elaborating UHDM...
 
@@ -162,7 +162,7 @@ param_assign                                          12
 parameter                                             14
 range                                                 13
 ref_obj                                                7
-unsupported_typespec                                   1
+unsupported_typespec                                   2
 === UHDM Object Stats End ===
 [INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/ImportBinding/slpp_all/surelog.uhdm ...
 

--- a/tests/IncompFunc/IncompFunc.log
+++ b/tests/IncompFunc/IncompFunc.log
@@ -170,6 +170,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
+assign_stmt                                            1
 assignment                                             1
 begin                                                  1
 bit_select                                             1
@@ -199,6 +200,7 @@ return_stmt                                            1
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
+assign_stmt                                            1
 assignment                                             2
 begin                                                  2
 bit_select                                             2

--- a/tests/LibraryIntercon/LibraryIntercon.log
+++ b/tests/LibraryIntercon/LibraryIntercon.log
@@ -9,46 +9,46 @@ LIB: work
      ${SURELOG_DIR}/tests/LibraryIntercon/lib.map
 
 LIB: realLib
-     ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr
      ${SURELOG_DIR}/tests/LibraryIntercon/driver.svr
+     ${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr
 
 LIB: logicLib
+     ${SURELOG_DIR}/tests/LibraryIntercon/top.sv
      ${SURELOG_DIR}/tests/LibraryIntercon/driver.sv
      ${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv
-     ${SURELOG_DIR}/tests/LibraryIntercon/top.sv
 
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/nets.pkg".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/lib.map".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.svr".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.svr".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/top.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/tests/LibraryIntercon/top.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/nets.pkg".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.svr".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.svr".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.svr".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/top.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/driver.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/tests/LibraryIntercon/top.sv".
-
 [WRN:PA0205] ${SURELOG_DIR}/tests/LibraryIntercon/nets.pkg:1:1: No timescale set for "NetsPkg".
 
-[WRN:PA0205] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv:2:1: No timescale set for "cmp".
-
 [WRN:PA0205] ${SURELOG_DIR}/tests/LibraryIntercon/top.sv:1:1: No timescale set for "top".
+
+[WRN:PA0205] ${SURELOG_DIR}/tests/LibraryIntercon/cmp.sv:2:1: No timescale set for "cmp".
 
 [INF:CP0300] Compilation...
 

--- a/tests/LocalScopeHierPath/LocalScopeHierPath.log
+++ b/tests/LocalScopeHierPath/LocalScopeHierPath.log
@@ -164,7 +164,7 @@ AST_DEBUG_END
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                         2
 array_var                                              2
-assign_stmt                                            2
+assign_stmt                                            3
 begin                                                  3
 bit_select                                             2
 class_defn                                             2
@@ -191,7 +191,7 @@ unsupported_typespec                                   3
 === UHDM Object Stats Begin (Elaborated Model) ===
 array_typespec                                         2
 array_var                                              5
-assign_stmt                                            4
+assign_stmt                                            5
 begin                                                  6
 bit_select                                             4
 class_defn                                             2

--- a/tests/NamedEventHierPath/NamedEventHierPath.log
+++ b/tests/NamedEventHierPath/NamedEventHierPath.log
@@ -93,6 +93,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
+assign_stmt                                            1
 assignment                                             1
 begin                                                  1
 class_defn                                             1
@@ -111,6 +112,7 @@ unsupported_typespec                                   1
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
+assign_stmt                                            1
 assignment                                             2
 begin                                                  2
 class_defn                                             1

--- a/tests/PackFuncParent/PackFuncParent.log
+++ b/tests/PackFuncParent/PackFuncParent.log
@@ -242,6 +242,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
+assign_stmt                                            2
 assignment                                             2
 begin                                                  2
 constant                                              57
@@ -266,6 +267,7 @@ return_stmt                                            4
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
+assign_stmt                                            2
 assignment                                             4
 begin                                                  4
 constant                                              57

--- a/tests/PackageBind/PackageBind.log
+++ b/tests/PackageBind/PackageBind.log
@@ -172,7 +172,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
-assign_stmt                                            2
+assign_stmt                                            4
 assignment                                             2
 begin                                                  4
 constant                                              18
@@ -198,7 +198,7 @@ return_stmt                                            2
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
-assign_stmt                                            4
+assign_stmt                                            6
 assignment                                             4
 begin                                                  8
 constant                                              18

--- a/tests/PackageFuncCall/PackageFuncCall.log
+++ b/tests/PackageFuncCall/PackageFuncCall.log
@@ -778,7 +778,7 @@ AST_DEBUG_END
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 always                                                 1
-assign_stmt                                            2
+assign_stmt                                            4
 assignment                                             5
 begin                                                  4
 bit_select                                             3
@@ -818,7 +818,7 @@ var_select                                             1
 
 === UHDM Object Stats Begin (Elaborated Model) ===
 always                                                 2
-assign_stmt                                            4
+assign_stmt                                            6
 assignment                                            10
 begin                                                  8
 bit_select                                             6

--- a/tests/PackageHierRef/PackageHierRef.log
+++ b/tests/PackageHierRef/PackageHierRef.log
@@ -759,7 +759,7 @@ Instance tree:
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
-assign_stmt                                            1
+assign_stmt                                            9
 assignment                                             8
 class_defn                                             8
 class_typespec                                         4

--- a/tests/PackedEnumVar/PackedEnumVar.log
+++ b/tests/PackedEnumVar/PackedEnumVar.log
@@ -192,6 +192,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
+assign_stmt                                            1
 assignment                                             2
 begin                                                  1
 bit_select                                             2
@@ -220,6 +221,7 @@ return_stmt                                            1
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
+assign_stmt                                            1
 assignment                                             4
 begin                                                  2
 bit_select                                             4

--- a/tests/ParamNoSubst/ParamNoSubst.log
+++ b/tests/ParamNoSubst/ParamNoSubst.log
@@ -274,54 +274,54 @@ typespec_member                                       11
 [INF:UH0711] Decompiling UHDM...
 
 ====== UHDM =======
-design: (work@aes_core), id:150
+design: (work@aes_core), id:151
 |vpiElaborated:1
 |vpiName:work@aes_core
 |uhdmallPackages:
-\_package: aes_pkg (aes_pkg::), id:30, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+\_package: aes_pkg (aes_pkg::), id:31, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
   |vpiParent:
-  \_design: (work@aes_core), id:150
+  \_design: (work@aes_core), id:151
   |vpiName:aes_pkg
   |vpiFullName:aes_pkg::
   |vpiParameter:
-  \_parameter: (aes_pkg::CTRL_RESET), id:37, line:6:22, endln:6:32
+  \_parameter: (aes_pkg::CTRL_RESET), id:38, line:6:22, endln:6:32
     |vpiParent:
-    \_package: aes_pkg (aes_pkg::), id:30, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+    \_package: aes_pkg (aes_pkg::), id:31, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
     |vpiTypespec:
-    \_struct_typespec: (aes_pkg::ctrl_reg_t), id:31, line:2:9, endln:4:2
+    \_struct_typespec: (aes_pkg::ctrl_reg_t), id:32, line:2:9, endln:4:2
       |vpiParent:
-      \_package: aes_pkg (aes_pkg::), id:30, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+      \_package: aes_pkg (aes_pkg::), id:31, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
       |vpiName:aes_pkg::ctrl_reg_t
       |vpiInstance:
-      \_package: aes_pkg (aes_pkg::), id:30, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+      \_package: aes_pkg (aes_pkg::), id:31, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
       |vpiPacked:1
       |vpiTypespecMember:
-      \_typespec_member: (manual_operation), id:36, line:3:15, endln:3:31
+      \_typespec_member: (manual_operation), id:37, line:3:15, endln:3:31
         |vpiParent:
-        \_struct_typespec: (aes_pkg::ctrl_reg_t), id:31, line:2:9, endln:4:2
+        \_struct_typespec: (aes_pkg::ctrl_reg_t), id:32, line:2:9, endln:4:2
         |vpiName:manual_operation
         |vpiTypespec:
-        \_logic_typespec: , id:35, line:3:3, endln:3:14
+        \_logic_typespec: , id:36, line:3:3, endln:3:14
           |vpiParent:
-          \_typespec_member: (manual_operation), id:36, line:3:15, endln:3:31
+          \_typespec_member: (manual_operation), id:37, line:3:15, endln:3:31
           |vpiInstance:
-          \_package: aes_pkg (aes_pkg::), id:30, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+          \_package: aes_pkg (aes_pkg::), id:31, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
           |vpiRange:
-          \_range: , id:32, line:3:8, endln:3:14
+          \_range: , id:33, line:3:8, endln:3:14
             |vpiParent:
-            \_logic_typespec: , id:35, line:3:3, endln:3:14
+            \_logic_typespec: , id:36, line:3:3, endln:3:14
             |vpiLeftRange:
-            \_constant: , id:33, line:3:9, endln:3:11
+            \_constant: , id:34, line:3:9, endln:3:11
               |vpiParent:
-              \_range: , id:32, line:3:8, endln:3:14
+              \_range: , id:33, line:3:8, endln:3:14
               |vpiDecompile:31
               |vpiSize:64
               |UINT:31
               |vpiConstType:9
             |vpiRightRange:
-            \_constant: , id:34, line:3:12, endln:3:13
+            \_constant: , id:35, line:3:12, endln:3:13
               |vpiParent:
-              \_range: , id:32, line:3:8, endln:3:14
+              \_range: , id:33, line:3:8, endln:3:14
               |vpiDecompile:0
               |vpiSize:64
               |UINT:0
@@ -334,79 +334,79 @@ design: (work@aes_core), id:150
     |vpiName:CTRL_RESET
     |vpiFullName:aes_pkg::CTRL_RESET
   |vpiParamAssign:
-  \_param_assign: , id:43, line:6:22, endln:8:2
+  \_param_assign: , id:44, line:6:22, endln:8:2
     |vpiParent:
-    \_package: aes_pkg (aes_pkg::), id:30, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+    \_package: aes_pkg (aes_pkg::), id:31, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
     |vpiRhs:
-    \_operation: , id:56, line:6:35, endln:8:2
+    \_operation: , id:57, line:6:35, endln:8:2
       |vpiParent:
-      \_param_assign: , id:43, line:6:22, endln:8:2
+      \_param_assign: , id:44, line:6:22, endln:8:2
       |vpiOpType:75
       |vpiOperand:
-      \_tagged_pattern: , id:58, line:7:21, endln:7:23
+      \_tagged_pattern: , id:59, line:7:21, endln:7:23
         |vpiParent:
-        \_operation: , id:56, line:6:35, endln:8:2
+        \_operation: , id:57, line:6:35, endln:8:2
         |vpiPattern:
-        \_constant: , id:57, line:7:21, endln:7:23
+        \_constant: , id:58, line:7:21, endln:7:23
           |vpiDecompile:'0
           |vpiSize:-1
           |BIN:0
           |vpiConstType:3
         |vpiTypespec:
-        \_string_typespec: (manual_operation), id:59, line:7:3, endln:7:19
+        \_string_typespec: (manual_operation), id:60, line:7:3, endln:7:19
           |vpiParent:
-          \_tagged_pattern: , id:58, line:7:21, endln:7:23
+          \_tagged_pattern: , id:59, line:7:21, endln:7:23
           |vpiName:manual_operation
     |vpiLhs:
-    \_parameter: (aes_pkg::CTRL_RESET), id:37, line:6:22, endln:6:32
+    \_parameter: (aes_pkg::CTRL_RESET), id:38, line:6:22, endln:6:32
   |vpiTypedef:
-  \_struct_typespec: (aes_pkg::ctrl_reg_t), id:31, line:2:9, endln:4:2
+  \_struct_typespec: (aes_pkg::ctrl_reg_t), id:32, line:2:9, endln:4:2
   |vpiDefName:aes_pkg
 |uhdmtopPackages:
-\_package: aes_pkg (aes_pkg::), id:0, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+\_package: aes_pkg (aes_pkg::), id:1, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
   |vpiParent:
-  \_design: (work@aes_core), id:150
+  \_design: (work@aes_core), id:151
   |vpiName:aes_pkg
   |vpiFullName:aes_pkg::
   |vpiParameter:
-  \_parameter: (aes_pkg::CTRL_RESET), id:8, line:6:22, endln:6:32
+  \_parameter: (aes_pkg::CTRL_RESET), id:9, line:6:22, endln:6:32
     |vpiParent:
-    \_package: aes_pkg (aes_pkg::), id:0, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+    \_package: aes_pkg (aes_pkg::), id:1, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
     |vpiTypespec:
-    \_struct_typespec: (aes_pkg::ctrl_reg_t), id:1, line:2:9, endln:4:2
+    \_struct_typespec: (aes_pkg::ctrl_reg_t), id:2, line:2:9, endln:4:2
       |vpiParent:
-      \_module_inst: work@aes_core (work@aes_core), id:151, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
+      \_module_inst: work@aes_core (work@aes_core), id:152, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
       |vpiName:aes_pkg::ctrl_reg_t
       |vpiInstance:
-      \_package: aes_pkg (aes_pkg::), id:0, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+      \_package: aes_pkg (aes_pkg::), id:1, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
       |vpiPacked:1
       |vpiTypespecMember:
-      \_typespec_member: (manual_operation), id:7, line:3:15, endln:3:31
+      \_typespec_member: (manual_operation), id:8, line:3:15, endln:3:31
         |vpiParent:
-        \_struct_typespec: (aes_pkg::ctrl_reg_t), id:1, line:2:9, endln:4:2
+        \_struct_typespec: (aes_pkg::ctrl_reg_t), id:2, line:2:9, endln:4:2
         |vpiName:manual_operation
         |vpiTypespec:
-        \_logic_typespec: , id:6, line:3:3, endln:3:14
+        \_logic_typespec: , id:7, line:3:3, endln:3:14
           |vpiParent:
-          \_typespec_member: (manual_operation), id:7, line:3:15, endln:3:31
+          \_typespec_member: (manual_operation), id:8, line:3:15, endln:3:31
           |vpiInstance:
-          \_package: aes_pkg (aes_pkg::), id:0, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+          \_package: aes_pkg (aes_pkg::), id:1, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
           |vpiRange:
-          \_range: , id:2, line:3:8, endln:3:14
+          \_range: , id:3, line:3:8, endln:3:14
             |vpiParent:
-            \_logic_typespec: , id:6, line:3:3, endln:3:14
+            \_logic_typespec: , id:7, line:3:3, endln:3:14
             |vpiLeftRange:
-            \_constant: , id:3, line:3:9, endln:3:11
+            \_constant: , id:4, line:3:9, endln:3:11
               |vpiParent:
-              \_range: , id:2, line:3:8, endln:3:14
+              \_range: , id:3, line:3:8, endln:3:14
               |vpiDecompile:31
               |vpiSize:64
               |UINT:31
               |vpiConstType:9
             |vpiRightRange:
-            \_constant: , id:5, line:3:12, endln:3:13
+            \_constant: , id:6, line:3:12, endln:3:13
               |vpiParent:
-              \_range: , id:2, line:3:8, endln:3:14
+              \_range: , id:3, line:3:8, endln:3:14
               |vpiDecompile:0
               |vpiSize:64
               |UINT:0
@@ -419,79 +419,79 @@ design: (work@aes_core), id:150
     |vpiName:CTRL_RESET
     |vpiFullName:aes_pkg::CTRL_RESET
   |vpiParamAssign:
-  \_param_assign: , id:13, line:6:22, endln:8:2
+  \_param_assign: , id:14, line:6:22, endln:8:2
     |vpiParent:
-    \_package: aes_pkg (aes_pkg::), id:0, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+    \_package: aes_pkg (aes_pkg::), id:1, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
     |vpiRhs:
-    \_operation: , id:26, line:6:35, endln:8:2
+    \_operation: , id:27, line:6:35, endln:8:2
       |vpiParent:
-      \_param_assign: , id:13, line:6:22, endln:8:2
+      \_param_assign: , id:14, line:6:22, endln:8:2
       |vpiOpType:75
       |vpiOperand:
-      \_tagged_pattern: , id:28, line:7:21, endln:7:23
+      \_tagged_pattern: , id:29, line:7:21, endln:7:23
         |vpiParent:
-        \_operation: , id:26, line:6:35, endln:8:2
+        \_operation: , id:27, line:6:35, endln:8:2
         |vpiPattern:
-        \_constant: , id:27, line:7:21, endln:7:23
+        \_constant: , id:28, line:7:21, endln:7:23
           |vpiDecompile:'0
           |vpiSize:-1
           |BIN:0
           |vpiConstType:3
         |vpiTypespec:
-        \_string_typespec: (manual_operation), id:29, line:7:3, endln:7:19
+        \_string_typespec: (manual_operation), id:30, line:7:3, endln:7:19
           |vpiParent:
-          \_tagged_pattern: , id:28, line:7:21, endln:7:23
+          \_tagged_pattern: , id:29, line:7:21, endln:7:23
           |vpiName:manual_operation
     |vpiLhs:
-    \_parameter: (aes_pkg::CTRL_RESET), id:8, line:6:22, endln:6:32
+    \_parameter: (aes_pkg::CTRL_RESET), id:9, line:6:22, endln:6:32
   |vpiTypedef:
-  \_struct_typespec: (aes_pkg::ctrl_reg_t), id:1, line:2:9, endln:4:2
+  \_struct_typespec: (aes_pkg::ctrl_reg_t), id:2, line:2:9, endln:4:2
   |vpiDefName:aes_pkg
   |vpiTop:1
 |uhdmallModules:
-\_module_inst: work@aes_core (work@aes_core), id:151, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
+\_module_inst: work@aes_core (work@aes_core), id:152, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
   |vpiParent:
-  \_design: (work@aes_core), id:150
+  \_design: (work@aes_core), id:151
   |vpiFullName:work@aes_core
   |vpiParameter:
-  \_parameter: (work@aes_core.CTRL_RESET), id:60, line:6:22, endln:6:32
+  \_parameter: (work@aes_core.CTRL_RESET), id:61, line:6:22, endln:6:32
     |vpiParent:
-    \_module_inst: work@aes_core (work@aes_core), id:151, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
+    \_module_inst: work@aes_core (work@aes_core), id:152, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
     |vpiTypespec:
-    \_struct_typespec: (aes_pkg::ctrl_reg_t), id:61, line:2:9, endln:4:2
+    \_struct_typespec: (aes_pkg::ctrl_reg_t), id:62, line:2:9, endln:4:2
       |vpiParent:
-      \_parameter: (work@aes_core.CTRL_RESET), id:60, line:6:22, endln:6:32
+      \_parameter: (work@aes_core.CTRL_RESET), id:61, line:6:22, endln:6:32
       |vpiName:aes_pkg::ctrl_reg_t
       |vpiInstance:
-      \_package: aes_pkg (aes_pkg::), id:0, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+      \_package: aes_pkg (aes_pkg::), id:1, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
       |vpiPacked:1
       |vpiTypespecMember:
-      \_typespec_member: (manual_operation), id:62, line:3:15, endln:3:31
+      \_typespec_member: (manual_operation), id:63, line:3:15, endln:3:31
         |vpiParent:
-        \_struct_typespec: (aes_pkg::ctrl_reg_t), id:61, line:2:9, endln:4:2
+        \_struct_typespec: (aes_pkg::ctrl_reg_t), id:62, line:2:9, endln:4:2
         |vpiName:manual_operation
         |vpiTypespec:
-        \_logic_typespec: , id:63, line:3:3, endln:3:14
+        \_logic_typespec: , id:64, line:3:3, endln:3:14
           |vpiParent:
-          \_typespec_member: (manual_operation), id:62, line:3:15, endln:3:31
+          \_typespec_member: (manual_operation), id:63, line:3:15, endln:3:31
           |vpiInstance:
-          \_package: aes_pkg (aes_pkg::), id:0, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+          \_package: aes_pkg (aes_pkg::), id:1, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
           |vpiRange:
-          \_range: , id:64, line:3:8, endln:3:14
+          \_range: , id:65, line:3:8, endln:3:14
             |vpiParent:
-            \_logic_typespec: , id:63, line:3:3, endln:3:14
+            \_logic_typespec: , id:64, line:3:3, endln:3:14
             |vpiLeftRange:
-            \_constant: , id:65, line:3:9, endln:3:11
+            \_constant: , id:66, line:3:9, endln:3:11
               |vpiParent:
-              \_range: , id:64, line:3:8, endln:3:14
+              \_range: , id:65, line:3:8, endln:3:14
               |vpiDecompile:31
               |vpiSize:64
               |UINT:31
               |vpiConstType:9
             |vpiRightRange:
-            \_constant: , id:66, line:3:12, endln:3:13
+            \_constant: , id:67, line:3:12, endln:3:13
               |vpiParent:
-              \_range: , id:64, line:3:8, endln:3:14
+              \_range: , id:65, line:3:8, endln:3:14
               |vpiDecompile:0
               |vpiSize:64
               |UINT:0
@@ -505,70 +505,70 @@ design: (work@aes_core), id:150
     |vpiFullName:work@aes_core.CTRL_RESET
     |vpiImported:aes_pkg
   |vpiParamAssign:
-  \_param_assign: , id:67, line:6:22, endln:8:2
+  \_param_assign: , id:68, line:6:22, endln:8:2
     |vpiParent:
-    \_module_inst: work@aes_core (work@aes_core), id:151, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
+    \_module_inst: work@aes_core (work@aes_core), id:152, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
     |vpiRhs:
-    \_operation: , id:68, line:6:35, endln:8:2
+    \_operation: , id:69, line:6:35, endln:8:2
       |vpiParent:
-      \_param_assign: , id:67, line:6:22, endln:8:2
+      \_param_assign: , id:68, line:6:22, endln:8:2
       |vpiOpType:75
       |vpiOperand:
-      \_tagged_pattern: , id:69, line:7:21, endln:7:23
+      \_tagged_pattern: , id:70, line:7:21, endln:7:23
         |vpiParent:
-        \_operation: , id:68, line:6:35, endln:8:2
+        \_operation: , id:69, line:6:35, endln:8:2
         |vpiPattern:
-        \_constant: , id:71, line:7:21, endln:7:23
+        \_constant: , id:72, line:7:21, endln:7:23
           |vpiParent:
-          \_tagged_pattern: , id:69, line:7:21, endln:7:23
+          \_tagged_pattern: , id:70, line:7:21, endln:7:23
           |vpiDecompile:'0
           |vpiSize:-1
           |BIN:0
           |vpiConstType:3
         |vpiTypespec:
-        \_string_typespec: (manual_operation), id:70, line:7:3, endln:7:19
+        \_string_typespec: (manual_operation), id:71, line:7:3, endln:7:19
           |vpiParent:
-          \_tagged_pattern: , id:69, line:7:21, endln:7:23
+          \_tagged_pattern: , id:70, line:7:21, endln:7:23
           |vpiName:manual_operation
     |vpiLhs:
-    \_parameter: (work@aes_core.CTRL_RESET), id:72, line:6:22, endln:6:32
+    \_parameter: (work@aes_core.CTRL_RESET), id:73, line:6:22, endln:6:32
       |vpiParent:
-      \_param_assign: , id:67, line:6:22, endln:8:2
+      \_param_assign: , id:68, line:6:22, endln:8:2
       |vpiTypespec:
-      \_struct_typespec: (aes_pkg::ctrl_reg_t), id:73, line:2:9, endln:4:2
+      \_struct_typespec: (aes_pkg::ctrl_reg_t), id:74, line:2:9, endln:4:2
         |vpiParent:
-        \_parameter: (work@aes_core.CTRL_RESET), id:72, line:6:22, endln:6:32
+        \_parameter: (work@aes_core.CTRL_RESET), id:73, line:6:22, endln:6:32
         |vpiName:aes_pkg::ctrl_reg_t
         |vpiInstance:
-        \_package: aes_pkg (aes_pkg::), id:0, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+        \_package: aes_pkg (aes_pkg::), id:1, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
         |vpiPacked:1
         |vpiTypespecMember:
-        \_typespec_member: (manual_operation), id:74, line:3:15, endln:3:31
+        \_typespec_member: (manual_operation), id:75, line:3:15, endln:3:31
           |vpiParent:
-          \_struct_typespec: (aes_pkg::ctrl_reg_t), id:73, line:2:9, endln:4:2
+          \_struct_typespec: (aes_pkg::ctrl_reg_t), id:74, line:2:9, endln:4:2
           |vpiName:manual_operation
           |vpiTypespec:
-          \_logic_typespec: , id:75, line:3:3, endln:3:14
+          \_logic_typespec: , id:76, line:3:3, endln:3:14
             |vpiParent:
-            \_typespec_member: (manual_operation), id:74, line:3:15, endln:3:31
+            \_typespec_member: (manual_operation), id:75, line:3:15, endln:3:31
             |vpiInstance:
-            \_package: aes_pkg (aes_pkg::), id:0, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+            \_package: aes_pkg (aes_pkg::), id:1, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
             |vpiRange:
-            \_range: , id:76, line:3:8, endln:3:14
+            \_range: , id:77, line:3:8, endln:3:14
               |vpiParent:
-              \_logic_typespec: , id:75, line:3:3, endln:3:14
+              \_logic_typespec: , id:76, line:3:3, endln:3:14
               |vpiLeftRange:
-              \_constant: , id:77, line:3:9, endln:3:11
+              \_constant: , id:78, line:3:9, endln:3:11
                 |vpiParent:
-                \_range: , id:76, line:3:8, endln:3:14
+                \_range: , id:77, line:3:8, endln:3:14
                 |vpiDecompile:31
                 |vpiSize:64
                 |UINT:31
                 |vpiConstType:9
               |vpiRightRange:
-              \_constant: , id:78, line:3:12, endln:3:13
+              \_constant: , id:79, line:3:12, endln:3:13
                 |vpiParent:
-                \_range: , id:76, line:3:8, endln:3:14
+                \_range: , id:77, line:3:8, endln:3:14
                 |vpiDecompile:0
                 |vpiSize:64
                 |UINT:0
@@ -582,56 +582,56 @@ design: (work@aes_core), id:150
       |vpiFullName:work@aes_core.CTRL_RESET
       |vpiImported:aes_pkg
   |vpiTypedef:
-  \_struct_typespec: (aes_pkg::ctrl_reg_t), id:1, line:2:9, endln:4:2
+  \_struct_typespec: (aes_pkg::ctrl_reg_t), id:2, line:2:9, endln:4:2
   |vpiTypedef:
-  \_import_typespec: (aes_pkg), id:79, line:23:10, endln:23:20
+  \_import_typespec: (aes_pkg), id:80, line:23:10, endln:23:20
   |vpiDefName:work@aes_core
   |vpiNet:
-  \_logic_net: (work@aes_core.ctrl_q), id:152, line:24:14, endln:24:20
+  \_logic_net: (work@aes_core.ctrl_q), id:153, line:24:14, endln:24:20
     |vpiParent:
-    \_module_inst: work@aes_core (work@aes_core), id:151, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
+    \_module_inst: work@aes_core (work@aes_core), id:152, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
     |vpiTypespec:
-    \_struct_typespec: (aes_pkg::ctrl_reg_t), id:1, line:2:9, endln:4:2
+    \_struct_typespec: (aes_pkg::ctrl_reg_t), id:2, line:2:9, endln:4:2
     |vpiName:ctrl_q
     |vpiFullName:work@aes_core.ctrl_q
   |vpiRefModule:
-  \_ref_module: work@prim_subreg_shadow (ctrl_shadowed_reg), id:81, line:25:45, endln:25:62
+  \_ref_module: work@prim_subreg_shadow (ctrl_shadowed_reg), id:82, line:25:45, endln:25:62
     |vpiParent:
-    \_module_inst: work@aes_core (work@aes_core), id:151, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
+    \_module_inst: work@aes_core (work@aes_core), id:152, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
     |vpiName:ctrl_shadowed_reg
     |vpiDefName:work@prim_subreg_shadow
     |vpiActual:
-    \_module_inst: work@prim_subreg_shadow (work@prim_subreg_shadow), id:154, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:16:1, endln:20:10
+    \_module_inst: work@prim_subreg_shadow (work@prim_subreg_shadow), id:155, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:16:1, endln:20:10
 |uhdmallModules:
-\_module_inst: work@prim_subreg (work@prim_subreg), id:153, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:11:1, endln:14:10
+\_module_inst: work@prim_subreg (work@prim_subreg), id:154, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:11:1, endln:14:10
   |vpiParent:
-  \_design: (work@aes_core), id:150
+  \_design: (work@aes_core), id:151
   |vpiFullName:work@prim_subreg
   |vpiParameter:
-  \_parameter: (work@prim_subreg.RESVAL), id:86, line:12:26, endln:12:32
+  \_parameter: (work@prim_subreg.RESVAL), id:87, line:12:26, endln:12:32
     |vpiParent:
-    \_module_inst: work@prim_subreg (work@prim_subreg), id:153, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:11:1, endln:14:10
+    \_module_inst: work@prim_subreg (work@prim_subreg), id:154, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:11:1, endln:14:10
     |BIN:0
     |vpiTypespec:
-    \_logic_typespec: , id:85, line:12:13, endln:12:25
+    \_logic_typespec: , id:86, line:12:13, endln:12:25
       |vpiParent:
-      \_parameter: (work@prim_subreg.RESVAL), id:86, line:12:26, endln:12:32
+      \_parameter: (work@prim_subreg.RESVAL), id:87, line:12:26, endln:12:32
       |vpiRange:
-      \_range: , id:82, line:12:19, endln:12:25
+      \_range: , id:83, line:12:19, endln:12:25
         |vpiParent:
-        \_logic_typespec: , id:85, line:12:13, endln:12:25
+        \_logic_typespec: , id:86, line:12:13, endln:12:25
         |vpiLeftRange:
-        \_constant: , id:83, line:12:20, endln:12:22
+        \_constant: , id:84, line:12:20, endln:12:22
           |vpiParent:
-          \_range: , id:82, line:12:19, endln:12:25
+          \_range: , id:83, line:12:19, endln:12:25
           |vpiDecompile:31
           |vpiSize:64
           |UINT:31
           |vpiConstType:9
         |vpiRightRange:
-        \_constant: , id:84, line:12:23, endln:12:24
+        \_constant: , id:85, line:12:23, endln:12:24
           |vpiParent:
-          \_range: , id:82, line:12:19, endln:12:25
+          \_range: , id:83, line:12:19, endln:12:25
           |vpiDecompile:0
           |vpiSize:64
           |UINT:0
@@ -639,52 +639,52 @@ design: (work@aes_core), id:150
     |vpiName:RESVAL
     |vpiFullName:work@prim_subreg.RESVAL
   |vpiParamAssign:
-  \_param_assign: , id:87, line:12:26, endln:12:37
+  \_param_assign: , id:88, line:12:26, endln:12:37
     |vpiParent:
-    \_module_inst: work@prim_subreg (work@prim_subreg), id:153, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:11:1, endln:14:10
+    \_module_inst: work@prim_subreg (work@prim_subreg), id:154, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:11:1, endln:14:10
     |vpiRhs:
-    \_constant: , id:88, line:12:35, endln:12:37
+    \_constant: , id:89, line:12:35, endln:12:37
       |vpiParent:
-      \_param_assign: , id:87, line:12:26, endln:12:37
+      \_param_assign: , id:88, line:12:26, endln:12:37
       |vpiDecompile:'0
       |vpiSize:32
       |BIN:0
       |vpiTypespec:
-      \_logic_typespec: , id:85, line:12:13, endln:12:25
+      \_logic_typespec: , id:86, line:12:13, endln:12:25
       |vpiConstType:3
     |vpiLhs:
-    \_parameter: (work@prim_subreg.RESVAL), id:86, line:12:26, endln:12:32
+    \_parameter: (work@prim_subreg.RESVAL), id:87, line:12:26, endln:12:32
   |vpiDefName:work@prim_subreg
 |uhdmallModules:
-\_module_inst: work@prim_subreg_shadow (work@prim_subreg_shadow), id:154, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:16:1, endln:20:10
+\_module_inst: work@prim_subreg_shadow (work@prim_subreg_shadow), id:155, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:16:1, endln:20:10
   |vpiParent:
-  \_design: (work@aes_core), id:150
+  \_design: (work@aes_core), id:151
   |vpiFullName:work@prim_subreg_shadow
   |vpiParameter:
-  \_parameter: (work@prim_subreg_shadow.RESVAL), id:94, line:17:26, endln:17:32
+  \_parameter: (work@prim_subreg_shadow.RESVAL), id:95, line:17:26, endln:17:32
     |vpiParent:
-    \_module_inst: work@prim_subreg_shadow (work@prim_subreg_shadow), id:154, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:16:1, endln:20:10
+    \_module_inst: work@prim_subreg_shadow (work@prim_subreg_shadow), id:155, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:16:1, endln:20:10
     |BIN:0
     |vpiTypespec:
-    \_logic_typespec: , id:93, line:17:13, endln:17:25
+    \_logic_typespec: , id:94, line:17:13, endln:17:25
       |vpiParent:
-      \_parameter: (work@prim_subreg_shadow.RESVAL), id:94, line:17:26, endln:17:32
+      \_parameter: (work@prim_subreg_shadow.RESVAL), id:95, line:17:26, endln:17:32
       |vpiRange:
-      \_range: , id:90, line:17:19, endln:17:25
+      \_range: , id:91, line:17:19, endln:17:25
         |vpiParent:
-        \_logic_typespec: , id:93, line:17:13, endln:17:25
+        \_logic_typespec: , id:94, line:17:13, endln:17:25
         |vpiLeftRange:
-        \_constant: , id:91, line:17:20, endln:17:22
+        \_constant: , id:92, line:17:20, endln:17:22
           |vpiParent:
-          \_range: , id:90, line:17:19, endln:17:25
+          \_range: , id:91, line:17:19, endln:17:25
           |vpiDecompile:31
           |vpiSize:64
           |UINT:31
           |vpiConstType:9
         |vpiRightRange:
-        \_constant: , id:92, line:17:23, endln:17:24
+        \_constant: , id:93, line:17:23, endln:17:24
           |vpiParent:
-          \_range: , id:90, line:17:19, endln:17:25
+          \_range: , id:91, line:17:19, endln:17:25
           |vpiDecompile:0
           |vpiSize:64
           |UINT:0
@@ -692,72 +692,72 @@ design: (work@aes_core), id:150
     |vpiName:RESVAL
     |vpiFullName:work@prim_subreg_shadow.RESVAL
   |vpiParamAssign:
-  \_param_assign: , id:95, line:17:26, endln:17:37
+  \_param_assign: , id:96, line:17:26, endln:17:37
     |vpiParent:
-    \_module_inst: work@prim_subreg_shadow (work@prim_subreg_shadow), id:154, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:16:1, endln:20:10
+    \_module_inst: work@prim_subreg_shadow (work@prim_subreg_shadow), id:155, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:16:1, endln:20:10
     |vpiRhs:
-    \_constant: , id:96, line:17:35, endln:17:37
+    \_constant: , id:97, line:17:35, endln:17:37
       |vpiParent:
-      \_param_assign: , id:95, line:17:26, endln:17:37
+      \_param_assign: , id:96, line:17:26, endln:17:37
       |vpiDecompile:'0
       |vpiSize:32
       |BIN:0
       |vpiTypespec:
-      \_logic_typespec: , id:93, line:17:13, endln:17:25
+      \_logic_typespec: , id:94, line:17:13, endln:17:25
       |vpiConstType:3
     |vpiLhs:
-    \_parameter: (work@prim_subreg_shadow.RESVAL), id:94, line:17:26, endln:17:32
+    \_parameter: (work@prim_subreg_shadow.RESVAL), id:95, line:17:26, endln:17:32
   |vpiDefName:work@prim_subreg_shadow
   |vpiRefModule:
-  \_ref_module: work@prim_subreg (committed_reg), id:98, line:19:34, endln:19:47
+  \_ref_module: work@prim_subreg (committed_reg), id:99, line:19:34, endln:19:47
     |vpiParent:
-    \_module_inst: work@prim_subreg_shadow (work@prim_subreg_shadow), id:154, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:16:1, endln:20:10
+    \_module_inst: work@prim_subreg_shadow (work@prim_subreg_shadow), id:155, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:16:1, endln:20:10
     |vpiName:committed_reg
     |vpiDefName:work@prim_subreg
     |vpiActual:
-    \_module_inst: work@prim_subreg (work@prim_subreg), id:153, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:11:1, endln:14:10
+    \_module_inst: work@prim_subreg (work@prim_subreg), id:154, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:11:1, endln:14:10
 |uhdmtopModules:
-\_module_inst: work@aes_core (work@aes_core), id:155, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
+\_module_inst: work@aes_core (work@aes_core), id:156, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
   |vpiName:work@aes_core
   |vpiParameter:
-  \_parameter: (work@aes_core.CTRL_RESET), id:156, line:6:22, endln:6:32
+  \_parameter: (work@aes_core.CTRL_RESET), id:157, line:6:22, endln:6:32
     |vpiParent:
-    \_module_inst: work@aes_core (work@aes_core), id:155, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
+    \_module_inst: work@aes_core (work@aes_core), id:156, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
     |vpiTypespec:
-    \_struct_typespec: (aes_pkg::ctrl_reg_t), id:157, line:2:9, endln:4:2
+    \_struct_typespec: (aes_pkg::ctrl_reg_t), id:158, line:2:9, endln:4:2
       |vpiParent:
-      \_parameter: (work@aes_core.CTRL_RESET), id:156, line:6:22, endln:6:32
+      \_parameter: (work@aes_core.CTRL_RESET), id:157, line:6:22, endln:6:32
       |vpiName:aes_pkg::ctrl_reg_t
       |vpiInstance:
-      \_package: aes_pkg (aes_pkg::), id:0, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+      \_package: aes_pkg (aes_pkg::), id:1, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
       |vpiPacked:1
       |vpiTypespecMember:
-      \_typespec_member: (manual_operation), id:158, line:3:15, endln:3:31
+      \_typespec_member: (manual_operation), id:159, line:3:15, endln:3:31
         |vpiParent:
-        \_struct_typespec: (aes_pkg::ctrl_reg_t), id:157, line:2:9, endln:4:2
+        \_struct_typespec: (aes_pkg::ctrl_reg_t), id:158, line:2:9, endln:4:2
         |vpiName:manual_operation
         |vpiTypespec:
-        \_logic_typespec: , id:159, line:3:3, endln:3:14
+        \_logic_typespec: , id:160, line:3:3, endln:3:14
           |vpiParent:
-          \_typespec_member: (manual_operation), id:158, line:3:15, endln:3:31
+          \_typespec_member: (manual_operation), id:159, line:3:15, endln:3:31
           |vpiInstance:
-          \_package: aes_pkg (aes_pkg::), id:0, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+          \_package: aes_pkg (aes_pkg::), id:1, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
           |vpiRange:
-          \_range: , id:160, line:3:8, endln:3:14
+          \_range: , id:161, line:3:8, endln:3:14
             |vpiParent:
-            \_logic_typespec: , id:159, line:3:3, endln:3:14
+            \_logic_typespec: , id:160, line:3:3, endln:3:14
             |vpiLeftRange:
-            \_constant: , id:161, line:3:9, endln:3:11
+            \_constant: , id:162, line:3:9, endln:3:11
               |vpiParent:
-              \_range: , id:160, line:3:8, endln:3:14
+              \_range: , id:161, line:3:8, endln:3:14
               |vpiDecompile:31
               |vpiSize:64
               |UINT:31
               |vpiConstType:9
             |vpiRightRange:
-            \_constant: , id:162, line:3:12, endln:3:13
+            \_constant: , id:163, line:3:12, endln:3:13
               |vpiParent:
-              \_range: , id:160, line:3:8, endln:3:14
+              \_range: , id:161, line:3:8, endln:3:14
               |vpiDecompile:0
               |vpiSize:64
               |UINT:0
@@ -771,48 +771,48 @@ design: (work@aes_core), id:150
     |vpiFullName:work@aes_core.CTRL_RESET
     |vpiImported:aes_pkg
   |vpiParamAssign:
-  \_param_assign: , id:109, line:6:22, endln:8:2
+  \_param_assign: , id:110, line:6:22, endln:8:2
     |vpiParent:
-    \_module_inst: work@aes_core (work@aes_core), id:155, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
+    \_module_inst: work@aes_core (work@aes_core), id:156, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
     |vpiRhs:
-    \_operation: , id:121, line:6:35, endln:8:2
+    \_operation: , id:122, line:6:35, endln:8:2
       |vpiParent:
-      \_param_assign: , id:109, line:6:22, endln:8:2
+      \_param_assign: , id:110, line:6:22, endln:8:2
       |vpiTypespec:
-      \_struct_typespec: (aes_pkg::ctrl_reg_t), id:122, line:2:9, endln:4:2
+      \_struct_typespec: (aes_pkg::ctrl_reg_t), id:123, line:2:9, endln:4:2
         |vpiParent:
-        \_operation: , id:121, line:6:35, endln:8:2
+        \_operation: , id:122, line:6:35, endln:8:2
         |vpiName:aes_pkg::ctrl_reg_t
         |vpiInstance:
-        \_package: aes_pkg (aes_pkg::), id:0, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+        \_package: aes_pkg (aes_pkg::), id:1, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
         |vpiPacked:1
         |vpiTypespecMember:
-        \_typespec_member: (manual_operation), id:123, line:3:15, endln:3:31
+        \_typespec_member: (manual_operation), id:124, line:3:15, endln:3:31
           |vpiParent:
-          \_struct_typespec: (aes_pkg::ctrl_reg_t), id:122, line:2:9, endln:4:2
+          \_struct_typespec: (aes_pkg::ctrl_reg_t), id:123, line:2:9, endln:4:2
           |vpiName:manual_operation
           |vpiTypespec:
-          \_logic_typespec: , id:124, line:3:3, endln:3:14
+          \_logic_typespec: , id:125, line:3:3, endln:3:14
             |vpiParent:
-            \_typespec_member: (manual_operation), id:123, line:3:15, endln:3:31
+            \_typespec_member: (manual_operation), id:124, line:3:15, endln:3:31
             |vpiInstance:
-            \_package: aes_pkg (aes_pkg::), id:0, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
+            \_package: aes_pkg (aes_pkg::), id:1, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:1:1, endln:9:11
             |vpiRange:
-            \_range: , id:125, line:3:8, endln:3:14
+            \_range: , id:126, line:3:8, endln:3:14
               |vpiParent:
-              \_logic_typespec: , id:124, line:3:3, endln:3:14
+              \_logic_typespec: , id:125, line:3:3, endln:3:14
               |vpiLeftRange:
-              \_constant: , id:126, line:3:9, endln:3:11
+              \_constant: , id:127, line:3:9, endln:3:11
                 |vpiParent:
-                \_range: , id:125, line:3:8, endln:3:14
+                \_range: , id:126, line:3:8, endln:3:14
                 |vpiDecompile:31
                 |vpiSize:64
                 |UINT:31
                 |vpiConstType:9
               |vpiRightRange:
-              \_constant: , id:127, line:3:12, endln:3:13
+              \_constant: , id:128, line:3:12, endln:3:13
                 |vpiParent:
-                \_range: , id:125, line:3:8, endln:3:14
+                \_range: , id:126, line:3:8, endln:3:14
                 |vpiDecompile:0
                 |vpiSize:64
                 |UINT:0
@@ -824,61 +824,61 @@ design: (work@aes_core), id:150
           |vpiRefEndColumnNo:14
       |vpiOpType:75
       |vpiOperand:
-      \_constant: , id:130, line:7:21, endln:7:23
+      \_constant: , id:131, line:7:21, endln:7:23
         |vpiParent:
-        \_operation: , id:131, line:6:35, endln:8:2
+        \_operation: , id:132, line:6:35, endln:8:2
         |vpiDecompile:0
         |vpiSize:32
         |UINT:0
         |vpiConstType:9
     |vpiLhs:
-    \_parameter: (work@aes_core.CTRL_RESET), id:156, line:6:22, endln:6:32
+    \_parameter: (work@aes_core.CTRL_RESET), id:157, line:6:22, endln:6:32
   |vpiTypedef:
-  \_struct_typespec: (aes_pkg::ctrl_reg_t), id:1, line:2:9, endln:4:2
+  \_struct_typespec: (aes_pkg::ctrl_reg_t), id:2, line:2:9, endln:4:2
   |vpiTypedef:
-  \_import_typespec: (aes_pkg), id:79, line:23:10, endln:23:20
+  \_import_typespec: (aes_pkg), id:80, line:23:10, endln:23:20
   |vpiDefName:work@aes_core
   |vpiTop:1
   |vpiNet:
-  \_struct_net: (work@aes_core.ctrl_q), id:141, line:24:14, endln:24:20
+  \_struct_net: (work@aes_core.ctrl_q), id:142, line:24:14, endln:24:20
     |vpiParent:
-    \_module_inst: work@aes_core (work@aes_core), id:155, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
+    \_module_inst: work@aes_core (work@aes_core), id:156, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
     |vpiTypespec:
-    \_struct_typespec: (aes_pkg::ctrl_reg_t), id:1, line:2:9, endln:4:2
+    \_struct_typespec: (aes_pkg::ctrl_reg_t), id:2, line:2:9, endln:4:2
     |vpiName:ctrl_q
     |vpiFullName:work@aes_core.ctrl_q
   |vpiTopModule:1
   |vpiModule:
-  \_module_inst: work@prim_subreg_shadow (work@aes_core.ctrl_shadowed_reg), id:163, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:25:3, endln:25:65
+  \_module_inst: work@prim_subreg_shadow (work@aes_core.ctrl_shadowed_reg), id:164, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:25:3, endln:25:65
     |vpiParent:
-    \_module_inst: work@aes_core (work@aes_core), id:155, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
+    \_module_inst: work@aes_core (work@aes_core), id:156, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
     |vpiName:ctrl_shadowed_reg
     |vpiFullName:work@aes_core.ctrl_shadowed_reg
     |vpiParameter:
-    \_parameter: (work@aes_core.ctrl_shadowed_reg.RESVAL), id:164, line:17:26, endln:17:32
+    \_parameter: (work@aes_core.ctrl_shadowed_reg.RESVAL), id:165, line:17:26, endln:17:32
       |vpiParent:
-      \_module_inst: work@prim_subreg_shadow (work@aes_core.ctrl_shadowed_reg), id:163, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:25:3, endln:25:65
+      \_module_inst: work@prim_subreg_shadow (work@aes_core.ctrl_shadowed_reg), id:164, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:25:3, endln:25:65
       |BIN:0
       |vpiTypespec:
-      \_logic_typespec: , id:165, line:17:13, endln:17:25
+      \_logic_typespec: , id:166, line:17:13, endln:17:25
         |vpiParent:
-        \_parameter: (work@aes_core.ctrl_shadowed_reg.RESVAL), id:164, line:17:26, endln:17:32
+        \_parameter: (work@aes_core.ctrl_shadowed_reg.RESVAL), id:165, line:17:26, endln:17:32
         |vpiRange:
-        \_range: , id:166, line:17:19, endln:17:25
+        \_range: , id:167, line:17:19, endln:17:25
           |vpiParent:
-          \_logic_typespec: , id:165, line:17:13, endln:17:25
+          \_logic_typespec: , id:166, line:17:13, endln:17:25
           |vpiLeftRange:
-          \_constant: , id:167, line:17:20, endln:17:22
+          \_constant: , id:168, line:17:20, endln:17:22
             |vpiParent:
-            \_range: , id:166, line:17:19, endln:17:25
+            \_range: , id:167, line:17:19, endln:17:25
             |vpiDecompile:31
             |vpiSize:64
             |UINT:31
             |vpiConstType:9
           |vpiRightRange:
-          \_constant: , id:168, line:17:23, endln:17:24
+          \_constant: , id:169, line:17:23, endln:17:24
             |vpiParent:
-            \_range: , id:166, line:17:19, endln:17:25
+            \_range: , id:167, line:17:19, endln:17:25
             |vpiDecompile:0
             |vpiSize:64
             |UINT:0
@@ -886,56 +886,56 @@ design: (work@aes_core), id:150
       |vpiName:RESVAL
       |vpiFullName:work@aes_core.ctrl_shadowed_reg.RESVAL
     |vpiParamAssign:
-    \_param_assign: , id:145, line:17:26, endln:17:37
+    \_param_assign: , id:146, line:17:26, endln:17:37
       |vpiParent:
-      \_module_inst: work@prim_subreg_shadow (work@aes_core.ctrl_shadowed_reg), id:163, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:25:3, endln:25:65
+      \_module_inst: work@prim_subreg_shadow (work@aes_core.ctrl_shadowed_reg), id:164, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:25:3, endln:25:65
       |vpiOverriden:1
       |vpiRhs:
-      \_ref_obj: (work@aes_core.ctrl_shadowed_reg.CTRL_RESET), id:144, line:25:32, endln:25:42
+      \_ref_obj: (work@aes_core.ctrl_shadowed_reg.CTRL_RESET), id:145, line:25:32, endln:25:42
         |vpiParent:
-        \_param_assign: , id:145, line:17:26, endln:17:37
+        \_param_assign: , id:146, line:17:26, endln:17:37
         |vpiName:CTRL_RESET
         |vpiFullName:work@aes_core.ctrl_shadowed_reg.CTRL_RESET
         |vpiActual:
-        \_parameter: (work@aes_core.CTRL_RESET), id:156, line:6:22, endln:6:32
+        \_parameter: (work@aes_core.CTRL_RESET), id:157, line:6:22, endln:6:32
       |vpiLhs:
-      \_parameter: (work@aes_core.ctrl_shadowed_reg.RESVAL), id:164, line:17:26, endln:17:32
+      \_parameter: (work@aes_core.ctrl_shadowed_reg.RESVAL), id:165, line:17:26, endln:17:32
     |vpiDefName:work@prim_subreg_shadow
     |vpiDefFile:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv
     |vpiDefLineNo:16
     |vpiInstance:
-    \_module_inst: work@aes_core (work@aes_core), id:155, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
+    \_module_inst: work@aes_core (work@aes_core), id:156, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:22:1, endln:26:10
     |vpiModule:
-    \_module_inst: work@prim_subreg (work@aes_core.ctrl_shadowed_reg.committed_reg), id:169, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:19:3, endln:19:50
+    \_module_inst: work@prim_subreg (work@aes_core.ctrl_shadowed_reg.committed_reg), id:170, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:19:3, endln:19:50
       |vpiParent:
-      \_module_inst: work@prim_subreg_shadow (work@aes_core.ctrl_shadowed_reg), id:163, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:25:3, endln:25:65
+      \_module_inst: work@prim_subreg_shadow (work@aes_core.ctrl_shadowed_reg), id:164, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:25:3, endln:25:65
       |vpiName:committed_reg
       |vpiFullName:work@aes_core.ctrl_shadowed_reg.committed_reg
       |vpiParameter:
-      \_parameter: (work@aes_core.ctrl_shadowed_reg.committed_reg.RESVAL), id:170, line:12:26, endln:12:32
+      \_parameter: (work@aes_core.ctrl_shadowed_reg.committed_reg.RESVAL), id:171, line:12:26, endln:12:32
         |vpiParent:
-        \_module_inst: work@prim_subreg (work@aes_core.ctrl_shadowed_reg.committed_reg), id:169, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:19:3, endln:19:50
+        \_module_inst: work@prim_subreg (work@aes_core.ctrl_shadowed_reg.committed_reg), id:170, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:19:3, endln:19:50
         |BIN:0
         |vpiTypespec:
-        \_logic_typespec: , id:171, line:12:13, endln:12:25
+        \_logic_typespec: , id:172, line:12:13, endln:12:25
           |vpiParent:
-          \_parameter: (work@aes_core.ctrl_shadowed_reg.committed_reg.RESVAL), id:170, line:12:26, endln:12:32
+          \_parameter: (work@aes_core.ctrl_shadowed_reg.committed_reg.RESVAL), id:171, line:12:26, endln:12:32
           |vpiRange:
-          \_range: , id:172, line:12:19, endln:12:25
+          \_range: , id:173, line:12:19, endln:12:25
             |vpiParent:
-            \_logic_typespec: , id:171, line:12:13, endln:12:25
+            \_logic_typespec: , id:172, line:12:13, endln:12:25
             |vpiLeftRange:
-            \_constant: , id:173, line:12:20, endln:12:22
+            \_constant: , id:174, line:12:20, endln:12:22
               |vpiParent:
-              \_range: , id:172, line:12:19, endln:12:25
+              \_range: , id:173, line:12:19, endln:12:25
               |vpiDecompile:31
               |vpiSize:64
               |UINT:31
               |vpiConstType:9
             |vpiRightRange:
-            \_constant: , id:174, line:12:23, endln:12:24
+            \_constant: , id:175, line:12:23, endln:12:24
               |vpiParent:
-              \_range: , id:172, line:12:19, endln:12:25
+              \_range: , id:173, line:12:19, endln:12:25
               |vpiDecompile:0
               |vpiSize:64
               |UINT:0
@@ -943,27 +943,27 @@ design: (work@aes_core), id:150
         |vpiName:RESVAL
         |vpiFullName:work@aes_core.ctrl_shadowed_reg.committed_reg.RESVAL
       |vpiParamAssign:
-      \_param_assign: , id:148, line:12:26, endln:12:37
+      \_param_assign: , id:149, line:12:26, endln:12:37
         |vpiParent:
-        \_module_inst: work@prim_subreg (work@aes_core.ctrl_shadowed_reg.committed_reg), id:169, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:19:3, endln:19:50
+        \_module_inst: work@prim_subreg (work@aes_core.ctrl_shadowed_reg.committed_reg), id:170, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:19:3, endln:19:50
         |vpiOverriden:1
         |vpiRhs:
-        \_ref_obj: (work@aes_core.ctrl_shadowed_reg.CTRL_RESET), id:147, line:19:25, endln:19:31
+        \_ref_obj: (work@aes_core.ctrl_shadowed_reg.CTRL_RESET), id:148, line:19:25, endln:19:31
           |vpiParent:
-          \_param_assign: , id:145, line:17:26, endln:17:37
+          \_param_assign: , id:146, line:17:26, endln:17:37
           |vpiTypespec:
-          \_logic_typespec: , id:93, line:17:13, endln:17:25
+          \_logic_typespec: , id:94, line:17:13, endln:17:25
           |vpiName:CTRL_RESET
           |vpiFullName:work@aes_core.ctrl_shadowed_reg.CTRL_RESET
           |vpiActual:
-          \_parameter: (work@aes_core.CTRL_RESET), id:156, line:6:22, endln:6:32
+          \_parameter: (work@aes_core.CTRL_RESET), id:157, line:6:22, endln:6:32
         |vpiLhs:
-        \_parameter: (work@aes_core.ctrl_shadowed_reg.committed_reg.RESVAL), id:170, line:12:26, endln:12:32
+        \_parameter: (work@aes_core.ctrl_shadowed_reg.committed_reg.RESVAL), id:171, line:12:26, endln:12:32
       |vpiDefName:work@prim_subreg
       |vpiDefFile:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv
       |vpiDefLineNo:11
       |vpiInstance:
-      \_module_inst: work@prim_subreg_shadow (work@aes_core.ctrl_shadowed_reg), id:163, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:25:3, endln:25:65
+      \_module_inst: work@prim_subreg_shadow (work@aes_core.ctrl_shadowed_reg), id:164, file:${SURELOG_DIR}/tests/ParamNoSubst/dut.sv, line:25:3, endln:25:65
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0

--- a/tests/PreprocLine/PreprocLine.log
+++ b/tests/PreprocLine/PreprocLine.log
@@ -16,38 +16,38 @@ n<top> u<3> t<StringConst> p<4> l<1:8> el<1:11>
 n<> u<4> t<Module_ansi_header> p<66> c<2> s<64> l<1:1> el<1:12>
 n<> u<5> t<Dollar_keyword> p<17> s<6> l<3:9> el<3:10>
 n<display> u<6> t<StringConst> p<17> s<16> l<3:10> el<3:17>
-n<"${SURELOG_DIR}/tests/PreprocLine/dut.sv"> u<7> t<StringLiteral> p<8> l<3:18> el<3:64>
-n<> u<8> t<Primary_literal> p<9> c<7> l<3:18> el<3:64>
-n<> u<9> t<Primary> p<10> c<8> l<3:18> el<3:64>
-n<> u<10> t<Expression> p<16> c<9> s<15> l<3:18> el<3:64>
-n<3> u<11> t<IntConst> p<12> l<3:66> el<3:67>
-n<> u<12> t<Primary_literal> p<13> c<11> l<3:66> el<3:67>
-n<> u<13> t<Primary> p<14> c<12> l<3:66> el<3:67>
-n<> u<14> t<Expression> p<15> c<13> l<3:66> el<3:67>
-n<> u<15> t<Argument> p<16> c<14> l<3:66> el<3:67>
-n<> u<16> t<List_of_arguments> p<17> c<10> l<3:18> el<3:67>
-n<> u<17> t<Subroutine_call> p<18> c<5> l<3:9> el<3:68>
-n<> u<18> t<Subroutine_call_statement> p<19> c<17> l<3:9> el<3:69>
-n<> u<19> t<Statement_item> p<20> c<18> l<3:9> el<3:69>
-n<> u<20> t<Statement> p<21> c<19> l<3:9> el<3:69>
-n<> u<21> t<Statement_or_null> p<57> c<20> s<38> l<3:9> el<3:69>
+n<"${SURELOG_DIR}/tests/PreprocLine/dut.sv"> u<7> t<StringLiteral> p<8> l<3:18> el<3:78>
+n<> u<8> t<Primary_literal> p<9> c<7> l<3:18> el<3:78>
+n<> u<9> t<Primary> p<10> c<8> l<3:18> el<3:78>
+n<> u<10> t<Expression> p<16> c<9> s<15> l<3:18> el<3:78>
+n<3> u<11> t<IntConst> p<12> l<3:80> el<3:81>
+n<> u<12> t<Primary_literal> p<13> c<11> l<3:80> el<3:81>
+n<> u<13> t<Primary> p<14> c<12> l<3:80> el<3:81>
+n<> u<14> t<Expression> p<15> c<13> l<3:80> el<3:81>
+n<> u<15> t<Argument> p<16> c<14> l<3:80> el<3:81>
+n<> u<16> t<List_of_arguments> p<17> c<10> l<3:18> el<3:81>
+n<> u<17> t<Subroutine_call> p<18> c<5> l<3:9> el<3:82>
+n<> u<18> t<Subroutine_call_statement> p<19> c<17> l<3:9> el<3:83>
+n<> u<19> t<Statement_item> p<20> c<18> l<3:9> el<3:83>
+n<> u<20> t<Statement> p<21> c<19> l<3:9> el<3:83>
+n<> u<21> t<Statement_or_null> p<57> c<20> s<38> l<3:9> el<3:83>
 n<> u<22> t<Dollar_keyword> p<34> s<23> l<5:9> el<5:10>
 n<display> u<23> t<StringConst> p<34> s<33> l<5:10> el<5:17>
-n<"${SURELOG_DIR}/tests/PreprocLine/fake.v"> u<24> t<StringLiteral> p<25> l<5:18> el<5:64>
-n<> u<25> t<Primary_literal> p<26> c<24> l<5:18> el<5:64>
-n<> u<26> t<Primary> p<27> c<25> l<5:18> el<5:64>
-n<> u<27> t<Expression> p<33> c<26> s<32> l<5:18> el<5:64>
-n<102> u<28> t<IntConst> p<29> l<5:66> el<5:69>
-n<> u<29> t<Primary_literal> p<30> c<28> l<5:66> el<5:69>
-n<> u<30> t<Primary> p<31> c<29> l<5:66> el<5:69>
-n<> u<31> t<Expression> p<32> c<30> l<5:66> el<5:69>
-n<> u<32> t<Argument> p<33> c<31> l<5:66> el<5:69>
-n<> u<33> t<List_of_arguments> p<34> c<27> l<5:18> el<5:69>
-n<> u<34> t<Subroutine_call> p<35> c<22> l<5:9> el<5:70>
-n<> u<35> t<Subroutine_call_statement> p<36> c<34> l<5:9> el<5:71>
-n<> u<36> t<Statement_item> p<37> c<35> l<5:9> el<5:71>
-n<> u<37> t<Statement> p<38> c<36> l<5:9> el<5:71>
-n<> u<38> t<Statement_or_null> p<57> c<37> s<55> l<5:9> el<5:71>
+n<"${SURELOG_DIR}/tests/PreprocLine/fake.v"> u<24> t<StringLiteral> p<25> l<5:18> el<5:78>
+n<> u<25> t<Primary_literal> p<26> c<24> l<5:18> el<5:78>
+n<> u<26> t<Primary> p<27> c<25> l<5:18> el<5:78>
+n<> u<27> t<Expression> p<33> c<26> s<32> l<5:18> el<5:78>
+n<102> u<28> t<IntConst> p<29> l<5:80> el<5:83>
+n<> u<29> t<Primary_literal> p<30> c<28> l<5:80> el<5:83>
+n<> u<30> t<Primary> p<31> c<29> l<5:80> el<5:83>
+n<> u<31> t<Expression> p<32> c<30> l<5:80> el<5:83>
+n<> u<32> t<Argument> p<33> c<31> l<5:80> el<5:83>
+n<> u<33> t<List_of_arguments> p<34> c<27> l<5:18> el<5:83>
+n<> u<34> t<Subroutine_call> p<35> c<22> l<5:9> el<5:84>
+n<> u<35> t<Subroutine_call_statement> p<36> c<34> l<5:9> el<5:85>
+n<> u<36> t<Statement_item> p<37> c<35> l<5:9> el<5:85>
+n<> u<37> t<Statement> p<38> c<36> l<5:9> el<5:85>
+n<> u<38> t<Statement_or_null> p<57> c<37> s<55> l<5:9> el<5:85>
 n<> u<39> t<Dollar_keyword> p<51> s<40> f<0> l<10:9> el<10:10>
 n<display> u<40> t<StringConst> p<51> s<50> f<0> l<10:10> el<10:17>
 n<""> u<41> t<StringLiteral> p<42> f<0> l<10:18> el<10:20>

--- a/tests/SimpleClass1/SimpleClass1.log
+++ b/tests/SimpleClass1/SimpleClass1.log
@@ -792,7 +792,7 @@ Instance tree:
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                      1484
 array_var                                           1463
-assign_stmt                                         3557
+assign_stmt                                         5234
 assignment                                         15477
 begin                                              16140
 bit_select                                          5398
@@ -872,7 +872,7 @@ time_typespec                                        203
 time_var                                              74
 type_parameter                                       289
 typespec_member                                      415
-unsupported_typespec                                4205
+unsupported_typespec                                4536
 var_select                                           350
 wait_fork                                              1
 wait_stmt                                            117

--- a/tests/SimpleInterface/SimpleInterface.log
+++ b/tests/SimpleInterface/SimpleInterface.log
@@ -2179,7 +2179,7 @@ Instance tree:
 always                                                 3
 array_typespec                                       675
 array_var                                            654
-assign_stmt                                         1876
+assign_stmt                                         3548
 assignment                                          6303
 begin                                               6770
 bit_select                                          2128
@@ -2267,7 +2267,7 @@ time_typespec                                        107
 time_var                                              38
 type_parameter                                       273
 typespec_member                                       47
-unsupported_typespec                                1567
+unsupported_typespec                                1898
 var_select                                           306
 wait_fork                                              1
 wait_stmt                                             45

--- a/tests/TaskDeclNoOrder/TaskDeclNoOrder.log
+++ b/tests/TaskDeclNoOrder/TaskDeclNoOrder.log
@@ -239,7 +239,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
-assign_stmt                                            4
+assign_stmt                                            5
 begin                                                  1
 constant                                              26
 design                                                 1
@@ -256,7 +256,7 @@ task                                                   1
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
-assign_stmt                                            8
+assign_stmt                                            9
 begin                                                  2
 constant                                              30
 design                                                 1

--- a/tests/TaskDecls/TaskDecls.log
+++ b/tests/TaskDecls/TaskDecls.log
@@ -517,6 +517,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
+assign_stmt                                            4
 assignment                                             3
 begin                                                  4
 class_defn                                             8
@@ -548,6 +549,7 @@ task                                                  12
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
+assign_stmt                                            4
 assignment                                             6
 begin                                                  8
 class_defn                                             8

--- a/tests/TestSepComp/TestSepComp.log
+++ b/tests/TestSepComp/TestSepComp.log
@@ -27,14 +27,14 @@
 [   NOTE] : 0
 [INF:CM0023] Creating log file ${SURELOG_DIR}/tests/TestSepComp/slpp_all/surelog.log.
 
+PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/top.sv
 PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/pkg1.sv
 PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/pkg2.sv
-PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/top.sv
+[WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/top.sv:1:1: No timescale set for "top".
+
 [WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/pkg1.sv:1:1: No timescale set for "pkg1".
 
 [WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/pkg2.sv:1:1: No timescale set for "pkg2".
-
-[WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/top.sv:1:1: No timescale set for "top".
 
 [INF:CP0300] Compilation...
 

--- a/tests/TypeDefScope/TypeDefScope.log
+++ b/tests/TypeDefScope/TypeDefScope.log
@@ -386,6 +386,7 @@ there are 1 more instances of this message.
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
+assign_stmt                                            2
 begin                                                  1
 class_defn                                             8
 class_typespec                                         4
@@ -414,6 +415,7 @@ unsupported_typespec                                   3
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
+assign_stmt                                            2
 begin                                                  2
 class_defn                                             8
 class_typespec                                         4

--- a/tests/UnitForeach/UnitForeach.log
+++ b/tests/UnitForeach/UnitForeach.log
@@ -745,6 +745,7 @@ Instance tree:
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                         4
 array_var                                              4
+assign_stmt                                            2
 begin                                                  7
 bit_select                                             4
 class_defn                                            10

--- a/tests/UnitQueue/UnitQueue.log
+++ b/tests/UnitQueue/UnitQueue.log
@@ -484,6 +484,7 @@ Instance tree:
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                         2
 array_var                                              2
+assign_stmt                                            2
 begin                                                  1
 class_defn                                            10
 class_typespec                                         5

--- a/tests/UnitThisNew/UnitThisNew.log
+++ b/tests/UnitThisNew/UnitThisNew.log
@@ -578,6 +578,7 @@ AST_DEBUG_END
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                         2
 array_var                                              2
+assign_stmt                                            4
 assignment                                             6
 begin                                                 12
 bit_typespec                                           4
@@ -616,6 +617,7 @@ unsupported_typespec                                  12
 === UHDM Object Stats Begin (Elaborated Model) ===
 array_typespec                                         2
 array_var                                              6
+assign_stmt                                            4
 assignment                                            12
 begin                                                 24
 bit_typespec                                           4

--- a/tests/VarInFunc/VarInFunc.log
+++ b/tests/VarInFunc/VarInFunc.log
@@ -403,7 +403,7 @@ AST_DEBUG_END
 [INF:UH0706] Creating UHDM Model...
 
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
-assign_stmt                                            1
+assign_stmt                                            2
 begin                                                  1
 class_defn                                             8
 class_typespec                                         4
@@ -435,7 +435,7 @@ task                                                   9
 [INF:UH0707] Elaborating UHDM...
 
 === UHDM Object Stats Begin (Elaborated Model) ===
-assign_stmt                                            2
+assign_stmt                                            3
 begin                                                  2
 class_defn                                             8
 class_typespec                                         4

--- a/tests/VirtualClass/VirtualClass.log
+++ b/tests/VirtualClass/VirtualClass.log
@@ -293,7 +293,7 @@ ref_obj                                                5
 struct_typespec                                        1
 type_parameter                                         1
 typespec_member                                        2
-unsupported_typespec                                   6
+unsupported_typespec                                   7
 === UHDM Object Stats End ===
 [INF:UH0707] Elaborating UHDM...
 
@@ -316,7 +316,7 @@ ref_obj                                                7
 struct_typespec                                        2
 type_parameter                                         1
 typespec_member                                        4
-unsupported_typespec                                   6
+unsupported_typespec                                   7
 === UHDM Object Stats End ===
 [INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/VirtualClass/slpp_all/surelog.uhdm ...
 

--- a/third_party/tests/AVLMM/AVLMM.log
+++ b/third_party/tests/AVLMM/AVLMM.log
@@ -56,7 +56,7 @@
 always                                                 9
 array_typespec                                        10
 array_var                                              5
-assign_stmt                                           32
+assign_stmt                                           53
 assignment                                            67
 begin                                                 85
 bit_select                                            41

--- a/third_party/tests/AmiqEth/AmiqEth.log
+++ b/third_party/tests/AmiqEth/AmiqEth.log
@@ -1614,7 +1614,7 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/UVM/ovm-2.1.2/src/ovm_pkg.sv
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                      4907
 array_var                                           4662
-assign_stmt                                         5943
+assign_stmt                                         8663
 assignment                                         26129
 begin                                              27526
 bit_select                                          8927
@@ -1699,7 +1699,7 @@ time_typespec                                        378
 time_var                                             126
 type_parameter                                      1021
 typespec_member                                      599
-unsupported_typespec                                6230
+unsupported_typespec                                6952
 var_select                                           432
 wait_fork                                             10
 wait_stmt                                            174

--- a/third_party/tests/AmiqSimpleTestSuite/AmiqSimpleTestSuite.log
+++ b/third_party/tests/AmiqSimpleTestSuite/AmiqSimpleTestSuite.log
@@ -873,7 +873,7 @@ always                                                 1
 array_typespec                                      1560
 array_var                                           1539
 assert_stmt                                           32
-assign_stmt                                         3762
+assign_stmt                                         5509
 assignment                                         15786
 begin                                              16817
 bit_select                                          5585
@@ -964,7 +964,7 @@ time_typespec                                        220
 time_var                                              79
 type_parameter                                       543
 typespec_member                                      415
-unsupported_typespec                                4421
+unsupported_typespec                                4768
 var_select                                           350
 wait_fork                                              1
 wait_stmt                                            117

--- a/third_party/tests/ApbSlave/ApbSlave.log
+++ b/third_party/tests/ApbSlave/ApbSlave.log
@@ -72,7 +72,7 @@
 always                                                 1
 array_typespec                                         8
 array_var                                              8
-assign_stmt                                           24
+assign_stmt                                           36
 assignment                                            79
 begin                                                 78
 bit_select                                             2

--- a/third_party/tests/AzadiRTL/AzadiRTL.log
+++ b/third_party/tests/AzadiRTL/AzadiRTL.log
@@ -21733,7 +21733,7 @@ array_net                                             21
 array_typespec                                       197
 array_var                                            124
 assert_stmt                                           31
-assign_stmt                                          439
+assign_stmt                                          465
 assignment                                          5224
 begin                                               2961
 bit_select                                          9058
@@ -21804,7 +21804,7 @@ tagged_pattern                                     18364
 task                                                   9
 type_parameter                                        26
 typespec_member                                    13522
-unsupported_typespec                                 193
+unsupported_typespec                                 199
 var_select                                           284
 === UHDM Object Stats End ===
 [INF:UH0707] Elaborating UHDM...
@@ -21815,7 +21815,7 @@ array_net                                             21
 array_typespec                                       349
 array_var                                            128
 assert_stmt                                          110
-assign_stmt                                          701
+assign_stmt                                          727
 assignment                                         10772
 begin                                               7885
 bit_select                                         21981
@@ -21886,7 +21886,7 @@ tagged_pattern                                     18535
 task                                                  18
 type_parameter                                        26
 typespec_member                                    13522
-unsupported_typespec                                 193
+unsupported_typespec                                 199
 var_select                                           497
 === UHDM Object Stats End ===
 [ERR:UH0725] ${SURELOG_DIR}/third_party/tests/AzadiRTL/brq_idu_controller.sv:163:78: Unresolved hierarchical reference "brq_core.hart_id_i".

--- a/third_party/tests/BuildOVMPkg/BuildOVMPkg.log
+++ b/third_party/tests/BuildOVMPkg/BuildOVMPkg.log
@@ -818,7 +818,7 @@
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                       142
 array_var                                            126
-assign_stmt                                          398
+assign_stmt                                         1150
 assignment                                          2675
 begin                                               2597
 bit_select                                           844
@@ -890,7 +890,7 @@ task_call                                             18
 time_typespec                                         81
 time_var                                              26
 type_parameter                                       363
-unsupported_typespec                                 275
+unsupported_typespec                                 378
 var_select                                            55
 wait_fork                                              5
 wait_stmt                                             15

--- a/third_party/tests/BuildUVMPkg/BuildUVMPkg.log
+++ b/third_party/tests/BuildUVMPkg/BuildUVMPkg.log
@@ -687,7 +687,7 @@
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                       662
 array_var                                            641
-assign_stmt                                         1873
+assign_stmt                                         3545
 assignment                                          6285
 begin                                               6766
 bit_select                                          2126
@@ -764,7 +764,7 @@ time_typespec                                        107
 time_var                                              38
 type_parameter                                       273
 typespec_member                                       47
-unsupported_typespec                                1566
+unsupported_typespec                                1897
 var_select                                           306
 wait_fork                                              1
 wait_stmt                                             45

--- a/third_party/tests/CoresSweRV/CoresSweRV.log
+++ b/third_party/tests/CoresSweRV/CoresSweRV.log
@@ -4809,7 +4809,7 @@ array_expr                                             1
 array_net                                             38
 array_typespec                                       671
 array_var                                            648
-assign_stmt                                         1947
+assign_stmt                                         3658
 assignment                                          7737
 begin                                               7196
 bit_select                                         20124
@@ -4902,7 +4902,7 @@ time_typespec                                        107
 time_var                                              38
 type_parameter                                       273
 typespec_member                                      481
-unsupported_typespec                                1612
+unsupported_typespec                                1943
 var_select                                          4815
 wait_fork                                              1
 wait_stmt                                             45
@@ -4916,7 +4916,7 @@ array_expr                                             1
 array_net                                             38
 array_typespec                                       674
 array_var                                           5037
-assign_stmt                                         8537
+assign_stmt                                        10248
 assignment                                         43769
 begin                                              46172
 bit_select                                         25897
@@ -5010,7 +5010,7 @@ time_typespec                                        107
 time_var                                             203
 type_parameter                                       273
 typespec_member                                      521
-unsupported_typespec                                1612
+unsupported_typespec                                1943
 var_select                                          4883
 wait_fork                                              3
 wait_stmt                                            140

--- a/third_party/tests/CoresSweRVMP/CoresSweRVMP.log
+++ b/third_party/tests/CoresSweRVMP/CoresSweRVMP.log
@@ -2,20 +2,12 @@
 
 [WRN:CM0010] Command line argument "-Wno-UNOPTFLAT" ignored.
 
-Running: cd ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser; cmake -G "Unix Makefiles" .; make -j 16
--- Configuring done (0.1s)
+Running: cd ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser; cmake -G "Unix Makefiles" .; make -j 2
+-- Configuring done (0.0s)
 -- Generating done (0.0s)
 -- Build files have been written to: ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser
-make[1]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser'
-make[2]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser'
-make[3]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser'
-make[3]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser'
-make[3]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser'
-[100%] [34m[1mGenerating preprocessing[0m
-make[3]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser'
+[100%] Generating preprocessing
 [100%] Built target Parse
-make[2]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser'
-make[1]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_parser'
 Surelog preproc status: 0
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/UVM/1800.2-2017-1.0/src/uvm_pkg.sv".
 
@@ -122,35 +114,13 @@ PP CACHE USED FOR: ${SURELOG_DIR}/third_party/UVM/1800.2-2017-1.0/src/uvm_pkg.sv
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/CoresSweRVMP/design/lib/axi4_to_ahb.sv".
 
-Running: cd ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess; cmake -G "Unix Makefiles" .; make -j 16
--- Configuring done (0.1s)
+Running: cd ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess; cmake -G "Unix Makefiles" .; make -j 2
+-- Configuring done (0.0s)
 -- Generating done (0.0s)
 -- Build files have been written to: ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess
-make[1]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess'
-make[2]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess'
-make[3]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess'
-make[3]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess'
-make[3]: Entering directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess'
-[  6%] [34m[1mGenerating 10_lsu_bus_intf.sv[0m
-[ 12%] [34m[1mGenerating 11_ifu_bp_ctl.sv[0m
-[ 18%] [34m[1mGenerating 12_beh_lib.sv[0m
-[ 25%] [34m[1mGenerating 13_ifu_mem_ctl.sv[0m
-[ 31%] [34m[1mGenerating 14_mem_lib.sv[0m
-[ 37%] [34m[1mGenerating 15_exu.sv[0m
-[ 43%] [34m[1mGenerating 16_dec_decode_ctl.sv[0m
-[ 50%] [34m[1mGenerating 1_lsu_stbuf.sv[0m
-[ 56%] [34m[1mGenerating 3_rvjtag_tap.sv[0m
-[ 62%] [34m[1mGenerating 2_ahb_to_axi4.sv[0m
-[ 68%] [34m[1mGenerating 4_dec_tlu_ctl.sv[0m
-[ 75%] [34m[1mGenerating 5_lsu_bus_buffer.sv[0m
-[ 81%] [34m[1mGenerating 6_dbg.sv[0m
-[ 87%] [34m[1mGenerating 7_axi4_to_ahb.sv[0m
-[ 93%] [34m[1mGenerating 8_ifu_aln_ctl.sv[0m
-[100%] [34m[1mGenerating 9_tb_top.sv[0m
-make[3]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess'
+[ 50%] Generating 1_axi4_to_ahb.sv
+[100%] Generating 2_mem_lib.sv
 [100%] Built target Parse
-make[2]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess'
-make[1]: Leaving directory '${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess'
 Surelog parsing status: 0
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/UVM/1800.2-2017-1.0/src/uvm_pkg.sv".
 
@@ -4900,7 +4870,7 @@ array_expr                                             1
 array_net                                             38
 array_typespec                                       671
 array_var                                            648
-assign_stmt                                         1947
+assign_stmt                                         3658
 assignment                                          7737
 begin                                               7196
 bit_select                                         20124
@@ -4993,7 +4963,7 @@ time_typespec                                        107
 time_var                                              38
 type_parameter                                       273
 typespec_member                                      481
-unsupported_typespec                                1612
+unsupported_typespec                                1943
 var_select                                          4815
 wait_fork                                              1
 wait_stmt                                             45
@@ -5007,7 +4977,7 @@ array_expr                                             1
 array_net                                             38
 array_typespec                                       674
 array_var                                           5037
-assign_stmt                                         8537
+assign_stmt                                        10248
 assignment                                         43769
 begin                                              46172
 bit_select                                         25897
@@ -5101,7 +5071,7 @@ time_typespec                                        107
 time_var                                             203
 type_parameter                                       273
 typespec_member                                      521
-unsupported_typespec                                1612
+unsupported_typespec                                1943
 var_select                                          4883
 wait_fork                                              3
 wait_stmt                                            140

--- a/third_party/tests/Driver/Driver.log
+++ b/third_party/tests/Driver/Driver.log
@@ -795,7 +795,7 @@ there are 1 more instances of this message.
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                       685
 array_var                                            664
-assign_stmt                                         1901
+assign_stmt                                         3586
 assignment                                          6339
 begin                                               6842
 bit_select                                          2128
@@ -884,7 +884,7 @@ time_typespec                                        107
 time_var                                              38
 type_parameter                                       273
 typespec_member                                       47
-unsupported_typespec                                1570
+unsupported_typespec                                1904
 var_select                                           309
 wait_fork                                              1
 wait_stmt                                             45

--- a/third_party/tests/Earlgrey_0_1/sim-icarus/Earlgrey_0_1.log
+++ b/third_party/tests/Earlgrey_0_1/sim-icarus/Earlgrey_0_1.log
@@ -12309,7 +12309,7 @@ array_net                                             29
 array_typespec                                       840
 array_var                                            226
 assert_stmt                                            2
-assign_stmt                                          502
+assign_stmt                                          679
 assignment                                          8517
 begin                                               5057
 bit_select                                         22935
@@ -12385,7 +12385,7 @@ array_net                                             29
 array_typespec                                      1101
 array_var                                            259
 assert_stmt                                            4
-assign_stmt                                         1737
+assign_stmt                                         1914
 assignment                                         34005
 begin                                              20995
 bit_select                                         62153

--- a/third_party/tests/Earlgrey_Verilator_01_05_21/sim-icarus/Earlgrey_Verilator_01_05_21.log
+++ b/third_party/tests/Earlgrey_Verilator_01_05_21/sim-icarus/Earlgrey_Verilator_01_05_21.log
@@ -28232,7 +28232,7 @@ always                                              1957
 array_net                                             83
 array_typespec                                      3315
 array_var                                            477
-assign_stmt                                         1011
+assign_stmt                                         1180
 assignment                                         16228
 attribute                                             35
 begin                                               8926
@@ -28308,7 +28308,7 @@ sys_func_call                                        500
 tagged_pattern                                     33133
 task                                                   9
 typespec_member                                    68058
-unsupported_typespec                                 194
+unsupported_typespec                                 200
 var_select                                          3914
 === UHDM Object Stats End ===
 [INF:UH0707] Elaborating UHDM...
@@ -28318,7 +28318,7 @@ always                                             17644
 array_net                                             83
 array_typespec                                      3666
 array_var                                            749
-assign_stmt                                         9613
+assign_stmt                                         9782
 assignment                                        109977
 attribute                                             35
 begin                                              86444
@@ -28394,7 +28394,7 @@ sys_func_call                                       2410
 tagged_pattern                                     33523
 task                                                  18
 typespec_member                                    68058
-unsupported_typespec                                 194
+unsupported_typespec                                 200
 var_select                                         16611
 === UHDM Object Stats End ===
 [ERR:UH0725] ${SURELOG_DIR}/third_party/tests/Earlgrey_Verilator_01_05_21/src/lowrisc_systems_top_earlgrey_verilator_0.1/rtl/top_earlgrey_verilator.sv:269:5: Unresolved hierarchical reference "u_sim_sram.u_sim_sram_if.start_addr".

--- a/third_party/tests/Earlgrey_Verilator_0_1/sim-verilator/Earlgrey_Verilator_0_1.log
+++ b/third_party/tests/Earlgrey_Verilator_0_1/sim-verilator/Earlgrey_Verilator_0_1.log
@@ -11610,7 +11610,7 @@ always                                              1153
 array_net                                             29
 array_typespec                                       847
 array_var                                            246
-assign_stmt                                          516
+assign_stmt                                          717
 assignment                                          8948
 begin                                               5303
 bit_select                                         22433
@@ -11692,7 +11692,7 @@ always                                              6045
 array_net                                             29
 array_typespec                                      1108
 array_var                                            279
-assign_stmt                                         1735
+assign_stmt                                         1936
 assignment                                         34591
 begin                                              21437
 bit_select                                         60887

--- a/third_party/tests/Ibex/Ibex.log
+++ b/third_party/tests/Ibex/Ibex.log
@@ -1564,7 +1564,7 @@ array_net                                              9
 array_typespec                                      3622
 array_var                                           3581
 assert_stmt                                           75
-assign_stmt                                         7255
+assign_stmt                                         9034
 assignment                                         36357
 begin                                              36900
 bit_select                                         14755
@@ -1663,7 +1663,7 @@ time_typespec                                        396
 time_var                                             147
 type_parameter                                       649
 typespec_member                                     1237
-unsupported_typespec                                9503
+unsupported_typespec                                9879
 var_select                                           518
 wait_fork                                              1
 wait_stmt                                            300

--- a/third_party/tests/IbexGoogle/IbexGoogle.log
+++ b/third_party/tests/IbexGoogle/IbexGoogle.log
@@ -933,7 +933,7 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/UVM/uvm-1.2/src/uvm_pkg.sv
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                      1830
 array_var                                           1732
-assign_stmt                                         3792
+assign_stmt                                         5660
 assignment                                         16879
 begin                                              17510
 bit_select                                          6042
@@ -1014,7 +1014,7 @@ time_typespec                                        203
 time_var                                              74
 type_parameter                                       640
 typespec_member                                      421
-unsupported_typespec                                4379
+unsupported_typespec                                4756
 var_select                                           408
 wait_fork                                              1
 wait_stmt                                            117

--- a/third_party/tests/IncompTitan/IncompTitan.log
+++ b/third_party/tests/IncompTitan/IncompTitan.log
@@ -10645,7 +10645,7 @@ array_net                                             38
 array_typespec                                       866
 array_var                                            231
 assert_stmt                                          428
-assign_stmt                                          640
+assign_stmt                                          767
 assignment                                          5452
 assume                                                30
 attribute                                             33
@@ -10717,7 +10717,7 @@ sys_func_call                                       2727
 tagged_pattern                                      7929
 task                                                   9
 typespec_member                                    17850
-unsupported_typespec                                 472
+unsupported_typespec                                 501
 var_select                                           882
 === UHDM Object Stats End ===
 [INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/IncompTitan/slpp_all/surelog.uhdm ...

--- a/third_party/tests/MiniAmiq/MiniAmiq.log
+++ b/third_party/tests/MiniAmiq/MiniAmiq.log
@@ -803,7 +803,7 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/UVM/uvm-1.2/src/uvm_pkg.sv
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                      1126
 array_var                                           1105
-assign_stmt                                         2907
+assign_stmt                                         4652
 assignment                                         11150
 begin                                              12054
 bit_select                                          3949
@@ -887,7 +887,7 @@ time_typespec                                        172
 time_var                                              61
 type_parameter                                       531
 typespec_member                                      231
-unsupported_typespec                                3104
+unsupported_typespec                                3447
 var_select                                           328
 wait_fork                                              1
 wait_stmt                                             81

--- a/third_party/tests/Monitor/Monitor.log
+++ b/third_party/tests/Monitor/Monitor.log
@@ -863,7 +863,7 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/UVM/1800.2-2017-1.0/src/uvm_pk
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                      1138
 array_var                                           1117
-assign_stmt                                         2903
+assign_stmt                                         4660
 assignment                                         11190
 begin                                              12089
 bit_select                                          3949
@@ -954,7 +954,7 @@ time_typespec                                        172
 time_var                                              61
 type_parameter                                       540
 typespec_member                                      231
-unsupported_typespec                                3108
+unsupported_typespec                                3453
 var_select                                           330
 wait_fork                                              1
 wait_stmt                                             81

--- a/third_party/tests/NyuziProcessor/NyuziProcessor.log
+++ b/third_party/tests/NyuziProcessor/NyuziProcessor.log
@@ -22,125 +22,125 @@
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/sim_sdram.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/oh_to_idx.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/reciprocal_rom.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/thread_select_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/rr_arbiter.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/synchronizer.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage1.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage4.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_2r1w.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_load_miss_queue.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/synchronizer.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_1r1w.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/performance_counters.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/reciprocal_rom.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/writeback_stage.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_interconnect.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/idx_to_oh.sv".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/int_execute_stage.sv".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_2r1w.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/rr_arbiter.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/performance_counters.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/idx_to_oh.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage4.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/oh_to_idx.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_rom.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/timer.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_sequencer.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_transmit.sv".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/async_fifo.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_sram.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/spi_controller.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/logic_analyzer.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_async_bridge.sv".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_sequencer.sv".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/spi_controller.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_controller.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_sram.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_receive.sv".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_interconnect.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_rom.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/timer.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_transmit.sv".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv".
 
@@ -159,125 +159,125 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/sim_sdram.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/oh_to_idx.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/reciprocal_rom.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/thread_select_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/rr_arbiter.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/synchronizer.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage1.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage4.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_2r1w.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_load_miss_queue.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/synchronizer.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_1r1w.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/performance_counters.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/reciprocal_rom.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/writeback_stage.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_interconnect.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/idx_to_oh.sv".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/int_execute_stage.sv".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_2r1w.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/rr_arbiter.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/performance_counters.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/idx_to_oh.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage4.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/oh_to_idx.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_rom.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/timer.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_sequencer.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_transmit.sv".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/async_fifo.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_sram.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/spi_controller.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/logic_analyzer.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_async_bridge.sv".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_sequencer.sv".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/spi_controller.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_controller.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_sram.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_receive.sv".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_interconnect.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_rom.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/timer.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/uart_transmit.sv".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv".
 
 [INF:CM0029] Using global timescale: "10ps/10ps".
 
@@ -536,124 +536,124 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/trace_logger.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/thread_select_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage1.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage4.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_load_miss_queue.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage5.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_axi_bus_interface.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sram_1r1w.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/writeback_stage.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv:22:1: previous definition.
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_tag_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/control_registers.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage3.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_interconnect.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv:22:1: previous definition.
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cache_lru.sv:22:1: previous definition.
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_arb_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_store_queue.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/int_execute_stage.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_tag_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/sync_fifo.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/cam.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/instruction_decode_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_read_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/io_request_queue.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_pending_miss_cam.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_tag_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/operand_fetch_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/nyuzi.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/on_chip_debugger.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/ifetch_data_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage4.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/tlb.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l1_l2_interface.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/scoreboard.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/core.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/l2_cache_update_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/dcache_data_stage.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/jtag_tap_controller.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/core/fp_execute_stage2.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_rom.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/async_fifo.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_sram.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/spi_controller.sv:22:1: previous definition.
@@ -662,16 +662,16 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/vga_controller.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_interconnect.sv:22:1: previous definition.
-
-[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_rom.sv:22:1: previous definition.
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/gpio_controller.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
              ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/ps2_controller.sv:22:1: previous definition.
 
 [ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
-             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/sdram_controller.sv:22:1: previous definition.
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_sram.sv:22:1: previous definition.
+
+[ERR:CP0329] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/testbench/soc_tb.sv:22:1: Multiply defined package: "defines",
+             ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/axi_interconnect.sv:22:1: previous definition.
 
 [NTE:CP0309] ${SURELOG_DIR}/third_party/tests/NyuziProcessor/hardware/fpga/common/async_fifo.sv:37:29: Implicit port type (wire) for "read_data".
 

--- a/third_party/tests/OVMSwitch/OVMSwitch.log
+++ b/third_party/tests/OVMSwitch/OVMSwitch.log
@@ -722,7 +722,7 @@ always                                                13
 array_net                                              5
 array_typespec                                       253
 array_var                                            234
-assign_stmt                                          443
+assign_stmt                                         1209
 assignment                                          2940
 begin                                               2825
 bit_select                                           963
@@ -807,7 +807,7 @@ task_call                                             19
 time_typespec                                         81
 time_var                                              26
 type_parameter                                       369
-unsupported_typespec                                 291
+unsupported_typespec                                 403
 var_select                                            58
 wait_fork                                              5
 wait_stmt                                             16

--- a/third_party/tests/Opentitan/Opentitan.log
+++ b/third_party/tests/Opentitan/Opentitan.log
@@ -8315,7 +8315,7 @@ array_net                                             23
 array_typespec                                      1201
 array_var                                            870
 assert_stmt                                          526
-assign_stmt                                         2066
+assign_stmt                                         3789
 assignment                                         12636
 assume                                               114
 begin                                              10742
@@ -8416,7 +8416,7 @@ time_typespec                                        107
 time_var                                              38
 type_parameter                                       273
 typespec_member                                     3313
-unsupported_typespec                                1631
+unsupported_typespec                                1962
 var_select                                           564
 wait_fork                                              1
 wait_stmt                                             45
@@ -8430,7 +8430,7 @@ array_net                                             23
 array_typespec                                      1447
 array_var                                           5403
 assert_stmt                                         4393
-assign_stmt                                         9848
+assign_stmt                                        11571
 assignment                                         68436
 assume                                               360
 begin                                              62066
@@ -8532,7 +8532,7 @@ time_typespec                                        107
 time_var                                             203
 type_parameter                                       273
 typespec_member                                     3353
-unsupported_typespec                                1631
+unsupported_typespec                                1962
 var_select                                          1609
 wait_fork                                              3
 wait_stmt                                            140

--- a/third_party/tests/Rp32/rp32.log
+++ b/third_party/tests/Rp32/rp32.log
@@ -400,7 +400,7 @@ always                                                36
 array_net                                              7
 array_typespec                                         9
 array_var                                              1
-assign_stmt                                            9
+assign_stmt                                           13
 assignment                                           861
 begin                                                281
 bit_select                                           158
@@ -463,7 +463,7 @@ task                                                   9
 typespec_member                                     6883
 union_typespec                                         6
 union_var                                              1
-unsupported_typespec                                  14
+unsupported_typespec                                  15
 === UHDM Object Stats End ===
 [INF:UH0707] Elaborating UHDM...
 
@@ -472,7 +472,7 @@ always                                                62
 array_net                                              7
 array_typespec                                         9
 array_var                                              1
-assign_stmt                                           10
+assign_stmt                                           14
 assignment                                          5712
 begin                                               1795
 bit_select                                           215
@@ -535,7 +535,7 @@ task                                                  18
 typespec_member                                     6883
 union_typespec                                         6
 union_var                                              1
-unsupported_typespec                                  14
+unsupported_typespec                                  15
 === UHDM Object Stats End ===
 [ERR:UH0725] ${SURELOG_DIR}/third_party/tests/Rp32/hdl/rtl/soc/r5p_soc_top.sv:287:10: Unresolved hierarchical reference "bus_mem[0].rdy".
 

--- a/third_party/tests/SVSwitch/SVSwitch.log
+++ b/third_party/tests/SVSwitch/SVSwitch.log
@@ -341,7 +341,7 @@ always                                                13
 array_net                                              5
 array_typespec                                         5
 array_var                                              5
-assign_stmt                                            1
+assign_stmt                                            8
 assignment                                           200
 begin                                                 97
 bit_select                                           105

--- a/third_party/tests/Scoreboard/Scoreboard.log
+++ b/third_party/tests/Scoreboard/Scoreboard.log
@@ -783,7 +783,7 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/UVM/uvm-1.2/src/uvm_pkg.sv
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                       671
 array_var                                            650
-assign_stmt                                         1893
+assign_stmt                                         3577
 assignment                                          6324
 begin                                               6823
 bit_select                                          2126
@@ -864,7 +864,7 @@ time_typespec                                        107
 time_var                                              38
 type_parameter                                       275
 typespec_member                                       47
-unsupported_typespec                                1572
+unsupported_typespec                                1904
 var_select                                           308
 wait_fork                                              1
 wait_stmt                                             45

--- a/third_party/tests/Scr1/Scr1.log
+++ b/third_party/tests/Scr1/Scr1.log
@@ -443,7 +443,7 @@ always                                               242
 array_typespec                                        11
 array_var                                             11
 assert_stmt                                           38
-assign_stmt                                           67
+assign_stmt                                           73
 assignment                                          2074
 begin                                               1309
 bit_select                                           628

--- a/third_party/tests/Scr1SvTests/Scr1SvTests.log
+++ b/third_party/tests/Scr1SvTests/Scr1SvTests.log
@@ -307,7 +307,7 @@ always                                               266
 array_typespec                                        11
 array_var                                             11
 assert_stmt                                           32
-assign_stmt                                           59
+assign_stmt                                           65
 assignment                                          1813
 begin                                               1103
 bit_select                                           579

--- a/third_party/tests/SeqDriver/SeqDriver.log
+++ b/third_party/tests/SeqDriver/SeqDriver.log
@@ -767,7 +767,7 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/UVM/uvm-1.2/src/uvm_pkg.sv
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                      1054
 array_var                                           1033
-assign_stmt                                         2724
+assign_stmt                                         4400
 assignment                                         10901
 begin                                              11485
 bit_select                                          3762
@@ -853,7 +853,7 @@ time_typespec                                        155
 time_var                                              56
 type_parameter                                       509
 typespec_member                                      231
-unsupported_typespec                                2882
+unsupported_typespec                                3218
 var_select                                           328
 wait_fork                                              1
 wait_stmt                                             81

--- a/third_party/tests/SimpleOVM/SimpleOVM.log
+++ b/third_party/tests/SimpleOVM/SimpleOVM.log
@@ -647,7 +647,7 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/UVM/ovm-2.1.2/src/ovm_pkg.sv
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                       142
 array_var                                            126
-assign_stmt                                          398
+assign_stmt                                         1150
 assignment                                          2675
 begin                                               2597
 bit_select                                           844
@@ -719,7 +719,7 @@ task_call                                             18
 time_typespec                                         81
 time_var                                              26
 type_parameter                                       363
-unsupported_typespec                                 275
+unsupported_typespec                                 378
 var_select                                            55
 wait_fork                                              5
 wait_stmt                                             15

--- a/third_party/tests/SimpleUVM/SimpleUVM.log
+++ b/third_party/tests/SimpleUVM/SimpleUVM.log
@@ -760,7 +760,7 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/UVM/uvm-1.2/src/uvm_pkg.sv
 always                                                 1
 array_typespec                                       666
 array_var                                            645
-assign_stmt                                         1875
+assign_stmt                                         3547
 assignment                                          6293
 begin                                               6779
 bit_select                                          2126
@@ -847,7 +847,7 @@ time_typespec                                        107
 time_var                                              38
 type_parameter                                       273
 typespec_member                                       47
-unsupported_typespec                                1566
+unsupported_typespec                                1897
 var_select                                           306
 wait_fork                                              1
 wait_stmt                                             45

--- a/third_party/tests/SimpleVMM/SimpleVMM.log
+++ b/third_party/tests/SimpleVMM/SimpleVMM.log
@@ -198,7 +198,7 @@
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                        87
 array_var                                             87
-assign_stmt                                          169
+assign_stmt                                          280
 assignment                                           654
 begin                                               1034
 bit_select                                            98
@@ -257,7 +257,7 @@ sys_func_call                                        272
 task                                                  83
 time_typespec                                          9
 time_var                                               7
-unsupported_typespec                                 165
+unsupported_typespec                                 355
 var_select                                           214
 while_stmt                                            13
 === UHDM Object Stats End ===

--- a/third_party/tests/Tnoc/Tnoc.log
+++ b/third_party/tests/Tnoc/Tnoc.log
@@ -5707,7 +5707,7 @@
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 always                                              1996
 array_typespec                                        30
-assign_stmt                                           78
+assign_stmt                                          147
 assignment                                          3851
 begin                                               3486
 bit_select                                          7131
@@ -5776,7 +5776,7 @@ tagged_pattern                                     55751
 task                                                   9
 type_parameter                                         4
 typespec_member                                   667829
-unsupported_typespec                                  34
+unsupported_typespec                                  91
 var_select                                             5
 === UHDM Object Stats End ===
 [INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/Tnoc/slpp_all/surelog.uhdm ...

--- a/third_party/tests/UVMNestedSeq/UVMNestedSeq.log
+++ b/third_party/tests/UVMNestedSeq/UVMNestedSeq.log
@@ -862,7 +862,7 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/UVM/uvm-1.2/src/uvm_pkg.sv
 always                                                 1
 array_typespec                                      2260
 array_var                                           2239
-assign_stmt                                         5301
+assign_stmt                                         7029
 assignment                                         24796
 begin                                              25650
 bit_select                                          8670
@@ -947,7 +947,7 @@ time_typespec                                        299
 time_var                                             110
 type_parameter                                       609
 typespec_member                                      783
-unsupported_typespec                                6830
+unsupported_typespec                                7197
 var_select                                           394
 wait_fork                                              1
 wait_stmt                                            189

--- a/third_party/tests/UVMSwitch/UVMSwitch.log
+++ b/third_party/tests/UVMSwitch/UVMSwitch.log
@@ -6917,7 +6917,7 @@ always                                                13
 array_net                                              5
 array_typespec                                       739
 array_var                                            705
-assign_stmt                                         1916
+assign_stmt                                         3601
 assignment                                          6523
 begin                                               6997
 bit_select                                          2244
@@ -7010,7 +7010,7 @@ time_typespec                                        107
 time_var                                              38
 type_parameter                                       279
 typespec_member                                       47
-unsupported_typespec                                1588
+unsupported_typespec                                1928
 var_select                                           309
 wait_fork                                              1
 wait_stmt                                             46

--- a/third_party/tests/UnitAmiqEth/UnitAmiqEth.log
+++ b/third_party/tests/UnitAmiqEth/UnitAmiqEth.log
@@ -1285,7 +1285,7 @@ PARSER CACHE USED FOR: ${SURELOG_DIR}/third_party/UVM/ovm-2.1.2/src/ovm_pkg.sv
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 array_typespec                                      1290
 array_var                                           1243
-assign_stmt                                         3277
+assign_stmt                                         5724
 assignment                                         13692
 begin                                              14257
 bit_select                                          4637
@@ -1369,7 +1369,7 @@ time_typespec                                        236
 time_var                                              82
 type_parameter                                       829
 typespec_member                                      231
-unsupported_typespec                                3163
+unsupported_typespec                                3600
 var_select                                           383
 wait_fork                                              6
 wait_stmt                                             96

--- a/third_party/tests/oh/BasicOh.log
+++ b/third_party/tests/oh/BasicOh.log
@@ -2,563 +2,563 @@
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_async.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrqn.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_sync.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa42.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao221.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux7.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mult.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffqn.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_datagate.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa31.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao22.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux5.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor4.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux12.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockor.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_debouncer.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mult.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edge2pulse.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_iddr.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_arbiter.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_cdc.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobuflo.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rise2pulse.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa62.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg1.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rsync.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor3.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobufhi.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_tristate.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao222.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai21.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latnq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockgate.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pulse2pulse.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux9.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi211.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bitreverse.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_standby.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2onehot.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockor.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_stretcher.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai311.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oddr.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa211.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_header.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_dp.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao32.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi21.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao211.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa222.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffnq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi221.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa21.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_shift.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_cdc.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg0.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg1.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai32.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_add.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_inv.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao33.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi31.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockdiv.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux6.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pwr_buf.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fall2pulse.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa222.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buffer.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai22.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi33.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_iddr.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_delay.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_abs.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi222.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edgealign.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux5.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2gray.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao31.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rise2pulse.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat1.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx4.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dsync.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa221.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ser2par.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat0.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa62.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi211.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsq.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrqn.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa33.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and2.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_sp.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buf.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi32.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_par2ser.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi31.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi22.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pll.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux8.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai33.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_regfile.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa22.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao311.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pwr_buf.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_gray2bin.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi311.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao21.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai31.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai221.v".
-
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa311.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa32.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockgate.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latq.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_counter.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_7seg_decode.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai222.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor3.v".
-
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsqn.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffnq.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa32.v".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux7.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa42.v".
+
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_parity.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa31.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao31.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_regfile.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa92.v".
 
-[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffqn.v".
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao221.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edgealign.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_tristate.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_counter.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai222.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsqn.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffqn.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_dp.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux8.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat1.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_stretcher.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_inv.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobufhi.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fall2pulse.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_7seg_decode.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latnq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai311.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai221.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ser2par.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa22.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_add.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buf.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_gray2bin.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao311.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oddr.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao22.v".
 
 [INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsqn.v".
 
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_sp.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai33.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_arbiter.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buffer.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pll.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao222.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi311.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_abs.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrqn.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi221.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao211.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_datagate.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat0.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai31.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi21.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa33.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi222.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa21.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pulse2pulse.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai22.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_par2ser.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2gray.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dsync.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao21.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffqn.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bitreverse.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2onehot.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao33.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa221.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi22.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edge2pulse.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_header.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa211.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao32.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_delay.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_standby.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai21.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand4.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi33.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_shift.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux9.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffq.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrqn.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_debouncer.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobuflo.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_sync.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg0.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux6.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux2.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux3.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux12.v".
+
+[INF:PP0122] Preprocessing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or4.v".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_async.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrqn.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_sync.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa42.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao221.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux7.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mult.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffqn.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_datagate.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa31.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao22.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux5.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor4.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux12.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockor.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_debouncer.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mult.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edge2pulse.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_iddr.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_arbiter.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_cdc.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobuflo.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rise2pulse.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa62.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg1.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rsync.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor3.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobufhi.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_tristate.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao222.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai21.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latnq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockgate.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pulse2pulse.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux9.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi211.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bitreverse.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_standby.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2onehot.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockor.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_stretcher.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai311.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oddr.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa211.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_header.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_dp.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao32.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi21.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao211.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa222.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffnq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi221.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa21.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_shift.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_cdc.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg0.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg1.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai32.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_add.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_inv.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao33.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi31.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockdiv.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux6.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pwr_buf.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fall2pulse.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa222.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buffer.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai22.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi33.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_iddr.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_delay.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_abs.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi222.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edgealign.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux5.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2gray.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao31.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_rise2pulse.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat1.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx4.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dsync.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa221.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ser2par.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat0.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa62.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi211.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsq.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrqn.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa33.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and2.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_sp.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buf.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi32.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_par2ser.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi31.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi22.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pll.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux8.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai33.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_regfile.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa22.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao311.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pwr_buf.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_gray2bin.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi311.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao21.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai31.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai221.v".
-
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa311.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa32.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockgate.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latq.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_counter.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_7seg_decode.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai222.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor3.v".
-
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsqn.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffnq.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa32.v".
 
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux7.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa42.v".
+
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_parity.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa31.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao31.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_regfile.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_csa92.v".
 
-[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffqn.v".
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao221.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edgealign.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_tristate.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_counter.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai222.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffsqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_dp.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux8.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat1.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_stretcher.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_inv.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobufhi.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fall2pulse.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_7seg_decode.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_latnq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai311.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai221.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ser2par.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa22.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nor2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_add.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buf.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_gray2bin.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao311.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oddr.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao22.v".
 
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffsqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_memory_sp.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai33.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xor3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_arbiter.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_buffer.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pll.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao222.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi311.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_abs.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffrqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi221.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao211.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_datagate.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_lat0.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai31.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi21.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa33.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi222.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa21.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_xnor3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_pulse2pulse.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mx3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai22.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_par2ser.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2gray.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dsync.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao21.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_dffqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bitreverse.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mxi4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_bin2onehot.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao33.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa221.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi22.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_edge2pulse.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_header.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oa211.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_ao32.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_clockmux4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_delay.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_standby.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_and2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_oai21.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_nand4.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_aoi33.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_shift.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux9.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffq.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_sdffrqn.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_debouncer.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_isobuflo.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_fifo_sync.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_reg0.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux6.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux2.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux3.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_mux12.v".
+
+[INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/tests/oh/stdlib/hdl/oh_or4.v".
 
 [INF:CM0029] Using global timescale: "1ns/1ns".
 


### PR DESCRIPTION
Implement GC

Added a command-line option to explicitly disable it.

NOTE: Two tests are still failing with this change.
* third_party/tests/Google
* third_party/tests/IncompTitan

Both tests are crashing only on Linux builds.