### PR TITLE
Only use first include directory in json include directories list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,8 @@ endif()
 if (SURELOG_USE_HOST_JSON)
   find_package(nlohmann_json)
   get_target_property(JSON_INCLUDE_DIR nlohmann_json::nlohmann_json INTERFACE_INCLUDE_DIRECTORIES)
+  # the above returns a list of directories that seem to be duplicates, so take the first
+  list(POP_FRONT JSON_INCLUDE_DIR JSON_INCLUDE_DIR)
 else()
   # https://json.nlohmann.me/integration/cmake/#supporting-both
   set(JSON_BuildTests OFF CACHE INTERNAL "")


### PR DESCRIPTION
The generated CMake configuration includes local directories, e.g. from `homebrew`:

```
set_target_properties(surelog::surelog PROPERTIES
   INTERFACE_COMPILE_OPTIONS "SHELL:\$<IF:\$<CXX_COMPILER_ID:MSVC>,/FI Surelog/config.h,-include Surelog/config.h>"
   INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;${_IMPORT_PREFIX}/include;${_IMPORT_PREFIX}/include;/tmp/surelog-20231015-12198-wtj9jr/Surelog-1.76/;${_IMPORT_PREFIX}/include"
   INTERFACE_LINK_LIBRARIES "/opt/homebrew/lib/libantlr4-runtime.dylib;uhdm::uhdm;/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/lib/libz.tbd"
)
```

This is due to multiple directories in the JSON include interface, I have pruned them in this PR which fixes this issue. 