### PR TITLE
Fix some missing std:: includes in src/Design

### DIFF
--- a/src/Design/DataType.cpp
+++ b/src/Design/DataType.cpp
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
+#include "Surelog/Design/DataType.h"
 
 /*
  * File:   DataType.cpp
@@ -21,8 +22,9 @@
  * Created on June 14, 2018, 10:07 PM
  */
 
-#include <Surelog/Design/DataType.h>
 #include <Surelog/Expression/Value.h>
+
+#include <string>
 
 namespace SURELOG {
 

--- a/src/Design/DefParam.cpp
+++ b/src/Design/DefParam.cpp
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#include "Surelog/Design/DefParam.h"
+
 /*
  * File:   DefParam.cpp
  * Author: alain
@@ -21,8 +23,7 @@
  * Created on January 7, 2018, 8:55 PM
  */
 
-#include <Surelog/Design/DefParam.h>
-
+#include <string>
 #include <vector>
 
 namespace SURELOG {

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
+#include "Surelog/Design/Design.h"
 
 /*
  * File:   Design.cpp
@@ -22,7 +23,6 @@
  */
 
 #include <Surelog/Design/DefParam.h>
-#include <Surelog/Design/Design.h>
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Design/FileContent.h>
 #include <Surelog/Design/ModuleDefinition.h>
@@ -35,7 +35,14 @@
 #include <Surelog/Testbench/Program.h>
 #include <Surelog/Utils/StringUtils.h>
 
+#include <iterator>
+#include <map>
 #include <queue>
+#include <set>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/Design/DesignComponent.cpp
+++ b/src/Design/DesignComponent.cpp
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#include "Surelog/Design/DesignComponent.h"
+
 /*
  * File:   DesignComponent.cpp
  * Author: alain
@@ -21,13 +23,16 @@
  * Created on March 25, 2018, 10:27 PM
  */
 
-#include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Design/FileContent.h>
 #include <Surelog/Design/Parameter.h>
 #include <Surelog/Testbench/FunctionMethod.h>
 #include <Surelog/Testbench/TaskMethod.h>
 #include <Surelog/Testbench/TypeDef.h>
 #include <Surelog/Testbench/Variable.h>
+
+#include <string_view>
+#include <utility>
+#include <vector>
 
 namespace SURELOG {
 void DesignComponent::addFileContent(const FileContent* fileContent,

--- a/src/Design/DesignElement.cpp
+++ b/src/Design/DesignElement.cpp
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
+#include "Surelog/Design/DesignElement.h"
 
 /*
  * File:   DesignElement.cpp
@@ -21,7 +22,7 @@
  * Created on June 8, 2017, 8:05 PM
  */
 
-#include <Surelog/Design/DesignElement.h>
+#include <ostream>
 
 namespace SURELOG {
 DesignElement::DesignElement(SymbolId name, PathId fileId, ElemType type,

--- a/src/Design/Enum.cpp
+++ b/src/Design/Enum.cpp
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#include "Surelog/Design/Enum.h"
+
 /*
  * File:   Enum.cpp
  * Author: alain
@@ -21,8 +23,9 @@
  * Created on May 19, 2019, 11:55 AM
  */
 
-#include <Surelog/Design/Enum.h>
 #include <Surelog/Design/FileContent.h>
+
+#include <string_view>
 
 namespace SURELOG {
 Enum::Enum(const FileContent* fC, NodeId nameId, NodeId baseTypeId)

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#include "Surelog/Design/FileContent.h"
+
 /*
  * File:   FileContent.cpp
  * Author: alain
@@ -23,7 +25,6 @@
 
 #include <Surelog/Common/FileSystem.h>
 #include <Surelog/Design/DesignElement.h>
-#include <Surelog/Design/FileContent.h>
 #include <Surelog/ErrorReporting/ErrorContainer.h>
 #include <Surelog/Library/Library.h>
 #include <Surelog/SourceCompile/SymbolTable.h>
@@ -31,6 +32,9 @@
 
 #include <iostream>
 #include <stack>
+#include <string>
+#include <string_view>
+#include <vector>
 
 namespace SURELOG {
 FileContent::FileContent(PathId fileId, Library* library,

--- a/src/Design/Function.cpp
+++ b/src/Design/Function.cpp
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#include "Surelog/Design/Function.h"
+
 /*
  * File:   Function.cpp
  * Author: alain
@@ -22,8 +24,9 @@
  */
 
 #include <Surelog/Design/FileContent.h>
-#include <Surelog/Design/Function.h>
 #include <Surelog/DesignCompile/CompileHelper.h>
+
+#include <string_view>
 
 namespace SURELOG {
 Procedure::Procedure(DesignComponent* parent, const FileContent* fC, NodeId id,

--- a/src/Design/ModPort.cpp
+++ b/src/Design/ModPort.cpp
@@ -14,13 +14,16 @@
  limitations under the License.
  */
 
+#include "Surelog/Design/ModPort.h"
+
 /*
  * File:   ModPort.cpp
  * Author: alain
  *
  * Created on January 31, 2020, 9:46 PM
  */
-#include <Surelog/Design/ModPort.h>
+
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/Design/ModuleDefinition.cpp
+++ b/src/Design/ModuleDefinition.cpp
@@ -14,6 +14,8 @@
  limitations under the License.
  */
 
+#include "Surelog/Design/ModuleDefinition.h"
+
 /*
  * File:   ModuleDefinition.cpp
  * Author: alain
@@ -23,7 +25,9 @@
 
 #include <Surelog/Design/FileContent.h>
 #include <Surelog/Design/ModPort.h>
-#include <Surelog/Design/ModuleDefinition.h>
+
+#include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/Design/ModuleInstance.cpp
+++ b/src/Design/ModuleInstance.cpp
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
+#include "Surelog/Design/ModuleInstance.h"
 
 /*
  * File:   ModuleInstance.cpp
@@ -23,10 +24,13 @@
 
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Design/FileContent.h>
-#include <Surelog/Design/ModuleInstance.h>
 #include <Surelog/Design/Netlist.h>
 #include <Surelog/Expression/ExprBuilder.h>
 #include <Surelog/SourceCompile/SymbolTable.h>
+
+#include <set>
+#include <string_view>
+#include <vector>
 
 // UHDM
 #include <uhdm/ExprEval.h>

--- a/src/Design/Parameter.cpp
+++ b/src/Design/Parameter.cpp
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
+#include "Surelog/Design/Parameter.h"
 
 /*
  * File:   Parameter.cpp
@@ -22,7 +23,8 @@
  */
 
 #include <Surelog/Design/FileContent.h>
-#include <Surelog/Design/Parameter.h>
+
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/Design/Scope.cpp
+++ b/src/Design/Scope.cpp
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
+#include "Surelog/Design/Scope.h"
 
 /*
  * File:   Scope.cpp
@@ -21,8 +22,9 @@
  * Created on August 31, 2019, 11:24 AM
  */
 
-#include <Surelog/Design/Scope.h>
 #include <Surelog/Testbench/Variable.h>
+
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/Design/Signal.cpp
+++ b/src/Design/Signal.cpp
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
+#include "Surelog/Design/Signal.h"
 
 /*
  * File:   Signal.cpp
@@ -22,8 +23,10 @@
  */
 
 #include <Surelog/Design/FileContent.h>
-#include <Surelog/Design/Signal.h>
 #include <Surelog/Utils/StringUtils.h>
+
+#include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/Design/Statement.cpp
+++ b/src/Design/Statement.cpp
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
+#include "Surelog/Design/Statement.h"
 
 /*
  * File:   Statement.cpp
@@ -22,7 +23,9 @@
  */
 
 #include <Surelog/Design/FileContent.h>
-#include <Surelog/Design/Statement.h>
+
+#include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/Design/TimeInfo.cpp
+++ b/src/Design/TimeInfo.cpp
@@ -14,14 +14,15 @@
  limitations under the License.
  */
 
+#include "Surelog/Design/TimeInfo.h"
+
 /*
  * File:   TimeInfo.cpp
  * Author: alain
  *
  * Created on June 8, 2017, 8:27 PM
  */
-
-#include <Surelog/Design/TimeInfo.h>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/Design/VObject.cpp
+++ b/src/Design/VObject.cpp
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
+#include "Surelog/Design/VObject.h"
 
 /*
  * File:   VObject.cpp
@@ -21,9 +22,11 @@
  * Created on June 14, 2017, 10:58 PM
  */
 
-#include <Surelog/Design/VObject.h>
 #include <Surelog/SourceCompile/SymbolTable.h>
 #include <Surelog/Utils/StringUtils.h>
+
+#include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/Design/ValuedComponentI.cpp
+++ b/src/Design/ValuedComponentI.cpp
@@ -13,6 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
+#include "Surelog/Design/ValuedComponentI.h"
 
 /*
  * File:   ValuedComponentI.cpp
@@ -22,8 +23,12 @@
  */
 
 #include <Surelog/Design/ModuleInstance.h>
-#include <Surelog/Design/ValuedComponentI.h>
 #include <Surelog/Expression/ExprBuilder.h>
+
+#include <map>
+#include <string>
+#include <string_view>
+#include <utility>
 
 namespace SURELOG {
 Value* ValuedComponentI::getValue(std::string_view name) const {


### PR DESCRIPTION
After looking at the output of clang-tidy [misc-include-cleaner] results...

Also, whlie at it, move the foo.h header included in foo.cpp to the very top, as this is best practice to catch if the header is self-contained.