### PR TITLE
Fix a bunch of missing std:: headers

### DIFF
--- a/include/Surelog/CommandLine/CommandLineParser.h
+++ b/include/Surelog/CommandLine/CommandLineParser.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMMANDLINEPARSER_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>
 

--- a/include/Surelog/CommandLine/CommandLineParser.h
+++ b/include/Surelog/CommandLine/CommandLineParser.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMMANDLINEPARSER_H
 #pragma once
 
+#include <functional>
 #include <utility>
 #include <string_view>
 #include <Surelog/Common/PathId.h>

--- a/include/Surelog/CommandLine/CommandLineParser.h
+++ b/include/Surelog/CommandLine/CommandLineParser.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMMANDLINEPARSER_H
 #pragma once
 
+#include <utility>
 #include <string_view>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>

--- a/include/Surelog/Common/FileSystem.h
+++ b/include/Surelog/Common/FileSystem.h
@@ -25,6 +25,7 @@
 #define SURELOG_FILESYSTEM_H
 #pragma once
 
+#include <set>
 #include <utility>
 #include <vector>
 #include <Surelog/Common/PathId.h>

--- a/include/Surelog/Common/FileSystem.h
+++ b/include/Surelog/Common/FileSystem.h
@@ -25,6 +25,7 @@
 #define SURELOG_FILESYSTEM_H
 #pragma once
 
+#include <vector>
 #include <Surelog/Common/PathId.h>
 
 #include <cstdint>

--- a/include/Surelog/Common/FileSystem.h
+++ b/include/Surelog/Common/FileSystem.h
@@ -25,6 +25,7 @@
 #define SURELOG_FILESYSTEM_H
 #pragma once
 
+#include <utility>
 #include <vector>
 #include <Surelog/Common/PathId.h>
 

--- a/include/Surelog/Common/FileSystem.h
+++ b/include/Surelog/Common/FileSystem.h
@@ -25,6 +25,7 @@
 #define SURELOG_FILESYSTEM_H
 #pragma once
 
+#include <functional>
 #include <set>
 #include <utility>
 #include <vector>

--- a/include/Surelog/Common/PlatformFileSystem.h
+++ b/include/Surelog/Common/PlatformFileSystem.h
@@ -25,6 +25,7 @@
 #define SURELOG_PLATFORMFILESYSTEM_H
 #pragma once
 
+#include <string_view>
 #include <string>
 #include <Surelog/Common/FileSystem.h>
 

--- a/include/Surelog/Common/PlatformFileSystem.h
+++ b/include/Surelog/Common/PlatformFileSystem.h
@@ -25,6 +25,7 @@
 #define SURELOG_PLATFORMFILESYSTEM_H
 #pragma once
 
+#include <string>
 #include <Surelog/Common/FileSystem.h>
 
 #include <memory>

--- a/include/Surelog/Common/PlatformFileSystem.h
+++ b/include/Surelog/Common/PlatformFileSystem.h
@@ -25,6 +25,7 @@
 #define SURELOG_PLATFORMFILESYSTEM_H
 #pragma once
 
+#include <functional>
 #include <utility>
 #include <vector>
 #include <string_view>

--- a/include/Surelog/Common/PlatformFileSystem.h
+++ b/include/Surelog/Common/PlatformFileSystem.h
@@ -25,6 +25,7 @@
 #define SURELOG_PLATFORMFILESYSTEM_H
 #pragma once
 
+#include <vector>
 #include <string_view>
 #include <string>
 #include <Surelog/Common/FileSystem.h>

--- a/include/Surelog/Common/PlatformFileSystem.h
+++ b/include/Surelog/Common/PlatformFileSystem.h
@@ -25,6 +25,7 @@
 #define SURELOG_PLATFORMFILESYSTEM_H
 #pragma once
 
+#include <utility>
 #include <vector>
 #include <string_view>
 #include <string>

--- a/include/Surelog/Design/DefParam.h
+++ b/include/Surelog/Design/DefParam.h
@@ -25,6 +25,7 @@
 #define SURELOG_DEFPARAM_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/NodeId.h>
 
 #include <map>

--- a/include/Surelog/Design/Design.h
+++ b/include/Surelog/Design/Design.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGN_H
 #pragma once
 
+#include <string_view>
 #include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>

--- a/include/Surelog/Design/Design.h
+++ b/include/Surelog/Design/Design.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGN_H
 #pragma once
 
+#include <utility>
 #include <string_view>
 #include <string>
 #include <Surelog/Common/Containers.h>

--- a/include/Surelog/Design/Design.h
+++ b/include/Surelog/Design/Design.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGN_H
 #pragma once
 
+#include <functional>
 #include <utility>
 #include <string_view>
 #include <string>

--- a/include/Surelog/Design/Design.h
+++ b/include/Surelog/Design/Design.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGN_H
 #pragma once
 
+#include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/PathId.h>

--- a/include/Surelog/Design/DesignComponent.h
+++ b/include/Surelog/Design/DesignComponent.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNCOMPONENT_H
 #pragma once
 
+#include <map>
 #include <utility>
 #include <vector>
 #include <string_view>

--- a/include/Surelog/Design/DesignComponent.h
+++ b/include/Surelog/Design/DesignComponent.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNCOMPONENT_H
 #pragma once
 
+#include <vector>
 #include <string_view>
 #include <string>
 #include <Surelog/Common/Containers.h>

--- a/include/Surelog/Design/DesignComponent.h
+++ b/include/Surelog/Design/DesignComponent.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNCOMPONENT_H
 #pragma once
 
+#include <string_view>
 #include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/PathId.h>

--- a/include/Surelog/Design/DesignComponent.h
+++ b/include/Surelog/Design/DesignComponent.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNCOMPONENT_H
 #pragma once
 
+#include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/PortNetHolder.h>

--- a/include/Surelog/Design/DesignComponent.h
+++ b/include/Surelog/Design/DesignComponent.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNCOMPONENT_H
 #pragma once
 
+#include <functional>
 #include <map>
 #include <utility>
 #include <vector>

--- a/include/Surelog/Design/DesignComponent.h
+++ b/include/Surelog/Design/DesignComponent.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNCOMPONENT_H
 #pragma once
 
+#include <utility>
 #include <vector>
 #include <string_view>
 #include <string>

--- a/include/Surelog/Design/Enum.h
+++ b/include/Surelog/Design/Enum.h
@@ -25,6 +25,7 @@
 #define SURELOG_ENUM_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
 

--- a/include/Surelog/Design/Enum.h
+++ b/include/Surelog/Design/Enum.h
@@ -25,6 +25,7 @@
 #define SURELOG_ENUM_H
 #pragma once
 
+#include <utility>
 #include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>

--- a/include/Surelog/Design/Enum.h
+++ b/include/Surelog/Design/Enum.h
@@ -25,6 +25,7 @@
 #define SURELOG_ENUM_H
 #pragma once
 
+#include <functional>
 #include <utility>
 #include <string_view>
 #include <Surelog/Common/SymbolId.h>

--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -25,6 +25,7 @@
 #define SURELOG_FILECONTENT_H
 #pragma once
 
+#include <map>
 #include <string_view>
 #include <string>
 #include <Surelog/Common/Containers.h>

--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -25,6 +25,7 @@
 #define SURELOG_FILECONTENT_H
 #pragma once
 
+#include <set>
 #include <map>
 #include <string_view>
 #include <string>

--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -25,6 +25,7 @@
 #define SURELOG_FILECONTENT_H
 #pragma once
 
+#include <string_view>
 #include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>

--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -25,6 +25,7 @@
 #define SURELOG_FILECONTENT_H
 #pragma once
 
+#include <functional>
 #include <set>
 #include <map>
 #include <string_view>

--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -25,6 +25,7 @@
 #define SURELOG_FILECONTENT_H
 #pragma once
 
+#include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Design/DesignComponent.h>

--- a/include/Surelog/Design/Function.h
+++ b/include/Surelog/Design/Function.h
@@ -25,6 +25,7 @@
 #define SURELOG_FUNCTION_H
 #pragma once
 
+#include <vector>
 #include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/Scope.h>

--- a/include/Surelog/Design/Function.h
+++ b/include/Surelog/Design/Function.h
@@ -25,6 +25,7 @@
 #define SURELOG_FUNCTION_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/Scope.h>
 #include <Surelog/Design/Statement.h>

--- a/include/Surelog/Design/ModuleDefinition.h
+++ b/include/Surelog/Design/ModuleDefinition.h
@@ -25,6 +25,7 @@
 #define SURELOG_MODULEDEFINITION_H
 #pragma once
 
+#include <string>
 #include <Surelog/Common/ClockingBlockHolder.h>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/SymbolId.h>

--- a/include/Surelog/Design/ModuleDefinition.h
+++ b/include/Surelog/Design/ModuleDefinition.h
@@ -25,6 +25,7 @@
 #define SURELOG_MODULEDEFINITION_H
 #pragma once
 
+#include <map>
 #include <string>
 #include <Surelog/Common/ClockingBlockHolder.h>
 #include <Surelog/Common/Containers.h>

--- a/include/Surelog/Design/ModuleDefinition.h
+++ b/include/Surelog/Design/ModuleDefinition.h
@@ -25,6 +25,7 @@
 #define SURELOG_MODULEDEFINITION_H
 #pragma once
 
+#include <functional>
 #include <map>
 #include <string>
 #include <Surelog/Common/ClockingBlockHolder.h>

--- a/include/Surelog/Design/ModuleInstance.h
+++ b/include/Surelog/Design/ModuleInstance.h
@@ -25,6 +25,7 @@
 #define SURELOG_MODULEINSTANCE_H
 #pragma once
 
+#include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>

--- a/include/Surelog/Design/ModuleInstance.h
+++ b/include/Surelog/Design/ModuleInstance.h
@@ -25,6 +25,7 @@
 #define SURELOG_MODULEINSTANCE_H
 #pragma once
 
+#include <map>
 #include <vector>
 #include <string>
 #include <Surelog/Common/Containers.h>

--- a/include/Surelog/Design/ModuleInstance.h
+++ b/include/Surelog/Design/ModuleInstance.h
@@ -25,6 +25,7 @@
 #define SURELOG_MODULEINSTANCE_H
 #pragma once
 
+#include <set>
 #include <map>
 #include <vector>
 #include <string>

--- a/include/Surelog/Design/ModuleInstance.h
+++ b/include/Surelog/Design/ModuleInstance.h
@@ -25,6 +25,7 @@
 #define SURELOG_MODULEINSTANCE_H
 #pragma once
 
+#include <vector>
 #include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>

--- a/include/Surelog/Design/Netlist.h
+++ b/include/Surelog/Design/Netlist.h
@@ -26,6 +26,7 @@
 #pragma once
 
 // UHDM
+#include <functional>
 #include <utility>
 #include <uhdm/uhdm_forward_decl.h>
 

--- a/include/Surelog/Design/Netlist.h
+++ b/include/Surelog/Design/Netlist.h
@@ -26,6 +26,7 @@
 #pragma once
 
 // UHDM
+#include <utility>
 #include <uhdm/uhdm_forward_decl.h>
 
 #include <map>

--- a/include/Surelog/Design/Parameter.h
+++ b/include/Surelog/Design/Parameter.h
@@ -25,6 +25,7 @@
 #define SURELOG_PARAMETER_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
 

--- a/include/Surelog/Design/Scope.h
+++ b/include/Surelog/Design/Scope.h
@@ -25,6 +25,7 @@
 #define SURELOG_SCOPE_H
 #pragma once
 
+#include <functional>
 #include <string_view>
 #include <Surelog/Common/RTTI.h>
 

--- a/include/Surelog/Design/Scope.h
+++ b/include/Surelog/Design/Scope.h
@@ -25,6 +25,7 @@
 #define SURELOG_SCOPE_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/RTTI.h>
 
 #include <string>

--- a/include/Surelog/Design/Signal.h
+++ b/include/Surelog/Design/Signal.h
@@ -25,6 +25,7 @@
 #define SURELOG_SIGNAL_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 #include <uhdm/attribute.h>

--- a/include/Surelog/Design/Signal.h
+++ b/include/Surelog/Design/Signal.h
@@ -25,6 +25,7 @@
 #define SURELOG_SIGNAL_H
 #pragma once
 
+#include <vector>
 #include <string_view>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>

--- a/include/Surelog/Design/Statement.h
+++ b/include/Surelog/Design/Statement.h
@@ -25,6 +25,7 @@
 #define SURELOG_STATEMENT_H
 #pragma once
 
+#include <utility>
 #include <string_view>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/RTTI.h>

--- a/include/Surelog/Design/Statement.h
+++ b/include/Surelog/Design/Statement.h
@@ -25,6 +25,7 @@
 #define SURELOG_STATEMENT_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/RTTI.h>
 #include <Surelog/Design/Scope.h>

--- a/include/Surelog/Design/Task.h
+++ b/include/Surelog/Design/Task.h
@@ -25,6 +25,7 @@
 #define SURELOG_TASK_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/Function.h>
 

--- a/include/Surelog/Design/TfPortItem.h
+++ b/include/Surelog/Design/TfPortItem.h
@@ -25,6 +25,7 @@
 #define SURELOG_TFPORTITEM_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 #include <Surelog/Testbench/Variable.h>
 

--- a/include/Surelog/Design/VObject.h
+++ b/include/Surelog/Design/VObject.h
@@ -25,6 +25,7 @@
 #define SURELOG_VOBJECT_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>

--- a/include/Surelog/Design/ValuedComponentI.h
+++ b/include/Surelog/Design/ValuedComponentI.h
@@ -25,6 +25,7 @@
 #define SURELOG_VALUEDCOMPONENTI_H
 #pragma once
 
+#include <utility>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/RTTI.h>
 

--- a/include/Surelog/DesignCompile/CompileClass.h
+++ b/include/Surelog/DesignCompile/CompileClass.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMPILECLASS_H
 #pragma once
 
+#include <set>
 #include <string>
 #include <Surelog/DesignCompile/CompileHelper.h>
 #include <Surelog/Testbench/ClassDefinition.h>

--- a/include/Surelog/DesignCompile/CompileClass.h
+++ b/include/Surelog/DesignCompile/CompileClass.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMPILECLASS_H
 #pragma once
 
+#include <string>
 #include <Surelog/DesignCompile/CompileHelper.h>
 #include <Surelog/Testbench/ClassDefinition.h>
 

--- a/include/Surelog/DesignCompile/CompileDesign.h
+++ b/include/Surelog/DesignCompile/CompileDesign.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMPILEDESIGN_H
 #pragma once
 
+#include <vector>
 #include <Surelog/Design/Design.h>
 
 // UHDM

--- a/include/Surelog/DesignCompile/CompileDesign.h
+++ b/include/Surelog/DesignCompile/CompileDesign.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMPILEDESIGN_H
 #pragma once
 
+#include <map>
 #include <vector>
 #include <Surelog/Design/Design.h>
 

--- a/include/Surelog/DesignCompile/CompileHelper.h
+++ b/include/Surelog/DesignCompile/CompileHelper.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMPILEHELPER_H
 #pragma once
 
+#include <vector>
 #include <string_view>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Design/ValuedComponentI.h>

--- a/include/Surelog/DesignCompile/CompileHelper.h
+++ b/include/Surelog/DesignCompile/CompileHelper.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMPILEHELPER_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Design/ValuedComponentI.h>
 #include <Surelog/Expression/ExprBuilder.h>

--- a/include/Surelog/DesignCompile/CompileHelper.h
+++ b/include/Surelog/DesignCompile/CompileHelper.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMPILEHELPER_H
 #pragma once
 
+#include <utility>
 #include <vector>
 #include <string_view>
 #include <Surelog/Common/PathId.h>

--- a/include/Surelog/DesignCompile/DesignElaboration.h
+++ b/include/Surelog/DesignCompile/DesignElaboration.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNELABORATION_H
 #pragma once
 
+#include <vector>
 #include <string_view>
 #include <string>
 #include <Surelog/Config/Config.h>

--- a/include/Surelog/DesignCompile/DesignElaboration.h
+++ b/include/Surelog/DesignCompile/DesignElaboration.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNELABORATION_H
 #pragma once
 
+#include <map>
 #include <utility>
 #include <vector>
 #include <string_view>

--- a/include/Surelog/DesignCompile/DesignElaboration.h
+++ b/include/Surelog/DesignCompile/DesignElaboration.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNELABORATION_H
 #pragma once
 
+#include <string_view>
 #include <string>
 #include <Surelog/Config/Config.h>
 #include <Surelog/DesignCompile/TestbenchElaboration.h>

--- a/include/Surelog/DesignCompile/DesignElaboration.h
+++ b/include/Surelog/DesignCompile/DesignElaboration.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNELABORATION_H
 #pragma once
 
+#include <string>
 #include <Surelog/Config/Config.h>
 #include <Surelog/DesignCompile/TestbenchElaboration.h>
 

--- a/include/Surelog/DesignCompile/DesignElaboration.h
+++ b/include/Surelog/DesignCompile/DesignElaboration.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNELABORATION_H
 #pragma once
 
+#include <set>
 #include <map>
 #include <utility>
 #include <vector>

--- a/include/Surelog/DesignCompile/DesignElaboration.h
+++ b/include/Surelog/DesignCompile/DesignElaboration.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNELABORATION_H
 #pragma once
 
+#include <utility>
 #include <vector>
 #include <string_view>
 #include <string>

--- a/include/Surelog/DesignCompile/DesignElaboration.h
+++ b/include/Surelog/DesignCompile/DesignElaboration.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNELABORATION_H
 #pragma once
 
+#include <functional>
 #include <set>
 #include <map>
 #include <utility>

--- a/include/Surelog/DesignCompile/ElaborationStep.h
+++ b/include/Surelog/DesignCompile/ElaborationStep.h
@@ -25,6 +25,7 @@
 #define SURELOG_ELABORATIONSTEP_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/DesignCompile/CompileHelper.h>
 #include <Surelog/ErrorReporting/ErrorDefinition.h>
 #include <Surelog/Expression/ExprBuilder.h>

--- a/include/Surelog/DesignCompile/ElaborationStep.h
+++ b/include/Surelog/DesignCompile/ElaborationStep.h
@@ -25,6 +25,7 @@
 #define SURELOG_ELABORATIONSTEP_H
 #pragma once
 
+#include <map>
 #include <string_view>
 #include <Surelog/DesignCompile/CompileHelper.h>
 #include <Surelog/ErrorReporting/ErrorDefinition.h>

--- a/include/Surelog/DesignCompile/ElaboratorHarness.h
+++ b/include/Surelog/DesignCompile/ElaboratorHarness.h
@@ -25,6 +25,7 @@
 #define SURELOG_ELABORATORHARNESS_H
 #pragma once
 
+#include <string_view>
 #include <string>
 
 namespace SURELOG {

--- a/include/Surelog/DesignCompile/NetlistElaboration.h
+++ b/include/Surelog/DesignCompile/NetlistElaboration.h
@@ -25,6 +25,7 @@
 #define SURELOG_NETLISTELABORATION_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/DesignCompile/TestbenchElaboration.h>
 
 namespace SURELOG {

--- a/include/Surelog/DesignCompile/NetlistElaboration.h
+++ b/include/Surelog/DesignCompile/NetlistElaboration.h
@@ -25,6 +25,7 @@
 #define SURELOG_NETLISTELABORATION_H
 #pragma once
 
+#include <map>
 #include <string_view>
 #include <Surelog/DesignCompile/TestbenchElaboration.h>
 

--- a/include/Surelog/DesignCompile/ResolveSymbols.h
+++ b/include/Surelog/DesignCompile/ResolveSymbols.h
@@ -25,6 +25,7 @@
 #define SURELOG_RESOLVESYMBOLS_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/DesignCompile/CompileStep.h>
 

--- a/include/Surelog/DesignCompile/ResolveSymbols.h
+++ b/include/Surelog/DesignCompile/ResolveSymbols.h
@@ -25,6 +25,7 @@
 #define SURELOG_RESOLVESYMBOLS_H
 #pragma once
 
+#include <vector>
 #include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/DesignCompile/CompileStep.h>

--- a/include/Surelog/DesignCompile/UhdmChecker.h
+++ b/include/Surelog/DesignCompile/UhdmChecker.h
@@ -25,6 +25,7 @@
 #define SURELOG_UHDMCHECKER_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/PathId.h>
 
 #include <map>

--- a/include/Surelog/DesignCompile/UhdmChecker.h
+++ b/include/Surelog/DesignCompile/UhdmChecker.h
@@ -25,6 +25,7 @@
 #define SURELOG_UHDMCHECKER_H
 #pragma once
 
+#include <utility>
 #include <string_view>
 #include <Surelog/Common/PathId.h>
 

--- a/include/Surelog/DesignCompile/UhdmWriter.h
+++ b/include/Surelog/DesignCompile/UhdmWriter.h
@@ -25,6 +25,7 @@
 #define SURELOG_UHDMWRITER_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/DesignCompile/CompileHelper.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>

--- a/include/Surelog/DesignCompile/UhdmWriter.h
+++ b/include/Surelog/DesignCompile/UhdmWriter.h
@@ -25,6 +25,7 @@
 #define SURELOG_UHDMWRITER_H
 #pragma once
 
+#include <map>
 #include <vector>
 #include <string_view>
 #include <Surelog/Design/DesignComponent.h>

--- a/include/Surelog/DesignCompile/UhdmWriter.h
+++ b/include/Surelog/DesignCompile/UhdmWriter.h
@@ -25,6 +25,7 @@
 #define SURELOG_UHDMWRITER_H
 #pragma once
 
+#include <vector>
 #include <string_view>
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/DesignCompile/CompileHelper.h>

--- a/include/Surelog/DesignCompile/UhdmWriter.h
+++ b/include/Surelog/DesignCompile/UhdmWriter.h
@@ -25,6 +25,7 @@
 #define SURELOG_UHDMWRITER_H
 #pragma once
 
+#include <functional>
 #include <map>
 #include <vector>
 #include <string_view>

--- a/include/Surelog/ErrorReporting/ErrorContainer.h
+++ b/include/Surelog/ErrorReporting/ErrorContainer.h
@@ -25,6 +25,7 @@
 #define SURELOG_ERRORCONTAINER_H
 #pragma once
 
+#include <utility>
 #include <string_view>
 #include <Surelog/ErrorReporting/Error.h>
 

--- a/include/Surelog/ErrorReporting/ErrorContainer.h
+++ b/include/Surelog/ErrorReporting/ErrorContainer.h
@@ -25,6 +25,7 @@
 #define SURELOG_ERRORCONTAINER_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/ErrorReporting/Error.h>
 
 #include <set>

--- a/include/Surelog/ErrorReporting/LogListener.h
+++ b/include/Surelog/ErrorReporting/LogListener.h
@@ -25,6 +25,7 @@
 #define SURELOG_LOGLISTENER_H
 #pragma once
 
+#include <string_view>
 #include <deque>
 #include <mutex>
 #include <ostream>

--- a/include/Surelog/ErrorReporting/Waiver.h
+++ b/include/Surelog/ErrorReporting/Waiver.h
@@ -25,6 +25,7 @@
 #define SURELOG_WAIVER_H
 #pragma once
 
+#include <functional>
 #include <Surelog/ErrorReporting/ErrorDefinition.h>
 
 #include <map>

--- a/include/Surelog/Expression/ExprBuilder.h
+++ b/include/Surelog/Expression/ExprBuilder.h
@@ -25,6 +25,7 @@
 #define SURELOG_EXPRBUILDER_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Expression/Value.h>
 
 namespace SURELOG {

--- a/include/Surelog/Library/AntlrLibParserErrorListener.h
+++ b/include/Surelog/Library/AntlrLibParserErrorListener.h
@@ -25,6 +25,7 @@
 #define SURELOG_ANTLRLIBPARSERERRORLISTENER_H
 #pragma once
 
+#include <string>
 #include <ANTLRErrorListener.h>
 
 #include <cstddef>

--- a/include/Surelog/Library/SVLibShapeListener.h
+++ b/include/Surelog/Library/SVLibShapeListener.h
@@ -25,6 +25,7 @@
 #define SURELOG_SVLIBSHAPELISTENER_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/SourceCompile/SV3_1aTreeShapeHelper.h>
 #include <parser/SV3_1aParserBaseListener.h>

--- a/include/Surelog/Package/Precompiled.h
+++ b/include/Surelog/Package/Precompiled.h
@@ -25,6 +25,7 @@
 #define SURELOG_PRECOMPILED_H
 #pragma once
 
+#include <functional>
 #include <map>
 #include <set>
 #include <string>

--- a/include/Surelog/SourceCompile/AntlrParserErrorListener.h
+++ b/include/Surelog/SourceCompile/AntlrParserErrorListener.h
@@ -25,6 +25,7 @@
 #define SURELOG_ANTLRPARSERERRORLISTENER_H
 #pragma once
 
+#include <string>
 #include <Surelog/Common/PathId.h>
 #include <ANTLRErrorListener.h>
 

--- a/include/Surelog/SourceCompile/CommonListenerHelper.h
+++ b/include/Surelog/SourceCompile/CommonListenerHelper.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMMONLISTENERHELPER_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>

--- a/include/Surelog/SourceCompile/CompilationUnit.h
+++ b/include/Surelog/SourceCompile/CompilationUnit.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMPILATIONUNIT_H
 #pragma once
 
+#include <vector>
 #include <string_view>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>

--- a/include/Surelog/SourceCompile/CompilationUnit.h
+++ b/include/Surelog/SourceCompile/CompilationUnit.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMPILATIONUNIT_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Design/TimeInfo.h>

--- a/include/Surelog/SourceCompile/CompileSourceFile.h
+++ b/include/Surelog/SourceCompile/CompileSourceFile.h
@@ -25,6 +25,7 @@
 #define SURELOG_COMPILESOURCEFILE_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/SourceCompile/PreprocessFile.h>
 

--- a/include/Surelog/SourceCompile/Compiler.h
+++ b/include/Surelog/SourceCompile/Compiler.h
@@ -25,6 +25,7 @@ limitations under the License.
 #define SURELOG_COMPILER_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/ErrorReporting/ErrorContainer.h>

--- a/include/Surelog/SourceCompile/ParseFile.h
+++ b/include/Surelog/SourceCompile/ParseFile.h
@@ -25,6 +25,7 @@
 #define SURELOG_PARSEFILE_H
 #pragma once
 
+#include <vector>
 #include <string_view>
 #include <Surelog/ErrorReporting/Error.h>
 

--- a/include/Surelog/SourceCompile/ParseFile.h
+++ b/include/Surelog/SourceCompile/ParseFile.h
@@ -25,6 +25,7 @@
 #define SURELOG_PARSEFILE_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/ErrorReporting/Error.h>
 
 #include <string>

--- a/include/Surelog/SourceCompile/ParseTreeListener.template.hpp
+++ b/include/Surelog/SourceCompile/ParseTreeListener.template.hpp
@@ -27,6 +27,7 @@
 #define SURELOG_PARSETREELISTENER_H
 #pragma once
 
+#include <string>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>

--- a/include/Surelog/SourceCompile/ParseTreeTraceListener.template.hpp
+++ b/include/Surelog/SourceCompile/ParseTreeTraceListener.template.hpp
@@ -27,6 +27,7 @@
 #define SURELOG_PARSETREETRACELISTENER_H
 #pragma once
 
+#include <string>
 #include <Surelog/SourceCompile/ParseTreeListener.h>
 
 #include <filesystem>

--- a/include/Surelog/SourceCompile/ParseTreeTraceListener.template.hpp
+++ b/include/Surelog/SourceCompile/ParseTreeTraceListener.template.hpp
@@ -27,6 +27,7 @@
 #define SURELOG_PARSETREETRACELISTENER_H
 #pragma once
 
+#include <string_view>
 #include <string>
 #include <Surelog/SourceCompile/ParseTreeListener.h>
 

--- a/include/Surelog/SourceCompile/ParserHarness.h
+++ b/include/Surelog/SourceCompile/ParserHarness.h
@@ -25,6 +25,7 @@
 #define SURELOG_PARSERHARNESS_H
 #pragma once
 
+#include <string_view>
 #include <memory>
 #include <string>
 

--- a/include/Surelog/SourceCompile/PreprocessFile.h
+++ b/include/Surelog/SourceCompile/PreprocessFile.h
@@ -25,6 +25,7 @@
 #define SURELOG_PREPROCESSFILE_H
 #pragma once
 
+#include <string_view>
 #include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/PathId.h>

--- a/include/Surelog/SourceCompile/PreprocessFile.h
+++ b/include/Surelog/SourceCompile/PreprocessFile.h
@@ -25,6 +25,7 @@
 #define SURELOG_PREPROCESSFILE_H
 #pragma once
 
+#include <utility>
 #include <string_view>
 #include <string>
 #include <Surelog/Common/Containers.h>

--- a/include/Surelog/SourceCompile/PreprocessFile.h
+++ b/include/Surelog/SourceCompile/PreprocessFile.h
@@ -25,6 +25,7 @@
 #define SURELOG_PREPROCESSFILE_H
 #pragma once
 
+#include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>

--- a/include/Surelog/SourceCompile/PreprocessHarness.h
+++ b/include/Surelog/SourceCompile/PreprocessHarness.h
@@ -25,6 +25,7 @@
 #define SURELOG_PREPROCESSHARNESS_H
 #pragma once
 
+#include <string_view>
 #include <string>
 #include <Surelog/ErrorReporting/ErrorContainer.h>
 #include <Surelog/SourceCompile/CompilationUnit.h>

--- a/include/Surelog/SourceCompile/PreprocessHarness.h
+++ b/include/Surelog/SourceCompile/PreprocessHarness.h
@@ -25,6 +25,7 @@
 #define SURELOG_PREPROCESSHARNESS_H
 #pragma once
 
+#include <string>
 #include <Surelog/ErrorReporting/ErrorContainer.h>
 #include <Surelog/SourceCompile/CompilationUnit.h>
 #include <Surelog/SourceCompile/SymbolTable.h>

--- a/include/Surelog/SourceCompile/SV3_1aPpTreeListenerHelper.h
+++ b/include/Surelog/SourceCompile/SV3_1aPpTreeListenerHelper.h
@@ -25,6 +25,7 @@
 #define SURELOG_SV3_1APPTREELISTENERHELPER_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/ErrorReporting/ErrorDefinition.h>
 #include <Surelog/ErrorReporting/Location.h>

--- a/include/Surelog/SourceCompile/SV3_1aTreeShapeHelper.h
+++ b/include/Surelog/SourceCompile/SV3_1aTreeShapeHelper.h
@@ -25,6 +25,7 @@
 #define SURELOG_SV3_1ATREESHAPEHELPER_H
 #pragma once
 
+#include <utility>
 #include <Surelog/Design/DesignElement.h>
 #include <Surelog/ErrorReporting/ErrorDefinition.h>
 #include <Surelog/ErrorReporting/Location.h>

--- a/include/Surelog/Testbench/ClassDefinition.h
+++ b/include/Surelog/Testbench/ClassDefinition.h
@@ -25,6 +25,7 @@
 #define SURELOG_CLASSDEFINITION_H
 #pragma once
 
+#include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Design/DataType.h>
 #include <Surelog/Design/DesignComponent.h>

--- a/include/Surelog/Testbench/ClassDefinition.h
+++ b/include/Surelog/Testbench/ClassDefinition.h
@@ -25,6 +25,7 @@
 #define SURELOG_CLASSDEFINITION_H
 #pragma once
 
+#include <map>
 #include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Design/DataType.h>

--- a/include/Surelog/Testbench/ClassObject.h
+++ b/include/Surelog/Testbench/ClassObject.h
@@ -25,6 +25,7 @@
 #define SURELOG_CLASSOBJECT_H
 #pragma once
 
+#include <functional>
 #include <utility>
 #include <string_view>
 #include <map>

--- a/include/Surelog/Testbench/ClassObject.h
+++ b/include/Surelog/Testbench/ClassObject.h
@@ -25,6 +25,7 @@
 #define SURELOG_CLASSOBJECT_H
 #pragma once
 
+#include <string_view>
 #include <map>
 #include <string>
 

--- a/include/Surelog/Testbench/ClassObject.h
+++ b/include/Surelog/Testbench/ClassObject.h
@@ -25,6 +25,7 @@
 #define SURELOG_CLASSOBJECT_H
 #pragma once
 
+#include <utility>
 #include <string_view>
 #include <map>
 #include <string>

--- a/include/Surelog/Testbench/FunctionMethod.h
+++ b/include/Surelog/Testbench/FunctionMethod.h
@@ -25,6 +25,7 @@
 #define SURELOG_FUNCTIONMETHOD_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Design/Function.h>
 
 namespace SURELOG {

--- a/include/Surelog/Testbench/Program.h
+++ b/include/Surelog/Testbench/Program.h
@@ -25,6 +25,7 @@
 #define SURELOG_PROGRAM_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/ClockingBlockHolder.h>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/SymbolId.h>

--- a/include/Surelog/Testbench/Property.h
+++ b/include/Surelog/Testbench/Property.h
@@ -25,6 +25,7 @@
 #define SURELOG_PROPERTY_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Testbench/Variable.h>
 
 namespace SURELOG {

--- a/include/Surelog/Testbench/TypeDef.h
+++ b/include/Surelog/Testbench/TypeDef.h
@@ -25,6 +25,7 @@
 #define SURELOG_TYPEDEF_H
 #pragma once
 
+#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
 

--- a/include/Surelog/Utils/ParseUtils.h
+++ b/include/Surelog/Utils/ParseUtils.h
@@ -25,6 +25,7 @@
 #define SURELOG_PARSEUTILS_H
 #pragma once
 
+#include <utility>
 #include <vector>
 #include <string>
 #include <ParserRuleContext.h>

--- a/include/Surelog/Utils/ParseUtils.h
+++ b/include/Surelog/Utils/ParseUtils.h
@@ -25,6 +25,7 @@
 #define SURELOG_PARSEUTILS_H
 #pragma once
 
+#include <string>
 #include <ParserRuleContext.h>
 
 namespace SURELOG {

--- a/include/Surelog/Utils/ParseUtils.h
+++ b/include/Surelog/Utils/ParseUtils.h
@@ -25,6 +25,7 @@
 #define SURELOG_PARSEUTILS_H
 #pragma once
 
+#include <vector>
 #include <string>
 #include <ParserRuleContext.h>
 

--- a/src/API/PythonAPI.cpp
+++ b/src/API/PythonAPI.cpp
@@ -25,6 +25,8 @@
 
 #include <antlr4-runtime.h>
 
+#include <string>
+
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/Design.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"

--- a/src/API/PythonAPI.cpp
+++ b/src/API/PythonAPI.cpp
@@ -26,6 +26,7 @@
 #include <antlr4-runtime.h>
 
 #include <string>
+#include <vector>
 
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/Design.h"

--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -32,6 +32,7 @@
 
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/Design.h"

--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -31,6 +31,7 @@
 #include <antlr4-runtime.h>
 
 #include <iostream>
+#include <string>
 
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/Design.h"

--- a/src/API/Surelog.cpp
+++ b/src/API/Surelog.cpp
@@ -16,6 +16,8 @@
 
 #include "Surelog/API/Surelog.h"
 
+#include <vector>
+
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/Design.h"

--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -28,6 +28,7 @@
 #include <filesystem>
 #include <functional>
 #include <iostream>
+#include <string>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -29,6 +29,7 @@
 #include <functional>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 
 #include <string>
+#include <string_view>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -28,6 +28,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <string>
+
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/Design.h"

--- a/src/Cache/PPCache_test.cpp
+++ b/src/Cache/PPCache_test.cpp
@@ -26,6 +26,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <map>
 #include <string>
 #include <thread>

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 
 #include <string>
+#include <string_view>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -28,6 +28,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <string>
+
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/Design.h"

--- a/src/Cache/PythonAPICache.cpp
+++ b/src/Cache/PythonAPICache.cpp
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 
 #include <string>
+#include <string_view>
 
 #include "Surelog/API/PythonAPI.h"
 #include "Surelog/Cache/Cache.h"

--- a/src/Cache/PythonAPICache.cpp
+++ b/src/Cache/PythonAPICache.cpp
@@ -28,6 +28,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <string>
+
 #include "Surelog/API/PythonAPI.h"
 #include "Surelog/Cache/Cache.h"
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/Cache/PythonAPICache.cpp
+++ b/src/Cache/PythonAPICache.cpp
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/API/PythonAPI.h"
 #include "Surelog/Cache/Cache.h"

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -25,6 +25,7 @@
 
 #include <nlohmann/json.hpp>
 #include <string>
+#include <string_view>
 
 #include "Surelog/API/PythonAPI.h"
 #include "Surelog/Common/PlatformFileSystem.h"

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -26,6 +26,7 @@
 #include <nlohmann/json.hpp>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/API/PythonAPI.h"
 #include "Surelog/Common/PlatformFileSystem.h"

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 
+#include <map>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <string_view>

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -26,6 +26,7 @@
 #include <nlohmann/json.hpp>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "Surelog/API/PythonAPI.h"

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/CommandLine/CommandLineParser.h"
 
 #include <nlohmann/json.hpp>
+#include <string>
 
 #include "Surelog/API/PythonAPI.h"
 #include "Surelog/Common/PlatformFileSystem.h"

--- a/src/Common/FileSystem.cpp
+++ b/src/Common/FileSystem.cpp
@@ -30,6 +30,7 @@
 #include <Windows.h>
 
 #include <string>
+#include <string_view>
 #elif defined(__APPLE__)
 #include <mach-o/dyld.h>
 #include <sys/param.h>

--- a/src/Common/FileSystem.cpp
+++ b/src/Common/FileSystem.cpp
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 #elif defined(__APPLE__)
 #include <mach-o/dyld.h>
 #include <sys/param.h>

--- a/src/Common/FileSystem.cpp
+++ b/src/Common/FileSystem.cpp
@@ -28,6 +28,8 @@
 #if defined(_WIN32)
 #define NOMINMAX
 #include <Windows.h>
+
+#include <string>
 #elif defined(__APPLE__)
 #include <mach-o/dyld.h>
 #include <sys/param.h>

--- a/src/Common/FileSystem.cpp
+++ b/src/Common/FileSystem.cpp
@@ -29,6 +29,7 @@
 #define NOMINMAX
 #include <Windows.h>
 
+#include <iostream>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/Common/PlatformFileSystem.cpp
+++ b/src/Common/PlatformFileSystem.cpp
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <mutex>
 #include <string>
+#include <string_view>
 
 #include "Surelog/SourceCompile/SymbolTable.h"
 #include "Surelog/Utils/StringUtils.h"

--- a/src/Common/PlatformFileSystem.cpp
+++ b/src/Common/PlatformFileSystem.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <iostream>
 #include <mutex>
+#include <set>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/Common/PlatformFileSystem.cpp
+++ b/src/Common/PlatformFileSystem.cpp
@@ -29,6 +29,7 @@
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/SourceCompile/SymbolTable.h"
 #include "Surelog/Utils/StringUtils.h"

--- a/src/Common/PlatformFileSystem.cpp
+++ b/src/Common/PlatformFileSystem.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <iostream>
 #include <mutex>
+#include <string>
 
 #include "Surelog/SourceCompile/SymbolTable.h"
 #include "Surelog/Utils/StringUtils.h"

--- a/src/Common/PlatformFileSystem.cpp
+++ b/src/Common/PlatformFileSystem.cpp
@@ -29,6 +29,7 @@
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "Surelog/SourceCompile/SymbolTable.h"

--- a/src/Common/PlatformFileSystem_test.cpp
+++ b/src/Common/PlatformFileSystem_test.cpp
@@ -25,6 +25,7 @@
 
 #include <gtest/gtest.h>
 
+#include <iostream>
 #include <set>
 #include <string_view>
 #include <utility>

--- a/src/Common/PlatformFileSystem_test.cpp
+++ b/src/Common/PlatformFileSystem_test.cpp
@@ -26,6 +26,7 @@
 #include <gtest/gtest.h>
 
 #include <string_view>
+#include <utility>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Design/Design.h"

--- a/src/Common/PlatformFileSystem_test.cpp
+++ b/src/Common/PlatformFileSystem_test.cpp
@@ -25,6 +25,7 @@
 
 #include <gtest/gtest.h>
 
+#include <set>
 #include <string_view>
 #include <utility>
 

--- a/src/Common/PlatformFileSystem_test.cpp
+++ b/src/Common/PlatformFileSystem_test.cpp
@@ -25,6 +25,8 @@
 
 #include <gtest/gtest.h>
 
+#include <string_view>
+
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Design/Design.h"
 #include "Surelog/Library/Library.h"

--- a/src/Config/Config.cpp
+++ b/src/Config/Config.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/Config/Config.h"
 
+#include <string_view>
+
 namespace SURELOG {
 UseClause* Config::getInstanceUseClause(std::string_view instance) {
   const auto found = m_instanceUseClauses.find(instance);

--- a/src/Config/ConfigSet.cpp
+++ b/src/Config/ConfigSet.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/Config/ConfigSet.h"
 
+#include <string_view>
+
 namespace SURELOG {
 Config* ConfigSet::getMutableConfigByName(std::string_view configName) {
   for (auto& config : m_configs) {

--- a/src/DesignCompile/Builtin.cpp
+++ b/src/DesignCompile/Builtin.cpp
@@ -44,6 +44,7 @@
 #include <uhdm/Serializer.h>
 #include <uhdm/package.h>
 
+#include <string>
 #include <string_view>
 #include <vector>
 

--- a/src/DesignCompile/CompileAssertion.cpp
+++ b/src/DesignCompile/CompileAssertion.cpp
@@ -31,6 +31,7 @@
 #include <uhdm/uhdm.h>
 
 #include <iostream>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -41,6 +41,7 @@
 #include <uhdm/class_defn.h>
 
 #include <stack>
+#include <string>
 
 namespace SURELOG {
 int32_t FunctorCompileClass::operator()() const {

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -43,6 +43,7 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace SURELOG {
 int32_t FunctorCompileClass::operator()() const {

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -43,6 +43,7 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace SURELOG {

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -42,6 +42,7 @@
 
 #include <stack>
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 int32_t FunctorCompileClass::operator()() const {

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -55,6 +55,7 @@
 #include <uhdm/vpi_visitor.h>
 
 #include <climits>
+#include <map>
 #include <string>
 #include <string_view>
 #include <thread>

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -58,6 +58,7 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#include <vector>
 
 #ifdef USETBB
 #include <tbb/task.h>

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -55,6 +55,7 @@
 #include <uhdm/vpi_visitor.h>
 
 #include <climits>
+#include <string>
 #include <thread>
 
 #ifdef USETBB

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -55,6 +55,7 @@
 #include <uhdm/vpi_visitor.h>
 
 #include <climits>
+#include <iostream>
 #include <map>
 #include <string>
 #include <string_view>

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -56,6 +56,7 @@
 
 #include <climits>
 #include <string>
+#include <string_view>
 #include <thread>
 
 #ifdef USETBB

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <string>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <cstring>
 #include <string>
+#include <string_view>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <iostream>
 #include <set>
 #include <string>
 #include <string_view>

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <set>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/DesignCompile/CompileExpression_test.cpp
+++ b/src/DesignCompile/CompileExpression_test.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <vector>
 
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/DesignCompile/CompileDesign.h"

--- a/src/DesignCompile/CompileExpression_test.cpp
+++ b/src/DesignCompile/CompileExpression_test.cpp
@@ -17,6 +17,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <string>
+
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/DesignCompile/CompileDesign.h"
 #include "Surelog/DesignCompile/CompileHelper.h"

--- a/src/DesignCompile/CompileFileContent.cpp
+++ b/src/DesignCompile/CompileFileContent.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/DesignCompile/CompileFileContent.h"
 
 #include <stack>
+#include <vector>
 
 #include "Surelog/Design/FileContent.h"
 

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -67,6 +67,7 @@
 #include <iostream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace SURELOG {

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -64,6 +64,7 @@
 
 #include <climits>
 #include <cstring>
+#include <functional>
 #include <iostream>
 #include <map>
 #include <string>

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -66,6 +66,7 @@
 #include <cstring>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace SURELOG {

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -65,6 +65,7 @@
 #include <climits>
 #include <cstring>
 #include <iostream>
+#include <map>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/DesignCompile/CompileHelper_test.cpp
+++ b/src/DesignCompile/CompileHelper_test.cpp
@@ -21,6 +21,7 @@
 #include <uhdm/constant.h>
 
 #include <limits>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -50,6 +50,7 @@
 
 #include <stack>
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -51,6 +51,7 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -51,6 +51,7 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace SURELOG {

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -49,6 +49,7 @@
 #include <uhdm/udp_defn.h>
 
 #include <stack>
+#include <string>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -38,6 +38,7 @@
 #include <uhdm/package.h>
 
 #include <stack>
+#include <string>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -40,6 +40,7 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -39,6 +39,7 @@
 
 #include <stack>
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -28,6 +28,7 @@
 
 #include <stack>
 #include <string>
+#include <string_view>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Design/FileContent.h"

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -27,6 +27,7 @@
 #include <uhdm/initial.h>
 
 #include <stack>
+#include <string>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Design/FileContent.h"

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -29,6 +29,7 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Design/FileContent.h"

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -53,6 +53,7 @@
 #include <uhdm/ElaboratorListener.h>
 #include <uhdm/uhdm.h>
 
+#include <functional>
 #include <iostream>
 #include <map>
 #include <string>

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -56,6 +56,7 @@
 #include <iostream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace SURELOG {

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -54,6 +54,7 @@
 #include <uhdm/uhdm.h>
 
 #include <iostream>
+#include <map>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -55,6 +55,7 @@
 
 #include <iostream>
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -54,6 +54,7 @@
 #include <uhdm/uhdm.h>
 
 #include <iostream>
+#include <string>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -56,6 +56,7 @@
 #include <iostream>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -57,6 +57,7 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -55,6 +55,7 @@
 #include <uhdm/uhdm.h>
 
 #include <stack>
+#include <string>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -56,6 +56,7 @@
 
 #include <stack>
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -54,6 +54,7 @@
 #include <queue>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace SURELOG {

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -52,6 +52,7 @@
 
 #include <cstring>
 #include <functional>
+#include <iostream>
 #include <queue>
 #include <set>
 #include <string>

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -54,6 +54,7 @@
 #include <queue>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 namespace SURELOG {
 DesignElaboration::DesignElaboration(CompileDesign* compileDesign)

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -52,6 +52,7 @@
 
 #include <cstring>
 #include <queue>
+#include <string>
 #include <unordered_set>
 
 namespace SURELOG {

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -52,6 +52,7 @@
 
 #include <cstring>
 #include <queue>
+#include <set>
 #include <string>
 #include <unordered_set>
 #include <utility>

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -51,6 +51,7 @@
 #include <uhdm/uhdm.h>
 
 #include <cstring>
+#include <functional>
 #include <queue>
 #include <set>
 #include <string>

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/DesignCompile/ElaborationStep.h"
 
 #include <cstring>
+#include <map>
 #include <queue>
 #include <string>
 #include <string_view>

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -27,6 +27,7 @@
 #include <queue>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <queue>
 #include <string>
+#include <string_view>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -27,6 +27,7 @@
 #include <queue>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/DesignCompile/ElaborationStep.h"
 
 #include <cstring>
+#include <functional>
 #include <map>
 #include <queue>
 #include <string>

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -25,6 +25,7 @@
 
 #include <cstring>
 #include <queue>
+#include <string>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/DesignCompile/Elaboration_test.cpp
+++ b/src/DesignCompile/Elaboration_test.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <iostream>
 #include <string>
 #include <string_view>
 #include <tuple>

--- a/src/DesignCompile/ElaboratorHarness.cpp
+++ b/src/DesignCompile/ElaboratorHarness.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/DesignCompile/ElaboratorHarness.h"
 
+#include <string_view>
+
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Design/Design.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"

--- a/src/DesignCompile/EvalFunc.cpp
+++ b/src/DesignCompile/EvalFunc.cpp
@@ -39,6 +39,7 @@
 #include <iostream>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/EvalFunc.cpp
+++ b/src/DesignCompile/EvalFunc.cpp
@@ -37,6 +37,7 @@
 
 #include <bitset>
 #include <iostream>
+#include <string>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/EvalFunc.cpp
+++ b/src/DesignCompile/EvalFunc.cpp
@@ -38,6 +38,7 @@
 #include <bitset>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <string>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/DesignCompile/NetlistElaboration.h"
 
 #include <algorithm>
+#include <string>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/DesignCompile/NetlistElaboration.h"
 
 #include <algorithm>
+#include <map>
 #include <string>
 #include <vector>
 

--- a/src/DesignCompile/ResolveSymbols.cpp
+++ b/src/DesignCompile/ResolveSymbols.cpp
@@ -37,6 +37,8 @@
 // UHDM
 #include <uhdm/package.h>
 
+#include <string>
+
 namespace SURELOG {
 
 int32_t FunctorCreateLookup::operator()() const {

--- a/src/DesignCompile/ResolveSymbols.cpp
+++ b/src/DesignCompile/ResolveSymbols.cpp
@@ -38,6 +38,7 @@
 #include <uhdm/package.h>
 
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/ResolveSymbols.cpp
+++ b/src/DesignCompile/ResolveSymbols.cpp
@@ -39,6 +39,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -45,6 +45,7 @@
 
 #include <queue>
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -46,6 +46,7 @@
 #include <queue>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -44,6 +44,7 @@
 #include <uhdm/ref_typespec.h>
 
 #include <queue>
+#include <string>
 
 namespace SURELOG {
 

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -44,6 +44,7 @@
 #include <sstream>
 #include <stack>
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 using UHDM::BaseClass;

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -41,6 +41,7 @@
 #include <uhdm/vpi_visitor.h>
 
 #include <iomanip>
+#include <set>
 #include <sstream>
 #include <stack>
 #include <string>

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -45,6 +45,7 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace SURELOG {
 using UHDM::BaseClass;

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -43,6 +43,7 @@
 #include <iomanip>
 #include <sstream>
 #include <stack>
+#include <string>
 
 namespace SURELOG {
 using UHDM::BaseClass;

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/DesignCompile/UhdmWriter.h"
 
 #include <cstring>
+#include <map>
 #include <queue>
 #include <string>
 #include <string_view>

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <map>
 #include <queue>
+#include <set>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/DesignCompile/UhdmWriter.h"
 
 #include <cstring>
+#include <iostream>
 #include <map>
 #include <queue>
 #include <set>

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -27,6 +27,7 @@
 #include <queue>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <queue>
 #include <string>
+#include <string_view>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -27,6 +27,7 @@
 #include <queue>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -25,6 +25,7 @@
 
 #include <cstring>
 #include <queue>
+#include <string>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/ErrorReporting/Error.cpp
+++ b/src/ErrorReporting/Error.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/ErrorReporting/Error.h"
 
+#include <vector>
+
 namespace SURELOG {
 
 Error::Error(ErrorDefinition::ErrorType errorId, const Location& loc,

--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -26,6 +26,7 @@
 #include <cstdio>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 #include "Surelog/API/PythonAPI.h"
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/API/PythonAPI.h"
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -25,6 +25,7 @@
 
 #include <cstdio>
 #include <iostream>
+#include <string>
 
 #include "Surelog/API/PythonAPI.h"
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -25,6 +25,7 @@
 
 #include <cstdio>
 #include <iostream>
+#include <map>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "Surelog/API/PythonAPI.h"

--- a/src/ErrorReporting/ErrorDefinition.cpp
+++ b/src/ErrorReporting/ErrorDefinition.cpp
@@ -23,6 +23,7 @@
 #include "Surelog/ErrorReporting/ErrorDefinition.h"
 
 #include <string>
+#include <string_view>
 
 #include "Surelog/Utils/NumUtils.h"
 #include "Surelog/Utils/StringUtils.h"

--- a/src/ErrorReporting/ErrorDefinition.cpp
+++ b/src/ErrorReporting/ErrorDefinition.cpp
@@ -22,6 +22,8 @@
  */
 #include "Surelog/ErrorReporting/ErrorDefinition.h"
 
+#include <string>
+
 #include "Surelog/Utils/NumUtils.h"
 #include "Surelog/Utils/StringUtils.h"
 

--- a/src/ErrorReporting/LogListener.cpp
+++ b/src/ErrorReporting/LogListener.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/ErrorReporting/LogListener.h"
 
+#include <iostream>
 #include <string_view>
 
 #include "Surelog/Common/FileSystem.h"

--- a/src/ErrorReporting/LogListener.cpp
+++ b/src/ErrorReporting/LogListener.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/ErrorReporting/LogListener.h"
 
+#include <string_view>
+
 #include "Surelog/Common/FileSystem.h"
 
 namespace SURELOG {

--- a/src/ErrorReporting/Report.cpp
+++ b/src/ErrorReporting/Report.cpp
@@ -27,6 +27,7 @@
 #include <filesystem>
 #include <iostream>
 #include <regex>
+#include <string>
 #include <thread>
 
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/ErrorReporting/Report.cpp
+++ b/src/ErrorReporting/Report.cpp
@@ -30,6 +30,7 @@
 #include <string>
 #include <string_view>
 #include <thread>
+#include <utility>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/ErrorReporting/Report.cpp
+++ b/src/ErrorReporting/Report.cpp
@@ -28,6 +28,7 @@
 #include <iostream>
 #include <regex>
 #include <string>
+#include <string_view>
 #include <thread>
 
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/ErrorReporting/Waiver.cpp
+++ b/src/ErrorReporting/Waiver.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/ErrorReporting/Waiver.h"
 
+#include <functional>
 #include <set>
 #include <string>
 #include <string_view>

--- a/src/ErrorReporting/Waiver.cpp
+++ b/src/ErrorReporting/Waiver.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/ErrorReporting/Waiver.h"
 
 #include <string>
+#include <string_view>
 
 #include "Surelog/ErrorReporting/ErrorDefinition.h"
 

--- a/src/ErrorReporting/Waiver.cpp
+++ b/src/ErrorReporting/Waiver.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/ErrorReporting/Waiver.h"
 
+#include <set>
 #include <string>
 #include <string_view>
 

--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/Design/Design.h"
 #include "Surelog/Design/FileContent.h"

--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -23,6 +23,7 @@
 #include "Surelog/Expression/ExprBuilder.h"
 
 #include <cmath>
+#include <string>
 
 #include "Surelog/Design/Design.h"
 #include "Surelog/Design/FileContent.h"

--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -24,6 +24,7 @@
 
 #include <cmath>
 #include <string>
+#include <string_view>
 
 #include "Surelog/Design/Design.h"
 #include "Surelog/Design/FileContent.h"

--- a/src/Expression/Value.cpp
+++ b/src/Expression/Value.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/Expression/Value.h"
 
 #include <cmath>
+#include <string>
 
 #include "Surelog/Utils/NumUtils.h"
 #include "Surelog/Utils/StringUtils.h"

--- a/src/Library/AntlrLibParserErrorListener.cpp
+++ b/src/Library/AntlrLibParserErrorListener.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/Library/AntlrLibParserErrorListener.h"
 
+#include <string>
+
 #include "Surelog/ErrorReporting/ErrorContainer.h"
 #include "Surelog/Library/ParseLibraryDef.h"
 #include "Surelog/SourceCompile/SymbolTable.h"

--- a/src/Library/Library.cpp
+++ b/src/Library/Library.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/Library/Library.h"
 
+#include <iostream>
 #include <string_view>
 
 #include "Surelog/Design/ModuleDefinition.h"

--- a/src/Library/Library.cpp
+++ b/src/Library/Library.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/Library/Library.h"
 
+#include <string_view>
+
 #include "Surelog/Design/ModuleDefinition.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
 

--- a/src/Library/LibrarySet.cpp
+++ b/src/Library/LibrarySet.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/Library/LibrarySet.h"
 
+#include <iostream>
 #include <map>
 #include <sstream>
 #include <string>

--- a/src/Library/LibrarySet.cpp
+++ b/src/Library/LibrarySet.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/Library/LibrarySet.h"
 
+#include <map>
 #include <sstream>
 #include <string>
 #include <string_view>

--- a/src/Library/LibrarySet.cpp
+++ b/src/Library/LibrarySet.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/Library/LibrarySet.h"
 
 #include <sstream>
+#include <string>
 
 #include "Surelog/ErrorReporting/ErrorContainer.h"
 #include "Surelog/Library/Library.h"

--- a/src/Library/LibrarySet.cpp
+++ b/src/Library/LibrarySet.cpp
@@ -25,6 +25,7 @@
 
 #include <sstream>
 #include <string>
+#include <string_view>
 
 #include "Surelog/ErrorReporting/ErrorContainer.h"
 #include "Surelog/Library/Library.h"

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -26,6 +26,7 @@
 #include <parser/SV3_1aLexer.h>
 #include <parser/SV3_1aParser.h>
 
+#include <iostream>
 #include <string>
 #include <vector>
 

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -26,6 +26,8 @@
 #include <parser/SV3_1aLexer.h>
 #include <parser/SV3_1aParser.h>
 
+#include <string>
+
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Config/ConfigSet.h"

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -27,6 +27,7 @@
 #include <parser/SV3_1aParser.h>
 
 #include <string>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/Library/SVLibShapeListener.cpp
+++ b/src/Library/SVLibShapeListener.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/Library/SVLibShapeListener.h"
 
 #include <regex>
+#include <string>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/Library/SVLibShapeListener.cpp
+++ b/src/Library/SVLibShapeListener.cpp
@@ -25,6 +25,7 @@
 
 #include <regex>
 #include <string>
+#include <string_view>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/Package/Package.cpp
+++ b/src/Package/Package.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/Package/Package.h"
 
+#include <string_view>
+
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Testbench/ClassDefinition.h"
 

--- a/src/Package/Precompiled.cpp
+++ b/src/Package/Precompiled.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/Package/Precompiled.h"
 
+#include <string>
+
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Common/PathId.h"
 #include "Surelog/SourceCompile/SymbolTable.h"

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/SourceCompile/AnalyzeFile.h"
 
+#include <iostream>
 #include <regex>
 #include <sstream>
 #include <string>

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -25,6 +25,7 @@
 
 #include <regex>
 #include <sstream>
+#include <string>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -26,6 +26,7 @@
 #include <regex>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/SourceCompile/AntlrParserErrorListener.cpp
+++ b/src/SourceCompile/AntlrParserErrorListener.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/SourceCompile/AntlrParserErrorListener.h"
 
+#include <string>
+
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/SourceCompile/CompileSourceFile.h"
 #include "Surelog/SourceCompile/ParseFile.h"

--- a/src/SourceCompile/CheckCompile.cpp
+++ b/src/SourceCompile/CheckCompile.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/SourceCompile/CheckCompile.h"
 
+#include <string>
+
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/Design.h"

--- a/src/SourceCompile/CheckCompile.cpp
+++ b/src/SourceCompile/CheckCompile.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/SourceCompile/CheckCompile.h"
 
 #include <string>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/SourceCompile/CommonListenerHelper.cpp
+++ b/src/SourceCompile/CommonListenerHelper.cpp
@@ -26,6 +26,7 @@
 #include <antlr4-runtime.h>
 
 #include <string_view>
+#include <vector>
 
 #include "Surelog/Design/DesignElement.h"
 #include "Surelog/Design/FileContent.h"

--- a/src/SourceCompile/CommonListenerHelper.cpp
+++ b/src/SourceCompile/CommonListenerHelper.cpp
@@ -25,6 +25,8 @@
 
 #include <antlr4-runtime.h>
 
+#include <string_view>
+
 #include "Surelog/Design/DesignElement.h"
 #include "Surelog/Design/FileContent.h"
 

--- a/src/SourceCompile/CompilationUnit.cpp
+++ b/src/SourceCompile/CompilationUnit.cpp
@@ -22,6 +22,8 @@
  */
 #include "Surelog/SourceCompile/CompilationUnit.h"
 
+#include <string_view>
+
 namespace SURELOG {
 
 CompilationUnit::CompilationUnit(bool fileunit)

--- a/src/SourceCompile/CompilationUnit.cpp
+++ b/src/SourceCompile/CompilationUnit.cpp
@@ -23,6 +23,7 @@
 #include "Surelog/SourceCompile/CompilationUnit.h"
 
 #include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/SourceCompile/CompileSourceFile.cpp
+++ b/src/SourceCompile/CompileSourceFile.cpp
@@ -36,6 +36,8 @@
 #ifdef SURELOG_WITH_PYTHON
 #include <Python.h>
 
+#include <string_view>
+
 #include "Surelog/API/PythonAPI.h"
 #include "Surelog/SourceCompile/PythonListen.h"
 #endif

--- a/src/SourceCompile/CompileSourceFile.cpp
+++ b/src/SourceCompile/CompileSourceFile.cpp
@@ -37,6 +37,7 @@
 #include <Python.h>
 
 #include <string_view>
+#include <vector>
 
 #include "Surelog/API/PythonAPI.h"
 #include "Surelog/SourceCompile/PythonListen.h"

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -29,6 +29,7 @@
 #include <nlohmann/json.hpp>
 #include <string_view>
 #include <thread>
+#include <vector>
 
 #include "Surelog/API/PythonAPI.h"
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -27,6 +27,7 @@
 #include <filesystem>
 #include <fstream>
 #include <nlohmann/json.hpp>
+#include <string_view>
 #include <thread>
 
 #include "Surelog/API/PythonAPI.h"

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -26,6 +26,7 @@
 #include <climits>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <map>
 #include <nlohmann/json.hpp>
 #include <string_view>

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -26,6 +26,7 @@
 #include <climits>
 #include <filesystem>
 #include <fstream>
+#include <map>
 #include <nlohmann/json.hpp>
 #include <string_view>
 #include <thread>

--- a/src/SourceCompile/LoopCheck.cpp
+++ b/src/SourceCompile/LoopCheck.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/SourceCompile/LoopCheck.h"
 
+#include <map>
 #include <queue>
 #include <vector>
 

--- a/src/SourceCompile/LoopCheck.cpp
+++ b/src/SourceCompile/LoopCheck.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/SourceCompile/LoopCheck.h"
 
 #include <queue>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/SourceCompile/MacroInfo.cpp
+++ b/src/SourceCompile/MacroInfo.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/SourceCompile/MacroInfo.h"
 
+#include <string>
+
 namespace SURELOG {
 MacroInfo::MacroInfo(std::string_view name, int32_t type, PathId fileId,
                      uint32_t startLine, uint16_t startColumn, uint32_t endLine,

--- a/src/SourceCompile/MacroInfo.cpp
+++ b/src/SourceCompile/MacroInfo.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/SourceCompile/MacroInfo.h"
 
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 MacroInfo::MacroInfo(std::string_view name, int32_t type, PathId fileId,

--- a/src/SourceCompile/MacroInfo.cpp
+++ b/src/SourceCompile/MacroInfo.cpp
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace SURELOG {
 MacroInfo::MacroInfo(std::string_view name, int32_t type, PathId fileId,

--- a/src/SourceCompile/ParseFile.cpp
+++ b/src/SourceCompile/ParseFile.cpp
@@ -27,6 +27,7 @@
 #include <parser/SV3_1aLexer.h>
 #include <parser/SV3_1aParser.h>
 
+#include <iostream>
 #include <string_view>
 
 #include "Surelog/Cache/ParseCache.h"

--- a/src/SourceCompile/ParseFile.cpp
+++ b/src/SourceCompile/ParseFile.cpp
@@ -27,6 +27,8 @@
 #include <parser/SV3_1aLexer.h>
 #include <parser/SV3_1aParser.h>
 
+#include <string_view>
+
 #include "Surelog/Cache/ParseCache.h"
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/SourceCompile/ParseTreeListener.template.cxx
+++ b/src/SourceCompile/ParseTreeListener.template.cxx
@@ -23,6 +23,7 @@
  *
  */
 
+#include <vector>
 #include <string>
 #include <Surelog/Common/FileSystem.h>
 #include <Surelog/Design/VObject.h>

--- a/src/SourceCompile/ParseTreeListener.template.cxx
+++ b/src/SourceCompile/ParseTreeListener.template.cxx
@@ -23,6 +23,7 @@
  *
  */
 
+#include <string>
 #include <Surelog/Common/FileSystem.h>
 #include <Surelog/Design/VObject.h>
 #include <Surelog/SourceCompile/ParseTreeListener.h>

--- a/src/SourceCompile/ParserHarness.cpp
+++ b/src/SourceCompile/ParserHarness.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/SourceCompile/ParserHarness.h"
 
+#include <string_view>
+
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <regex>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "Surelog/Cache/PPCache.h"

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -27,6 +27,7 @@
 #include <parser/SV3_1aPpLexer.h>
 #include <parser/SV3_1aPpParser.h>
 
+#include <functional>
 #include <iostream>
 #include <regex>
 #include <set>

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -29,6 +29,7 @@
 
 #include <iostream>
 #include <regex>
+#include <set>
 #include <string_view>
 #include <utility>
 #include <vector>

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <regex>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/Cache/PPCache.h"
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/SourceCompile/PreprocessHarness.cpp
+++ b/src/SourceCompile/PreprocessHarness.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/SourceCompile/PreprocessHarness.h"
 
+#include <string>
+
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/SourceCompile/CompilationUnit.h"

--- a/src/SourceCompile/PreprocessHarness.cpp
+++ b/src/SourceCompile/PreprocessHarness.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/SourceCompile/PreprocessHarness.h"
 
 #include <string>
+#include <string_view>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Library/Library.h"

--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/SourceCompile/SV3_1aPpTreeListenerHelper.h"
 
+#include <string_view>
+
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
 #include "Surelog/SourceCompile/CompileSourceFile.h"

--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/SourceCompile/SV3_1aPpTreeListenerHelper.h"
 
 #include <string_view>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -18,6 +18,7 @@
 
 #include <regex>
 #include <string>
+#include <string_view>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -16,6 +16,7 @@
 
 #include "Surelog/SourceCompile/SV3_1aPpTreeShapeListener.h"
 
+#include <iostream>
 #include <regex>
 #include <set>
 #include <string>

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -17,6 +17,7 @@
 #include "Surelog/SourceCompile/SV3_1aPpTreeShapeListener.h"
 
 #include <regex>
+#include <set>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -17,6 +17,7 @@
 #include "Surelog/SourceCompile/SV3_1aPpTreeShapeListener.h"
 
 #include <regex>
+#include <string>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -19,6 +19,7 @@
 #include <regex>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Design/FileContent.h"

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/SourceCompile/SV3_1aTreeShapeHelper.h"
 
 #include <string>
+#include <string_view>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Design/FileContent.h"

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/SourceCompile/SV3_1aTreeShapeHelper.h"
 
+#include <string>
+
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/SourceCompile/SV3_1aTreeShapeListener.h"
 
 #include <regex>
+#include <string>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -25,6 +25,7 @@
 
 #include <regex>
 #include <string>
+#include <string_view>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -26,6 +26,7 @@
 #include <regex>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"

--- a/src/Testbench/ClassObject.cpp
+++ b/src/Testbench/ClassObject.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/Testbench/ClassObject.h"
 
+#include <string_view>
+
 #include "Surelog/Testbench/ClassDefinition.h"
 
 namespace SURELOG {

--- a/src/Testbench/TypeDef.cpp
+++ b/src/Testbench/TypeDef.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/Testbench/TypeDef.h"
 
+#include <string_view>
+
 #include "Surelog/Design/FileContent.h"
 
 namespace SURELOG {

--- a/src/Utils/NumUtils.cpp
+++ b/src/Utils/NumUtils.cpp
@@ -26,6 +26,7 @@
 #include <bitset>
 #include <cstring>
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/Utils/NumUtils.cpp
+++ b/src/Utils/NumUtils.cpp
@@ -25,6 +25,7 @@
 
 #include <bitset>
 #include <cstring>
+#include <string>
 
 namespace SURELOG {
 

--- a/src/Utils/ParseUtils.cpp
+++ b/src/Utils/ParseUtils.cpp
@@ -25,6 +25,8 @@
 
 #include <antlr4-runtime.h>
 
+#include <string>
+
 namespace SURELOG {
 
 ParseUtils::LineColumn ParseUtils::getLineColumn(antlr4::Token* token) {

--- a/src/Utils/ParseUtils.cpp
+++ b/src/Utils/ParseUtils.cpp
@@ -26,6 +26,7 @@
 #include <antlr4-runtime.h>
 
 #include <string>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -31,6 +31,7 @@
 #include <regex>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -32,6 +32,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/src/Utils/StringUtils.cpp
+++ b/src/Utils/StringUtils.cpp
@@ -30,6 +30,7 @@
 #include <map>
 #include <regex>
 #include <sstream>
+#include <string>
 
 namespace SURELOG {
 

--- a/src/Utils/StringUtils_test.cpp
+++ b/src/Utils/StringUtils_test.cpp
@@ -22,6 +22,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace SURELOG {
 using ::testing::ElementsAre;

--- a/src/Utils/StringUtils_test.cpp
+++ b/src/Utils/StringUtils_test.cpp
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 using ::testing::ElementsAre;

--- a/src/Utils/StringUtils_test.cpp
+++ b/src/Utils/StringUtils_test.cpp
@@ -20,6 +20,8 @@
 #include <gtest/gtest.h>
 #include <stdlib.h>
 
+#include <string>
+
 namespace SURELOG {
 using ::testing::ElementsAre;
 

--- a/src/hellodesign.cpp
+++ b/src/hellodesign.cpp
@@ -27,6 +27,7 @@
 
 #include <functional>
 #include <iostream>
+#include <string_view>
 
 #include "Surelog/API/Surelog.h"
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/hellouhdm.cpp
+++ b/src/hellouhdm.cpp
@@ -27,6 +27,7 @@
 
 #include <functional>
 #include <iostream>
+#include <string>
 
 #include "Surelog/API/Surelog.h"
 #include "Surelog/CommandLine/CommandLineParser.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,8 @@
 #if defined(_MSC_VER)
 #include <direct.h>
 #include <process.h>
+
+#include <string_view>
 #else
 #include <sys/param.h>
 #include <unistd.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 #include <process.h>
 
 #include <string_view>
+#include <utility>
 #else
 #include <sys/param.h>
 #include <unistd.h>

--- a/src/roundtrip.cpp
+++ b/src/roundtrip.cpp
@@ -40,6 +40,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "Surelog/API/Surelog.h"

--- a/src/roundtrip.cpp
+++ b/src/roundtrip.cpp
@@ -37,6 +37,7 @@
 #include <sstream>
 #include <stack>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
A start. Fixes about 400 misc-include-cleaner warnings.