### PR TITLE
Fix run-clang-format.sh to also run over headers.

### DIFF
--- a/.github/bin/run-clang-format.sh
+++ b/.github/bin/run-clang-format.sh
@@ -16,7 +16,7 @@
 FORMAT_OUT=${TMPDIR:-/tmp}/clang-format-diff.out
 
 # Run on all c++ files.
-find src -name "*.h" -o -name "*.cpp" | xargs clang-format --style=Google -i
+find include src -name "*.h" -o -name "*.cpp" | xargs clang-format --style=Google -i
 
 # Check if we got any diff, then print it out in in the CI.
 # TODO: make these suggested diffs in the pull request.

--- a/include/Surelog/API/SLAPI.h
+++ b/include/Surelog/API/SLAPI.h
@@ -78,16 +78,17 @@ void SLaddMLErrorContext(SV3_1aPythonListener* prog,
 void SLaddMLError(ErrorContainer* container, const char* messageId,
                   const char* fileName1, uint32_t line1, uint32_t col1,
                   const char* objectName1, const char* fileName2,
-                  uint32_t line2, uint32_t col2,
-                  const char* objectName2);
+                  uint32_t line2, uint32_t col2, const char* objectName2);
 
 /* File Listener API */
 std::string SLgetFile(SV3_1aPythonListener* prog,
                       antlr4::ParserRuleContext* context);
 
-int32_t SLgetLine(SV3_1aPythonListener* prog, antlr4::ParserRuleContext* context);
+int32_t SLgetLine(SV3_1aPythonListener* prog,
+                  antlr4::ParserRuleContext* context);
 
-int32_t SLgetColumn(SV3_1aPythonListener* prog, antlr4::ParserRuleContext* context);
+int32_t SLgetColumn(SV3_1aPythonListener* prog,
+                    antlr4::ParserRuleContext* context);
 
 std::string SLgetText(SV3_1aPythonListener* prog,
                       antlr4::ParserRuleContext* context);
@@ -119,10 +120,10 @@ std::string SLgetName(FileContent* fC, RawNodeId index);
 uint32_t SLgetType(FileContent* fC, RawNodeId index);
 
 RawNodeId SLgetChild(FileContent* fC, RawNodeId parent,
-                  uint32_t type);  // Get first child item of type
+                     uint32_t type);  // Get first child item of type
 
 RawNodeId SLgetParent(FileContent* fC, RawNodeId parent,
-                   uint32_t type);  // Get first parent item of type
+                      uint32_t type);  // Get first parent item of type
 
 UIntVector SLgetAll(FileContent* fC, RawNodeId parent,
                     uint32_t type);  // get all child items of type
@@ -143,8 +144,8 @@ UIntVector SLcollectAll(
     bool first);  // Recursively search for all items of types
 
 UIntVector SLcollectAll(FileContent* fC, RawNodeId parent,
-                        const UIntVector& types,
-                        const UIntVector& stopPoints, bool first);
+                        const UIntVector& types, const UIntVector& stopPoints,
+                        bool first);
 // Recursively search for all items of types
 // and stops at types stopPoints
 /* Design API */

--- a/include/Surelog/Cache/PPCache.h
+++ b/include/Surelog/Cache/PPCache.h
@@ -73,7 +73,7 @@ class PPCache : Cache {
                     const SymbolTable& sourceSymbols);
 
   void cacheTimeInfos(::PPCache::Builder builder, SymbolTable& targetSymbols,
-                    const SymbolTable& sourceSymbols);
+                      const SymbolTable& sourceSymbols);
 
   void cacheLineTranslationInfos(::PPCache::Builder builder,
                                  SymbolTable& targetSymbols,

--- a/include/Surelog/Cache/ParseCache.h
+++ b/include/Surelog/Cache/ParseCache.h
@@ -62,11 +62,11 @@ class ParseCache final : Cache {
   // to IDs used on the cache on disk.
   // Updates "targetSymbols" if new IDs are needed.
   void cacheVObjects(::ParseCache::Builder builder, const FileContent* fC,
-                     SymbolTable& targetSymbols, const SymbolTable& sourceSymbols,
-                     PathId fileId);
+                     SymbolTable& targetSymbols,
+                     const SymbolTable& sourceSymbols, PathId fileId);
 
-  void cacheDesignElements(::ParseCache::Builder builder,
-                           const FileContent* fC, SymbolTable& targetSymbols,
+  void cacheDesignElements(::ParseCache::Builder builder, const FileContent* fC,
+                           SymbolTable& targetSymbols,
                            const SymbolTable& sourceSymbols);
 
   bool restore(PathId cacheFileId);

--- a/include/Surelog/CommandLine/CommandLineParser.h
+++ b/include/Surelog/CommandLine/CommandLineParser.h
@@ -25,16 +25,16 @@
 #define SURELOG_COMMANDLINEPARSER_H
 #pragma once
 
-#include <functional>
-#include <utility>
-#include <string_view>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>
 
 #include <filesystem>
+#include <functional>
 #include <map>
 #include <set>
 #include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 namespace SURELOG {

--- a/include/Surelog/Common/FileSystem.h
+++ b/include/Surelog/Common/FileSystem.h
@@ -25,20 +25,20 @@
 #define SURELOG_FILESYSTEM_H
 #pragma once
 
-#include <functional>
-#include <set>
-#include <utility>
-#include <vector>
 #include <Surelog/Common/PathId.h>
 
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <istream>
 #include <map>
 #include <regex>
+#include <set>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 namespace SURELOG {
 class SymbolTable;
@@ -77,7 +77,8 @@ class SymbolTable;
  *
  *   NOTE:
  *     toPath(id) == toPath(toPathId(toPath(id))) but
- *     toPlatformAbsPath(id) <> toPlatformAbsPath(toPathId(toPlatformAbsPath(id)))
+ *     toPlatformAbsPath(id) <>
+ * toPlatformAbsPath(toPathId(toPlatformAbsPath(id)))
  *
  *     i.e. string representation can be converted to id (and vice-versa)
  *     using toPathId & toPath but the same is not necessarily guaranteed
@@ -132,7 +133,7 @@ class FileSystem {
   // and can be used for, say, system commands.
   virtual std::filesystem::path toPlatformAbsPath(PathId id) = 0;
   virtual std::filesystem::path toPlatformRelPath(PathId id) = 0;
-  // Returns base and relative paths 
+  // Returns base and relative paths
   virtual std::pair<std::filesystem::path, std::filesystem::path>
   toSplitPlatformPath(PathId id) = 0;
 
@@ -147,7 +148,8 @@ class FileSystem {
   // Open/Close an input stream represented by the input PathId.
   // openForRead defaults the ios_base::openmode to ios_base::text
   // openForLoad defaults the ios_base::openmode to ios_base::binary
-  virtual std::istream &openInput(PathId fileId, std::ios_base::openmode mode) = 0;
+  virtual std::istream &openInput(PathId fileId,
+                                  std::ios_base::openmode mode) = 0;
   std::istream &openForRead(PathId fileId);
   std::istream &openForLoad(PathId fileId);
   virtual bool close(std::istream &strm) = 0;
@@ -155,7 +157,8 @@ class FileSystem {
   // Open/Close an output stream represented by the input PathId.
   // openForWrite defaults the ios_base::openmode to ios_base::text
   // openForSave defaults the ios_base::openmode to ios_base::binary
-  virtual std::ostream &openOutput(PathId fileId, std::ios_base::openmode mode) = 0;
+  virtual std::ostream &openOutput(PathId fileId,
+                                   std::ios_base::openmode mode) = 0;
   std::ostream &openForWrite(PathId fileId);
   std::ostream &openForSave(PathId fileId);
   virtual bool close(std::ostream &strm) = 0;
@@ -203,9 +206,12 @@ class FileSystem {
   virtual PathId getProgramFile(std::string_view hint,
                                 SymbolTable *symbolTable) = 0;
 
-  virtual PathId getWorkingDir(std::string_view dir, SymbolTable *symbolTable) = 0;
-  virtual PathId getOutputDir(std::string_view dir, SymbolTable *symbolTable) = 0;
-  virtual PathId getPrecompiledDir(PathId programId, SymbolTable *symbolTable) = 0;
+  virtual PathId getWorkingDir(std::string_view dir,
+                               SymbolTable *symbolTable) = 0;
+  virtual PathId getOutputDir(std::string_view dir,
+                              SymbolTable *symbolTable) = 0;
+  virtual PathId getPrecompiledDir(PathId programId,
+                                   SymbolTable *symbolTable) = 0;
 
   virtual PathId getLogFile(bool isUnitCompilation, std::string_view filename,
                             SymbolTable *symbolTable) = 0;
@@ -222,23 +228,23 @@ class FileSystem {
                                  std::string_view libraryName,
                                  SymbolTable *symbolTable) = 0;
   PathId getPpOutputFile(bool isUnitCompilation, PathId sourceFileId,
-                                 SymbolId libraryNameId,
-                                 SymbolTable *symbolTable);
+                         SymbolId libraryNameId, SymbolTable *symbolTable);
 
   virtual PathId getPpCacheFile(bool isUnitCompilation, PathId sourceFileId,
                                 std::string_view libraryName,
-                                bool isPrecompiled, SymbolTable *symbolTable) = 0;
+                                bool isPrecompiled,
+                                SymbolTable *symbolTable) = 0;
   PathId getPpCacheFile(bool isUnitCompilation, PathId sourceFileId,
-                                SymbolId libraryNameId, bool isPrecompiled,
-                                SymbolTable *symbolTable);
+                        SymbolId libraryNameId, bool isPrecompiled,
+                        SymbolTable *symbolTable);
 
   virtual PathId getParseCacheFile(bool isUnitCompilation, PathId ppFileId,
                                    std::string_view libraryName,
                                    bool isPrecompiled,
                                    SymbolTable *symbolTable) = 0;
   PathId getParseCacheFile(bool isUnitCompilation, PathId ppFileId,
-                                   SymbolId libraryNameId, bool isPrecompiled,
-                                   SymbolTable *symbolTable);
+                           SymbolId libraryNameId, bool isPrecompiled,
+                           SymbolTable *symbolTable);
 
   virtual PathId getPythonCacheFile(bool isUnitCompilation, PathId sourceFileId,
                                     std::string_view libraryName,
@@ -257,7 +263,8 @@ class FileSystem {
 
   virtual PathId getCheckerDir(bool isUnitCompilation,
                                SymbolTable *symbolTable) = 0;
-  virtual PathId getCheckerFile(PathId uhdmFileId, SymbolTable *symbolTable) = 0;
+  virtual PathId getCheckerFile(PathId uhdmFileId,
+                                SymbolTable *symbolTable) = 0;
   virtual PathId getCheckerHtmlFile(PathId uhdmFileId,
                                     SymbolTable *symbolTable) = 0;
   virtual PathId getCheckerHtmlFile(PathId uhdmFileId, int32_t index,

--- a/include/Surelog/Common/NodeId.h
+++ b/include/Surelog/Common/NodeId.h
@@ -21,8 +21,8 @@
 #include <cstdint>
 #include <ostream>
 #include <set>
-#include <unordered_set>
 #include <type_traits>
+#include <unordered_set>
 
 namespace SURELOG {
 /**
@@ -33,7 +33,8 @@ namespace SURELOG {
  *
  */
 typedef uint32_t RawNodeId;
-inline static constexpr RawNodeId InvalidRawNodeId = 0;  // Max of 28 bits as per cache!
+inline static constexpr RawNodeId InvalidRawNodeId =
+    0;  // Max of 28 bits as per cache!
 class NodeId final {
  public:
   constexpr NodeId() : NodeId(InvalidRawNodeId) {}
@@ -64,28 +65,54 @@ class NodeId final {
   NodeId operator-(const NodeId &rhs) const { return NodeId(id - rhs.id); }
   NodeId operator+(const NodeId &rhs) const { return NodeId(id + rhs.id); }
 
-  NodeId &operator-=(const NodeId &rhs) { id -= rhs.id; return *this; }
-  NodeId &operator+=(const NodeId &rhs) { id += rhs.id; return *this; }
+  NodeId &operator-=(const NodeId &rhs) {
+    id -= rhs.id;
+    return *this;
+  }
+  NodeId &operator+=(const NodeId &rhs) {
+    id += rhs.id;
+    return *this;
+  }
 
   template <typename U, typename = typename std::enable_if<
                             std::is_integral<U>::value>::type>
-  bool operator<(const U &rhs) const { return id < rhs; }
+  bool operator<(const U &rhs) const {
+    return id < rhs;
+  }
   template <typename U, typename = typename std::enable_if<
                             std::is_integral<U>::value>::type>
-  bool operator<=(const U &rhs) const { return id <= rhs; }
+  bool operator<=(const U &rhs) const {
+    return id <= rhs;
+  }
 
   template <typename U, typename = typename std::enable_if<
                             std::is_integral<U>::value>::type>
-  bool operator>(const U &rhs) const { return id > rhs; }
+  bool operator>(const U &rhs) const {
+    return id > rhs;
+  }
   template <typename U, typename = typename std::enable_if<
                             std::is_integral<U>::value>::type>
-  bool operator>=(const U &rhs) const { return id >= rhs; }
+  bool operator>=(const U &rhs) const {
+    return id >= rhs;
+  }
 
-  NodeId &operator++() { ++id; return *this; }
-  NodeId operator++(int) { const NodeId rid(id++); return rid; }
+  NodeId &operator++() {
+    ++id;
+    return *this;
+  }
+  NodeId operator++(int) {
+    const NodeId rid(id++);
+    return rid;
+  }
 
-  NodeId &operator--() { --id; return *this; }
-  NodeId operator--(int) { const NodeId rid(id--); return rid; }
+  NodeId &operator--() {
+    --id;
+    return *this;
+  }
+  NodeId operator--(int) {
+    const NodeId rid(id--);
+    return rid;
+  }
 
   NodeId &operator=(const NodeId &rhs) {
     if (this != &rhs) {

--- a/include/Surelog/Common/PathId.h
+++ b/include/Surelog/Common/PathId.h
@@ -18,8 +18,6 @@
 #define SURELOG_PATHID_H
 #pragma once
 
-#include "Surelog/config.h"
-
 #include <Surelog/Common/SymbolId.h>
 
 #include <cstdint>
@@ -28,6 +26,8 @@
 #include <string_view>
 #include <unordered_set>
 #include <vector>
+
+#include "Surelog/config.h"
 
 namespace SURELOG {
 /**
@@ -52,8 +52,7 @@ class SymbolTable;
 class PathId final {
  public:
 #if SURELOG_PATHID_DEBUG_ENABLED
-  PathId()
-      : m_symbolTable(nullptr), m_id(BadRawPathId), m_value(BadRawPath) {}
+  PathId() : m_symbolTable(nullptr), m_id(BadRawPathId), m_value(BadRawPath) {}
   PathId(const SymbolTable *const symbolTable, RawPathId id,
          std::string_view value)
       : m_symbolTable(symbolTable), m_id(id), m_value(value) {}
@@ -66,8 +65,7 @@ class PathId final {
   PathId(const SymbolTable *const symbolTable, RawPathId id,
          std::string_view value)
       : m_symbolTable(symbolTable), m_id(id) {}
-  PathId(const PathId &rhs)
-      : PathId(rhs.m_symbolTable, rhs.m_id, BadRawPath) {}
+  PathId(const PathId &rhs) : PathId(rhs.m_symbolTable, rhs.m_id, BadRawPath) {}
   PathId(const SymbolTable *const symbolTable, SymbolId id)
       : PathId(symbolTable, (RawSymbolId)id, BadRawPath) {}
 #endif
@@ -117,7 +115,7 @@ inline std::ostream &operator<<(std::ostream &strm, const PathId &pathId) {
   return strm << pathId.m_id;
 }
 
-struct PathIdPP final { // Pretty Printer
+struct PathIdPP final {  // Pretty Printer
   const PathId &m_id;
 
   explicit PathIdPP(const PathId &id) : m_id(id) {}

--- a/include/Surelog/Common/PlatformFileSystem.h
+++ b/include/Surelog/Common/PlatformFileSystem.h
@@ -25,16 +25,16 @@
 #define SURELOG_PLATFORMFILESYSTEM_H
 #pragma once
 
-#include <functional>
-#include <utility>
-#include <vector>
-#include <string_view>
-#include <string>
 #include <Surelog/Common/FileSystem.h>
 
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <set>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 namespace SURELOG {
 class SymbolTable;

--- a/include/Surelog/Common/SymbolId.h
+++ b/include/Surelog/Common/SymbolId.h
@@ -10,15 +10,15 @@ using UHDM::RawSymbolId;
 using UHDM::SymbolId;
 using UHDM::SymbolIdPP;
 
-using UHDM::BadRawSymbolId;
 using UHDM::BadRawSymbol;
+using UHDM::BadRawSymbolId;
 using UHDM::BadSymbolId;
 
 using UHDM::operator<<;
 
-using UHDM::SymbolIdLessThanComparer;
-using UHDM::SymbolIdHasher;
 using UHDM::SymbolIdEqualityComparer;
+using UHDM::SymbolIdHasher;
+using UHDM::SymbolIdLessThanComparer;
 
 using UHDM::SymbolIdSet;
 using UHDM::SymbolIdUnorderedSet;

--- a/include/Surelog/Design/ClockingBlock.h
+++ b/include/Surelog/Design/ClockingBlock.h
@@ -41,13 +41,10 @@ class ClockingBlock final {
  public:
   enum Type { Global, Default, Regular };
   // TODO: some of these parameters are not used. Correct or oversight ?
-  ClockingBlock([[maybe_unused]] const FileContent* fileContent,
-                NodeId blockId,
-                [[maybe_unused]] NodeId clockingBlockId,
-                Type type, UHDM::clocking_block* actual)
-      : m_blockId(blockId),
-        m_actual(actual),
-        m_type(type) {}
+  ClockingBlock([[maybe_unused]] const FileContent* fileContent, NodeId blockId,
+                [[maybe_unused]] NodeId clockingBlockId, Type type,
+                UHDM::clocking_block* actual)
+      : m_blockId(blockId), m_actual(actual), m_type(type) {}
 
   void addSignal(Signal& signal) { m_signals.push_back(signal); }
   NodeId getNodeId() const { return m_blockId; }

--- a/include/Surelog/Design/DefParam.h
+++ b/include/Surelog/Design/DefParam.h
@@ -25,11 +25,11 @@
 #define SURELOG_DEFPARAM_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Common/NodeId.h>
 
 #include <map>
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/include/Surelog/Design/Design.h
+++ b/include/Surelog/Design/Design.h
@@ -25,16 +25,16 @@
 #define SURELOG_DESIGN_H
 #pragma once
 
-#include <functional>
-#include <utility>
-#include <string_view>
-#include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/PathId.h>
 
+#include <functional>
 #include <map>
 #include <mutex>
+#include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 namespace SURELOG {
@@ -130,8 +130,7 @@ class Design final {
 
   std::string reportInstanceTree() const;
 
-  void reportInstanceTreeStats(uint32_t& nbTopLevelModules,
-                               uint32_t& maxDepth,
+  void reportInstanceTreeStats(uint32_t& nbTopLevelModules, uint32_t& maxDepth,
                                uint32_t& numberOfInstances,
                                uint32_t& numberOfLeafInstances,
                                uint32_t& nbUndefinedModules,

--- a/include/Surelog/Design/DesignComponent.h
+++ b/include/Surelog/Design/DesignComponent.h
@@ -25,12 +25,6 @@
 #define SURELOG_DESIGNCOMPONENT_H
 #pragma once
 
-#include <functional>
-#include <map>
-#include <utility>
-#include <vector>
-#include <string_view>
-#include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/PortNetHolder.h>
@@ -39,6 +33,13 @@
 #include <Surelog/Design/LetStmt.h>
 #include <Surelog/Design/ValuedComponentI.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
+
+#include <functional>
+#include <map>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 // UHDM
 #include <uhdm/uhdm_forward_decl.h>
@@ -99,7 +100,8 @@ class DesignComponent : public ValuedComponentI, public PortNetHolder {
   typedef std::map<std::string, std::pair<FileCNodeId, DesignComponent*>,
                    StringViewCompare>
       NamedObjectMap;
-  typedef std::vector<std::pair<std::string, UHDM::typespec*>> FuncNameTypespecVec;
+  typedef std::vector<std::pair<std::string, UHDM::typespec*>>
+      FuncNameTypespecVec;
 
   void addFileContent(const FileContent* fileContent, NodeId nodeId);
   const std::vector<const FileContent*>& getFileContents() const {
@@ -244,7 +246,7 @@ class DesignComponent : public ValuedComponentI, public PortNetHolder {
   std::vector<UHDM::import_typespec*> m_imported_symbols;
   std::vector<UHDM::tf_call*> m_elab_sys_calls;
   std::vector<UHDM::property_decl*> m_property_decls;
-  std::vector<UHDM::sequence_decl*> m_sequence_decls;  
+  std::vector<UHDM::sequence_decl*> m_sequence_decls;
   std::vector<UHDM::ref_obj*> m_needLateBinding;
   std::vector<UHDM::any*> m_needLateTypedefBinding;
   FuncNameTypespecVec m_lateResolutionFunctions;

--- a/include/Surelog/Design/Enum.h
+++ b/include/Surelog/Design/Enum.h
@@ -25,11 +25,12 @@
 #define SURELOG_ENUM_H
 #pragma once
 
-#include <functional>
-#include <utility>
-#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
+
+#include <functional>
+#include <string_view>
+#include <utility>
 
 // UHDM
 #include <uhdm/uhdm_forward_decl.h>

--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -25,16 +25,16 @@
 #define SURELOG_FILECONTENT_H
 #pragma once
 
-#include <functional>
-#include <set>
-#include <map>
-#include <string_view>
-#include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Design/VObject.h>
 
+#include <functional>
+#include <map>
+#include <set>
+#include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -118,14 +118,15 @@ class FileContent final : public DesignComponent {
   PathId* getMutableFileId(NodeId id);
   Library* getLibrary() const { return m_library; }
   std::vector<DesignElement*>& getDesignElements() { return m_elements; }
-  const std::vector<DesignElement*>& getDesignElements() const { return m_elements; }
+  const std::vector<DesignElement*>& getDesignElements() const {
+    return m_elements;
+  }
   void addDesignElement(std::string_view name, DesignElement* elem);
   const DesignElement* getDesignElement(std::string_view name) const;
   using DesignComponent::addObject;
   NodeId addObject(SymbolId name, PathId fileId, VObjectType type,
-                   uint32_t line, uint16_t column,
-                   uint32_t endLine, uint16_t endColumn,
-                   NodeId parent = InvalidNodeId,
+                   uint32_t line, uint16_t column, uint32_t endLine,
+                   uint16_t endColumn, NodeId parent = InvalidNodeId,
                    NodeId definition = InvalidNodeId,
                    NodeId child = InvalidNodeId,
                    NodeId sibling = InvalidNodeId);

--- a/include/Surelog/Design/Function.h
+++ b/include/Surelog/Design/Function.h
@@ -25,14 +25,14 @@
 #define SURELOG_FUNCTION_H
 #pragma once
 
-#include <vector>
-#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/Scope.h>
 #include <Surelog/Design/Statement.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/include/Surelog/Design/ModuleDefinition.h
+++ b/include/Surelog/Design/ModuleDefinition.h
@@ -25,14 +25,15 @@
 #define SURELOG_MODULEDEFINITION_H
 #pragma once
 
-#include <functional>
-#include <map>
-#include <string>
 #include <Surelog/Common/ClockingBlockHolder.h>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Design/ModPort.h>
+
+#include <functional>
+#include <map>
+#include <string>
 
 // UHDM
 #include <uhdm/containers.h>
@@ -45,7 +46,8 @@ namespace SURELOG {
 class CompileModule;
 class FileContent;
 
-class ModuleDefinition final : public DesignComponent, public ClockingBlockHolder {
+class ModuleDefinition final : public DesignComponent,
+                               public ClockingBlockHolder {
   SURELOG_IMPLEMENT_RTTI(ModuleDefinition, DesignComponent)
   friend CompileModule;
 

--- a/include/Surelog/Design/ModuleInstance.h
+++ b/include/Surelog/Design/ModuleInstance.h
@@ -25,18 +25,18 @@
 #define SURELOG_MODULEINSTANCE_H
 #pragma once
 
-#include <set>
-#include <map>
-#include <vector>
-#include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/ValuedComponentI.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
-
-#include <string_view>
 #include <uhdm/Serializer.h>
+
+#include <map>
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
 
 namespace SURELOG {
 
@@ -104,8 +104,7 @@ class ModuleInstance final : public ValuedComponentI {
 
   std::vector<Parameter*>& getTypeParams() { return m_typeParams; }
 
-  Value* getValue(std::string_view name,
-                  ExprBuilder& exprBuilder) const final;
+  Value* getValue(std::string_view name, ExprBuilder& exprBuilder) const final;
   UHDM::expr* getComplexValue(std::string_view name) const final;
 
   ModuleInstance* getInstanceBinding() { return m_boundInstance; }

--- a/include/Surelog/Design/Netlist.h
+++ b/include/Surelog/Design/Netlist.h
@@ -26,12 +26,12 @@
 #pragma once
 
 // UHDM
-#include <functional>
-#include <utility>
 #include <uhdm/uhdm_forward_decl.h>
 
+#include <functional>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace SURELOG {

--- a/include/Surelog/Design/Parameter.h
+++ b/include/Surelog/Design/Parameter.h
@@ -25,9 +25,10 @@
 #define SURELOG_PARAMETER_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
+
+#include <string_view>
 
 // UHDM
 #include <uhdm/uhdm_forward_decl.h>

--- a/include/Surelog/Design/Scope.h
+++ b/include/Surelog/Design/Scope.h
@@ -25,12 +25,12 @@
 #define SURELOG_SCOPE_H
 #pragma once
 
-#include <functional>
-#include <string_view>
 #include <Surelog/Common/RTTI.h>
 
-#include <string>
+#include <functional>
 #include <map>
+#include <string>
+#include <string_view>
 #include <vector>
 
 namespace SURELOG {

--- a/include/Surelog/Design/Signal.h
+++ b/include/Surelog/Design/Signal.h
@@ -25,13 +25,13 @@
 #define SURELOG_SIGNAL_H
 #pragma once
 
-#include <vector>
-#include <string_view>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 #include <uhdm/attribute.h>
 
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/include/Surelog/Design/Statement.h
+++ b/include/Surelog/Design/Statement.h
@@ -25,14 +25,14 @@
 #define SURELOG_STATEMENT_H
 #pragma once
 
-#include <utility>
-#include <string_view>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/RTTI.h>
 #include <Surelog/Design/Scope.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 namespace SURELOG {
@@ -67,7 +67,9 @@ class Statement : public RTTI {
   virtual Function* getFunction() { return nullptr; }
   virtual void setFunction(Function* function) {}
 
-  void addStatement(Statement* statement) { m_statements.emplace_back(statement); }
+  void addStatement(Statement* statement) {
+    m_statements.emplace_back(statement);
+  }
   const StatementVector& getStatements() const { return m_statements; }
 
  private:

--- a/include/Surelog/Design/Task.h
+++ b/include/Surelog/Design/Task.h
@@ -25,11 +25,11 @@
 #define SURELOG_TASK_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/Function.h>
 
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/include/Surelog/Design/TfPortItem.h
+++ b/include/Surelog/Design/TfPortItem.h
@@ -25,9 +25,10 @@
 #define SURELOG_TFPORTITEM_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 #include <Surelog/Testbench/Variable.h>
+
+#include <string_view>
 
 namespace SURELOG {
 

--- a/include/Surelog/Design/VObject.h
+++ b/include/Surelog/Design/VObject.h
@@ -25,7 +25,6 @@
 #define SURELOG_VOBJECT_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>
@@ -33,6 +32,7 @@
 
 #include <ostream>
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 
@@ -48,8 +48,8 @@ class VObject final {
                 InvalidNodeId /* sibling */) {}
 
   VObject(SymbolId name, PathId fileId, VObjectType type, uint32_t line,
-          uint16_t column, uint32_t endLine, uint16_t endColumn,
-          NodeId parent, NodeId definition, NodeId child, NodeId sibling)
+          uint16_t column, uint32_t endLine, uint16_t endColumn, NodeId parent,
+          NodeId definition, NodeId child, NodeId sibling)
       : m_name(name),
         m_fileId(fileId),
         m_type(type),

--- a/include/Surelog/Design/ValuedComponentI.h
+++ b/include/Surelog/Design/ValuedComponentI.h
@@ -25,9 +25,10 @@
 #define SURELOG_VALUEDCOMPONENTI_H
 #pragma once
 
-#include <utility>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/RTTI.h>
+
+#include <utility>
 
 // UHDM
 #include <uhdm/uhdm_forward_decl.h>

--- a/include/Surelog/DesignCompile/CompileClass.h
+++ b/include/Surelog/DesignCompile/CompileClass.h
@@ -25,10 +25,11 @@
 #define SURELOG_COMPILECLASS_H
 #pragma once
 
-#include <set>
-#include <string>
 #include <Surelog/DesignCompile/CompileHelper.h>
 #include <Surelog/Testbench/ClassDefinition.h>
+
+#include <set>
+#include <string>
 
 namespace SURELOG {
 

--- a/include/Surelog/DesignCompile/CompileDesign.h
+++ b/include/Surelog/DesignCompile/CompileDesign.h
@@ -25,9 +25,10 @@
 #define SURELOG_COMPILEDESIGN_H
 #pragma once
 
+#include <Surelog/Design/Design.h>
+
 #include <map>
 #include <vector>
-#include <Surelog/Design/Design.h>
 
 // UHDM
 #include <uhdm/Serializer.h>
@@ -59,7 +60,10 @@ class CompileDesign {
   void lockSerializer() { m_serializerMutex.lock(); }
   void unlockSerializer() { m_serializerMutex.unlock(); }
   UHDM::VectorOfinclude_file_info* getFileInfo() { return m_fileInfo; }
-  std::map<const UHDM::typespec*, const UHDM::typespec*>& getSwapedObjects() { return m_typespecSwapMap; }
+  std::map<const UHDM::typespec*, const UHDM::typespec*>& getSwapedObjects() {
+    return m_typespecSwapMap;
+  }
+
  private:
   CompileDesign(const CompileDesign& orig) = delete;
 

--- a/include/Surelog/DesignCompile/CompileFileContent.h
+++ b/include/Surelog/DesignCompile/CompileFileContent.h
@@ -37,8 +37,8 @@ class ErrorContainer;
 
 struct FunctorCompileFileContentDecl {
   FunctorCompileFileContentDecl(CompileDesign* compiler, FileContent* file,
-                            Design* design, SymbolTable* symbols,
-                            ErrorContainer* errors)
+                                Design* design, SymbolTable* symbols,
+                                ErrorContainer* errors)
       : m_compileDesign(compiler),
         m_fileContent(file),
         m_design(design),
@@ -75,12 +75,13 @@ struct FunctorCompileFileContent {
 
 class CompileFileContent final {
  public:
-  CompileFileContent(CompileDesign* compiler, FileContent* file,
-                     Design* design,
-                     bool declOnly,
-                     [[maybe_unused]] SymbolTable* symbols,
+  CompileFileContent(CompileDesign* compiler, FileContent* file, Design* design,
+                     bool declOnly, [[maybe_unused]] SymbolTable* symbols,
                      [[maybe_unused]] ErrorContainer* errors)
-      : m_compileDesign(compiler), m_fileContent(file), m_design(design), m_declOnly(declOnly) {
+      : m_compileDesign(compiler),
+        m_fileContent(file),
+        m_design(design),
+        m_declOnly(declOnly) {
     m_helper.seterrorReporting(errors, symbols);
   }
 

--- a/include/Surelog/DesignCompile/CompileHelper.h
+++ b/include/Surelog/DesignCompile/CompileHelper.h
@@ -25,16 +25,16 @@
 #define SURELOG_COMPILEHELPER_H
 #pragma once
 
-#include <utility>
-#include <vector>
-#include <string_view>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Design/ValuedComponentI.h>
 #include <Surelog/Expression/ExprBuilder.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <string>
+#include <string_view>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 // UHDM
 #include <uhdm/constant.h>
@@ -287,18 +287,20 @@ class CompileHelper final {
                                         CompileDesign* compileDesign,
                                         UHDM::any* pstmt,
                                         ValuedComponentI* instance);
-                                        
+
   UHDM::property_decl* compilePropertyDeclaration(DesignComponent* component,
-                                        const FileContent* fC, NodeId nodeId,
-                                        CompileDesign* compileDesign,
-                                        UHDM::any* pstmt,
-                                        ValuedComponentI* instance);
-                                        
+                                                  const FileContent* fC,
+                                                  NodeId nodeId,
+                                                  CompileDesign* compileDesign,
+                                                  UHDM::any* pstmt,
+                                                  ValuedComponentI* instance);
+
   UHDM::sequence_decl* compileSequenceDeclaration(DesignComponent* component,
-                                        const FileContent* fC, NodeId nodeId,
-                                        CompileDesign* compileDesign,
-                                        UHDM::any* pstmt,
-                                        ValuedComponentI* instance);
+                                                  const FileContent* fC,
+                                                  NodeId nodeId,
+                                                  CompileDesign* compileDesign,
+                                                  UHDM::any* pstmt,
+                                                  ValuedComponentI* instance);
 
   UHDM::initial* compileInitialBlock(DesignComponent* component,
                                      const FileContent* fC, NodeId id,
@@ -509,7 +511,7 @@ class CompileHelper final {
                        int32_t opIndex, UHDM::expr* rhs,
                        DesignComponent* component, CompileDesign* compileDesign,
                        ValuedComponentI* instance);
-  
+
   void adjustUnsized(UHDM::constant* c, int32_t size);
 
   UHDM::any* defaultPatternAssignment(const UHDM::typespec* tps, UHDM::any* exp,

--- a/include/Surelog/DesignCompile/CompileModule.h
+++ b/include/Surelog/DesignCompile/CompileModule.h
@@ -60,8 +60,8 @@ struct FunctorCompileModule {
 
 class CompileModule final {
  public:
-  CompileModule(CompileDesign* compiler, ModuleDefinition* mdl,
-                Design* design, SymbolTable* symbols, ErrorContainer* errors,
+  CompileModule(CompileDesign* compiler, ModuleDefinition* mdl, Design* design,
+                SymbolTable* symbols, ErrorContainer* errors,
                 ValuedComponentI* instance = nullptr)
       : m_compileDesign(compiler),
         m_module(mdl),

--- a/include/Surelog/DesignCompile/DesignElaboration.h
+++ b/include/Surelog/DesignCompile/DesignElaboration.h
@@ -25,15 +25,16 @@
 #define SURELOG_DESIGNELABORATION_H
 #pragma once
 
-#include <functional>
-#include <set>
-#include <map>
-#include <utility>
-#include <vector>
-#include <string_view>
-#include <string>
 #include <Surelog/Config/Config.h>
 #include <Surelog/DesignCompile/TestbenchElaboration.h>
+
+#include <functional>
+#include <map>
+#include <set>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 namespace SURELOG {
 

--- a/include/Surelog/DesignCompile/ElaborationStep.h
+++ b/include/Surelog/DesignCompile/ElaborationStep.h
@@ -25,11 +25,12 @@
 #define SURELOG_ELABORATIONSTEP_H
 #pragma once
 
-#include <map>
-#include <string_view>
 #include <Surelog/DesignCompile/CompileHelper.h>
 #include <Surelog/ErrorReporting/ErrorDefinition.h>
 #include <Surelog/Expression/ExprBuilder.h>
+
+#include <map>
+#include <string_view>
 
 // UHDM
 #include <uhdm/uhdm_forward_decl.h>
@@ -107,8 +108,12 @@ class ElaborationStep {
                       UHDM::VectorOfvariables* vars, UHDM::expr* assignExp,
                       UHDM::typespec* tps);
 
-  void swapTypespecPointersInUhdm(UHDM::Serializer& s, std::map<const UHDM::typespec*, const UHDM::typespec*>& typespecSwapMap);
-  void swapTypespecPointersInTypedef(Design* design, std::map<const UHDM::typespec*, const UHDM::typespec*>& typespecSwapMap);
+  void swapTypespecPointersInUhdm(
+      UHDM::Serializer& s,
+      std::map<const UHDM::typespec*, const UHDM::typespec*>& typespecSwapMap);
+  void swapTypespecPointersInTypedef(
+      Design* design,
+      std::map<const UHDM::typespec*, const UHDM::typespec*>& typespecSwapMap);
 
   CompileDesign* m_compileDesign;
   ExprBuilder m_exprBuilder;

--- a/include/Surelog/DesignCompile/ElaboratorHarness.h
+++ b/include/Surelog/DesignCompile/ElaboratorHarness.h
@@ -25,8 +25,8 @@
 #define SURELOG_ELABORATORHARNESS_H
 #pragma once
 
-#include <string_view>
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/include/Surelog/DesignCompile/NetlistElaboration.h
+++ b/include/Surelog/DesignCompile/NetlistElaboration.h
@@ -25,9 +25,10 @@
 #define SURELOG_NETLISTELABORATION_H
 #pragma once
 
+#include <Surelog/DesignCompile/TestbenchElaboration.h>
+
 #include <map>
 #include <string_view>
-#include <Surelog/DesignCompile/TestbenchElaboration.h>
 
 namespace SURELOG {
 

--- a/include/Surelog/DesignCompile/ResolveSymbols.h
+++ b/include/Surelog/DesignCompile/ResolveSymbols.h
@@ -25,12 +25,12 @@
 #define SURELOG_RESOLVESYMBOLS_H
 #pragma once
 
-#include <vector>
-#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/DesignCompile/CompileStep.h>
 
+#include <string_view>
 #include <unordered_set>
+#include <vector>
 
 namespace SURELOG {
 

--- a/include/Surelog/DesignCompile/UhdmChecker.h
+++ b/include/Surelog/DesignCompile/UhdmChecker.h
@@ -25,12 +25,12 @@
 #define SURELOG_UHDMCHECKER_H
 #pragma once
 
-#include <utility>
-#include <string_view>
 #include <Surelog/Common/PathId.h>
 
 #include <map>
 #include <set>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 namespace SURELOG {

--- a/include/Surelog/DesignCompile/UhdmWriter.h
+++ b/include/Surelog/DesignCompile/UhdmWriter.h
@@ -25,13 +25,14 @@
 #define SURELOG_UHDMWRITER_H
 #pragma once
 
-#include <functional>
-#include <map>
-#include <vector>
-#include <string_view>
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/DesignCompile/CompileHelper.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
+
+#include <functional>
+#include <map>
+#include <string_view>
+#include <vector>
 
 // UHDM
 #include <uhdm/uhdm_forward_decl.h>
@@ -86,9 +87,11 @@ class UhdmWriter final {
                  SignalMap& signalMap, SignalMap& portMap,
                  ModuleInstance* instance = nullptr);
   void writeDataTypes(const DesignComponent::DataTypeMap& datatypeMap,
-                    UHDM::BaseClass* parent, UHDM::VectorOftypespec* dest_typespecs,
-                    UHDM::Serializer& s, bool setParent);
-  void writeImportedSymbols(DesignComponent* mod, UHDM::Serializer& s, UHDM::VectorOftypespec* typespecs); 
+                      UHDM::BaseClass* parent,
+                      UHDM::VectorOftypespec* dest_typespecs,
+                      UHDM::Serializer& s, bool setParent);
+  void writeImportedSymbols(DesignComponent* mod, UHDM::Serializer& s,
+                            UHDM::VectorOftypespec* typespecs);
   void writeVariables(const DesignComponent::VariableMap& orig_vars,
                       UHDM::BaseClass* parent,
                       UHDM::VectorOfvariables* dest_vars, UHDM::Serializer& s);
@@ -127,10 +130,11 @@ class UhdmWriter final {
 
   void lateBinding(UHDM::Serializer& s, DesignComponent* mod, UHDM::scope* m);
   UHDM::any* swapForSpecifiedVar(UHDM::Serializer& s, DesignComponent* mod,
-                           UHDM::any* tmp,
-                           UHDM::VectorOfvariables* lvariables,
-                           UHDM::variables* lvariable, std::string_view name,
-                           const UHDM::any* var, const UHDM::any* parent);
+                                 UHDM::any* tmp,
+                                 UHDM::VectorOfvariables* lvariables,
+                                 UHDM::variables* lvariable,
+                                 std::string_view name, const UHDM::any* var,
+                                 const UHDM::any* parent);
   void lateTypedefBinding(UHDM::Serializer& s, DesignComponent* mod,
                           UHDM::scope* m);
 

--- a/include/Surelog/ErrorReporting/ErrorContainer.h
+++ b/include/Surelog/ErrorReporting/ErrorContainer.h
@@ -25,12 +25,12 @@
 #define SURELOG_ERRORCONTAINER_H
 #pragma once
 
-#include <utility>
-#include <string_view>
 #include <Surelog/ErrorReporting/Error.h>
 
 #include <set>
 #include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 namespace SURELOG {

--- a/include/Surelog/ErrorReporting/ErrorDefinition.h
+++ b/include/Surelog/ErrorReporting/ErrorDefinition.h
@@ -26,24 +26,24 @@
 #pragma once
 
 #if defined(_WIN32)
-  #if defined(FATAL)
-    #undef FATAL
-  #endif
-  #if defined(SYNTAX)
-    #undef SYNTAX
-  #endif
-  #if defined(ERROR)
-    #undef ERROR
-  #endif
-  #if defined(WARNING)
-    #undef WARNING
-  #endif
-  #if defined(INFO)
-    #undef INFO
-  #endif
-  #if defined(NOTE)
-    #undef NOTE
-  #endif
+#if defined(FATAL)
+#undef FATAL
+#endif
+#if defined(SYNTAX)
+#undef SYNTAX
+#endif
+#if defined(ERROR)
+#undef ERROR
+#endif
+#if defined(WARNING)
+#undef WARNING
+#endif
+#if defined(INFO)
+#undef INFO
+#endif
+#if defined(NOTE)
+#undef NOTE
+#endif
 #endif
 
 #include <map>

--- a/include/Surelog/ErrorReporting/LogListener.h
+++ b/include/Surelog/ErrorReporting/LogListener.h
@@ -25,13 +25,13 @@
 #define SURELOG_LOGLISTENER_H
 #pragma once
 
-#include <string_view>
+#include <Surelog/Common/PathId.h>
+
 #include <deque>
 #include <mutex>
 #include <ostream>
 #include <string>
-
-#include <Surelog/Common/PathId.h>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/include/Surelog/ErrorReporting/Waiver.h
+++ b/include/Surelog/ErrorReporting/Waiver.h
@@ -25,13 +25,13 @@
 #define SURELOG_WAIVER_H
 #pragma once
 
-#include <functional>
 #include <Surelog/ErrorReporting/ErrorDefinition.h>
 
+#include <cstdint>
+#include <functional>
 #include <map>
 #include <set>
 #include <string>
-#include <cstdint>
 #include <string_view>
 
 namespace SURELOG {

--- a/include/Surelog/Expression/ExprBuilder.h
+++ b/include/Surelog/Expression/ExprBuilder.h
@@ -25,8 +25,9 @@
 #define SURELOG_EXPRBUILDER_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Expression/Value.h>
+
+#include <string_view>
 
 namespace SURELOG {
 

--- a/include/Surelog/Expression/Value.h
+++ b/include/Surelog/Expression/Value.h
@@ -443,9 +443,14 @@ class StValue final : public Value {
   friend LValue;
 
  public:
-  StValue() : m_type(Type::String), m_size(0), m_valid(false), m_typespec(nullptr) {}
+  StValue()
+      : m_type(Type::String), m_size(0), m_valid(false), m_typespec(nullptr) {}
   explicit StValue(std::string_view val)
-      : m_type(Type::String), m_value(val), m_size(val.size()), m_valid(true), m_typespec(nullptr) {}
+      : m_type(Type::String),
+        m_value(val),
+        m_size(val.size()),
+        m_valid(true),
+        m_typespec(nullptr) {}
   ~StValue() final;
 
   int32_t getSize() const final { return m_size; }

--- a/include/Surelog/Library/AntlrLibParserErrorListener.h
+++ b/include/Surelog/Library/AntlrLibParserErrorListener.h
@@ -25,11 +25,11 @@
 #define SURELOG_ANTLRLIBPARSERERRORLISTENER_H
 #pragma once
 
-#include <string>
 #include <ANTLRErrorListener.h>
 
 #include <cstddef>
 #include <exception>
+#include <string>
 
 namespace SURELOG {
 
@@ -37,7 +37,8 @@ class ParseLibraryDef;
 
 class AntlrLibParserErrorListener final : public antlr4::ANTLRErrorListener {
  public:
-  explicit AntlrLibParserErrorListener(ParseLibraryDef *parser) : m_parser(parser) {}
+  explicit AntlrLibParserErrorListener(ParseLibraryDef *parser)
+      : m_parser(parser) {}
 
   ~AntlrLibParserErrorListener() final{};
 

--- a/include/Surelog/Library/SVLibShapeListener.h
+++ b/include/Surelog/Library/SVLibShapeListener.h
@@ -25,10 +25,11 @@
 #define SURELOG_SVLIBSHAPELISTENER_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/SourceCompile/SV3_1aTreeShapeHelper.h>
 #include <parser/SV3_1aParserBaseListener.h>
+
+#include <string_view>
 
 namespace SURELOG {
 
@@ -36,9 +37,10 @@ class Config;
 class ParseLibraryDef;
 
 class SVLibShapeListener final : public SV3_1aParserBaseListener,
-                           public SV3_1aTreeShapeHelper {
+                                 public SV3_1aTreeShapeHelper {
  public:
-  SVLibShapeListener(ParseLibraryDef* parser, antlr4::CommonTokenStream* tokens);
+  SVLibShapeListener(ParseLibraryDef* parser,
+                     antlr4::CommonTokenStream* tokens);
 
   SymbolId registerSymbol(std::string_view symbol) final;
 

--- a/include/Surelog/SourceCompile/AnalyzeFile.h
+++ b/include/Surelog/SourceCompile/AnalyzeFile.h
@@ -44,8 +44,8 @@ class AnalyzeFile final {
  public:
   class FileChunk final {
    public:
-    FileChunk(DesignElement::ElemType type, uint64_t from,
-              uint64_t to, uint64_t startChar, uint64_t endChar)
+    FileChunk(DesignElement::ElemType type, uint64_t from, uint64_t to,
+              uint64_t startChar, uint64_t endChar)
         : m_chunkType(type),
           m_fromLine(from),
           m_toLine(to),
@@ -73,9 +73,7 @@ class AnalyzeFile final {
 
   void analyze();
   const std::vector<PathId>& getSplitFiles() const { return m_splitFiles; }
-  const std::vector<uint32_t>& getLineOffsets() const {
-    return m_lineOffsets;
-  }
+  const std::vector<uint32_t>& getLineOffsets() const { return m_lineOffsets; }
 
   AnalyzeFile(const AnalyzeFile& orig) = delete;
   ~AnalyzeFile() = default;

--- a/include/Surelog/SourceCompile/AntlrParserErrorListener.h
+++ b/include/Surelog/SourceCompile/AntlrParserErrorListener.h
@@ -25,12 +25,11 @@
 #define SURELOG_ANTLRPARSERERRORLISTENER_H
 #pragma once
 
-#include <string>
-#include <Surelog/Common/PathId.h>
 #include <ANTLRErrorListener.h>
+#include <Surelog/Common/PathId.h>
 
+#include <string>
 #include <vector>
-
 
 namespace SURELOG {
 
@@ -39,7 +38,8 @@ class ParseFile;
 class AntlrParserErrorListener final : public antlr4::ANTLRErrorListener {
  public:
   AntlrParserErrorListener(ParseFile *parser, bool watchDogOn,
-                           uint32_t lineOffset, PathId fileId, bool printExtraPpLineInfo)
+                           uint32_t lineOffset, PathId fileId,
+                           bool printExtraPpLineInfo)
       : m_parser(parser),
         m_reportedSyntaxError(0),
         m_watchDogOn(watchDogOn),

--- a/include/Surelog/SourceCompile/CommonListenerHelper.h
+++ b/include/Surelog/SourceCompile/CommonListenerHelper.h
@@ -25,13 +25,13 @@
 #define SURELOG_COMMONLISTENERHELPER_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <map>
 #include <string>
+#include <string_view>
 
 namespace antlr4 {
 class CommonTokenStream;
@@ -86,8 +86,7 @@ class CommonListenerHelper {
 
   NodeId getObjectId(antlr4::ParserRuleContext* ctx) const;
 
-  virtual std::tuple<PathId, uint32_t, uint16_t, uint32_t,
-                     uint16_t>
+  virtual std::tuple<PathId, uint32_t, uint16_t, uint32_t, uint16_t>
   getFileLine(antlr4::ParserRuleContext* ctx, antlr4::Token* token) const = 0;
 
   NodeId& MutableChild(NodeId index);

--- a/include/Surelog/SourceCompile/CompilationUnit.h
+++ b/include/Surelog/SourceCompile/CompilationUnit.h
@@ -25,11 +25,12 @@
 #define SURELOG_COMPILATIONUNIT_H
 #pragma once
 
-#include <vector>
-#include <string_view>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Design/TimeInfo.h>
+
+#include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/include/Surelog/SourceCompile/CompileSourceFile.h
+++ b/include/Surelog/SourceCompile/CompileSourceFile.h
@@ -25,12 +25,12 @@
 #define SURELOG_COMPILESOURCEFILE_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/SourceCompile/PreprocessFile.h>
 
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #ifdef SURELOG_WITH_PYTHON

--- a/include/Surelog/SourceCompile/Compiler.h
+++ b/include/Surelog/SourceCompile/Compiler.h
@@ -25,13 +25,14 @@ limitations under the License.
 #define SURELOG_COMPILER_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/ErrorReporting/ErrorContainer.h>
 #include <Surelog/SourceCompile/CompileSourceFile.h>
 #include <Surelog/SourceCompile/PreprocessFile.h>
 #include <uhdm/vpi_user.h>
+
+#include <string_view>
 
 #ifdef USETBB
 #include <tbb/task.h>

--- a/include/Surelog/SourceCompile/ParseFile.h
+++ b/include/Surelog/SourceCompile/ParseFile.h
@@ -25,11 +25,11 @@
 #define SURELOG_PARSEFILE_H
 #pragma once
 
-#include <vector>
-#include <string_view>
 #include <Surelog/ErrorReporting/Error.h>
 
 #include <string>
+#include <string_view>
+#include <vector>
 
 namespace SURELOG {
 

--- a/include/Surelog/SourceCompile/ParserHarness.h
+++ b/include/Surelog/SourceCompile/ParserHarness.h
@@ -25,11 +25,11 @@
 #define SURELOG_PARSERHARNESS_H
 #pragma once
 
-#include <string_view>
+#include <Surelog/Common/PathId.h>
+
 #include <memory>
 #include <string>
-
-#include <Surelog/Common/PathId.h>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/include/Surelog/SourceCompile/PreprocessFile.h
+++ b/include/Surelog/SourceCompile/PreprocessFile.h
@@ -25,9 +25,6 @@
 #define SURELOG_PREPROCESSFILE_H
 #pragma once
 
-#include <utility>
-#include <string_view>
-#include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>
@@ -35,6 +32,9 @@
 #include <Surelog/SourceCompile/LoopCheck.h>
 
 #include <set>
+#include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 namespace antlr4 {

--- a/include/Surelog/SourceCompile/PreprocessHarness.h
+++ b/include/Surelog/SourceCompile/PreprocessHarness.h
@@ -25,11 +25,12 @@
 #define SURELOG_PREPROCESSHARNESS_H
 #pragma once
 
-#include <string_view>
-#include <string>
 #include <Surelog/ErrorReporting/ErrorContainer.h>
 #include <Surelog/SourceCompile/CompilationUnit.h>
 #include <Surelog/SourceCompile/SymbolTable.h>
+
+#include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/include/Surelog/SourceCompile/SV3_1aPpTreeListenerHelper.h
+++ b/include/Surelog/SourceCompile/SV3_1aPpTreeListenerHelper.h
@@ -25,7 +25,6 @@
 #define SURELOG_SV3_1APPTREELISTENERHELPER_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/ErrorReporting/ErrorDefinition.h>
 #include <Surelog/ErrorReporting/Location.h>
@@ -33,6 +32,7 @@
 #include <Surelog/SourceCompile/PreprocessFile.h>
 
 #include <set>
+#include <string_view>
 #include <vector>
 
 namespace SURELOG {
@@ -75,9 +75,8 @@ class SV3_1aPpTreeListenerHelper : public CommonListenerHelper {
   SymbolTable* getSymbolTable() const;
   SymbolId registerSymbol(std::string_view symbol) final;
 
-  std::tuple<PathId, uint32_t, uint16_t, uint32_t, uint16_t>
-  getFileLine(antlr4::ParserRuleContext* ctx,
-              antlr4::Token* token) const final;
+  std::tuple<PathId, uint32_t, uint16_t, uint32_t, uint16_t> getFileLine(
+      antlr4::ParserRuleContext* ctx, antlr4::Token* token) const final;
 
  protected:
   SV3_1aPpTreeListenerHelper(PreprocessFile* pp,

--- a/include/Surelog/SourceCompile/SV3_1aTreeShapeHelper.h
+++ b/include/Surelog/SourceCompile/SV3_1aTreeShapeHelper.h
@@ -25,7 +25,6 @@
 #define SURELOG_SV3_1ATREESHAPEHELPER_H
 #pragma once
 
-#include <utility>
 #include <Surelog/Design/DesignElement.h>
 #include <Surelog/ErrorReporting/ErrorDefinition.h>
 #include <Surelog/ErrorReporting/Location.h>
@@ -35,6 +34,7 @@
 
 #include <stack>
 #include <string_view>
+#include <utility>
 
 namespace antlr4 {
 class CommonTokenStream;
@@ -80,9 +80,8 @@ class SV3_1aTreeShapeHelper : public CommonListenerHelper {
   std::pair<double, TimeInfo::Unit> getTimeValue(
       SV3_1aParser::Time_literalContext* ctx);
 
-  std::tuple<PathId, uint32_t, uint16_t, uint32_t, uint16_t>
-  getFileLine(antlr4::ParserRuleContext* ctx,
-              antlr4::Token* token) const final;
+  std::tuple<PathId, uint32_t, uint16_t, uint32_t, uint16_t> getFileLine(
+      antlr4::ParserRuleContext* ctx, antlr4::Token* token) const final;
 
  protected:
   SV3_1aTreeShapeHelper(ParseFile* pf, antlr4::CommonTokenStream* tokens,

--- a/include/Surelog/Testbench/ClassDefinition.h
+++ b/include/Surelog/Testbench/ClassDefinition.h
@@ -25,13 +25,13 @@
 #define SURELOG_CLASSDEFINITION_H
 #pragma once
 
-#include <map>
-#include <string>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Design/DataType.h>
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Testbench/TaskMethod.h>
 
+#include <map>
+#include <string>
 #include <string_view>
 
 // UHDM
@@ -61,9 +61,7 @@ class ClassDefinition final : public DesignComponent, public DataType {
   ~ClassDefinition() final = default;
 
   uint32_t getSize() const final;
-  VObjectType getType() const final {
-    return VObjectType::paClass_declaration;
-  }
+  VObjectType getType() const final { return VObjectType::paClass_declaration; }
   bool isInstance() const final { return false; }
   std::string_view getName() const final { return m_name; }
   Library* getLibrary() { return m_library; }

--- a/include/Surelog/Testbench/ClassObject.h
+++ b/include/Surelog/Testbench/ClassObject.h
@@ -26,10 +26,10 @@
 #pragma once
 
 #include <functional>
-#include <utility>
-#include <string_view>
 #include <map>
 #include <string>
+#include <string_view>
+#include <utility>
 
 namespace SURELOG {
 

--- a/include/Surelog/Testbench/FunctionMethod.h
+++ b/include/Surelog/Testbench/FunctionMethod.h
@@ -25,8 +25,9 @@
 #define SURELOG_FUNCTIONMETHOD_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Design/Function.h>
+
+#include <string_view>
 
 namespace SURELOG {
 

--- a/include/Surelog/Testbench/Program.h
+++ b/include/Surelog/Testbench/Program.h
@@ -25,11 +25,12 @@
 #define SURELOG_PROGRAM_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Common/ClockingBlockHolder.h>
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DesignComponent.h>
+
+#include <string_view>
 
 // UHDM
 #include <uhdm/containers.h>

--- a/include/Surelog/Testbench/Property.h
+++ b/include/Surelog/Testbench/Property.h
@@ -25,8 +25,9 @@
 #define SURELOG_PROPERTY_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Testbench/Variable.h>
+
+#include <string_view>
 
 namespace SURELOG {
 

--- a/include/Surelog/Testbench/TaskMethod.h
+++ b/include/Surelog/Testbench/TaskMethod.h
@@ -25,9 +25,9 @@
 #define SURELOG_TASKMETHOD_H
 #pragma once
 
-#include <string_view>
-
 #include <Surelog/Design/Task.h>
+
+#include <string_view>
 
 namespace SURELOG {
 

--- a/include/Surelog/Testbench/TypeDef.h
+++ b/include/Surelog/Testbench/TypeDef.h
@@ -25,11 +25,11 @@
 #define SURELOG_TYPEDEF_H
 #pragma once
 
-#include <string_view>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
 
 #include <string>
+#include <string_view>
 
 namespace SURELOG {
 

--- a/include/Surelog/Utils/ParseUtils.h
+++ b/include/Surelog/Utils/ParseUtils.h
@@ -25,10 +25,11 @@
 #define SURELOG_PARSEUTILS_H
 #pragma once
 
+#include <ParserRuleContext.h>
+
+#include <string>
 #include <utility>
 #include <vector>
-#include <string>
-#include <ParserRuleContext.h>
 
 namespace SURELOG {
 namespace ParseUtils {

--- a/include/Surelog/Utils/StringUtils.h
+++ b/include/Surelog/Utils/StringUtils.h
@@ -25,8 +25,8 @@
 #define SURELOG_STRINGUTILS_H
 #pragma once
 
-#include <string>
 #include <sstream>
+#include <string>
 #include <string_view>
 #include <vector>
 


### PR DESCRIPTION
Since the headers moved to its include/... directory a while back, the run-clang-format.sh was not seeing them anymore, as it only was looking in src. Fix that, and run clang-format.