### PR TITLE
fix: don't try to attribute names to ordered ports

### DIFF
--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -731,10 +731,6 @@ ModuleInstance* NetlistElaboration::getInterfaceInstance_(
         NodeId Expression = fC->Sibling(formalId);
         if (orderedConnection) {
           Expression = formalId;
-          NodeId Primary = fC->Child(Expression);
-          NodeId Primary_literal = fC->Child(Primary);
-          NodeId formalNameId = fC->Child(Primary_literal);
-          formalName = fC->SymName(formalNameId);
         } else {
           NodeId tmp = Expression;
           if (fC->Type(tmp) == VObjectType::paOPEN_PARENS) {

--- a/tests/OrderedPortUnkownModule/OrderedPortUnkownModule.log
+++ b/tests/OrderedPortUnkownModule/OrderedPortUnkownModule.log
@@ -1,0 +1,369 @@
+[INF:CM0023] Creating log file "${SURELOG_DIR}/build/regression/OrderedPortUnkownModule/slpp_all/surelog.log".
+AST_DEBUG_BEGIN
+LIB:  work
+FILE: ${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv
+n<> u<0> t<_INVALID_> f<0> l<0:0>
+n<> u<1> t<Null_rule> p<58> s<57> l<1:1> el<1:0>
+n<module> u<2> t<Module_keyword> p<6> s<3> l<1:1> el<1:7>
+n<dut> u<3> t<StringConst> p<6> s<5> l<1:8> el<1:11>
+n<> u<4> t<Port> p<5> l<1:12> el<1:12>
+n<> u<5> t<List_of_ports> p<6> c<4> l<1:11> el<1:13>
+n<> u<6> t<Module_nonansi_header> p<55> c<2> s<27> l<1:1> el<1:14>
+n<unkown_module> u<7> t<StringConst> p<24> s<23> l<2:3> el<2:16>
+n<u0> u<8> t<StringConst> p<9> l<2:17> el<2:19>
+n<> u<9> t<Name_of_instance> p<23> c<8> s<14> l<2:17> el<2:19>
+n<a> u<10> t<StringConst> p<11> l<2:21> el<2:22>
+n<> u<11> t<Ps_or_hierarchical_identifier> p<14> c<10> s<13> l<2:21> el<2:22>
+n<> u<12> t<Constant_bit_select> p<13> l<2:22> el<2:22>
+n<> u<13> t<Constant_select> p<14> c<12> l<2:22> el<2:22>
+n<> u<14> t<Net_lvalue> p<23> c<11> s<18> l<2:21> el<2:22>
+n<b> u<15> t<StringConst> p<16> l<2:24> el<2:25>
+n<> u<16> t<Primary_literal> p<17> c<15> l<2:24> el<2:25>
+n<> u<17> t<Primary> p<18> c<16> l<2:24> el<2:25>
+n<> u<18> t<Expression> p<23> c<17> s<22> l<2:24> el<2:25>
+n<c> u<19> t<StringConst> p<20> l<2:27> el<2:28>
+n<> u<20> t<Primary_literal> p<21> c<19> l<2:27> el<2:28>
+n<> u<21> t<Primary> p<22> c<20> l<2:27> el<2:28>
+n<> u<22> t<Expression> p<23> c<21> l<2:27> el<2:28>
+n<> u<23> t<Udp_instance> p<24> c<9> l<2:17> el<2:29>
+n<> u<24> t<Udp_instantiation> p<25> c<7> l<2:3> el<2:30>
+n<> u<25> t<Module_or_generate_item> p<26> c<24> l<2:3> el<2:30>
+n<> u<26> t<Non_port_module_item> p<27> c<25> l<2:3> el<2:30>
+n<> u<27> t<Module_item> p<55> c<26> s<53> l<2:3> el<2:30>
+n<unkown_module> u<28> t<StringConst> p<50> s<49> l<3:3> el<3:16>
+n<u1> u<29> t<StringConst> p<30> l<3:17> el<3:19>
+n<> u<30> t<Name_of_instance> p<49> c<29> s<48> l<3:17> el<3:19>
+n<a> u<31> t<StringConst> p<32> l<3:22> el<3:23>
+n<> u<32> t<Primary_literal> p<33> c<31> l<3:22> el<3:23>
+n<> u<33> t<Primary> p<34> c<32> l<3:22> el<3:23>
+n<> u<34> t<Expression> p<36> c<33> l<3:22> el<3:23>
+n<> u<35> t<Unary_Tilda> p<36> s<34> l<3:21> el<3:22>
+n<> u<36> t<Expression> p<37> c<35> l<3:21> el<3:23>
+n<> u<37> t<Ordered_port_connection> p<48> c<36> s<42> l<3:21> el<3:23>
+n<b> u<38> t<StringConst> p<39> l<3:25> el<3:26>
+n<> u<39> t<Primary_literal> p<40> c<38> l<3:25> el<3:26>
+n<> u<40> t<Primary> p<41> c<39> l<3:25> el<3:26>
+n<> u<41> t<Expression> p<42> c<40> l<3:25> el<3:26>
+n<> u<42> t<Ordered_port_connection> p<48> c<41> s<47> l<3:25> el<3:26>
+n<c> u<43> t<StringConst> p<44> l<3:28> el<3:29>
+n<> u<44> t<Primary_literal> p<45> c<43> l<3:28> el<3:29>
+n<> u<45> t<Primary> p<46> c<44> l<3:28> el<3:29>
+n<> u<46> t<Expression> p<47> c<45> l<3:28> el<3:29>
+n<> u<47> t<Ordered_port_connection> p<48> c<46> l<3:28> el<3:29>
+n<> u<48> t<List_of_port_connections> p<49> c<37> l<3:21> el<3:29>
+n<> u<49> t<Hierarchical_instance> p<50> c<30> l<3:17> el<3:30>
+n<> u<50> t<Module_instantiation> p<51> c<28> l<3:3> el<3:31>
+n<> u<51> t<Module_or_generate_item> p<52> c<50> l<3:3> el<3:31>
+n<> u<52> t<Non_port_module_item> p<53> c<51> l<3:3> el<3:31>
+n<> u<53> t<Module_item> p<55> c<52> s<54> l<3:3> el<3:31>
+n<> u<54> t<ENDMODULE> p<55> l<4:1> el<4:10>
+n<> u<55> t<Module_declaration> p<56> c<6> l<1:1> el<4:10>
+n<> u<56> t<Description> p<57> c<55> l<1:1> el<4:10>
+n<> u<57> t<Source_text> p<58> c<56> l<1:1> el<4:10>
+n<> u<58> t<Top_level_rule> c<1> l<1:1> el<5:1>
+AST_DEBUG_END
+[WRN:PA0205] ${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv:1:1: No timescale set for "dut".
+[INF:CP0300] Compilation...
+[INF:CP0303] ${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv:1:1: Compile module "work@dut".
+[INF:EL0526] Design Elaboration...
+[NTE:EL0503] ${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv:1:1: Top level module "work@dut".
+[WRN:EL0500] ${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv:2:3: Cannot find a module definition for "work@dut::unkown_module".
+[WRN:EL0500] ${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv:3:3: Cannot find a module definition for "work@dut::unkown_module".
+[NTE:EL0508] Nb Top level modules: 1.
+[NTE:EL0509] Max instance depth: 2.
+[NTE:EL0510] Nb instances: 3.
+[NTE:EL0511] Nb leaf instances: 2.
+[WRN:EL0512] Nb undefined modules: 1.
+[WRN:EL0513] Nb undefined instances: 2.
+[INF:UH0706] Creating UHDM Model...
+=== UHDM Object Stats Begin (Non-Elaborated Model) ===
+design                                                 1
+logic_net                                              6
+module_inst                                            5
+operation                                              2
+port                                                   9
+prim_term                                              3
+ref_module                                             1
+ref_obj                                               12
+udp                                                    1
+=== UHDM Object Stats End ===
+[INF:UH0707] Elaborating UHDM...
+=== UHDM Object Stats Begin (Elaborated Model) ===
+design                                                 1
+logic_net                                              6
+module_inst                                            5
+operation                                              2
+port                                                   9
+prim_term                                              3
+ref_module                                             1
+ref_obj                                               12
+udp                                                    1
+=== UHDM Object Stats End ===
+[INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/OrderedPortUnkownModule/slpp_all/surelog.uhdm ...
+[INF:UH0709] Writing UHDM Html Coverage: ${SURELOG_DIR}/build/regression/OrderedPortUnkownModule/slpp_all/checker/surelog.chk.html ...
+[INF:UH0710] Loading UHDM DB: ${SURELOG_DIR}/build/regression/OrderedPortUnkownModule/slpp_all/surelog.uhdm ...
+[INF:UH0711] Decompiling UHDM...
+====== UHDM =======
+design: (work@dut)
+|vpiElaborated:1
+|vpiName:work@dut
+|uhdmallModules:
+\_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+  |vpiParent:
+  \_design: (work@dut)
+  |vpiFullName:work@dut
+  |vpiDefName:work@dut
+  |vpiNet:
+  \_logic_net: (work@dut.a), line:2:21, endln:2:22
+    |vpiParent:
+    \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+    |vpiName:a
+    |vpiFullName:work@dut.a
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (work@dut.b), line:2:24, endln:2:25
+    |vpiParent:
+    \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+    |vpiName:b
+    |vpiFullName:work@dut.b
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (work@dut.c), line:2:27, endln:2:28
+    |vpiParent:
+    \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+    |vpiName:c
+    |vpiFullName:work@dut.c
+    |vpiNetType:1
+  |vpiPrimitive:
+  \_udp: unkown_module (work@dut.u0), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:2:3, endln:2:30
+    |vpiParent:
+    \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+    |vpiDefName:unkown_module
+    |vpiName:u0
+    |vpiFullName:work@dut.u0
+    |vpiPrimTerm:
+    \_prim_term: , line:2:21, endln:2:22
+      |vpiParent:
+      \_udp: unkown_module (work@dut.u0), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:2:3, endln:2:30
+      |vpiDirection:2
+      |vpiExpr:
+      \_ref_obj: (work@dut.u0.a), line:2:21, endln:2:22
+        |vpiParent:
+        \_udp: unkown_module (work@dut.u0), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:2:3, endln:2:30
+        |vpiName:a
+        |vpiFullName:work@dut.u0.a
+        |vpiActual:
+        \_logic_net: (work@dut.a), line:2:21, endln:2:22
+    |vpiPrimTerm:
+    \_prim_term: , line:2:24, endln:2:25
+      |vpiParent:
+      \_udp: unkown_module (work@dut.u0), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:2:3, endln:2:30
+      |vpiDirection:1
+      |vpiTermIndex:1
+      |vpiExpr:
+      \_ref_obj: (work@dut.u0.b), line:2:24, endln:2:25
+        |vpiParent:
+        \_udp: unkown_module (work@dut.u0), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:2:3, endln:2:30
+        |vpiName:b
+        |vpiFullName:work@dut.u0.b
+        |vpiActual:
+        \_logic_net: (work@dut.b), line:2:24, endln:2:25
+    |vpiPrimTerm:
+    \_prim_term: , line:2:27, endln:2:28
+      |vpiParent:
+      \_udp: unkown_module (work@dut.u0), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:2:3, endln:2:30
+      |vpiDirection:1
+      |vpiTermIndex:2
+      |vpiExpr:
+      \_ref_obj: (work@dut.u0.c), line:2:27, endln:2:28
+        |vpiParent:
+        \_udp: unkown_module (work@dut.u0), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:2:3, endln:2:30
+        |vpiName:c
+        |vpiFullName:work@dut.u0.c
+        |vpiActual:
+        \_logic_net: (work@dut.c), line:2:27, endln:2:28
+  |vpiRefModule:
+  \_ref_module: work@unkown_module (u1), line:3:17, endln:3:19
+    |vpiParent:
+    \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+    |vpiName:u1
+    |vpiDefName:work@unkown_module
+    |vpiPort:
+    \_port: , line:3:21, endln:3:23
+      |vpiParent:
+      \_ref_module: work@unkown_module (u1), line:3:17, endln:3:19
+      |vpiHighConn:
+      \_operation: , line:3:21, endln:3:23
+        |vpiParent:
+        \_port: , line:3:21, endln:3:23
+        |vpiOpType:4
+        |vpiOperand:
+        \_ref_obj: (work@dut.u1.a), line:3:22, endln:3:23
+          |vpiParent:
+          \_operation: , line:3:21, endln:3:23
+          |vpiName:a
+          |vpiFullName:work@dut.u1.a
+          |vpiActual:
+          \_logic_net: (work@dut.a), line:2:21, endln:2:22
+    |vpiPort:
+    \_port: , line:3:25, endln:3:26
+      |vpiParent:
+      \_ref_module: work@unkown_module (u1), line:3:17, endln:3:19
+      |vpiHighConn:
+      \_ref_obj: (work@dut.u1.b), line:3:25, endln:3:26
+        |vpiParent:
+        \_port: , line:3:25, endln:3:26
+        |vpiName:b
+        |vpiFullName:work@dut.u1.b
+        |vpiActual:
+        \_logic_net: (work@dut.b), line:2:24, endln:2:25
+    |vpiPort:
+    \_port: , line:3:28, endln:3:29
+      |vpiParent:
+      \_ref_module: work@unkown_module (u1), line:3:17, endln:3:19
+      |vpiHighConn:
+      \_ref_obj: (work@dut.u1.c), line:3:28, endln:3:29
+        |vpiParent:
+        \_port: , line:3:28, endln:3:29
+        |vpiName:c
+        |vpiFullName:work@dut.u1.c
+        |vpiActual:
+        \_logic_net: (work@dut.c), line:2:27, endln:2:28
+|uhdmtopModules:
+\_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+  |vpiName:work@dut
+  |vpiDefName:work@dut
+  |vpiTop:1
+  |vpiNet:
+  \_logic_net: (work@dut.a), line:2:21, endln:2:22
+    |vpiParent:
+    \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+    |vpiName:a
+    |vpiFullName:work@dut.a
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (work@dut.b), line:2:24, endln:2:25
+    |vpiParent:
+    \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+    |vpiName:b
+    |vpiFullName:work@dut.b
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (work@dut.c), line:2:27, endln:2:28
+    |vpiParent:
+    \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+    |vpiName:c
+    |vpiFullName:work@dut.c
+    |vpiNetType:1
+  |vpiTopModule:1
+  |vpiModule:
+  \_module_inst: work@dut::unkown_module (work@dut.u0), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:2:3, endln:2:30
+    |vpiParent:
+    \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+    |vpiName:u0
+    |vpiFullName:work@dut.u0
+    |vpiDefName:work@dut::unkown_module
+    |vpiInstance:
+    \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+    |vpiPort:
+    \_port: , line:2:21, endln:2:22
+      |vpiParent:
+      \_module_inst: work@dut::unkown_module (work@dut.u0), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:2:3, endln:2:30
+      |vpiHighConn:
+      \_ref_obj: (work@dut.a), line:2:21, endln:2:22
+        |vpiParent:
+        \_port: , line:2:21, endln:2:22
+        |vpiName:a
+        |vpiFullName:work@dut.a
+        |vpiActual:
+        \_logic_net: (work@dut.a), line:2:21, endln:2:22
+    |vpiPort:
+    \_port: , line:2:24, endln:2:25
+      |vpiParent:
+      \_module_inst: work@dut::unkown_module (work@dut.u0), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:2:3, endln:2:30
+      |vpiHighConn:
+      \_ref_obj: (work@dut.b), line:2:24, endln:2:25
+        |vpiParent:
+        \_port: , line:2:24, endln:2:25
+        |vpiName:b
+        |vpiFullName:work@dut.b
+        |vpiActual:
+        \_logic_net: (work@dut.b), line:2:24, endln:2:25
+    |vpiPort:
+    \_port: , line:2:27, endln:2:28
+      |vpiParent:
+      \_module_inst: work@dut::unkown_module (work@dut.u0), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:2:3, endln:2:30
+      |vpiHighConn:
+      \_ref_obj: (work@dut.c), line:2:27, endln:2:28
+        |vpiParent:
+        \_port: , line:2:27, endln:2:28
+        |vpiName:c
+        |vpiFullName:work@dut.c
+        |vpiActual:
+        \_logic_net: (work@dut.c), line:2:27, endln:2:28
+  |vpiModule:
+  \_module_inst: work@dut::unkown_module (work@dut.u1), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:3:3, endln:3:31
+    |vpiParent:
+    \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+    |vpiName:u1
+    |vpiFullName:work@dut.u1
+    |vpiDefName:work@dut::unkown_module
+    |vpiInstance:
+    \_module_inst: work@dut (work@dut), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:1:1, endln:4:10
+    |vpiPort:
+    \_port: , line:3:21, endln:3:23
+      |vpiParent:
+      \_module_inst: work@dut::unkown_module (work@dut.u1), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:3:3, endln:3:31
+      |vpiHighConn:
+      \_operation: , line:3:21, endln:3:23
+        |vpiParent:
+        \_port: , line:3:21, endln:3:23
+        |vpiOpType:4
+        |vpiOperand:
+        \_ref_obj: (work@dut.u1.a), line:3:22, endln:3:23
+          |vpiParent:
+          \_operation: , line:3:21, endln:3:23
+          |vpiName:a
+          |vpiFullName:work@dut.u1.a
+          |vpiActual:
+          \_logic_net: (work@dut.a), line:2:21, endln:2:22
+    |vpiPort:
+    \_port: (b), line:3:25, endln:3:26
+      |vpiParent:
+      \_module_inst: work@dut::unkown_module (work@dut.u1), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:3:3, endln:3:31
+      |vpiName:b
+      |vpiHighConn:
+      \_ref_obj: (work@dut.b), line:3:25, endln:3:26
+        |vpiParent:
+        \_port: (b), line:3:25, endln:3:26
+        |vpiName:b
+        |vpiFullName:work@dut.b
+        |vpiActual:
+        \_logic_net: (work@dut.b), line:2:24, endln:2:25
+    |vpiPort:
+    \_port: (c), line:3:28, endln:3:29
+      |vpiParent:
+      \_module_inst: work@dut::unkown_module (work@dut.u1), file:${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv, line:3:3, endln:3:31
+      |vpiName:c
+      |vpiHighConn:
+      \_ref_obj: (work@dut.c), line:3:28, endln:3:29
+        |vpiParent:
+        \_port: (c), line:3:28, endln:3:29
+        |vpiName:c
+        |vpiFullName:work@dut.c
+        |vpiActual:
+        \_logic_net: (work@dut.c), line:2:27, endln:2:28
+===================
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
+[WARNING] : 5
+[   NOTE] : 5
+
+============================== Begin Linting Results ==============================
+[LINT]: ${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv:2:3: Non synthesizable construct, u0
+============================== End Linting Results ==============================
+
+============================== Begin RoundTrip Results ==============================
+[roundtrip]: ${SURELOG_DIR}/tests/OrderedPortUnkownModule/dut.sv | ${SURELOG_DIR}/build/regression/OrderedPortUnkownModule/roundtrip/dut_000.sv | 2 | 4 |
+============================== End RoundTrip Results ==============================

--- a/tests/OrderedPortUnkownModule/OrderedPortUnkownModule.sl
+++ b/tests/OrderedPortUnkownModule/OrderedPortUnkownModule.sl
@@ -1,0 +1,1 @@
+-parse -d uhdm -d coveruhdm -elabuhdm -d ast dut.sv -nobuiltin

--- a/tests/OrderedPortUnkownModule/dut.sv
+++ b/tests/OrderedPortUnkownModule/dut.sv
@@ -1,0 +1,4 @@
+module dut();
+  unkown_module u0 (a, b, c);
+  unkown_module u1 (~a, b, c);
+endmodule


### PR DESCRIPTION
The code was attributing name to ordered ports based on the Primary literal passed to the port of the module instantiation (if any), which is not the name of the port. I believe the port name is later corrected when the module is resolve to its declaration. But if the module is not resolve (is a unknown module) the generated UHDM would have the wrong name for the ports. It is better to keep the port unnamed.

Fix https://github.com/chipsalliance/synlig/issues/2767.