### PR TITLE
Issue #3755: Move non-vendored workflow out of main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,13 @@ concurrency:
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
 
 # Linux build, test, and publish
   linux-install:
-    name: "Linux | Install | ${{ matrix.compiler }} | ${{ matrix.config }} | ${{ matrix.vendored_dependencies }}"
+    name: "Linux | Install | ${{ matrix.compiler }} | ${{ matrix.config }}"
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -23,13 +24,6 @@ jobs:
         config:
         - debug
         - release
-        vendored_dependencies: [true, false]
-        exclude:
-          # Unnecessary to test no-vendoring across every strategy
-          - compiler: clang
-            vendored_dependencies: false
-          - config: debug
-            vendored_dependencies: false
 
     env:
       artifact-name: sl-${{ github.run_number }}-linux-${{ matrix.compiler }}-${{ matrix.config }}
@@ -40,11 +34,6 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
-      if: ${{ matrix.vendored_dependencies }}
-
-    - name: Checkout code
-      uses: actions/checkout@v3
-      if: ${{ !matrix.vendored_dependencies }}
 
     # Fetch tags for CMakeLists version check
     # https://github.com/actions/checkout/issues/701
@@ -55,36 +44,6 @@ jobs:
       with:
         compiler: ${{ matrix.compiler }}
         ccache-key: linux-install-${{ matrix.compiler }}-${{ matrix.config }}
-
-    - name: Install vendored dependencies
-      if: ${{ !matrix.vendored_dependencies }}
-      run: |
-        git clone https://github.com/google/flatbuffers.git
-        pushd flatbuffers
-        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DBUILD_SHARED_LIBS=ON . && cmake --build build && sudo cmake --install build
-        popd
-
-        git clone https://github.com/google/googletest.git
-        pushd googletest
-        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DBUILD_SHARED_LIBS=ON . && cmake --build build && sudo cmake --install build
-        popd
-
-        git clone https://github.com/capnproto/capnproto.git
-        pushd capnproto
-        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DCMAKE_POSITION_INDEPENDENT_CODE=ON . && cmake --build build && sudo cmake --install build
-        popd
-
-        git clone https://github.com/chipsalliance/UHDM.git
-        pushd UHDM
-        cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DUHDM_USE_HOST_GTEST=ON -DUHDM_USE_HOST_CAPNP=ON . && cmake --build build && sudo cmake --install build
-        popd
-
-        sudo mkdir -p /usr/share/java
-        sudo wget https://www.antlr.org/download/antlr-4.12.0-complete.jar -P /usr/share/java
-        wget https://www.antlr.org/download/antlr4-cpp-runtime-4.12.0-source.zip && mkdir antlr4
-        pushd antlr4
-        unzip ../antlr4-cpp-runtime-4.12.0-source.zip && cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DBUILD_SHARED_LIBS=ON . && cmake --build build && sudo cmake --install build
-        popd
 
     - name: Build, install & test
       run: |
@@ -98,18 +57,7 @@ jobs:
 
         export INSTALL_DIR=`pwd`/install
 
-        if [ "${{ matrix.vendored_dependencies }}" == "false" ]; then
-          # Ensure that vendored dependencies' shared libraries are available
-          # for any run checks, such as those in the `TestInstall` project
-          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-        fi
-
-        if [ "${{ matrix.vendored_dependencies }}" == "false" ]; then
-          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DBUILD_SHARED_LIBS=ON -DSURELOG_USE_HOST_FLATBUFFERS=ON -DSURELOG_USE_HOST_ANTLR=ON -DSURELOG_USE_HOST_UHDM=ON -DSURELOG_USE_HOST_GTEST=ON -DSURELOG_WITH_TCMALLOC=OFF -DCMAKE_MODULE_PATH="/usr/share/CMake/Modules;/usr/local/lib/cmake" -S . -B build
-        else
-          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR $CMAKE_ADDITIONAL_ARGS -S . -B build
-        fi
-
+        cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR $CMAKE_ADDITIONAL_ARGS -S . -B build
         cmake --build build -j $(nproc)
         cmake --install build
 
@@ -118,15 +66,10 @@ jobs:
 
         rm -rf build      # make sure we only see installation artifacts
         
-        # this shouldnt be necessary, and can't be reproduced outside CI
+        # This shouldn''t be necessary, and can't be reproduced outside CI
         export CMAKE_PREFIX_PATH=$INSTALL_DIR
 
-        if [ "${{ matrix.vendored_dependencies }}" == "false" ]; then
-          cmake -DCMAKE_BUILD_TYPE=Release -DINSTALL_DIR=$INSTALL_DIR -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DBUILD_SHARED_LIBS=ON -DSURELOG_USE_HOST_FLATBUFFERS=ON -DSURELOG_USE_HOST_ANTLR=ON -DSURELOG_USE_HOST_UHDM=ON -DSURELOG_USE_HOST_GTEST=ON -S tests/TestInstall -B tests/TestInstall/build
-        else
-          cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DINSTALL_DIR=$INSTALL_DIR -S tests/TestInstall -B tests/TestInstall/build
-        fi
-
+        cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DINSTALL_DIR=$INSTALL_DIR -S tests/TestInstall -B tests/TestInstall/build
         cmake --build tests/TestInstall/build -j $(nproc)
 
         echo "-- pkg-config content --"
@@ -138,14 +81,12 @@ jobs:
         mkdir artifacts
         mv install ${{ env.artifact-name }}
         tar czfp artifacts/${{ env.artifact-name }}.tar.gz ${{ env.artifact-name }}
-      if: ${{ matrix.vendored_dependencies }}
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.artifact-name }}
         path: artifacts/${{ env.artifact-name }}.tar.gz
-      if: ${{ matrix.vendored_dependencies }}
 
 
 # Linux regression

--- a/.github/workflows/non_vendored.yml
+++ b/.github/workflows/non_vendored.yml
@@ -1,0 +1,105 @@
+name: 'non_vendored'
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+
+# Linux build and test
+  linux-install:
+    name: "Linux | Install | ${{ matrix.compiler }} | ${{ matrix.config }}"
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+        - gcc
+        config:
+        - release
+
+    env:
+      artifact-name: sl-${{ github.run_number }}-linux-${{ matrix.compiler }}-${{ matrix.config }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    # Fetch tags for CMakeLists version check
+    # https://github.com/actions/checkout/issues/701
+    - name: Git fetch tags
+      run: git fetch --tags origin
+
+    - uses: ./.github/linux-setup
+      with:
+        compiler: ${{ matrix.compiler }}
+        ccache-key: linux-install-${{ matrix.compiler }}-${{ matrix.config }}
+
+    - name: Install vendored dependencies
+      run: |
+        git clone https://github.com/google/flatbuffers.git
+        pushd flatbuffers
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DBUILD_SHARED_LIBS=ON . && cmake --build build && sudo cmake --install build
+        popd
+
+        git clone https://github.com/google/googletest.git
+        pushd googletest
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DBUILD_SHARED_LIBS=ON . && cmake --build build && sudo cmake --install build
+        popd
+
+        git clone https://github.com/capnproto/capnproto.git
+        pushd capnproto
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DCMAKE_POSITION_INDEPENDENT_CODE=ON . && cmake --build build && sudo cmake --install build
+        popd
+
+        git clone https://github.com/chipsalliance/UHDM.git
+        pushd UHDM
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DUHDM_USE_HOST_GTEST=ON -DUHDM_USE_HOST_CAPNP=ON . && cmake --build build && sudo cmake --install build
+        popd
+
+        sudo mkdir -p /usr/share/java
+        sudo wget https://www.antlr.org/download/antlr-4.12.0-complete.jar -P /usr/share/java
+        wget https://www.antlr.org/download/antlr4-cpp-runtime-4.12.0-source.zip && mkdir antlr4
+        pushd antlr4
+        unzip ../antlr4-cpp-runtime-4.12.0-source.zip && cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DBUILD_SHARED_LIBS=ON . && cmake --build build && sudo cmake --install build
+        popd
+
+    - name: Build, install & test
+      run: |
+        if [ "${{ matrix.config }}" == "debug" ]; then
+          export BUILD_TYPE=Debug
+          export CMAKE_ADDITIONAL_ARGS=-DSURELOG_WITH_TCMALLOC=Off
+        else
+          export BUILD_TYPE=Release
+          export CMAKE_ADDITIONAL_ARGS=
+        fi
+
+        export INSTALL_DIR=`pwd`/install
+        # Ensure that vendored dependencies' shared libraries are available
+        # for any run checks, such as those in the `TestInstall` project
+        export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
+        cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DBUILD_SHARED_LIBS=ON -DSURELOG_USE_HOST_FLATBUFFERS=ON -DSURELOG_USE_HOST_ANTLR=ON -DSURELOG_USE_HOST_UHDM=ON -DSURELOG_USE_HOST_GTEST=ON -DSURELOG_WITH_TCMALLOC=OFF -DCMAKE_MODULE_PATH="/usr/share/CMake/Modules;/usr/local/lib/cmake" -S . -B build
+        cmake --build build -j $(nproc)
+        cmake --install build
+
+        cmake --build build --target UnitTests -j $(nproc)
+        pushd build && ctest --output-on-failure && popd
+
+        rm -rf build      # make sure we only see installation artifacts
+        
+        # this shouldnt be necessary, and can't be reproduced outside CI
+        export CMAKE_PREFIX_PATH=$INSTALL_DIR
+
+        cmake -DCMAKE_BUILD_TYPE=Release -DINSTALL_DIR=$INSTALL_DIR -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DBUILD_SHARED_LIBS=ON -DSURELOG_USE_HOST_FLATBUFFERS=ON -DSURELOG_USE_HOST_ANTLR=ON -DSURELOG_USE_HOST_UHDM=ON -DSURELOG_USE_HOST_GTEST=ON -S tests/TestInstall -B tests/TestInstall/build
+        cmake --build tests/TestInstall/build -j $(nproc)
+
+        echo "-- pkg-config content --"
+        cat $INSTALL_DIR/lib/pkgconfig/Surelog.pc
+        PREFIX=$INSTALL_DIR make test_install_pkgconfig


### PR DESCRIPTION
Issue #3755: Move non-vendored workflow out of main

Move non-vendored workflow out of main and into a separate workflow. Also, run it only for master branch, this is where it matters.