### PR TITLE
Prototype implementation to bring preprocessor directives into parse tree

### DIFF
--- a/grammar/SV3_1aLexer.g4
+++ b/grammar/SV3_1aLexer.g4
@@ -27,8 +27,12 @@ lexer grammar SV3_1aLexer;
 
 channels {
   WHITESPACES,
-  COMMENTS
+  COMMENTS,
+  PREPROC
 }
+
+PREPROC_BEGIN: '/*{#' Decimal_digit+ '*/' -> channel(PREPROC);
+PREPROC_END: '/*#' Decimal_digit+ '}*/' -> channel(PREPROC);
 
 QMARK: '?';
 

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -31,6 +31,8 @@
 #include <regex>
 
 namespace SURELOG {
+static constexpr std::string_view kPreprocBeginIdentifier = "/*{*/";
+static constexpr std::string_view kPreprocEndIdentifier = "/*}*/";
 
 SV3_1aPpTreeShapeListener::SV3_1aPpTreeShapeListener(
     PreprocessFile *pp, antlr4::CommonTokenStream *tokens,
@@ -388,6 +390,7 @@ void SV3_1aPpTreeShapeListener::exitInclude_directive(
 
 void SV3_1aPpTreeShapeListener::enterSimple_no_args_macro_definition(
     SV3_1aPpParser::Simple_no_args_macro_definitionContext *ctx) {
+  m_pp->append(StrCat("/*{#", m_fileContent->getVObjects().size(), "*/"));
   if (m_inActiveBranch) {
     std::string macroName;
     if (ctx->Simple_identifier())
@@ -433,7 +436,9 @@ void SV3_1aPpTreeShapeListener::enterSimple_no_args_macro_definition(
 void SV3_1aPpTreeShapeListener::exitSimple_no_args_macro_definition(
     SV3_1aPpParser::Simple_no_args_macro_definitionContext *ctx) {
   m_inMacroDefinitionParsing = false;
-  addVObject(ctx, VObjectType::slMacro_definition);
+  const size_t index =
+      (RawNodeId)addVObject(ctx, VObjectType::slMacro_definition);
+  m_pp->append(StrCat("/*#", index, "}*/"));
 }
 
 void SV3_1aPpTreeShapeListener::enterMacroInstanceWithArgs(

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -1862,7 +1862,29 @@ void SV3_1aTreeShapeListener::enterNounconnected_drive_directive(
 
 void SV3_1aTreeShapeListener::enterEveryRule(antlr4::ParserRuleContext *ctx) {}
 void SV3_1aTreeShapeListener::exitEveryRule(antlr4::ParserRuleContext *ctx) {}
-void SV3_1aTreeShapeListener::visitTerminal(antlr4::tree::TerminalNode *node) {}
+
+void SV3_1aTreeShapeListener::visitTerminal(antlr4::tree::TerminalNode *node) {
+  const antlr4::Token *const token = node->getSymbol();
+  if (token->getType() == antlr4::Token::EOF) return;
+
+  const size_t index = token->getTokenIndex();
+
+  // Track line/column offset to apply because of additional
+  // text in the preprocessor generated text stream.
+
+  switch (token->getType()) {
+    case SV3_1aParser::PREPROC_BEGIN: {
+    } break;
+
+    case SV3_1aParser::PREPROC_END: {
+      // Parse out the node-id from the token text
+      // Merge the tree from preprocessor FileContent
+    } break;
+
+    default: break;
+  }
+}
+
 void SV3_1aTreeShapeListener::visitErrorNode(antlr4::tree::ErrorNode *node) {}
 
 void SV3_1aTreeShapeListener::exitBegin_keywords_directive(


### PR DESCRIPTION
Prototype implementation to bring preprocessor directives into parse tree

This approach doesn't require polluting the grammar. The preproc identifiers are pushed into a separate channel and are handled in visitTerminal where all tokens include the ones in the _special_ channel can be traversed.

NOTE: This is for prototype purpose only and not intended to be merged.