### PR TITLE
Make sure C++ compiler does not generate unexpected implicit conversi…

### DIFF
--- a/.github/bin/run-clang-tidy.sh
+++ b/.github/bin/run-clang-tidy.sh
@@ -51,6 +51,7 @@ Checks: >
     clang-diagnostic-overloaded-virtual
     clang-diagnostic-unused-private-field,
     google-build-using-namespace,
+    google-explicit-constructor,
     modernize-loop-convert,
     modernize-raw-string-literal,
     modernize-use-override,

--- a/include/Surelog/Common/NodeId.h
+++ b/include/Surelog/Common/NodeId.h
@@ -40,13 +40,13 @@ class NodeId final {
   constexpr explicit NodeId(RawNodeId id) : id(id) {}
   constexpr NodeId(const NodeId &rhs) : id(rhs.id) {}
 
-  operator RawNodeId() const { return id; }
+  operator RawNodeId() const { return id; }  // NOLINT
 
   // Don't include size_t conversion on 32Bit machines where sizeof(size_t)==32
   template <typename T = std::size_t,
             typename std::enable_if<!std::is_same<T, RawNodeId>::value>::type
                 * = nullptr>
-  operator std::size_t() const {
+  operator std::size_t() const {  // NOLINT
     return id;
   }
 

--- a/include/Surelog/Common/PathId.h
+++ b/include/Surelog/Common/PathId.h
@@ -120,7 +120,7 @@ inline std::ostream &operator<<(std::ostream &strm, const PathId &pathId) {
 struct PathIdPP final { // Pretty Printer
   const PathId &m_id;
 
-  PathIdPP(const PathId &id) : m_id(id) {}
+  explicit PathIdPP(const PathId &id) : m_id(id) {}
 };
 
 std::ostream &operator<<(std::ostream &strm, const PathIdPP &id);

--- a/include/Surelog/Common/PlatformFileSystem.h
+++ b/include/Surelog/Common/PlatformFileSystem.h
@@ -197,11 +197,11 @@ class PlatformFileSystem : public FileSystem {
       T *ptr = nullptr;
       Helper() : ptr(nullptr) {}
       Helper(Helper const &) = default;
-      Helper(T *p) : ptr(p) {}
+      Helper(T *p) : ptr(p) {}  // NOLINT
       template <class U>
-      Helper(std::shared_ptr<U> const &sp) : ptr(sp.get()) {}
+      Helper(std::shared_ptr<U> const &sp) : ptr(sp.get()) {}  // NOLINT
       template <class U, class... Ts>
-      Helper(std::unique_ptr<U, Ts...> const &up) : ptr(up.get()) {}
+      Helper(std::unique_ptr<U, Ts...> const &up) : ptr(up.get()) {}  // NOLINT
       // && optional: enforces rvalue use only
       bool operator<(const Helper &o) const {
         return std::less<T *>()(ptr, o.ptr);

--- a/include/Surelog/Design/DefParam.h
+++ b/include/Surelog/Design/DefParam.h
@@ -37,7 +37,7 @@ class Value;
 
 class DefParam final {
  public:
-  DefParam(std::string_view name, DefParam* parent = nullptr)
+  explicit DefParam(std::string_view name, DefParam* parent = nullptr)
       : m_name(name),
         m_value(nullptr),
         m_used(false),

--- a/include/Surelog/Design/Netlist.h
+++ b/include/Surelog/Design/Netlist.h
@@ -39,7 +39,7 @@ class ModPort;
 
 class Netlist {
  public:
-  Netlist(ModuleInstance* parent) : m_parent(parent) {}
+  explicit Netlist(ModuleInstance* parent) : m_parent(parent) {}
   ~Netlist();
 
   typedef std::map<std::string, std::pair<ModPort*, UHDM::modport*>,

--- a/include/Surelog/DesignCompile/CompileDesign.h
+++ b/include/Surelog/DesignCompile/CompileDesign.h
@@ -44,7 +44,7 @@ void decompile(ValuedComponentI* instance);
 class CompileDesign {
  public:
   // Note: takes owernship of compiler
-  CompileDesign(Compiler* compiler);
+  explicit CompileDesign(Compiler* compiler);
   virtual ~CompileDesign();  // Used in MockCompileDesign
 
   bool compile();

--- a/include/Surelog/DesignCompile/DesignElaboration.h
+++ b/include/Surelog/DesignCompile/DesignElaboration.h
@@ -36,7 +36,7 @@ class ModuleInstanceFactory;
 
 class DesignElaboration : public TestbenchElaboration {
  public:
-  DesignElaboration(CompileDesign* compileDesign);
+  explicit DesignElaboration(CompileDesign* compileDesign);
   DesignElaboration(const DesignElaboration& orig) = delete;
   ~DesignElaboration() override;
 

--- a/include/Surelog/DesignCompile/ElaborationStep.h
+++ b/include/Surelog/DesignCompile/ElaborationStep.h
@@ -49,7 +49,7 @@ class Variable;
 
 class ElaborationStep {
  public:
-  ElaborationStep(CompileDesign* compileDesign);
+  explicit ElaborationStep(CompileDesign* compileDesign);
   ElaborationStep(const ElaborationStep& orig) = delete;
 
   virtual bool elaborate() = 0;

--- a/include/Surelog/DesignCompile/NetlistElaboration.h
+++ b/include/Surelog/DesignCompile/NetlistElaboration.h
@@ -38,7 +38,7 @@ class Signal;
 
 class NetlistElaboration : public TestbenchElaboration {
  public:
-  NetlistElaboration(CompileDesign* compileDesign);
+  explicit NetlistElaboration(CompileDesign* compileDesign);
   NetlistElaboration(const NetlistElaboration& orig) = delete;
 
   bool elaborate() override;

--- a/include/Surelog/DesignCompile/PackageAndRootElaboration.h
+++ b/include/Surelog/DesignCompile/PackageAndRootElaboration.h
@@ -31,7 +31,7 @@ namespace SURELOG {
 
 class PackageAndRootElaboration : public ElaborationStep {
  public:
-  PackageAndRootElaboration(CompileDesign* compileDesign)
+  explicit PackageAndRootElaboration(CompileDesign* compileDesign)
       : ElaborationStep(compileDesign) {}
 
   ~PackageAndRootElaboration() override = default;

--- a/include/Surelog/DesignCompile/TestbenchElaboration.h
+++ b/include/Surelog/DesignCompile/TestbenchElaboration.h
@@ -38,7 +38,7 @@ class Variable;
 
 class TestbenchElaboration : public ElaborationStep {
  public:
-  TestbenchElaboration(CompileDesign* compileDesign)
+  explicit TestbenchElaboration(CompileDesign* compileDesign)
       : ElaborationStep(compileDesign) {}
 
   TestbenchElaboration(const TestbenchElaboration& orig);

--- a/include/Surelog/DesignCompile/UVMElaboration.h
+++ b/include/Surelog/DesignCompile/UVMElaboration.h
@@ -33,7 +33,7 @@ class CompileDesign;
 
 class UVMElaboration : public TestbenchElaboration {
  public:
-  UVMElaboration(CompileDesign* compileDesign);
+  explicit UVMElaboration(CompileDesign* compileDesign);
   UVMElaboration(const UVMElaboration& orig) = delete;
   ~UVMElaboration() override = default;
 

--- a/include/Surelog/Expression/Value.h
+++ b/include/Surelog/Expression/Value.h
@@ -174,11 +174,11 @@ class SValue final : public Value {
         m_signed(true) {
     m_value.s_int = val;
   }
-  SValue(uint64_t val)
+  explicit SValue(uint64_t val)
       : m_type(Value::Type::Unsigned), m_size(64), m_valid(1), m_negative(0) {
     m_value.u_int = val;
   }
-  SValue(int64_t val)
+  explicit SValue(int64_t val)
       : m_type(Value::Type::Integer),
         m_size(64),
         m_valid(1),
@@ -186,7 +186,7 @@ class SValue final : public Value {
         m_signed(true) {
     m_value.s_int = val;
   }
-  SValue(double val)
+  explicit SValue(double val)
       : m_type(Value::Type::Double),
         m_size(64),
         m_valid(1),

--- a/include/Surelog/Library/AntlrLibParserErrorListener.h
+++ b/include/Surelog/Library/AntlrLibParserErrorListener.h
@@ -36,7 +36,7 @@ class ParseLibraryDef;
 
 class AntlrLibParserErrorListener : public antlr4::ANTLRErrorListener {
  public:
-  AntlrLibParserErrorListener(ParseLibraryDef *parser) : m_parser(parser) {}
+  explicit AntlrLibParserErrorListener(ParseLibraryDef *parser) : m_parser(parser) {}
 
   ~AntlrLibParserErrorListener() override{};
 

--- a/include/Surelog/SourceCompile/CheckCompile.h
+++ b/include/Surelog/SourceCompile/CheckCompile.h
@@ -31,7 +31,7 @@ class Compiler;
 
 class CheckCompile {
  public:
-  CheckCompile(Compiler* compiler) : m_compiler(compiler) {}
+  explicit CheckCompile(Compiler* compiler) : m_compiler(compiler) {}
   bool check();
   virtual ~CheckCompile() = default;
 

--- a/include/Surelog/SourceCompile/CompilationUnit.h
+++ b/include/Surelog/SourceCompile/CompilationUnit.h
@@ -35,7 +35,7 @@ class MacroInfo;
 
 class CompilationUnit {
  public:
-  CompilationUnit(bool fileunit);
+  explicit CompilationUnit(bool fileunit);
   CompilationUnit(const CompilationUnit& orig) = delete;
   virtual ~CompilationUnit() = default;
 

--- a/include/Surelog/SourceCompile/LoopCheck.h
+++ b/include/Surelog/SourceCompile/LoopCheck.h
@@ -50,7 +50,7 @@ class LoopCheck {
 
   class Node {
    public:
-    Node(SymbolId objId) : m_objId(objId), m_visited(false) {}
+    explicit Node(SymbolId objId) : m_objId(objId), m_visited(false) {}
     const SymbolId m_objId;
     std::set<Node*> m_toList;
     bool m_visited;


### PR DESCRIPTION
…ons.

Marking single-argument constructors `explicit` makes sure they are not considered for invisible type-conversion chains.

Enable them with `// NOLINT` in places where we explicitly want this behavior.