### PR TITLE
Sort capnp factories, ref_typespec, and naming consistency

### DIFF
--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -527,7 +527,7 @@ void ElaborationStep::swapTypespecPointersInUhdm(
     } else if (ports* ex = any_cast<ports*>(var)) {
       ex->Typespec(replace(ex->Typespec(), typespecSwapMap));
     } else if (prop_formal_decl* ex = any_cast<prop_formal_decl*>(var)) {
-      ex->VpiTypespec(replace(ex->VpiTypespec(), typespecSwapMap));
+      ex->Typespec(replace(ex->Typespec(), typespecSwapMap));
     } else if (class_obj* ex = any_cast<class_obj*>(var)) {
       if (ex->Typespecs()) {
         for (auto& tps : *ex->Typespecs()) {


### PR DESCRIPTION
Sort capnp factories, ref_typespec, and naming consistency
* Sort the factories in capnp output so comparisons are easier
* Introducing ref_typespec, parallel to ref_obj to reference typespecs
* Enforce naming consistency

