### PR TITLE
Don't remove always blocks from uhdmtopModules

### DIFF
--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -4555,107 +4555,6 @@ void UhdmWriter::writeInstance(ModuleDefinition* mod, ModuleInstance* instance,
   }
 }
 
-class AlwaysWithForLoop : public VpiListener {
- public:
-  explicit AlwaysWithForLoop() {}
-  ~AlwaysWithForLoop() override = default;
-  void leaveFor_stmt(const for_stmt* object, vpiHandle handle) override {
-    containtsForStmt = true;
-  }
-  bool containtsForStmt = false;
-};
-
-bool alwaysContainsForLoop(Serializer& serializer, any* root) {
-  AlwaysWithForLoop* listener = new AlwaysWithForLoop();
-  vpiHandle handle = serializer.MakeUhdmHandle(root->UhdmType(), root);
-  listener->listenAny(handle);
-  vpi_release_handle(handle);
-  bool result = listener->containtsForStmt;
-  delete listener;
-  return result;
-}
-
-// synlig has a major problem processing always blocks.
-// They are processed mainly in the allModules section which is incorrect in
-// some case. They should be processed from the topModules section. Here we try
-// to fix temporarily this by filtering out the always blocks containing
-// for-loops from the allModules, and those without from the topModules
-void filterAlwaysBlocks(Serializer& s, design* d) {
-  if (d->AllModules()) {
-    for (auto module : *d->AllModules()) {
-      if (module->Process()) {
-        bool more = true;
-        while (more) {
-          more = false;
-          for (std::vector<process_stmt*>::iterator itr =
-                   module->Process()->begin();
-               itr != module->Process()->end(); itr++) {
-            if ((*itr)->UhdmType() == uhdmalways) {
-              if (alwaysContainsForLoop(s, (*itr))) {
-                more = true;
-                module->Process()->erase(itr);
-                break;
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  std::queue<scope*> instances;
-  if (d->TopModules()) {
-    for (auto mod : *d->TopModules()) {
-      instances.push(mod);
-    }
-  }
-  while (!instances.empty()) {
-    scope* current = instances.front();
-    instances.pop();
-    if (current->UhdmType() == uhdmmodule_inst) {
-      module_inst* mod = (module_inst*)current;
-      if (mod->Process()) {
-        bool more = true;
-        while (more) {
-          more = false;
-          for (std::vector<process_stmt*>::iterator itr =
-                   mod->Process()->begin();
-               itr != mod->Process()->end(); itr++) {
-            if ((*itr)->UhdmType() == uhdmalways) {
-              if (!alwaysContainsForLoop(s, (*itr))) {
-                more = true;
-                mod->Process()->erase(itr);
-                break;
-              }
-            }
-          }
-        }
-      }
-      if (mod->Modules()) {
-        for (auto m : *mod->Modules()) {
-          instances.push(m);
-        }
-      }
-      if (mod->Gen_scope_arrays()) {
-        for (auto m : *mod->Gen_scope_arrays()) {
-          instances.push(m->Gen_scopes()->at(0));
-        }
-      }
-    } else if (current->UhdmType() == uhdmgen_scope) {
-      gen_scope* sc = (gen_scope*)current;
-      if (sc->Modules()) {
-        for (auto m : *sc->Modules()) {
-          instances.push(m);
-        }
-      }
-      if (sc->Gen_scope_arrays()) {
-        for (auto m : *sc->Gen_scope_arrays()) {
-          instances.push(m->Gen_scopes()->at(0));
-        }
-      }
-    }
-  }
-}
-
 vpiHandle UhdmWriter::write(PathId uhdmFileId) {
   FileSystem* const fileSystem = FileSystem::getInstance();
   ModPortMap modPortMap;
@@ -5096,7 +4995,6 @@ vpiHandle UhdmWriter::write(PathId uhdmFileId) {
       annotate->listenDesigns(designs);
       annotate->filterNonSynthesizable();
       delete annotate;
-      filterAlwaysBlocks(s, d);
     }
   }
 

--- a/tests/3SigsSensList/3SigsSensList.log
+++ b/tests/3SigsSensList/3SigsSensList.log
@@ -517,6 +517,94 @@ design: (work@dut)
       \_logic_typespec: , line:5:7, endln:5:11
     |vpiInstance:
     \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/3SigsSensList/dut.sv, line:1:1, endln:36:10
+  |vpiProcess:
+  \_always: , line:24:1, endln:34:4
+    |vpiParent:
+    \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/3SigsSensList/dut.sv, line:1:1, endln:36:10
+    |vpiStmt:
+    \_event_control: , line:24:8, endln:24:55
+      |vpiParent:
+      \_always: , line:24:1, endln:34:4
+      |vpiCondition:
+      \_operation: , line:24:11, endln:24:54
+        |vpiParent:
+        \_event_control: , line:24:8, endln:24:55
+        |vpiOpType:35
+        |vpiOperand:
+        \_operation: , line:24:11, endln:24:22
+          |vpiParent:
+          \_operation: , line:24:11, endln:24:37
+          |vpiOpType:39
+          |vpiOperand:
+          \_ref_obj: (work@dut.clk), line:24:19, endln:24:22
+            |vpiParent:
+            \_operation: , line:24:11, endln:24:22
+            |vpiName:clk
+            |vpiFullName:work@dut.clk
+            |vpiActual:
+            \_logic_net: (work@dut.clk), line:3:18, endln:3:21
+        |vpiOperand:
+        \_operation: , line:24:41, endln:24:54
+          |vpiParent:
+          \_operation: , line:24:11, endln:24:54
+          |vpiOpType:39
+          |vpiOperand:
+          \_ref_obj: (synlig_tmp_rst_or_start)
+            |vpiName:synlig_tmp_rst_or_start
+            |vpiActual:
+            \_logic_net: (synlig_tmp_rst_or_start)
+      |vpiStmt:
+      \_begin: (work@dut), line:25:1, endln:34:4
+        |vpiParent:
+        \_event_control: , line:24:8, endln:24:55
+        |vpiFullName:work@dut
+        |vpiStmt:
+        \_if_else: , line:26:2, endln:33:5
+          |vpiParent:
+          \_begin: (work@dut), line:25:1, endln:34:4
+          |vpiCondition:
+          \_ref_obj: (synlig_tmp_rst_or_start)
+          |vpiStmt:
+          \_begin: (work@dut), line:27:2, endln:29:5
+            |vpiParent:
+            \_if_else: , line:26:2, endln:33:5
+            |vpiFullName:work@dut
+            |vpiStmt:
+            \_assignment: , line:28:4, endln:28:19
+              |vpiParent:
+              \_begin: (work@dut), line:27:2, endln:29:5
+              |vpiOpType:82
+              |vpiRhs:
+              \_constant: , line:28:18, endln:28:19
+              |vpiLhs:
+              \_ref_obj: (work@dut.outputLine), line:28:4, endln:28:14
+                |vpiParent:
+                \_assignment: , line:28:4, endln:28:19
+                |vpiName:outputLine
+                |vpiFullName:work@dut.outputLine
+                |vpiActual:
+                \_logic_net: (work@dut.outputLine), line:28:4, endln:28:14
+          |vpiElseStmt:
+          \_begin: (work@dut), line:31:2, endln:33:5
+            |vpiParent:
+            \_if_else: , line:26:2, endln:33:5
+            |vpiFullName:work@dut
+            |vpiStmt:
+            \_assignment: , line:32:3, endln:32:24
+              |vpiParent:
+              \_begin: (work@dut), line:31:2, endln:33:5
+              |vpiOpType:82
+              |vpiRhs:
+              \_constant: , line:32:23, endln:32:24
+              |vpiLhs:
+              \_ref_obj: (work@dut.yScaleAmountNext), line:32:3, endln:32:19
+                |vpiParent:
+                \_assignment: , line:32:3, endln:32:24
+                |vpiName:yScaleAmountNext
+                |vpiFullName:work@dut.yScaleAmountNext
+                |vpiActual:
+                \_logic_net: (work@dut.yScaleAmountNext), line:32:3, endln:32:19
+    |vpiAlwaysType:1
   |vpiContAssign:
   \_cont_assign: 
     |vpiRhs:
@@ -569,113 +657,29 @@ design: (work@dut)
 \_logic_typespec: , line:3:7, endln:3:11
 \_logic_typespec: , line:4:7, endln:4:11
 \_logic_typespec: , line:5:7, endln:5:11
-\_operation: , line:24:26, endln:24:37
-  |vpiParent:
-  \_operation: , line:24:11, endln:24:37
-  |vpiOpType:39
-  |vpiOperand:
-  \_ref_obj: (work@dut.rst), line:24:34, endln:24:37
 \_operation: , line:24:11, endln:24:37
   |vpiParent:
   \_operation: , line:24:11, endln:24:54
   |vpiOpType:35
   |vpiOperand:
   \_operation: , line:24:11, endln:24:22
-    |vpiParent:
-    \_operation: , line:24:11, endln:24:37
-    |vpiOpType:39
-    |vpiOperand:
-    \_ref_obj: (work@dut.clk), line:24:19, endln:24:22
-      |vpiParent:
-      \_operation: , line:24:11, endln:24:22
-      |vpiName:clk
-      |vpiFullName:work@dut.clk
-      |vpiActual:
-      \_logic_net: (work@dut.clk), line:3:18, endln:3:21
-\_operation: , line:24:11, endln:24:54
+\_operation: , line:24:26, endln:24:37
   |vpiParent:
-  \_event_control: , line:24:8, endln:24:55
-  |vpiOpType:35
+  \_operation: , line:24:11, endln:24:37
+  |vpiOpType:39
   |vpiOperand:
-  \_operation: , line:24:11, endln:24:22
-  |vpiOperand:
-  \_operation: , line:24:41, endln:24:54
-    |vpiParent:
-    \_operation: , line:24:11, endln:24:54
-    |vpiOpType:39
-    |vpiOperand:
-    \_ref_obj: (synlig_tmp_rst_or_start)
-      |vpiName:synlig_tmp_rst_or_start
-      |vpiActual:
-      \_logic_net: (synlig_tmp_rst_or_start)
-\_event_control: , line:24:8, endln:24:55
-  |vpiParent:
-  \_always: , line:24:1, endln:34:4
-  |vpiCondition:
-  \_operation: , line:24:11, endln:24:54
-  |vpiStmt:
-  \_begin: (work@dut), line:25:1, endln:34:4
-    |vpiParent:
-    \_event_control: , line:24:8, endln:24:55
-    |vpiFullName:work@dut
-    |vpiStmt:
-    \_if_else: , line:26:2, endln:33:5
-      |vpiParent:
-      \_begin: (work@dut), line:25:1, endln:34:4
-      |vpiCondition:
-      \_ref_obj: (synlig_tmp_rst_or_start)
-      |vpiStmt:
-      \_begin: (work@dut), line:27:2, endln:29:5
-        |vpiParent:
-        \_if_else: , line:26:2, endln:33:5
-        |vpiFullName:work@dut
-        |vpiStmt:
-        \_assignment: , line:28:4, endln:28:19
-          |vpiParent:
-          \_begin: (work@dut), line:27:2, endln:29:5
-          |vpiOpType:82
-          |vpiRhs:
-          \_constant: , line:28:18, endln:28:19
-          |vpiLhs:
-          \_ref_obj: (work@dut.outputLine), line:28:4, endln:28:14
-            |vpiParent:
-            \_assignment: , line:28:4, endln:28:19
-            |vpiName:outputLine
-            |vpiFullName:work@dut.outputLine
-            |vpiActual:
-            \_logic_net: (work@dut.outputLine), line:28:4, endln:28:14
-      |vpiElseStmt:
-      \_begin: (work@dut), line:31:2, endln:33:5
-        |vpiParent:
-        \_if_else: , line:26:2, endln:33:5
-        |vpiFullName:work@dut
-        |vpiStmt:
-        \_assignment: , line:32:3, endln:32:24
-          |vpiParent:
-          \_begin: (work@dut), line:31:2, endln:33:5
-          |vpiOpType:82
-          |vpiRhs:
-          \_constant: , line:32:23, endln:32:24
-          |vpiLhs:
-          \_ref_obj: (work@dut.yScaleAmountNext), line:32:3, endln:32:19
-            |vpiParent:
-            \_assignment: , line:32:3, endln:32:24
-            |vpiName:yScaleAmountNext
-            |vpiFullName:work@dut.yScaleAmountNext
-            |vpiActual:
-            \_logic_net: (work@dut.yScaleAmountNext), line:32:3, endln:32:19
-\_always: , line:24:1, endln:34:4
-  |vpiParent:
-  \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/3SigsSensList/dut.sv, line:1:1, endln:36:10
-  |vpiStmt:
-  \_event_control: , line:24:8, endln:24:55
-  |vpiAlwaysType:1
+  \_ref_obj: (work@dut.rst), line:24:34, endln:24:37
 ===================
 [  FATAL] : 0
 [ SYNTAX] : 0
 [  ERROR] : 2
 [WARNING] : 0
 [   NOTE] : 5
+
+============================== Begin Linting Results ==============================
+[LINT]: ${SURELOG_DIR}/tests/3SigsSensList/dut.sv:28:4: Illegal wire LHS, outputLine
+[LINT]: ${SURELOG_DIR}/tests/3SigsSensList/dut.sv:32:3: Illegal wire LHS, yScaleAmountNext
+============================== End Linting Results ==============================
 
 ============================== Begin RoundTrip Results ==============================
 [roundtrip]: ${SURELOG_DIR}/tests/3SigsSensList/dut.sv | ${SURELOG_DIR}/build/regression/3SigsSensList/roundtrip/dut_000.sv | 20 | 36 |

--- a/tests/PreprocLine/PreprocLine.log
+++ b/tests/PreprocLine/PreprocLine.log
@@ -13,38 +13,38 @@ n<top> u<3> t<StringConst> p<4> l<1:8> el<1:11>
 n<> u<4> t<Module_ansi_header> p<66> c<2> s<64> l<1:1> el<1:12>
 n<> u<5> t<Dollar_keyword> p<17> s<6> l<3:9> el<3:10>
 n<display> u<6> t<StringConst> p<17> s<16> l<3:10> el<3:17>
-n<"${SURELOG_DIR}/tests/PreprocLine/dut.sv"> u<7> t<StringLiteral> p<8> l<3:18> el<3:91>
-n<> u<8> t<Primary_literal> p<9> c<7> l<3:18> el<3:91>
-n<> u<9> t<Primary> p<10> c<8> l<3:18> el<3:91>
-n<> u<10> t<Expression> p<16> c<9> s<15> l<3:18> el<3:91>
-n<3> u<11> t<IntConst> p<12> l<3:93> el<3:94>
-n<> u<12> t<Primary_literal> p<13> c<11> l<3:93> el<3:94>
-n<> u<13> t<Primary> p<14> c<12> l<3:93> el<3:94>
-n<> u<14> t<Expression> p<15> c<13> l<3:93> el<3:94>
-n<> u<15> t<Argument> p<16> c<14> l<3:93> el<3:94>
-n<> u<16> t<List_of_arguments> p<17> c<10> l<3:18> el<3:94>
-n<> u<17> t<Subroutine_call> p<18> c<5> l<3:9> el<3:95>
-n<> u<18> t<Subroutine_call_statement> p<19> c<17> l<3:9> el<3:96>
-n<> u<19> t<Statement_item> p<20> c<18> l<3:9> el<3:96>
-n<> u<20> t<Statement> p<21> c<19> l<3:9> el<3:96>
-n<> u<21> t<Statement_or_null> p<57> c<20> s<38> l<3:9> el<3:96>
+n<"${SURELOG_DIR}/tests/PreprocLine/dut.sv"> u<7> t<StringLiteral> p<8> l<3:18> el<3:98>
+n<> u<8> t<Primary_literal> p<9> c<7> l<3:18> el<3:98>
+n<> u<9> t<Primary> p<10> c<8> l<3:18> el<3:98>
+n<> u<10> t<Expression> p<16> c<9> s<15> l<3:18> el<3:98>
+n<3> u<11> t<IntConst> p<12> l<3:100> el<3:101>
+n<> u<12> t<Primary_literal> p<13> c<11> l<3:100> el<3:101>
+n<> u<13> t<Primary> p<14> c<12> l<3:100> el<3:101>
+n<> u<14> t<Expression> p<15> c<13> l<3:100> el<3:101>
+n<> u<15> t<Argument> p<16> c<14> l<3:100> el<3:101>
+n<> u<16> t<List_of_arguments> p<17> c<10> l<3:18> el<3:101>
+n<> u<17> t<Subroutine_call> p<18> c<5> l<3:9> el<3:102>
+n<> u<18> t<Subroutine_call_statement> p<19> c<17> l<3:9> el<3:103>
+n<> u<19> t<Statement_item> p<20> c<18> l<3:9> el<3:103>
+n<> u<20> t<Statement> p<21> c<19> l<3:9> el<3:103>
+n<> u<21> t<Statement_or_null> p<57> c<20> s<38> l<3:9> el<3:103>
 n<> u<22> t<Dollar_keyword> p<34> s<23> l<5:9> el<5:10>
 n<display> u<23> t<StringConst> p<34> s<33> l<5:10> el<5:17>
-n<"${SURELOG_DIR}/tests/PreprocLine/fake.v"> u<24> t<StringLiteral> p<25> l<5:18> el<5:91>
-n<> u<25> t<Primary_literal> p<26> c<24> l<5:18> el<5:91>
-n<> u<26> t<Primary> p<27> c<25> l<5:18> el<5:91>
-n<> u<27> t<Expression> p<33> c<26> s<32> l<5:18> el<5:91>
-n<102> u<28> t<IntConst> p<29> l<5:93> el<5:96>
-n<> u<29> t<Primary_literal> p<30> c<28> l<5:93> el<5:96>
-n<> u<30> t<Primary> p<31> c<29> l<5:93> el<5:96>
-n<> u<31> t<Expression> p<32> c<30> l<5:93> el<5:96>
-n<> u<32> t<Argument> p<33> c<31> l<5:93> el<5:96>
-n<> u<33> t<List_of_arguments> p<34> c<27> l<5:18> el<5:96>
-n<> u<34> t<Subroutine_call> p<35> c<22> l<5:9> el<5:97>
-n<> u<35> t<Subroutine_call_statement> p<36> c<34> l<5:9> el<5:98>
-n<> u<36> t<Statement_item> p<37> c<35> l<5:9> el<5:98>
-n<> u<37> t<Statement> p<38> c<36> l<5:9> el<5:98>
-n<> u<38> t<Statement_or_null> p<57> c<37> s<55> l<5:9> el<5:98>
+n<"${SURELOG_DIR}/tests/PreprocLine/fake.v"> u<24> t<StringLiteral> p<25> l<5:18> el<5:98>
+n<> u<25> t<Primary_literal> p<26> c<24> l<5:18> el<5:98>
+n<> u<26> t<Primary> p<27> c<25> l<5:18> el<5:98>
+n<> u<27> t<Expression> p<33> c<26> s<32> l<5:18> el<5:98>
+n<102> u<28> t<IntConst> p<29> l<5:100> el<5:103>
+n<> u<29> t<Primary_literal> p<30> c<28> l<5:100> el<5:103>
+n<> u<30> t<Primary> p<31> c<29> l<5:100> el<5:103>
+n<> u<31> t<Expression> p<32> c<30> l<5:100> el<5:103>
+n<> u<32> t<Argument> p<33> c<31> l<5:100> el<5:103>
+n<> u<33> t<List_of_arguments> p<34> c<27> l<5:18> el<5:103>
+n<> u<34> t<Subroutine_call> p<35> c<22> l<5:9> el<5:104>
+n<> u<35> t<Subroutine_call_statement> p<36> c<34> l<5:9> el<5:105>
+n<> u<36> t<Statement_item> p<37> c<35> l<5:9> el<5:105>
+n<> u<37> t<Statement> p<38> c<36> l<5:9> el<5:105>
+n<> u<38> t<Statement_or_null> p<57> c<37> s<55> l<5:9> el<5:105>
 n<> u<39> t<Dollar_keyword> p<51> s<40> f<0> l<10:9> el<10:10>
 n<display> u<40> t<StringConst> p<51> s<50> f<0> l<10:10> el<10:17>
 n<""> u<41> t<StringLiteral> p<42> f<0> l<10:18> el<10:20>

--- a/tests/TestSepComp/TestSepComp.log
+++ b/tests/TestSepComp/TestSepComp.log
@@ -20,12 +20,12 @@
 [WARNING] : 1
 [   NOTE] : 0
 [INF:CM0023] Creating log file "${SURELOG_DIR}/tests/TestSepComp/slpp_all/surelog.log".
+PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/top.sv
 PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/pkg1.sv
 PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/pkg2.sv
-PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/top.sv
+[WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/top.sv:1:1: No timescale set for "top".
 [WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/pkg1.sv:1:1: No timescale set for "pkg1".
 [WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/pkg2.sv:1:1: No timescale set for "pkg2".
-[WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/top.sv:1:1: No timescale set for "top".
 [INF:CP0300] Compilation...
 [INF:CP0301] ${SURELOG_DIR}/tests/TestSepComp/pkg1.sv:1:1: Compile package "pkg1".
 [INF:CP0301] ${SURELOG_DIR}/tests/TestSepComp/pkg2.sv:1:1: Compile package "pkg2".

--- a/tests/TestSepComp/badpath/TestSepCompBadPath.log
+++ b/tests/TestSepComp/badpath/TestSepCompBadPath.log
@@ -22,19 +22,19 @@
 [WARNING] : 3
 [   NOTE] : 0
 [INF:CM0023] Creating log file "${SURELOG_DIR}/tests/TestSepComp/badpath/slpp_all/surelog.log".
-PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/pkg1.sv
-PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/pkg2.sv
 PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/badpath/badtop.sv
 PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/EvalFunc/dut.sv
-[WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/pkg1.sv:1:1: No timescale set for "pkg1".
-[WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/pkg2.sv:1:1: No timescale set for "pkg2".
+PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/pkg1.sv
+PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepComp/pkg2.sv
 [WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/badpath/badtop.sv:1:1: No timescale set for "badtop".
 [WRN:PA0205] ${SURELOG_DIR}/tests/EvalFunc/dut.sv:1:1: No timescale set for "prim_util_pkg".
 [WRN:PA0205] ${SURELOG_DIR}/tests/EvalFunc/dut.sv:22:1: No timescale set for "top".
+[WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/pkg1.sv:1:1: No timescale set for "pkg1".
+[WRN:PA0205] ${SURELOG_DIR}/tests/TestSepComp/pkg2.sv:1:1: No timescale set for "pkg2".
 [INF:CP0300] Compilation...
+[INF:CP0301] ${SURELOG_DIR}/tests/EvalFunc/dut.sv:1:1: Compile package "prim_util_pkg".
 [INF:CP0301] ${SURELOG_DIR}/tests/TestSepComp/pkg1.sv:1:1: Compile package "pkg1".
 [INF:CP0301] ${SURELOG_DIR}/tests/TestSepComp/pkg2.sv:1:1: Compile package "pkg2".
-[INF:CP0301] ${SURELOG_DIR}/tests/EvalFunc/dut.sv:1:1: Compile package "prim_util_pkg".
 [INF:CP0303] ${SURELOG_DIR}/tests/TestSepComp/badpath/badtop.sv:1:1: Compile module "work@badtop".
 [INF:CP0303] ${SURELOG_DIR}/tests/EvalFunc/dut.sv:22:1: Compile module "work@top".
 [INF:CP0302] Compile class "work@mailbox".

--- a/tests/TestSepCompNoHash/TestSepCompNoHash.log
+++ b/tests/TestSepCompNoHash/TestSepCompNoHash.log
@@ -20,15 +20,15 @@
 [WARNING] : 1
 [   NOTE] : 0
 [INF:CM0023] Creating log file "${SURELOG_DIR}/tests/TestSepCompNoHash/slpp_all/surelog.log".
+PP CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepCompNoHash/top.sv
 PP CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepCompNoHash/pkg1.sv
 PP CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepCompNoHash/pkg2.sv
-PP CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepCompNoHash/top.sv
+PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepCompNoHash/top.sv
 PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepCompNoHash/pkg1.sv
 PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepCompNoHash/pkg2.sv
-PARSER CACHE USED FOR: ${SURELOG_DIR}/tests/TestSepCompNoHash/top.sv
+[WRN:PA0205] ${SURELOG_DIR}/tests/TestSepCompNoHash/top.sv:1:1: No timescale set for "top".
 [WRN:PA0205] ${SURELOG_DIR}/tests/TestSepCompNoHash/pkg1.sv:1:1: No timescale set for "pkg1".
 [WRN:PA0205] ${SURELOG_DIR}/tests/TestSepCompNoHash/pkg2.sv:1:1: No timescale set for "pkg2".
-[WRN:PA0205] ${SURELOG_DIR}/tests/TestSepCompNoHash/top.sv:1:1: No timescale set for "top".
 [INF:CP0300] Compilation...
 [INF:CP0301] ${SURELOG_DIR}/tests/TestSepCompNoHash/pkg1.sv:1:1: Compile package "pkg1".
 [INF:CP0301] ${SURELOG_DIR}/tests/TestSepCompNoHash/pkg2.sv:1:1: Compile package "pkg2".

--- a/tests/UnboundForLoop/UnboundForLoop.log
+++ b/tests/UnboundForLoop/UnboundForLoop.log
@@ -264,6 +264,119 @@ design: (work@signed_shifter)
       |vpiFullName:work@signed_shifter.Q
       |vpiActual:
       \_logic_typespec: , line:3:10, endln:3:26
+  |vpiProcess:
+  \_always: , line:5:3, endln:7:6
+    |vpiParent:
+    \_module_inst: work@signed_shifter (work@signed_shifter), file:${SURELOG_DIR}/tests/UnboundForLoop/dut.sv, line:1:1, endln:8:10
+    |vpiStmt:
+    \_event_control: , line:5:10, endln:5:13
+      |vpiParent:
+      \_always: , line:5:3, endln:7:6
+      |vpiStmt:
+      \_begin: (work@signed_shifter), line:5:14, endln:7:6
+        |vpiParent:
+        \_event_control: , line:5:10, endln:5:13
+        |vpiFullName:work@signed_shifter
+        |vpiStmt:
+        \_for_stmt: (work@signed_shifter), line:6:5, endln:6:8
+          |vpiParent:
+          \_begin: (work@signed_shifter), line:5:14, endln:7:6
+          |vpiFullName:work@signed_shifter
+          |vpiForInitStmt:
+          \_assignment: , line:6:9, endln:6:12
+            |vpiParent:
+            \_for_stmt: (work@signed_shifter), line:6:5, endln:6:8
+            |vpiRhs:
+            \_constant: , line:6:11, endln:6:12
+              |vpiParent:
+              \_assignment: , line:6:9, endln:6:12
+              |vpiDecompile:0
+              |vpiSize:64
+              |UINT:0
+              |vpiConstType:9
+            |vpiLhs:
+            \_ref_var: (work@signed_shifter.j), line:6:9, endln:6:10
+              |vpiParent:
+              \_assignment: , line:6:9, endln:6:12
+              |vpiName:j
+              |vpiFullName:work@signed_shifter.j
+          |vpiForIncStmt:
+          \_assignment: , line:6:17, endln:6:22
+            |vpiParent:
+            \_for_stmt: (work@signed_shifter), line:6:5, endln:6:8
+            |vpiOpType:82
+            |vpiBlocking:1
+            |vpiRhs:
+            \_operation: , line:6:19, endln:6:22
+              |vpiParent:
+              \_assignment: , line:6:17, endln:6:22
+              |vpiOpType:24
+              |vpiOperand:
+              \_ref_obj: (work@signed_shifter.j), line:6:19, endln:6:20
+                |vpiParent:
+                \_operation: , line:6:19, endln:6:22
+                |vpiName:j
+                |vpiFullName:work@signed_shifter.j
+                |vpiActual:
+                \_logic_net: (work@signed_shifter.j), line:4:11, endln:4:12
+              |vpiOperand:
+              \_constant: , line:6:21, endln:6:22
+                |vpiParent:
+                \_operation: , line:6:19, endln:6:22
+                |vpiDecompile:1
+                |vpiSize:64
+                |UINT:1
+                |vpiConstType:9
+            |vpiLhs:
+            \_ref_obj: (work@signed_shifter.j), line:6:17, endln:6:18
+              |vpiParent:
+              \_assignment: , line:6:17, endln:6:22
+              |vpiName:j
+              |vpiFullName:work@signed_shifter.j
+              |vpiActual:
+              \_logic_net: (work@signed_shifter.j), line:4:11, endln:4:12
+          |vpiCondition:
+          \_operation: , line:6:13, endln:6:16
+            |vpiParent:
+            \_for_stmt: (work@signed_shifter), line:6:5, endln:6:8
+            |vpiOpType:20
+            |vpiOperand:
+            \_ref_obj: (work@signed_shifter.j), line:6:13, endln:6:14
+              |vpiParent:
+              \_operation: , line:6:13, endln:6:16
+              |vpiName:j
+              |vpiFullName:work@signed_shifter.j
+              |vpiActual:
+              \_logic_net: (work@signed_shifter.j), line:4:11, endln:4:12
+            |vpiOperand:
+            \_ref_obj: (work@signed_shifter.i), line:6:15, endln:6:16
+              |vpiParent:
+              \_operation: , line:6:13, endln:6:16
+              |vpiName:i
+              |vpiFullName:work@signed_shifter.i
+              |vpiActual:
+              \_logic_net: (work@signed_shifter.i), line:2:20, endln:2:21
+          |vpiStmt:
+          \_assignment: , line:6:24, endln:6:32
+            |vpiParent:
+            \_for_stmt: (work@signed_shifter), line:6:5, endln:6:8
+            |vpiOpType:82
+            |vpiBlocking:1
+            |vpiRhs:
+            \_constant: , line:6:28, endln:6:32
+              |vpiDecompile:1'b1
+              |vpiSize:1
+              |BIN:1
+              |vpiConstType:3
+            |vpiLhs:
+            \_ref_obj: (work@signed_shifter.Q), line:6:24, endln:6:25
+              |vpiParent:
+              \_assignment: , line:6:24, endln:6:32
+              |vpiName:Q
+              |vpiFullName:work@signed_shifter.Q
+              |vpiActual:
+              \_logic_net: (work@signed_shifter.Q), line:3:27, endln:3:28
+    |vpiAlwaysType:1
 |uhdmtopModules:
 \_module_inst: work@signed_shifter (work@signed_shifter), file:${SURELOG_DIR}/tests/UnboundForLoop/dut.sv, line:1:1, endln:8:10
   |vpiName:work@signed_shifter
@@ -749,5 +862,5 @@ design: (work@signed_shifter)
 [   NOTE] : 5
 
 ============================== Begin RoundTrip Results ==============================
-[roundtrip]: ${SURELOG_DIR}/tests/UnboundForLoop/dut.sv | ${SURELOG_DIR}/build/regression/UnboundForLoop/roundtrip/dut_000.sv | 6 | 8 |
+[roundtrip]: ${SURELOG_DIR}/tests/UnboundForLoop/dut.sv | ${SURELOG_DIR}/build/regression/UnboundForLoop/roundtrip/dut_000.sv | 5 | 8 |
 ============================== End RoundTrip Results ==============================

--- a/third_party/tests/CoresSweRVMP/CoresSweRVMP.log
+++ b/third_party/tests/CoresSweRVMP/CoresSweRVMP.log
@@ -80,18 +80,18 @@ CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
 -- Configuring done (0.0s)
 -- Generating done (0.0s)
 -- Build files have been written to: ${SURELOG_DIR}/build/regression/CoresSweRVMP/slpp_all/mp_preprocess
-[  8%] Generating 10_dec_tlu_ctl.sv
+[ 16%] Generating 10_dec_tlu_ctl.sv
 [ 16%] Generating 11_axi4_to_ahb.sv
 [ 25%] Generating 2_dec_decode_ctl.sv
 [ 33%] Generating 12_tb_top.sv
 [ 41%] Generating 1_ifu_mem_ctl.sv
-[ 50%] Generating 4_lsu_bus_buffer.sv
-[ 58%] Generating 7_lsu_bus_intf.sv
+[ 50%] Generating 3_mem_lib.sv
+[ 58%] Generating 4_lsu_bus_buffer.sv
+[ 66%] Generating 5_beh_lib.sv
 [ 75%] Generating 6_dbg.sv
-[ 75%] Generating 3_mem_lib.sv
-[ 91%] Generating 8_ahb_to_axi4.sv
-[ 91%] Generating 5_beh_lib.sv
-[100%] Generating 9_exu.sv
+[ 83%] Generating 9_exu.sv
+[ 91%] Generating 7_lsu_bus_intf.sv
+[100%] Generating 8_ahb_to_axi4.sv
 [100%] Built target Parse
 Surelog parsing status: 0
 [INF:PA0201] Parsing source file "${SURELOG_DIR}/third_party/UVM/1800.2-2017-1.0/src/uvm_pkg.sv".

--- a/third_party/tests/Earlgrey_Verilator_01_05_21/sim-icarus/Earlgrey_Verilator_01_05_21.log
+++ b/third_party/tests/Earlgrey_Verilator_01_05_21/sim-icarus/Earlgrey_Verilator_01_05_21.log
@@ -14499,7 +14499,7 @@ var_select                                         16611
 [   NOTE] : 111
 
 ============================== Begin Linting Results ==============================
-[LINT]: ${SURELOG_DIR}/third_party/tests/Earlgrey_Verilator_01_05_21/src/lowrisc_dv_dv_macros_0/dv_macros.svh:476:275: Non synthesizable construct, name
+[LINT]: ${SURELOG_DIR}/third_party/tests/Earlgrey_Verilator_01_05_21/src/lowrisc_dv_dv_macros_0/dv_macros.svh:476:282: Non synthesizable construct, name
 [LINT]: ${SURELOG_DIR}/third_party/tests/Earlgrey_Verilator_01_05_21/src/lowrisc_dv_dpi_dmidpi_0.1/dmidpi.sv:25:12: Non synthesizable construct,
 [LINT]: ${SURELOG_DIR}/third_party/tests/Earlgrey_Verilator_01_05_21/src/lowrisc_dv_dpi_dmidpi_0.1/dmidpi.sv:25:12: Non synthesizable construct,
 [LINT]: ${SURELOG_DIR}/third_party/tests/Earlgrey_Verilator_01_05_21/src/lowrisc_dv_dpi_dmidpi_0.1/dmidpi.sv:28:35: Non synthesizable construct,


### PR DESCRIPTION
This MR removes filtering of `always` blocks from UHDM. 
Now synlig only walks `uhdmtopModules` tree and this blocks are required to correctly process designs.

Corresponding `synlig` PR: https://github.com/chipsalliance/synlig/pull/2501