### PR TITLE
Include config.h where needed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,6 @@ option(
    SURELOG_WITH_TCMALLOC
    "Use tcmalloc if installed" ON)
 option(
-  SURELOG_SYMBOLID_DEBUG_ENABLED
-  "Enable SymbolId debugging" OFF)
-option(
   SURELOG_PATHID_DEBUG_ENABLED
   "Enable PathId debugging" OFF)
 
@@ -58,11 +55,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-# Make sure both SURELOG_SYMBOLID_DEBUG_ENABLED & UHDM_SYMBOLID_DEBUG_ENABLED
-# are set the same
-set(UHDM_SYMBOLID_DEBUG_ENABLED ${SURELOG_SYMBOLID_DEBUG_ENABLED}
-  CACHE BOOL "Enforcing" FORCE)
 
 # Setup code generation directory
 set(GENDIR ${CMAKE_CURRENT_BINARY_DIR}/generated)

--- a/include/Surelog/Common/PathId.h
+++ b/include/Surelog/Common/PathId.h
@@ -18,6 +18,8 @@
 #define SURELOG_PATHID_H
 #pragma once
 
+#include "Surelog/config.h"
+
 #include <Surelog/Common/SymbolId.h>
 
 #include <cstdint>

--- a/include/Surelog/config.h.in
+++ b/include/Surelog/config.h.in
@@ -24,7 +24,6 @@
 
 #include <uhdm/config.h>
 
-#cmakedefine01 SURELOG_SYMBOLID_DEBUG_ENABLED
 #cmakedefine01 SURELOG_PATHID_DEBUG_ENABLED
 
 #if defined(_MSC_VER)

--- a/shell.nix
+++ b/shell.nix
@@ -39,9 +39,6 @@ pkgs.mkShell {
     ];
   shellHook = ''
     export CMAKE_CXX_COMPILER_LAUNCHER=ccache
-    export ADDITIONAL_CMAKE_OPTIONS="-DSURELOG_USE_HOST_GTEST=On -DSURELOG_USE_HOST_ANTLR=On -DANTLR_JAR_LOCATION=${pkgs.antlr4.jarLocation}"
-
-    # For the UHDM dependency: tell it to use local capnp
-    export ADDITIONAL_CMAKE_OPTIONS="$ADDITIONAL_CMAKE_OPTIONS -DUHDM_USE_HOST_CAPNP=On"
+    export ADDITIONAL_CMAKE_OPTIONS="-DSURELOG_USE_HOST_GTEST=On -DSURELOG_USE_HOST_CAPNP=On -DSURELOG_USE_HOST_ANTLR=On -DANTLR_JAR_LOCATION=${pkgs.antlr4.jarLocation}"
   '';
 }

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -41,6 +41,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include "Surelog/config.h"
+
 #if defined(_MSC_VER)
 #include <io.h>
 #else

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -39,6 +39,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include "Surelog/config.h"
+
 #if defined(_MSC_VER)
 #include <io.h>
 #else


### PR DESCRIPTION
Also remove `SURELOG_SYMBOLID_DEBUG_ENABLED` define which is not used anymore (looks like UHDM symbolId is used)