### PR TITLE
Fix issue with linking dependency of -lstdc++fs when using flatpak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,10 +655,6 @@ if (UNIX)
 endif()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
-  if(NOT SURELOG_USE_HOST_UHDM)
-    target_link_libraries(uhdm PRIVATE stdc++fs)
-  endif()
-  target_link_libraries(surelog PRIVATE stdc++fs)
   target_link_libraries(surelog PRIVATE rt)
 endif()
 


### PR DESCRIPTION
When trying to build Surelog inside a flatpak, it fails due to a linking issue with `-lstdc++fs`.
See opened topic here: https://github.com/flathub/flathub/issues/5221

It seems to be an old legacy linking practice that should be removed or it should be able to properly detect old versions of Ubuntu that requires it.