### PR TITLE
Small tweak to default antlr jar installation paths

### DIFF
--- a/cmake/modules/FindANTLR.cmake
+++ b/cmake/modules/FindANTLR.cmake
@@ -13,7 +13,7 @@ find_package(Java QUIET COMPONENTS Runtime)
 if(NOT ANTLR_JAR_LOCATION)
   find_file(ANTLR_JAR_LOCATION
             NAMES antlr-4.12.0-complete.jar antlr.jar antlr4.jar antlr-4.jar 
-            HINTS /usr /usr/local /usr/local/lib/ /usr/share /usr/share/java /usr/local/Homebrew ~/homebrew /usr/local/homebrew/Cellar /opt/homebrew/Cellar
+            HINTS /usr /usr/local /usr/local/share /usr/local/share/java /usr/local/lib/ /usr/share /usr/share/java /usr/local/Homebrew ~/homebrew /usr/local/homebrew/Cellar /opt/homebrew/Cellar
             PATH_SUFFIXES antlr 4.12.0 antlr/4.12.0 
             NO_CMAKE_SYSTEM_PATH
             NO_SYSTEM_ENVIRONMENT_PATH)


### PR DESCRIPTION
This is a small tweak to account for `/usr/local/share` as a possible location for the antlr jar, the non-vendored CI puts it into `/usr/share/java` but its quite reasonable to end up in `/usr/local/share/java`. 