### PR TITLE
Include cstdint for all files that use u?int.._t.

### DIFF
--- a/include/Surelog/API/PythonAPI.h
+++ b/include/Surelog/API/PythonAPI.h
@@ -25,6 +25,7 @@
 #define SURELOG_PYTHONAPI_H
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
 #include <string>
 #include <vector>

--- a/include/Surelog/API/SLAPI.h
+++ b/include/Surelog/API/SLAPI.h
@@ -28,6 +28,7 @@
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/include/Surelog/Cache/Cache.h
+++ b/include/Surelog/Cache/Cache.h
@@ -29,6 +29,7 @@
 #include <Surelog/Common/PathId.h>
 #include <Surelog/ErrorReporting/Error.h>
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 

--- a/include/Surelog/Cache/PPCache.h
+++ b/include/Surelog/Cache/PPCache.h
@@ -28,6 +28,8 @@
 #include <Surelog/Cache/Cache.h>
 #include <Surelog/Cache/PPCache.capnp.h>
 
+#include <cstdint>
+
 namespace SURELOG {
 
 class PreprocessFile;

--- a/include/Surelog/CommandLine/CommandLineParser.h
+++ b/include/Surelog/CommandLine/CommandLineParser.h
@@ -28,6 +28,7 @@
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>
 
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <map>

--- a/include/Surelog/Common/PlatformFileSystem.h
+++ b/include/Surelog/Common/PlatformFileSystem.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/Common/FileSystem.h>
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>

--- a/include/Surelog/Design/Design.h
+++ b/include/Surelog/Design/Design.h
@@ -29,6 +29,7 @@
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/PathId.h>
 
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <mutex>

--- a/include/Surelog/Design/DesignComponent.h
+++ b/include/Surelog/Design/DesignComponent.h
@@ -34,6 +34,7 @@
 #include <Surelog/Design/ValuedComponentI.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <string>

--- a/include/Surelog/Design/DesignComponent.h
+++ b/include/Surelog/Design/DesignComponent.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <Surelog/Common/Containers.h>
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/PortNetHolder.h>
 #include <Surelog/Common/SymbolId.h>

--- a/include/Surelog/Design/DesignElement.h
+++ b/include/Surelog/Design/DesignElement.h
@@ -29,6 +29,7 @@
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/TimeInfo.h>
+#include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <cstdint>
 #include <ostream>

--- a/include/Surelog/Design/DesignElement.h
+++ b/include/Surelog/Design/DesignElement.h
@@ -30,6 +30,7 @@
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/TimeInfo.h>
 
+#include <cstdint>
 #include <ostream>
 
 namespace SURELOG {

--- a/include/Surelog/Design/DummyType.h
+++ b/include/Surelog/Design/DummyType.h
@@ -25,6 +25,7 @@
 #define SURELOG_DUMMY_TYPE_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
 

--- a/include/Surelog/Design/Enum.h
+++ b/include/Surelog/Design/Enum.h
@@ -28,6 +28,7 @@
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
 
+#include <cstdint>
 #include <functional>
 #include <string_view>
 #include <utility>

--- a/include/Surelog/Design/Enum.h
+++ b/include/Surelog/Design/Enum.h
@@ -25,6 +25,7 @@
 #define SURELOG_ENUM_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
 

--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -29,6 +29,7 @@
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Design/VObject.h>
+#include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <cstdint>
 #include <functional>

--- a/include/Surelog/Design/FileContent.h
+++ b/include/Surelog/Design/FileContent.h
@@ -30,6 +30,7 @@
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Design/VObject.h>
 
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <set>

--- a/include/Surelog/Design/Function.h
+++ b/include/Surelog/Design/Function.h
@@ -25,6 +25,7 @@
 #define SURELOG_FUNCTION_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/Scope.h>
 #include <Surelog/Design/Statement.h>

--- a/include/Surelog/Design/ModPort.h
+++ b/include/Surelog/Design/ModPort.h
@@ -25,6 +25,7 @@
 #define SURELOG_MODPORT_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/Signal.h>
 

--- a/include/Surelog/Design/ModuleDefinition.h
+++ b/include/Surelog/Design/ModuleDefinition.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/Common/ClockingBlockHolder.h>
 #include <Surelog/Common/Containers.h>
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Design/ModPort.h>

--- a/include/Surelog/Design/ModuleDefinition.h
+++ b/include/Surelog/Design/ModuleDefinition.h
@@ -31,6 +31,7 @@
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Design/ModPort.h>
+#include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <cstdint>
 #include <functional>

--- a/include/Surelog/Design/ModuleDefinition.h
+++ b/include/Surelog/Design/ModuleDefinition.h
@@ -31,6 +31,7 @@
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Design/ModPort.h>
 
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <string>

--- a/include/Surelog/Design/ModuleInstance.h
+++ b/include/Surelog/Design/ModuleInstance.h
@@ -32,6 +32,7 @@
 #include <Surelog/SourceCompile/VObjectTypes.h>
 #include <uhdm/Serializer.h>
 
+#include <cstdint>
 #include <map>
 #include <set>
 #include <string>

--- a/include/Surelog/Design/Parameter.h
+++ b/include/Surelog/Design/Parameter.h
@@ -28,6 +28,7 @@
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
+#include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <string_view>
 

--- a/include/Surelog/Design/Parameter.h
+++ b/include/Surelog/Design/Parameter.h
@@ -25,6 +25,7 @@
 #define SURELOG_PARAMETER_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
 

--- a/include/Surelog/Design/SimpleType.h
+++ b/include/Surelog/Design/SimpleType.h
@@ -25,6 +25,7 @@
 #define SURELOG_SIMPLE_TYPE_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
 

--- a/include/Surelog/Design/Task.h
+++ b/include/Surelog/Design/Task.h
@@ -25,6 +25,7 @@
 #define SURELOG_TASK_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/Function.h>
 

--- a/include/Surelog/Design/TfPortItem.h
+++ b/include/Surelog/Design/TfPortItem.h
@@ -25,6 +25,7 @@
 #define SURELOG_TFPORTITEM_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 #include <Surelog/Testbench/Variable.h>
 

--- a/include/Surelog/Design/TimeInfo.h
+++ b/include/Surelog/Design/TimeInfo.h
@@ -28,6 +28,7 @@
 #include <Surelog/Common/PathId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
+#include <cstdint>
 #include <string_view>
 
 namespace SURELOG {

--- a/include/Surelog/Design/Union.h
+++ b/include/Surelog/Design/Union.h
@@ -25,6 +25,7 @@
 #define SURELOG_UNION_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
 

--- a/include/Surelog/Design/VObject.h
+++ b/include/Surelog/Design/VObject.h
@@ -30,6 +30,7 @@
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
+#include <cstdint>
 #include <ostream>
 #include <string>
 #include <string_view>

--- a/include/Surelog/Design/ValuedComponentI.h
+++ b/include/Surelog/Design/ValuedComponentI.h
@@ -28,6 +28,7 @@
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/RTTI.h>
 
+#include <cstdint>
 #include <utility>
 
 // UHDM

--- a/include/Surelog/DesignCompile/CompileClass.h
+++ b/include/Surelog/DesignCompile/CompileClass.h
@@ -28,6 +28,7 @@
 #include <Surelog/DesignCompile/CompileHelper.h>
 #include <Surelog/Testbench/ClassDefinition.h>
 
+#include <cstdint>
 #include <set>
 #include <string>
 

--- a/include/Surelog/DesignCompile/CompileDesign.h
+++ b/include/Surelog/DesignCompile/CompileDesign.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/Design/Design.h>
 
+#include <cstdint>
 #include <map>
 #include <vector>
 

--- a/include/Surelog/DesignCompile/CompileFileContent.h
+++ b/include/Surelog/DesignCompile/CompileFileContent.h
@@ -27,6 +27,8 @@
 
 #include <Surelog/DesignCompile/CompileHelper.h>
 
+#include <cstdint>
+
 namespace SURELOG {
 
 class CompileDesign;

--- a/include/Surelog/DesignCompile/CompileHelper.h
+++ b/include/Surelog/DesignCompile/CompileHelper.h
@@ -30,6 +30,7 @@
 #include <Surelog/Expression/ExprBuilder.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <unordered_map>

--- a/include/Surelog/DesignCompile/CompileModule.h
+++ b/include/Surelog/DesignCompile/CompileModule.h
@@ -27,6 +27,8 @@
 
 #include <Surelog/DesignCompile/CompileHelper.h>
 
+#include <cstdint>
+
 namespace SURELOG {
 
 class CompileDesign;

--- a/include/Surelog/DesignCompile/CompilePackage.h
+++ b/include/Surelog/DesignCompile/CompilePackage.h
@@ -27,6 +27,8 @@
 
 #include <Surelog/DesignCompile/CompileHelper.h>
 
+#include <cstdint>
+
 namespace SURELOG {
 
 class CompileDesign;

--- a/include/Surelog/DesignCompile/CompileProgram.h
+++ b/include/Surelog/DesignCompile/CompileProgram.h
@@ -28,6 +28,8 @@
 #include <Surelog/DesignCompile/CompileHelper.h>
 #include <Surelog/DesignCompile/CompileToolbox.h>
 
+#include <cstdint>
+
 namespace SURELOG {
 
 class CompileDesign;

--- a/include/Surelog/DesignCompile/CompileStep.h
+++ b/include/Surelog/DesignCompile/CompileStep.h
@@ -29,6 +29,7 @@
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 

--- a/include/Surelog/DesignCompile/DesignElaboration.h
+++ b/include/Surelog/DesignCompile/DesignElaboration.h
@@ -25,6 +25,7 @@
 #define SURELOG_DESIGNELABORATION_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Config/Config.h>
 #include <Surelog/DesignCompile/TestbenchElaboration.h>
 

--- a/include/Surelog/DesignCompile/DesignElaboration.h
+++ b/include/Surelog/DesignCompile/DesignElaboration.h
@@ -28,6 +28,7 @@
 #include <Surelog/Config/Config.h>
 #include <Surelog/DesignCompile/TestbenchElaboration.h>
 
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <set>

--- a/include/Surelog/DesignCompile/ElaborationStep.h
+++ b/include/Surelog/DesignCompile/ElaborationStep.h
@@ -29,6 +29,7 @@
 #include <Surelog/ErrorReporting/ErrorDefinition.h>
 #include <Surelog/Expression/ExprBuilder.h>
 
+#include <cstdint>
 #include <map>
 #include <string_view>
 

--- a/include/Surelog/DesignCompile/NetlistElaboration.h
+++ b/include/Surelog/DesignCompile/NetlistElaboration.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/DesignCompile/TestbenchElaboration.h>
 
+#include <cstdint>
 #include <map>
 #include <string_view>
 

--- a/include/Surelog/DesignCompile/NetlistElaboration.h
+++ b/include/Surelog/DesignCompile/NetlistElaboration.h
@@ -25,6 +25,7 @@
 #define SURELOG_NETLISTELABORATION_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/DesignCompile/TestbenchElaboration.h>
 
 #include <cstdint>

--- a/include/Surelog/DesignCompile/ResolveSymbols.h
+++ b/include/Surelog/DesignCompile/ResolveSymbols.h
@@ -25,6 +25,7 @@
 #define SURELOG_RESOLVESYMBOLS_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/DesignCompile/CompileStep.h>
 

--- a/include/Surelog/DesignCompile/ResolveSymbols.h
+++ b/include/Surelog/DesignCompile/ResolveSymbols.h
@@ -28,6 +28,7 @@
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/DesignCompile/CompileStep.h>
+#include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <cstdint>
 #include <string_view>

--- a/include/Surelog/DesignCompile/ResolveSymbols.h
+++ b/include/Surelog/DesignCompile/ResolveSymbols.h
@@ -28,6 +28,7 @@
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/DesignCompile/CompileStep.h>
 
+#include <cstdint>
 #include <string_view>
 #include <unordered_set>
 #include <vector>

--- a/include/Surelog/DesignCompile/UhdmChecker.h
+++ b/include/Surelog/DesignCompile/UhdmChecker.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/Common/PathId.h>
 
+#include <cstdint>
 #include <map>
 #include <set>
 #include <string_view>

--- a/include/Surelog/DesignCompile/UhdmWriter.h
+++ b/include/Surelog/DesignCompile/UhdmWriter.h
@@ -29,6 +29,7 @@
 #include <Surelog/DesignCompile/CompileHelper.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <string_view>

--- a/include/Surelog/ErrorReporting/ErrorContainer.h
+++ b/include/Surelog/ErrorReporting/ErrorContainer.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/ErrorReporting/Error.h>
 
+#include <cstdint>
 #include <set>
 #include <string>
 #include <string_view>

--- a/include/Surelog/ErrorReporting/Location.h
+++ b/include/Surelog/ErrorReporting/Location.h
@@ -28,6 +28,7 @@
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>
 
+#include <cstdint>
 #include <ostream>
 
 namespace SURELOG {

--- a/include/Surelog/ErrorReporting/LogListener.h
+++ b/include/Surelog/ErrorReporting/LogListener.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/Common/PathId.h>
 
+#include <cstdint>
 #include <deque>
 #include <mutex>
 #include <ostream>

--- a/include/Surelog/Expression/ExprBuilder.h
+++ b/include/Surelog/Expression/ExprBuilder.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/Expression/Value.h>
 
+#include <cstdint>
 #include <string_view>
 
 namespace SURELOG {

--- a/include/Surelog/Library/SVLibShapeListener.h
+++ b/include/Surelog/Library/SVLibShapeListener.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/Common/PathId.h>
 #include <Surelog/SourceCompile/SV3_1aTreeShapeHelper.h>
+#include <Surelog/SourceCompile/VObjectTypes.h>
 #include <parser/SV3_1aParserBaseListener.h>
 
 #include <string_view>

--- a/include/Surelog/Package/Package.h
+++ b/include/Surelog/Package/Package.h
@@ -29,6 +29,7 @@
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Expression/ExprBuilder.h>
 
+#include <cstdint>
 #include <string_view>
 
 // UHDM

--- a/include/Surelog/Package/Package.h
+++ b/include/Surelog/Package/Package.h
@@ -28,6 +28,7 @@
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Expression/ExprBuilder.h>
+#include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <cstdint>
 #include <string_view>

--- a/include/Surelog/SourceCompile/AnalyzeFile.h
+++ b/include/Surelog/SourceCompile/AnalyzeFile.h
@@ -29,6 +29,7 @@
 #include <Surelog/Design/DesignElement.h>
 #include <Surelog/SourceCompile/IncludeFileInfo.h>
 
+#include <cstdint>
 #include <stack>
 #include <string>
 #include <string_view>

--- a/include/Surelog/SourceCompile/AntlrParserErrorListener.h
+++ b/include/Surelog/SourceCompile/AntlrParserErrorListener.h
@@ -28,6 +28,7 @@
 #include <ANTLRErrorListener.h>
 #include <Surelog/Common/PathId.h>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/include/Surelog/SourceCompile/CommonListenerHelper.h
+++ b/include/Surelog/SourceCompile/CommonListenerHelper.h
@@ -29,6 +29,7 @@
 #include <Surelog/Common/PathId.h>
 #include <Surelog/SourceCompile/VObjectTypes.h>
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <string_view>

--- a/include/Surelog/SourceCompile/CompilationUnit.h
+++ b/include/Surelog/SourceCompile/CompilationUnit.h
@@ -29,6 +29,7 @@
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Design/TimeInfo.h>
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 

--- a/include/Surelog/SourceCompile/CompilationUnit.h
+++ b/include/Surelog/SourceCompile/CompilationUnit.h
@@ -28,6 +28,7 @@
 #include <Surelog/Common/Containers.h>
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Design/TimeInfo.h>
+#include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <cstdint>
 #include <string_view>

--- a/include/Surelog/SourceCompile/CompileSourceFile.h
+++ b/include/Surelog/SourceCompile/CompileSourceFile.h
@@ -28,6 +28,7 @@
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/SourceCompile/PreprocessFile.h>
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <string_view>

--- a/include/Surelog/SourceCompile/IncludeFileInfo.h
+++ b/include/Surelog/SourceCompile/IncludeFileInfo.h
@@ -28,6 +28,8 @@
 #include <Surelog/Common/PathId.h>
 #include <Surelog/Common/SymbolId.h>
 
+#include <cstdint>
+
 namespace SURELOG {
 
 class IncludeFileInfo {

--- a/include/Surelog/SourceCompile/MacroInfo.h
+++ b/include/Surelog/SourceCompile/MacroInfo.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/Common/PathId.h>
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/include/Surelog/SourceCompile/ParseFile.h
+++ b/include/Surelog/SourceCompile/ParseFile.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/ErrorReporting/Error.h>
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/include/Surelog/SourceCompile/PreprocessFile.h
+++ b/include/Surelog/SourceCompile/PreprocessFile.h
@@ -31,6 +31,7 @@
 #include <Surelog/SourceCompile/IncludeFileInfo.h>
 #include <Surelog/SourceCompile/LoopCheck.h>
 
+#include <cstdint>
 #include <set>
 #include <string>
 #include <string_view>

--- a/include/Surelog/SourceCompile/SV3_1aPpTreeListenerHelper.h
+++ b/include/Surelog/SourceCompile/SV3_1aPpTreeListenerHelper.h
@@ -31,6 +31,7 @@
 #include <Surelog/SourceCompile/CommonListenerHelper.h>
 #include <Surelog/SourceCompile/PreprocessFile.h>
 
+#include <cstdint>
 #include <set>
 #include <string_view>
 #include <vector>

--- a/include/Surelog/SourceCompile/SV3_1aTreeShapeHelper.h
+++ b/include/Surelog/SourceCompile/SV3_1aTreeShapeHelper.h
@@ -25,6 +25,7 @@
 #define SURELOG_SV3_1ATREESHAPEHELPER_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Design/DesignElement.h>
 #include <Surelog/ErrorReporting/ErrorDefinition.h>
 #include <Surelog/ErrorReporting/Location.h>

--- a/include/Surelog/SourceCompile/SV3_1aTreeShapeHelper.h
+++ b/include/Surelog/SourceCompile/SV3_1aTreeShapeHelper.h
@@ -32,6 +32,7 @@
 #include <Surelog/SourceCompile/IncludeFileInfo.h>
 #include <parser/SV3_1aParser.h>
 
+#include <cstdint>
 #include <stack>
 #include <string_view>
 #include <utility>

--- a/include/Surelog/SourceCompile/SV3_1aTreeShapeHelper.h
+++ b/include/Surelog/SourceCompile/SV3_1aTreeShapeHelper.h
@@ -31,6 +31,7 @@
 #include <Surelog/ErrorReporting/Location.h>
 #include <Surelog/SourceCompile/CommonListenerHelper.h>
 #include <Surelog/SourceCompile/IncludeFileInfo.h>
+#include <Surelog/SourceCompile/VObjectTypes.h>
 #include <parser/SV3_1aParser.h>
 
 #include <cstdint>

--- a/include/Surelog/Testbench/ClassDefinition.h
+++ b/include/Surelog/Testbench/ClassDefinition.h
@@ -30,6 +30,7 @@
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Testbench/TaskMethod.h>
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <string_view>

--- a/include/Surelog/Testbench/ClassDefinition.h
+++ b/include/Surelog/Testbench/ClassDefinition.h
@@ -29,6 +29,7 @@
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Design/DataType.h>
 #include <Surelog/Design/DesignComponent.h>
+#include <Surelog/SourceCompile/VObjectTypes.h>
 #include <Surelog/Testbench/TaskMethod.h>
 
 #include <cstdint>

--- a/include/Surelog/Testbench/ClassDefinition.h
+++ b/include/Surelog/Testbench/ClassDefinition.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <Surelog/Common/Containers.h>
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Design/DataType.h>
 #include <Surelog/Design/DesignComponent.h>
 #include <Surelog/Testbench/TaskMethod.h>

--- a/include/Surelog/Testbench/FunctionMethod.h
+++ b/include/Surelog/Testbench/FunctionMethod.h
@@ -25,6 +25,7 @@
 #define SURELOG_FUNCTIONMETHOD_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Design/Function.h>
 
 #include <string_view>

--- a/include/Surelog/Testbench/Program.h
+++ b/include/Surelog/Testbench/Program.h
@@ -27,6 +27,7 @@
 
 #include <Surelog/Common/ClockingBlockHolder.h>
 #include <Surelog/Common/Containers.h>
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DesignComponent.h>
 

--- a/include/Surelog/Testbench/Program.h
+++ b/include/Surelog/Testbench/Program.h
@@ -30,6 +30,7 @@
 #include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DesignComponent.h>
+#include <Surelog/SourceCompile/VObjectTypes.h>
 
 #include <cstdint>
 #include <string_view>

--- a/include/Surelog/Testbench/Program.h
+++ b/include/Surelog/Testbench/Program.h
@@ -30,6 +30,7 @@
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DesignComponent.h>
 
+#include <cstdint>
 #include <string_view>
 
 // UHDM

--- a/include/Surelog/Testbench/Property.h
+++ b/include/Surelog/Testbench/Property.h
@@ -25,6 +25,7 @@
 #define SURELOG_PROPERTY_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Testbench/Variable.h>
 
 #include <string_view>

--- a/include/Surelog/Testbench/TaskMethod.h
+++ b/include/Surelog/Testbench/TaskMethod.h
@@ -25,6 +25,7 @@
 #define SURELOG_TASKMETHOD_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Design/Task.h>
 
 #include <string_view>

--- a/include/Surelog/Testbench/TypeDef.h
+++ b/include/Surelog/Testbench/TypeDef.h
@@ -25,6 +25,7 @@
 #define SURELOG_TYPEDEF_H
 #pragma once
 
+#include <Surelog/Common/NodeId.h>
 #include <Surelog/Common/SymbolId.h>
 #include <Surelog/Design/DataType.h>
 

--- a/include/Surelog/Utils/ParseUtils.h
+++ b/include/Surelog/Utils/ParseUtils.h
@@ -27,6 +27,7 @@
 
 #include <ParserRuleContext.h>
 
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>

--- a/include/Surelog/Utils/StringUtils.h
+++ b/include/Surelog/Utils/StringUtils.h
@@ -25,6 +25,7 @@
 #define SURELOG_STRINGUTILS_H
 #pragma once
 
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <string_view>

--- a/src/API/PythonAPI.cpp
+++ b/src/API/PythonAPI.cpp
@@ -25,6 +25,7 @@
 
 #include <antlr4-runtime.h>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -25,6 +25,7 @@
 
 #ifdef SURELOG_WITH_PYTHON
 #include "Surelog/API/SV3_1aPythonListener.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/SourceCompile/PythonListen.h"
 #endif
 

--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -30,6 +30,7 @@
 
 #include <antlr4-runtime.h>
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -26,6 +26,7 @@
 #ifdef SURELOG_WITH_PYTHON
 #include "Surelog/API/SV3_1aPythonListener.h"
 #include "Surelog/Common/NodeId.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/SourceCompile/PythonListen.h"
 #include "Surelog/SourceCompile/VObjectTypes.h"
 #endif

--- a/src/API/SLAPI.cpp
+++ b/src/API/SLAPI.cpp
@@ -27,6 +27,7 @@
 #include "Surelog/API/SV3_1aPythonListener.h"
 #include "Surelog/Common/NodeId.h"
 #include "Surelog/SourceCompile/PythonListen.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #endif
 
 #include <antlr4-runtime.h>

--- a/src/API/SV3_1aPythonListener.cpp
+++ b/src/API/SV3_1aPythonListener.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/API/SV3_1aPythonListener.h"
 
+#include <cstdint>
+
 #include "Surelog/ErrorReporting/ErrorContainer.h"
 #include "Surelog/SourceCompile/PythonListen.h"
 #include "Surelog/SourceCompile/SymbolTable.h"

--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -38,6 +38,7 @@
 #include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
 #include "Surelog/SourceCompile/VObjectTypes.h"
 

--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -35,6 +35,7 @@
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
 #include "Surelog/SourceCompile/SymbolTable.h"

--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -39,6 +39,7 @@
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 namespace SURELOG {
 static constexpr std::string_view UnknownRawPath = "<unknown>";

--- a/src/Cache/Cache.cpp
+++ b/src/Cache/Cache.cpp
@@ -25,6 +25,7 @@
 
 #include <capnp/serialize-packed.h>
 
+#include <cstdint>
 #include <filesystem>
 #include <functional>
 #include <iostream>

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -38,6 +38,7 @@
 #include "Surelog/Design/Design.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Design/TimeInfo.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/Package/Precompiled.h"
 #include "Surelog/SourceCompile/CompilationUnit.h"

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -35,6 +35,7 @@
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/Design.h"
 #include "Surelog/Design/DesignElement.h"
 #include "Surelog/Design/FileContent.h"

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -45,6 +45,7 @@
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/ParseFile.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Utils/StringUtils.h"
 #include "Surelog/config.h"
 

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -39,6 +39,7 @@
 #include "Surelog/Design/Design.h"
 #include "Surelog/Design/DesignElement.h"
 #include "Surelog/Design/FileContent.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/Package/Precompiled.h"
 #include "Surelog/SourceCompile/CompileSourceFile.h"

--- a/src/Cache/PythonAPICache.cpp
+++ b/src/Cache/PythonAPICache.cpp
@@ -28,6 +28,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -34,6 +34,7 @@
 #include "Surelog/API/PythonAPI.h"
 #include "Surelog/Common/PlatformFileSystem.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
 #include "Surelog/Utils/StringUtils.h"
 #include "Surelog/surelog-version.h"

--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 
+#include <cstdint>
 #include <map>
 #include <nlohmann/json.hpp>
 #include <string>

--- a/src/Common/FileSystem.cpp
+++ b/src/Common/FileSystem.cpp
@@ -29,6 +29,7 @@
 #define NOMINMAX
 #include <Windows.h>
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <string_view>

--- a/src/Common/PlatformFileSystem.cpp
+++ b/src/Common/PlatformFileSystem.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/Common/PlatformFileSystem.h"
 
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>

--- a/src/Common/PlatformFileSystem_test.cpp
+++ b/src/Common/PlatformFileSystem_test.cpp
@@ -25,6 +25,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <iostream>
 #include <set>
 #include <string_view>

--- a/src/Design/BindStmt.cpp
+++ b/src/Design/BindStmt.cpp
@@ -23,6 +23,8 @@
 
 #include "Surelog/Design/BindStmt.h"
 
+#include "Surelog/Common/NodeId.h"
+
 namespace SURELOG {
 
 BindStmt::BindStmt(const FileContent* fC, NodeId stmtId, NodeId targetModId,

--- a/src/Design/DataType.cpp
+++ b/src/Design/DataType.cpp
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "Surelog/Expression/Value.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 namespace SURELOG {
 

--- a/src/Design/DefParam.cpp
+++ b/src/Design/DefParam.cpp
@@ -23,6 +23,7 @@
  * Created on January 7, 2018, 8:55 PM
  */
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -39,6 +39,7 @@
 #include "Surelog/Design/ModuleDefinition.h"
 #include "Surelog/Design/ModuleInstance.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Expression/Value.h"
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/SymbolTable.h"

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -42,6 +42,7 @@
 #include "Surelog/Expression/Value.h"
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/ClassDefinition.h"
 #include "Surelog/Testbench/Program.h"
 #include "Surelog/Utils/StringUtils.h"

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -32,6 +32,7 @@
 #include <utility>
 #include <vector>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/DefParam.h"
 #include "Surelog/Design/DesignComponent.h"
 #include "Surelog/Design/FileContent.h"

--- a/src/Design/Design.cpp
+++ b/src/Design/Design.cpp
@@ -22,6 +22,7 @@
  * Created on July 1, 2017, 1:23 PM
  */
 
+#include <cstdint>
 #include <iterator>
 #include <map>
 #include <queue>

--- a/src/Design/DesignComponent.cpp
+++ b/src/Design/DesignComponent.cpp
@@ -30,6 +30,7 @@
 #include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Design/Parameter.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/FunctionMethod.h"
 #include "Surelog/Testbench/TaskMethod.h"
 #include "Surelog/Testbench/TypeDef.h"

--- a/src/Design/DesignComponent.cpp
+++ b/src/Design/DesignComponent.cpp
@@ -27,6 +27,7 @@
 #include <utility>
 #include <vector>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Design/Parameter.h"
 #include "Surelog/Testbench/FunctionMethod.h"

--- a/src/Design/DesignElement.cpp
+++ b/src/Design/DesignElement.cpp
@@ -22,6 +22,7 @@
  * Created on June 8, 2017, 8:05 PM
  */
 
+#include <cstdint>
 #include <ostream>
 
 namespace SURELOG {

--- a/src/Design/DesignElement.cpp
+++ b/src/Design/DesignElement.cpp
@@ -15,6 +15,8 @@
  */
 #include "Surelog/Design/DesignElement.h"
 
+#include "Surelog/Common/NodeId.h"
+
 /*
  * File:   DesignElement.cpp
  * Author: alain

--- a/src/Design/DummyType.cpp
+++ b/src/Design/DummyType.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/Design/DummyType.h"
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 
 // UHDM

--- a/src/Design/Enum.cpp
+++ b/src/Design/Enum.cpp
@@ -25,6 +25,7 @@
 
 #include <string_view>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 
 namespace SURELOG {

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -23,6 +23,7 @@
  * Created on June 8, 2017, 8:22 PM
  */
 
+#include <cstdint>
 #include <iostream>
 #include <stack>
 #include <string>

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -35,6 +35,7 @@
 #include "Surelog/ErrorReporting/ErrorContainer.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Utils/StringUtils.h"
 
 namespace SURELOG {

--- a/src/Design/FileContent.cpp
+++ b/src/Design/FileContent.cpp
@@ -33,6 +33,7 @@
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/DesignElement.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
 #include "Surelog/SourceCompile/VObjectTypes.h"

--- a/src/Design/Function.cpp
+++ b/src/Design/Function.cpp
@@ -27,6 +27,7 @@
 
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/DesignCompile/CompileHelper.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 namespace SURELOG {
 Procedure::Procedure(DesignComponent* parent, const FileContent* fC, NodeId id,

--- a/src/Design/ModuleDefinition.cpp
+++ b/src/Design/ModuleDefinition.cpp
@@ -29,6 +29,7 @@
 
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Design/ModPort.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 namespace SURELOG {
 

--- a/src/Design/ModuleDefinition.cpp
+++ b/src/Design/ModuleDefinition.cpp
@@ -23,6 +23,7 @@
  * Created on October 20, 2017, 10:29 PM
  */
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 

--- a/src/Design/ModuleInstance.cpp
+++ b/src/Design/ModuleInstance.cpp
@@ -32,6 +32,7 @@
 #include "Surelog/Design/Netlist.h"
 #include "Surelog/Expression/ExprBuilder.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 // UHDM
 #include <uhdm/ExprEval.h>

--- a/src/Design/ModuleInstance.cpp
+++ b/src/Design/ModuleInstance.cpp
@@ -22,6 +22,7 @@
  * Created on October 16, 2017, 10:48 PM
  */
 
+#include <cstdint>
 #include <set>
 #include <string_view>
 #include <vector>

--- a/src/Design/Parameter.cpp
+++ b/src/Design/Parameter.cpp
@@ -26,6 +26,7 @@
 
 #include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 namespace SURELOG {
 

--- a/src/Design/Parameter.cpp
+++ b/src/Design/Parameter.cpp
@@ -24,6 +24,7 @@
 
 #include <string_view>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 
 namespace SURELOG {

--- a/src/Design/Signal.cpp
+++ b/src/Design/Signal.cpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <string_view>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Utils/StringUtils.h"
 

--- a/src/Design/Signal.cpp
+++ b/src/Design/Signal.cpp
@@ -27,6 +27,7 @@
 
 #include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Utils/StringUtils.h"
 
 namespace SURELOG {

--- a/src/Design/SimpleType.cpp
+++ b/src/Design/SimpleType.cpp
@@ -24,6 +24,7 @@
 
 #include "Surelog/Design/SimpleType.h"
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 
 // UHDM

--- a/src/Design/Statement.cpp
+++ b/src/Design/Statement.cpp
@@ -27,6 +27,7 @@
 
 #include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 namespace SURELOG {
 

--- a/src/Design/Statement.cpp
+++ b/src/Design/Statement.cpp
@@ -25,6 +25,7 @@
 #include <string_view>
 #include <vector>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 
 namespace SURELOG {

--- a/src/Design/Struct.cpp
+++ b/src/Design/Struct.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/Design/Struct.h"
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 
 // UHDM

--- a/src/Design/TimeInfo.cpp
+++ b/src/Design/TimeInfo.cpp
@@ -22,6 +22,7 @@
  *
  * Created on June 8, 2017, 8:27 PM
  */
+#include <cstdint>
 #include <string_view>
 
 namespace SURELOG {

--- a/src/Design/Union.cpp
+++ b/src/Design/Union.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/Design/Union.h"
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 
 namespace SURELOG {

--- a/src/Design/VObject.cpp
+++ b/src/Design/VObject.cpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <string_view>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
 #include "Surelog/Utils/StringUtils.h"
 

--- a/src/Design/ValuedComponentI.cpp
+++ b/src/Design/ValuedComponentI.cpp
@@ -22,6 +22,7 @@
  * Created on May 20, 2019, 21:03 PM
  */
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <string_view>

--- a/src/Design/ValuedComponentI.cpp
+++ b/src/Design/ValuedComponentI.cpp
@@ -30,6 +30,7 @@
 
 #include "Surelog/Design/ModuleInstance.h"
 #include "Surelog/Expression/ExprBuilder.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 namespace SURELOG {
 Value* ValuedComponentI::getValue(std::string_view name) const {

--- a/src/DesignCompile/CompileAssertion.cpp
+++ b/src/DesignCompile/CompileAssertion.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/DesignCompile/CompileDesign.h"
 #include "Surelog/DesignCompile/CompileHelper.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 // UHDM
 #include <uhdm/ElaboratorListener.h>

--- a/src/DesignCompile/CompileAssertion.cpp
+++ b/src/DesignCompile/CompileAssertion.cpp
@@ -30,6 +30,7 @@
 #include <uhdm/clone_tree.h>
 #include <uhdm/uhdm.h>
 
+#include <cstdint>
 #include <iostream>
 #include <string_view>
 

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -40,6 +40,7 @@
 // UHDM
 #include <uhdm/class_defn.h>
 
+#include <cstdint>
 #include <stack>
 #include <string>
 #include <string_view>

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -25,6 +25,7 @@
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/DesignCompile/CompileDesign.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -31,6 +31,7 @@
 #include "Surelog/ErrorReporting/ErrorContainer.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/ClassDefinition.h"
 #include "Surelog/Testbench/Constraint.h"
 #include "Surelog/Testbench/CoverGroupDefinition.h"

--- a/src/DesignCompile/CompileClass.cpp
+++ b/src/DesignCompile/CompileClass.cpp
@@ -29,6 +29,7 @@
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/DesignCompile/CompileDesign.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
 #include "Surelog/SourceCompile/VObjectTypes.h"

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -42,6 +42,7 @@
 #include "Surelog/DesignCompile/UVMElaboration.h"
 #include "Surelog/DesignCompile/UhdmWriter.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"

--- a/src/DesignCompile/CompileDesign.cpp
+++ b/src/DesignCompile/CompileDesign.cpp
@@ -55,6 +55,7 @@
 #include <uhdm/vpi_visitor.h>
 
 #include <climits>
+#include <cstdint>
 #include <iostream>
 #include <map>
 #include <string>

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -51,6 +51,7 @@
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/TypeDef.h"
 #include "Surelog/Utils/NumUtils.h"
 #include "Surelog/Utils/StringUtils.h"

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -48,6 +48,7 @@
 #include "Surelog/DesignCompile/CompileDesign.h"
 #include "Surelog/DesignCompile/CompileHelper.h"
 #include "Surelog/DesignCompile/UhdmWriter.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <set>

--- a/src/DesignCompile/CompileExpression_test.cpp
+++ b/src/DesignCompile/CompileExpression_test.cpp
@@ -26,6 +26,7 @@
 #include "Surelog/DesignCompile/CompilerHarness.h"
 #include "Surelog/SourceCompile/ParserHarness.h"
 #include "Surelog/SourceCompile/PreprocessHarness.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 // UHDM
 #include <uhdm/ExprEval.h>

--- a/src/DesignCompile/CompileFileContent.cpp
+++ b/src/DesignCompile/CompileFileContent.cpp
@@ -29,6 +29,7 @@
 
 #include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 namespace SURELOG {
 

--- a/src/DesignCompile/CompileFileContent.cpp
+++ b/src/DesignCompile/CompileFileContent.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/DesignCompile/CompileFileContent.h"
 
+#include <cstdint>
 #include <stack>
 #include <vector>
 

--- a/src/DesignCompile/CompileFileContent.cpp
+++ b/src/DesignCompile/CompileFileContent.cpp
@@ -27,6 +27,7 @@
 #include <stack>
 #include <vector>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 
 namespace SURELOG {

--- a/src/DesignCompile/CompileGenStmt.cpp
+++ b/src/DesignCompile/CompileGenStmt.cpp
@@ -47,6 +47,7 @@
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/ClassDefinition.h"
 #include "Surelog/Testbench/Program.h"
 #include "Surelog/Testbench/TypeDef.h"

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -63,6 +63,7 @@
 #include <uhdm/uhdm.h>
 
 #include <climits>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <iostream>

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -48,6 +48,7 @@
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/ClassDefinition.h"
 #include "Surelog/Testbench/Program.h"
 #include "Surelog/Testbench/TypeDef.h"

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -43,6 +43,7 @@
 #include "Surelog/DesignCompile/UhdmWriter.h"
 #include "Surelog/ErrorReporting/Error.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/ErrorReporting/Location.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/Package/Package.h"

--- a/src/DesignCompile/CompileHelper_test.cpp
+++ b/src/DesignCompile/CompileHelper_test.cpp
@@ -20,6 +20,7 @@
 #include <uhdm/Serializer.h>
 #include <uhdm/constant.h>
 
+#include <cstdint>
 #include <limits>
 #include <string_view>
 

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -25,6 +25,7 @@
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Design/ModuleDefinition.h"
 #include "Surelog/Design/ModuleInstance.h"

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -31,6 +31,7 @@
 #include "Surelog/Design/ModuleInstance.h"
 #include "Surelog/DesignCompile/CompileDesign.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -34,6 +34,7 @@
 #include "Surelog/Library/Library.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Utils/StringUtils.h"
 
 // UHDM

--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -48,6 +48,7 @@
 #include <uhdm/table_entry.h>
 #include <uhdm/udp_defn.h>
 
+#include <cstdint>
 #include <stack>
 #include <string>
 #include <string_view>

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -29,6 +29,7 @@
 #include "Surelog/Design/VObject.h"
 #include "Surelog/DesignCompile/CompileDesign.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/DesignCompile/CompilePackage.h"
 
 #include "Surelog/CommandLine/CommandLineParser.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Design/VObject.h"
 #include "Surelog/DesignCompile/CompileDesign.h"

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -33,6 +33,7 @@
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Utils/StringUtils.h"
 
 // UHDM

--- a/src/DesignCompile/CompilePackage.cpp
+++ b/src/DesignCompile/CompilePackage.cpp
@@ -37,6 +37,7 @@
 // UHDM
 #include <uhdm/package.h>
 
+#include <cstdint>
 #include <stack>
 #include <string>
 #include <string_view>

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/DesignCompile/CompileDesign.h"
 #include "Surelog/ErrorReporting/Error.h"

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -26,6 +26,7 @@
 #include <uhdm/final_stmt.h>
 #include <uhdm/initial.h>
 
+#include <cstdint>
 #include <stack>
 #include <string>
 #include <string_view>

--- a/src/DesignCompile/CompileProgram.cpp
+++ b/src/DesignCompile/CompileProgram.cpp
@@ -42,6 +42,7 @@
 #include "Surelog/ErrorReporting/Location.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/Program.h"
 #include "Surelog/Utils/StringUtils.h"
 

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -45,6 +45,7 @@
 #include "Surelog/SourceCompile/ParseFile.h"
 #include "Surelog/SourceCompile/PreprocessFile.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/ClassDefinition.h"
 #include "Surelog/Testbench/Property.h"
 #include "Surelog/Utils/StringUtils.h"

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -35,6 +35,7 @@
 #include "Surelog/DesignCompile/CompileHelper.h"
 #include "Surelog/DesignCompile/UhdmWriter.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Expression/ExprBuilder.h"
 #include "Surelog/Expression/Value.h"
 #include "Surelog/Library/Library.h"

--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -53,6 +53,7 @@
 #include <uhdm/ElaboratorListener.h>
 #include <uhdm/uhdm.h>
 
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <map>

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -43,6 +43,7 @@
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/ClassDefinition.h"
 #include "Surelog/Testbench/TypeDef.h"
 #include "Surelog/Testbench/Variable.h"

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -54,6 +54,7 @@
 #include <uhdm/clone_tree.h>
 #include <uhdm/uhdm.h>
 
+#include <cstdint>
 #include <stack>
 #include <string>
 #include <string_view>

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -39,6 +39,7 @@
 #include "Surelog/Design/Union.h"
 #include "Surelog/DesignCompile/CompileDesign.h"
 #include "Surelog/DesignCompile/CompileHelper.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -41,6 +41,7 @@
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/Program.h"
 #include "Surelog/Utils/StringUtils.h"
 

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -37,6 +37,7 @@
 #include "Surelog/DesignCompile/CompileModule.h"
 #include "Surelog/DesignCompile/NetlistElaboration.h"
 #include "Surelog/DesignCompile/UhdmWriter.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -50,6 +50,7 @@
 #include <uhdm/clone_tree.h>
 #include <uhdm/uhdm.h>
 
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <iostream>

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -50,6 +50,7 @@
 #include "Surelog/Design/TfPortItem.h"
 #include "Surelog/Design/Union.h"
 #include "Surelog/DesignCompile/CompileDesign.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -54,6 +54,7 @@
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/ClassDefinition.h"
 #include "Surelog/Testbench/Program.h"
 #include "Surelog/Testbench/Property.h"

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -35,6 +35,7 @@
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/DataType.h"
 #include "Surelog/Design/DummyType.h"
 #include "Surelog/Design/Enum.h"

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/DesignCompile/ElaborationStep.h"
 
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <map>

--- a/src/DesignCompile/Elaboration_test.cpp
+++ b/src/DesignCompile/Elaboration_test.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <string_view>

--- a/src/DesignCompile/EvalFunc.cpp
+++ b/src/DesignCompile/EvalFunc.cpp
@@ -36,6 +36,7 @@
 #include <uhdm/uhdm.h>
 
 #include <bitset>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <string_view>

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -52,6 +52,7 @@
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/TypeDef.h"
 #include "Surelog/Utils/StringUtils.h"
 

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -32,6 +32,7 @@
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/DesignComponent.h"
 #include "Surelog/Design/DesignElement.h"
 #include "Surelog/Design/DummyType.h"

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -49,6 +49,7 @@
 #include "Surelog/Design/Union.h"
 #include "Surelog/DesignCompile/CompileDesign.h"
 #include "Surelog/DesignCompile/UhdmWriter.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/DesignCompile/NetlistElaboration.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <map>
 #include <set>
 #include <string>

--- a/src/DesignCompile/ResolveSymbols.cpp
+++ b/src/DesignCompile/ResolveSymbols.cpp
@@ -37,6 +37,7 @@
 // UHDM
 #include <uhdm/package.h>
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/DesignCompile/ResolveSymbols.cpp
+++ b/src/DesignCompile/ResolveSymbols.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/DesignCompile/ResolveSymbols.h"
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Design/ModuleDefinition.h"
 #include "Surelog/DesignCompile/CompileDesign.h"

--- a/src/DesignCompile/ResolveSymbols.cpp
+++ b/src/DesignCompile/ResolveSymbols.cpp
@@ -31,6 +31,7 @@
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/ClassDefinition.h"
 #include "Surelog/Testbench/Program.h"
 #include "Surelog/Utils/StringUtils.h"

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -32,6 +32,7 @@
 #include "Surelog/Design/Statement.h"
 #include "Surelog/Design/TfPortItem.h"
 #include "Surelog/DesignCompile/CompileDesign.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
 #include "Surelog/SourceCompile/VObjectTypes.h"

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/DesignCompile/TestbenchElaboration.h"
 
 #include "Surelog/Common/FileSystem.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/Design.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Design/Parameter.h"

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -34,6 +34,7 @@
 #include "Surelog/DesignCompile/CompileDesign.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/ClassDefinition.h"
 #include "Surelog/Testbench/Property.h"
 #include "Surelog/Utils/StringUtils.h"

--- a/src/DesignCompile/TestbenchElaboration.cpp
+++ b/src/DesignCompile/TestbenchElaboration.cpp
@@ -43,6 +43,7 @@
 #include <uhdm/extends.h>
 #include <uhdm/ref_typespec.h>
 
+#include <cstdint>
 #include <queue>
 #include <string>
 #include <string_view>

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -25,6 +25,7 @@
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Design/ModuleInstance.h"
 #include "Surelog/Design/VObject.h"

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -40,6 +40,7 @@
 #include <uhdm/uhdm.h>
 #include <uhdm/vpi_visitor.h>
 
+#include <cstdint>
 #include <iomanip>
 #include <set>
 #include <sstream>

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -30,6 +30,7 @@
 #include "Surelog/Design/ModuleInstance.h"
 #include "Surelog/Design/VObject.h"
 #include "Surelog/DesignCompile/CompileDesign.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"

--- a/src/DesignCompile/UhdmChecker.cpp
+++ b/src/DesignCompile/UhdmChecker.cpp
@@ -34,6 +34,7 @@
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Utils/StringUtils.h"
 
 // UHDM

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -50,6 +50,7 @@
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/ClassDefinition.h"
 #include "Surelog/Testbench/Program.h"
 #include "Surelog/Testbench/TypeDef.h"

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/DesignCompile/UhdmWriter.h"
 
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <map>

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -36,6 +36,7 @@
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/DesignElement.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Design/ModPort.h"

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -47,6 +47,7 @@
 #include "Surelog/Design/Signal.h"
 #include "Surelog/DesignCompile/CompileDesign.h"
 #include "Surelog/DesignCompile/UhdmChecker.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"

--- a/src/ErrorReporting/Error.cpp
+++ b/src/ErrorReporting/Error.cpp
@@ -26,6 +26,8 @@
 #include <cstdint>
 #include <vector>
 
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
+
 namespace SURELOG {
 
 Error::Error(ErrorDefinition::ErrorType errorId, const Location& loc,

--- a/src/ErrorReporting/Error.cpp
+++ b/src/ErrorReporting/Error.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/ErrorReporting/Error.h"
 
+#include <cstdint>
 #include <vector>
 
 namespace SURELOG {

--- a/src/ErrorReporting/ErrorContainer.cpp
+++ b/src/ErrorReporting/ErrorContainer.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/ErrorReporting/ErrorContainer.h"
 
+#include <cstdint>
 #include <cstdio>
 #include <iostream>
 #include <map>

--- a/src/ErrorReporting/ErrorDefinition.cpp
+++ b/src/ErrorReporting/ErrorDefinition.cpp
@@ -22,6 +22,7 @@
  */
 #include "Surelog/ErrorReporting/ErrorDefinition.h"
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 

--- a/src/ErrorReporting/LogListener.cpp
+++ b/src/ErrorReporting/LogListener.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/ErrorReporting/LogListener.h"
 
+#include <cstdint>
 #include <iostream>
 #include <string_view>
 

--- a/src/ErrorReporting/Report.cpp
+++ b/src/ErrorReporting/Report.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/ErrorReporting/Report.h"
 
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <iostream>
 #include <regex>

--- a/src/ErrorReporting/Waiver.cpp
+++ b/src/ErrorReporting/Waiver.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/ErrorReporting/Waiver.h"
 
+#include <cstdint>
 #include <functional>
 #include <set>
 #include <string>

--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -31,6 +31,7 @@
 #include "Surelog/Design/Design.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Package/Package.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
 #include "Surelog/SourceCompile/VObjectTypes.h"

--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -23,6 +23,7 @@
 #include "Surelog/Expression/ExprBuilder.h"
 
 #include <cmath>
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/Expression/ExprBuilder_test.cpp
+++ b/src/Expression/ExprBuilder_test.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/src/Expression/ExprBuilder_test.cpp
+++ b/src/Expression/ExprBuilder_test.cpp
@@ -24,6 +24,7 @@
 
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/SourceCompile/ParserHarness.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 namespace SURELOG {
 

--- a/src/Expression/Value.cpp
+++ b/src/Expression/Value.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/Expression/Value.h"
 
 #include <cmath>
+#include <cstdint>
 #include <string>
 
 #include "Surelog/Utils/NumUtils.h"

--- a/src/Library/AntlrLibParserErrorListener.cpp
+++ b/src/Library/AntlrLibParserErrorListener.cpp
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/ParseLibraryDef.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
 

--- a/src/Library/LibrarySet.cpp
+++ b/src/Library/LibrarySet.cpp
@@ -30,6 +30,7 @@
 #include <string_view>
 
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
 #include "Surelog/Utils/StringUtils.h"

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -32,6 +32,7 @@
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Config/ConfigSet.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -36,6 +36,7 @@
 #include "Surelog/Config/ConfigSet.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/AntlrLibParserErrorListener.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/Library/LibrarySet.h"

--- a/src/Library/ParseLibraryDef.cpp
+++ b/src/Library/ParseLibraryDef.cpp
@@ -41,6 +41,7 @@
 #include "Surelog/Library/LibrarySet.h"
 #include "Surelog/Library/SVLibShapeListener.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Utils/StringUtils.h"
 
 namespace SURELOG {

--- a/src/Library/SVLibShapeListener.cpp
+++ b/src/Library/SVLibShapeListener.cpp
@@ -31,6 +31,7 @@
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/Library/LibrarySet.h"
 #include "Surelog/Library/ParseLibraryDef.h"

--- a/src/Library/SVLibShapeListener.cpp
+++ b/src/Library/SVLibShapeListener.cpp
@@ -36,6 +36,7 @@
 #include "Surelog/Library/ParseLibraryDef.h"
 #include "Surelog/SourceCompile/ParseFile.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Utils/ParseUtils.h"
 
 namespace SURELOG {

--- a/src/Package/Package.cpp
+++ b/src/Package/Package.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/Package/Package.h"
 
+#include <cstdint>
 #include <string_view>
 
 #include "Surelog/Design/FileContent.h"

--- a/src/Package/Package.cpp
+++ b/src/Package/Package.cpp
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <string_view>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Testbench/ClassDefinition.h"
 

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -35,6 +35,7 @@
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/Design.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
 #include "Surelog/Utils/StringUtils.h"
 

--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/SourceCompile/AnalyzeFile.h"
 
+#include <cstdint>
 #include <iostream>
 #include <regex>
 #include <sstream>

--- a/src/SourceCompile/AntlrParserErrorListener.cpp
+++ b/src/SourceCompile/AntlrParserErrorListener.cpp
@@ -27,6 +27,7 @@
 #include <string>
 
 #include "Surelog/Common/FileSystem.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/SourceCompile/CompileSourceFile.h"
 #include "Surelog/SourceCompile/ParseFile.h"
 #include "Surelog/Utils/StringUtils.h"

--- a/src/SourceCompile/AntlrParserErrorListener.cpp
+++ b/src/SourceCompile/AntlrParserErrorListener.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/SourceCompile/AntlrParserErrorListener.h"
 
+#include <cstdint>
 #include <string>
 
 #include "Surelog/Common/FileSystem.h"

--- a/src/SourceCompile/CheckCompile.cpp
+++ b/src/SourceCompile/CheckCompile.cpp
@@ -33,6 +33,7 @@
 #include "Surelog/Design/DesignElement.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
 

--- a/src/SourceCompile/CheckCompile.cpp
+++ b/src/SourceCompile/CheckCompile.cpp
@@ -28,6 +28,7 @@
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/Design.h"
 #include "Surelog/Design/DesignElement.h"
 #include "Surelog/Design/FileContent.h"

--- a/src/SourceCompile/CommonListenerHelper.cpp
+++ b/src/SourceCompile/CommonListenerHelper.cpp
@@ -25,6 +25,7 @@
 
 #include <antlr4-runtime.h>
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 

--- a/src/SourceCompile/CommonListenerHelper.cpp
+++ b/src/SourceCompile/CommonListenerHelper.cpp
@@ -29,6 +29,7 @@
 #include <string_view>
 #include <vector>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/DesignElement.h"
 #include "Surelog/Design/FileContent.h"
 

--- a/src/SourceCompile/CommonListenerHelper.cpp
+++ b/src/SourceCompile/CommonListenerHelper.cpp
@@ -32,6 +32,7 @@
 #include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/DesignElement.h"
 #include "Surelog/Design/FileContent.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 namespace SURELOG {
 

--- a/src/SourceCompile/CompilationUnit.cpp
+++ b/src/SourceCompile/CompilationUnit.cpp
@@ -22,6 +22,7 @@
  */
 #include "Surelog/SourceCompile/CompilationUnit.h"
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 

--- a/src/SourceCompile/CompilationUnit.cpp
+++ b/src/SourceCompile/CompilationUnit.cpp
@@ -26,6 +26,8 @@
 #include <string_view>
 #include <vector>
 
+#include "Surelog/SourceCompile/VObjectTypes.h"
+
 namespace SURELOG {
 
 CompilationUnit::CompilationUnit(bool fileunit)

--- a/src/SourceCompile/CompileSourceFile.cpp
+++ b/src/SourceCompile/CompileSourceFile.cpp
@@ -26,6 +26,7 @@
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/Package/Precompiled.h"
 #include "Surelog/SourceCompile/AnalyzeFile.h"

--- a/src/SourceCompile/CompileSourceFile.cpp
+++ b/src/SourceCompile/CompileSourceFile.cpp
@@ -36,6 +36,7 @@
 #ifdef SURELOG_WITH_PYTHON
 #include <Python.h>
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 

--- a/src/SourceCompile/Compiler.cpp
+++ b/src/SourceCompile/Compiler.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/SourceCompile/Compiler.h"
 
 #include <climits>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>

--- a/src/SourceCompile/MacroInfo.cpp
+++ b/src/SourceCompile/MacroInfo.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/SourceCompile/MacroInfo.h"
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/SourceCompile/ParseFile.cpp
+++ b/src/SourceCompile/ParseFile.cpp
@@ -27,6 +27,7 @@
 #include <parser/SV3_1aLexer.h>
 #include <parser/SV3_1aParser.h>
 
+#include <cstdint>
 #include <iostream>
 #include <string_view>
 

--- a/src/SourceCompile/ParseFile.cpp
+++ b/src/SourceCompile/ParseFile.cpp
@@ -36,6 +36,7 @@
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Package/Precompiled.h"
 #include "Surelog/SourceCompile/AntlrParserErrorListener.h"
 #include "Surelog/SourceCompile/AntlrParserHandler.h"

--- a/src/SourceCompile/ParseFile_test.cpp
+++ b/src/SourceCompile/ParseFile_test.cpp
@@ -19,6 +19,7 @@
 #include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/SourceCompile/ParserHarness.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 namespace SURELOG {
 

--- a/src/SourceCompile/ParseFile_test.cpp
+++ b/src/SourceCompile/ParseFile_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/SourceCompile/ParserHarness.h"
 

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -27,6 +27,7 @@
 #include <parser/SV3_1aPpLexer.h>
 #include <parser/SV3_1aPpParser.h>
 
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <regex>

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -41,6 +41,7 @@
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/ErrorReporting/Waiver.h"
 #include "Surelog/Package/Precompiled.h"
 #include "Surelog/SourceCompile/CompilationUnit.h"

--- a/src/SourceCompile/PreprocessFile_test.cpp
+++ b/src/SourceCompile/PreprocessFile_test.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/SourceCompile/PreprocessHarness.h"
 
 namespace SURELOG {

--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
@@ -29,6 +29,7 @@
 
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/SourceCompile/CompileSourceFile.h"
 #include "Surelog/SourceCompile/MacroInfo.h"
 #include "Surelog/SourceCompile/SymbolTable.h"

--- a/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeListenerHelper.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/SourceCompile/SV3_1aPpTreeListenerHelper.h"
 
+#include <cstdint>
 #include <string_view>
 #include <vector>
 

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -28,6 +28,7 @@
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/Design.h"
 #include "Surelog/Design/FileContent.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/SourceCompile/CompilationUnit.h"
 #include "Surelog/SourceCompile/CompileSourceFile.h"
 #include "Surelog/SourceCompile/Compiler.h"

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -34,6 +34,7 @@
 #include "Surelog/SourceCompile/MacroInfo.h"
 #include "Surelog/SourceCompile/PreprocessFile.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Utils/ParseUtils.h"
 #include "Surelog/Utils/StringUtils.h"
 

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -16,6 +16,7 @@
 
 #include "Surelog/SourceCompile/SV3_1aPpTreeShapeListener.h"
 
+#include <cstdint>
 #include <iostream>
 #include <regex>
 #include <set>

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "Surelog/CommandLine/CommandLineParser.h"
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
 #include "Surelog/Library/Library.h"

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
@@ -33,6 +33,7 @@
 #include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/Library/Library.h"
 #include "Surelog/SourceCompile/CompilationUnit.h"
 #include "Surelog/SourceCompile/CompileSourceFile.h"

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
@@ -38,6 +38,7 @@
 #include "Surelog/SourceCompile/CompileSourceFile.h"
 #include "Surelog/SourceCompile/ParseFile.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Utils/ParseUtils.h"
 #include "Surelog/Utils/StringUtils.h"
 

--- a/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeHelper.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/SourceCompile/SV3_1aTreeShapeHelper.h"
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -33,6 +33,7 @@
 #include "Surelog/Common/FileSystem.h"
 #include "Surelog/Design/Design.h"
 #include "Surelog/Design/FileContent.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/SourceCompile/CompilationUnit.h"
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/ParseFile.h"

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/SourceCompile/SV3_1aTreeShapeListener.h"
 
+#include <cstdint>
 #include <regex>
 #include <string>
 #include <string_view>

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -37,6 +37,7 @@
 #include "Surelog/SourceCompile/Compiler.h"
 #include "Surelog/SourceCompile/ParseFile.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Utils/ParseUtils.h"
 #include "Surelog/Utils/StringUtils.h"
 

--- a/src/SourceCompile/SymbolTable_test.cpp
+++ b/src/SourceCompile/SymbolTable_test.cpp
@@ -19,6 +19,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/Testbench/ClassDefinition.cpp
+++ b/src/Testbench/ClassDefinition.cpp
@@ -22,6 +22,7 @@
  */
 #include "Surelog/Testbench/ClassDefinition.h"
 
+#include <cstdint>
 #include <string_view>
 
 #include "Surelog/Design/FileContent.h"

--- a/src/Testbench/ClassDefinition.cpp
+++ b/src/Testbench/ClassDefinition.cpp
@@ -28,6 +28,7 @@
 #include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Design/Parameter.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 #include "Surelog/Testbench/Constraint.h"
 #include "Surelog/Testbench/CoverGroupDefinition.h"
 #include "Surelog/Testbench/Property.h"

--- a/src/Testbench/ClassDefinition.cpp
+++ b/src/Testbench/ClassDefinition.cpp
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <string_view>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 #include "Surelog/Design/Parameter.h"
 #include "Surelog/Testbench/Constraint.h"

--- a/src/Testbench/Program.cpp
+++ b/src/Testbench/Program.cpp
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <string_view>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/DesignComponent.h"
 #include "Surelog/Design/FileContent.h"
 

--- a/src/Testbench/Program.cpp
+++ b/src/Testbench/Program.cpp
@@ -29,6 +29,7 @@
 #include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/DesignComponent.h"
 #include "Surelog/Design/FileContent.h"
+#include "Surelog/SourceCompile/VObjectTypes.h"
 
 namespace SURELOG {
 

--- a/src/Testbench/Program.cpp
+++ b/src/Testbench/Program.cpp
@@ -23,6 +23,7 @@
 
 #include "Surelog/Testbench/Program.h"
 
+#include <cstdint>
 #include <string_view>
 
 #include "Surelog/Design/DesignComponent.h"

--- a/src/Testbench/TypeDef.cpp
+++ b/src/Testbench/TypeDef.cpp
@@ -25,6 +25,7 @@
 
 #include <string_view>
 
+#include "Surelog/Common/NodeId.h"
 #include "Surelog/Design/FileContent.h"
 
 namespace SURELOG {

--- a/src/Utils/NumUtils.cpp
+++ b/src/Utils/NumUtils.cpp
@@ -24,6 +24,7 @@
 #include "Surelog/Utils/NumUtils.h"
 
 #include <bitset>
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <string_view>

--- a/src/Utils/NumUtils_test.cpp
+++ b/src/Utils/NumUtils_test.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
+
 namespace SURELOG {
 TEST(NumUtilsTest, ParseDecimalInt) {
   int64_t value;

--- a/src/Utils/ParseUtils.cpp
+++ b/src/Utils/ParseUtils.cpp
@@ -25,6 +25,7 @@
 
 #include <antlr4-runtime.h>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/hellodesign.cpp
+++ b/src/hellodesign.cpp
@@ -25,6 +25,7 @@
 // cd tests/UnitElabBlock
 // hellodesign top.v -parse -mutestdout
 
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <string_view>

--- a/src/hellosureworld.cpp
+++ b/src/hellosureworld.cpp
@@ -24,6 +24,7 @@
 // Example of usage:
 // cd tests/UnitElabBlock
 // hellouhdm top.v -parse -mutestdout
+#include <cstdint>
 #include <functional>
 #include <iostream>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,7 @@
 #include "Surelog/CommandLine/CommandLineParser.h"
 #include "Surelog/Common/PlatformFileSystem.h"
 #include "Surelog/ErrorReporting/ErrorContainer.h"
+#include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/ErrorReporting/Report.h"
 #include "Surelog/ErrorReporting/Waiver.h"
 #include "Surelog/SourceCompile/SymbolTable.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include <direct.h>
 #include <process.h>
 
+#include <cstdint>
 #include <string_view>
 #include <utility>
 #else

--- a/src/roundtrip.cpp
+++ b/src/roundtrip.cpp
@@ -30,6 +30,7 @@
 #include <uhdm/uhdm.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <map>


### PR DESCRIPTION
Essentially using the clang-tidy output `Surelog_clang-tidy.out` and running the `insert-header` script from [`hzeller/dev-tools`](https://github.com/hzeller/dev-tools)

```
../dev-tools/insert-header.cc '<cstdint>' $(grep "no header providing.*misc-include-cleaner" Surelog_clang-tidy.out | awk -F: '/^(include|src)\/.*"u?int.._t"/ { print $1}' | sort -u)
.github/bin/run-clang-format.sh
```