### PR TITLE
Issue#3812#3818 Introducing json, and cache working directories for sepcmd

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 	path = third_party/antlr4
 	url = https://github.com/antlr/antlr4.git
 	branch = dev
+[submodule "third_party/json"]
+	path = third_party/json
+	url = https://github.com/nlohmann/json.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,8 @@ else()
   # Requires SURELOG_USE_HOST_UHDM=Off
 endif()
 
+add_subdirectory(third_party/json)
+
 # NOTE: Set the global output directories after the subprojects have had their go at it
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
@@ -520,6 +522,9 @@ target_include_directories(surelog PUBLIC
   $<INSTALL_INTERFACE:include>)
 target_include_directories(surelog PUBLIC
   $<BUILD_INTERFACE:${UHDM_INCLUDE_DIRS}>
+  $<INSTALL_INTERFACE:include>)
+target_include_directories(surelog PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third_party/json/single_include>
   $<INSTALL_INTERFACE:include>)
 
 if (SURELOG_WITH_PYTHON)

--- a/include/Surelog/Common/FileSystem.h
+++ b/include/Surelog/Common/FileSystem.h
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <istream>
+#include <map>
 #include <regex>
 #include <sstream>
 #include <string>
@@ -100,6 +101,9 @@ class FileSystem {
   static constexpr std::string_view kParserCacheDirName = kCacheDirName;
   static constexpr std::string_view kPythonCacheDirName = kCacheDirName;
 
+  typedef std::map<std::string, std::string, std::less<>>
+      filepath_to_working_directories_cache_t;
+
  public:
   static FileSystem *getInstance();
   static FileSystem *setInstance(FileSystem *fileSystem);
@@ -124,6 +128,9 @@ class FileSystem {
   // and can be used for, say, system commands.
   virtual std::filesystem::path toPlatformAbsPath(PathId id) = 0;
   virtual std::filesystem::path toPlatformRelPath(PathId id) = 0;
+  // Returns base and relative paths 
+  virtual std::pair<std::filesystem::path, std::filesystem::path>
+  toSplitPlatformPath(PathId id) = 0;
 
   // Returns the current working directory as either the native filesystem
   // path or as a PathId registered in the input SymbolTable.
@@ -182,6 +189,11 @@ class FileSystem {
   // after relocation.
   virtual bool addMapping(std::string_view what, std::string_view with) = 0;
   virtual std::string remap(std::string_view what) = 0;
+
+  // Adds a working directory cache entry
+  // This is used primarily for use with _sepcmd_ command.
+  virtual bool addWorkingDirectoryCacheEntry(std::string_view prefix,
+                                             std::string_view suffix) = 0;
 
   // Path computation APIs for different contexts
   virtual PathId getProgramFile(std::string_view hint,
@@ -336,6 +348,8 @@ class FileSystem {
  protected:
   std::istringstream m_nullInputStream;
   std::ostringstream m_nullOutputStream;
+
+  filepath_to_working_directories_cache_t m_filepathToWorkingDirectoriesCache;
 
  private:
   static FileSystem *sInstance;

--- a/include/Surelog/Common/PlatformFileSystem.h
+++ b/include/Surelog/Common/PlatformFileSystem.h
@@ -59,6 +59,9 @@ class PlatformFileSystem : public FileSystem {
   std::filesystem::path toPlatformAbsPath(PathId id) override;
   std::filesystem::path toPlatformRelPath(PathId id) override;
 
+  std::pair<std::filesystem::path, std::filesystem::path> toSplitPlatformPath(
+      PathId id) override;
+
   std::string getWorkingDir() override;
   std::set<std::string> getWorkingDirs() override;
 
@@ -77,6 +80,9 @@ class PlatformFileSystem : public FileSystem {
 
   bool addMapping(std::string_view what, std::string_view with) override;
   std::string remap(std::string_view what) override;
+
+  bool addWorkingDirectoryCacheEntry(std::string_view prefix,
+                                     std::string_view suffix) override;
 
   PathId getProgramFile(std::string_view hint,
                         SymbolTable *symbolTable) override;

--- a/include/Surelog/Utils/StringUtils.h
+++ b/include/Surelog/Utils/StringUtils.h
@@ -146,6 +146,12 @@ void registerEnvVar(std::string_view var, std::string_view value);
 
 // Strip quotes, if any. "abc" => abc
 [[nodiscard]] std::string_view unquoted(std::string_view text);
+
+// Returns true if string 'text' starts with 'prefix'
+[[nodiscard]] bool startsWith(std::string_view text, std::string_view prefix);
+
+// Returns true if string 'text' ends with 'suffix'
+[[nodiscard]] bool endsWith(std::string_view text, std::string_view suffix);
 }  // namespace StringUtils
 }  // namespace SURELOG
 

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -29,6 +29,8 @@
 #include <Surelog/Utils/StringUtils.h>
 #include <Surelog/surelog-version.h>
 
+#include <nlohmann/json.hpp>
+
 #if defined(_MSC_VER)
 #include <direct.h>
 #endif
@@ -685,19 +687,22 @@ void CommandLineParser::processArgs_(const std::vector<std::string>& args,
       PathId compileDirId =
           fileSystem->getCompileDir(m_fileUnit, m_symbolTable);
       PathIdVector fileList;
-      fileSystem->collect(compileDirId, ".sep_lst", m_symbolTable, fileList);
+      fileSystem->collect(compileDirId, ".sepcmd.json", m_symbolTable, fileList);
       for (const auto& fileId : fileList) {
-        std::string fileContent;
-        if (fileSystem->readContent(fileId, fileContent)) {
-          fileContent = StringUtils::removeComments(fileContent);
-          fileContent = StringUtils::evaluateEnvVars(fileContent);
-          std::vector<std::string> argsInFile;
-          StringUtils::tokenize(fileContent, " \n\t\r", argsInFile);
-          processArgs_(argsInFile, wd, cd, container);
-        } else {
-          Location loc(fileId);
-          Error err(ErrorDefinition::CMD_DASH_F_FILE_DOES_NOT_EXIST, loc);
-          m_errors->addError(err);
+        nlohmann::json fileContent;
+        std::istream& ifs = fileSystem->openForRead(fileId);
+        if (ifs.good()) ifs >> fileContent;
+        fileSystem->close(ifs);
+
+        for (const auto& entry : fileContent["sources"]) {
+          const std::string baseDirectory = entry["base_directory"];
+          const std::string relativeFilepath = entry["relative_filepath"];
+          fileSystem->addWorkingDirectoryCacheEntry(baseDirectory,
+                                                    relativeFilepath);
+
+          std::filesystem::path absFilepath =
+              std::filesystem::path(baseDirectory) / relativeFilepath;
+          container.emplace_back(absFilepath.string());
         }
       }
     } else if (!arg.empty()) {

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -44,6 +44,8 @@
 #include <Surelog/Utils/StringUtils.h>
 #include <Surelog/Utils/Timer.h>
 
+#include <nlohmann/json.hpp>
+
 #include <climits>
 #include <filesystem>
 #include <thread>
@@ -327,19 +329,39 @@ bool Compiler::createFileList_() {
         concatFiles << fileSystem->toPath(sourceFileId) << "|";
       }
       std::size_t val = std::hash<std::string>{}(concatFiles.str());
-      std::string hashedName = std::to_string(val) + ".sep_lst";
-      PathId fileId = fileSystem->getChild(
-          m_commandLineParser->getCompileDirId(), hashedName,
-          m_commandLineParser->getSymbolTable());
-      std::ostream& ofs = fileSystem->openForWrite(fileId);
-      if (ofs.good()) {
-        for (CompileSourceFile* sourceFile : m_compilers) {
-          ofs << fileSystem->toPath(sourceFile->getFileId()) << " ";
+      {
+        std::string hashedName = std::to_string(val) + ".sep_lst";
+        PathId fileId = fileSystem->getChild(
+            m_commandLineParser->getCompileDirId(), hashedName,
+            m_commandLineParser->getSymbolTable());
+        std::ostream& ofs = fileSystem->openForWrite(fileId);
+        if (ofs.good()) {
+          for (CompileSourceFile* sourceFile : m_compilers) {
+            ofs << fileSystem->toPath(sourceFile->getFileId()) << " ";
+          }
+          fileSystem->close(ofs);
+        } else {
+          std::cerr << "Could not create filelist: " << PathIdPP(fileId)
+                    << std::endl;
         }
-        fileSystem->close(ofs);
-      } else {
-        std::cerr << "Could not create filelist: " << PathIdPP(fileId)
-                  << std::endl;
+      }
+      {
+        std::string hashedName = std::to_string(val) + ".sepcmd.json";
+        PathId fileId = fileSystem->getChild(
+            m_commandLineParser->getCompileDirId(), hashedName,
+            m_commandLineParser->getSymbolTable());
+        std::ostream& ofs = fileSystem->openForWrite(fileId);
+        if (ofs.good()) {
+
+
+          for (CompileSourceFile* sourceFile : m_compilers) {
+            ofs << fileSystem->toPath(sourceFile->getFileId()) << " ";
+          }
+          fileSystem->close(ofs);
+        } else {
+          std::cerr << "Could not create filelist: " << PathIdPP(fileId)
+                    << std::endl;
+        }
       }
     }
   }

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -371,4 +371,14 @@ std::string_view StringUtils::unquoted(std::string_view text) {
   return text;
 }
 
+bool StringUtils::startsWith(std::string_view text, std::string_view prefix) {
+  return (text.size() >= prefix.size()) &&
+         (text.compare(0, prefix.size(), prefix) == 0);
+}
+
+bool StringUtils::endsWith(std::string_view text, std::string_view suffix) {
+  return (text.size() >= suffix.size()) &&
+         (text.compare(text.size() - suffix.size(), suffix.size(), suffix) ==
+          0);
+}
 }  // namespace SURELOG


### PR DESCRIPTION
Issue #3812: Extend support for sepcmd running out of directories not sharing the same root folder

Issue #3818: Include a json formatted text serializer. Added nlohmann/json in third_party

NOTE: Generating both the sep_lst and sepcmd.json file for backward compatibility. Loading only the latter though.

