### PR TITLE
run-clang-tidyu-cached: make sure to run over both, src/, and include/

### DIFF
--- a/.github/bin/run-clang-tidy-cached.cc
+++ b/.github/bin/run-clang-tidy-cached.cc
@@ -115,7 +115,8 @@ struct ConfigValues {
 
 // --------------[ Project-specific configuration ]--------------
 static constexpr ConfigValues kConfig = {
-    .start_dir = "src/",
+    .start_dir = ".",
+    .file_include_re = "^(src|include)",
     // Not clean yet, don't revisit yet.
     .revisit_brokenfiles_if_build_config_newer = false,
 };


### PR DESCRIPTION
Current counts:

```
---- Summary ----
 3332 [misc-include-cleaner]
  494 [modernize-use-nodiscard]
  234 [misc-non-private-member-variables-in-classes]
  101 [modernize-use-using]
   82 [modernize-use-default-member-init]
   46 [readability-redundant-casting]
   30 [modernize-use-equals-delete]
   25 [modernize-use-equals-default]
   24 [clang-diagnostic-error]
   22 [performance-enum-size]
   21 [modernize-use-nullptr]
   16 [modernize-use-bool-literals]
   13 [bugprone-assignment-in-if-condition]
   12 [google-default-arguments]
   12 [modernize-avoid-c-arrays]
   12 [readability-redundant-inline-specifier]
   11 [clang-analyzer-deadcode.DeadStores]
   11 [clang-diagnostic-unused-but-set-variable]
   10 [bugprone-unused-local-non-trivial-variable]
   10 [modernize-return-braced-init-list]
   10 [modernize-type-traits]
    8 [modernize-use-emplace]
    5 [misc-unused-using-decls]
    4 [bugprone-signed-char-misuse]
    4 [misc-header-include-cycle]
    4 [modernize-deprecated-headers]
    3 [bugprone-reserved-identifier]
    3 [readability-avoid-unconditional-preprocessor-if]
    2 [bugprone-implicit-widening-of-multiplication-result]
    2 [clang-analyzer-core.NonNullParamChecker]
    2 [clang-analyzer-optin.core.EnumCastOutOfRange]
    2 [clang-analyzer-optin.cplusplus.VirtualCall]
    2 [google-explicit-constructor]
    2 [modernize-concat-nested-namespaces]
    2 [readability-container-data-pointer]
    1 [bugprone-switch-missing-default-case]
    1 [clang-diagnostic-unneeded-internal-declaration]
    1 [clang-tidy-nolint]
    1 [modernize-make-unique]
    1 [modernize-raw-string-literal]
    1 [performance-inefficient-string-concatenation]
    1 [performance-inefficient-vector-operation]
    1 [performance-unnecessary-value-param]
    1 [readability-avoid-const-params-in-decls]
    1 [readability-redundant-member-init]
```