### PR TITLE
clang-tidy config: The Analyze temp constructor option does not exist…

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,6 @@
 # readability.
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 Checks: >
   clang-diagnostic-*,clang-analyzer-*,
   -clang-analyzer-core.CallAndMessage,


### PR DESCRIPTION
… anymore.

Deprecated and removed configuration option is not recognized anymore with current clang-tidy.