### PR TITLE
Fix handling of line comments in multi-line macros

### DIFF
--- a/grammar/SV3_1aPpLexer.g4
+++ b/grammar/SV3_1aPpLexer.g4
@@ -19,7 +19,7 @@ lexer grammar SV3_1aPpLexer;
 ESCAPED_IDENTIFIER: '\\' ~[WS\r\t\n]*? WS |
                     '\\' ( OPEN_BRACKET? [A-Za-z0-9_$+-.]+ CLOSE_BRACKET?)* WS;
 
-
+ESCAPED_LINE_COMMENT: '//' ~[\\\r\n]* ESCAPED_CR;
 
 // A.9.2 Comments
 

--- a/grammar/SV3_1aPpParser.g4
+++ b/grammar/SV3_1aPpParser.g4
@@ -113,7 +113,7 @@ unterminated_string: DOUBLE_QUOTE string_blob* CR;
 
 macro_actual_args: macro_arg* (COMMA macro_arg*)*;
 
-comment: One_line_comment | Block_comment;
+comment: One_line_comment | ESCAPED_LINE_COMMENT | Block_comment;
 
 integral_number: INTEGRAL_NUMBER;
 
@@ -473,11 +473,19 @@ macro_arguments
   ;
 
 escaped_macro_definition_body
-  : escaped_macro_definition_body_alt1
-  | escaped_macro_definition_body_alt2
+  : escaped_macro_definition_body_inner ESCAPED_CR Spaces* (
+    One_line_comment
+    | CR
+    | EOF
+  )
+  | escaped_macro_definition_body_inner (
+    One_line_comment
+    | CR Spaces*
+    | EOF
+  )
   ;
 
-escaped_macro_definition_body_alt1
+escaped_macro_definition_body_inner
   : (
     unterminated_string
     | Macro_identifier
@@ -499,7 +507,8 @@ escaped_macro_definition_body_alt1
     | Spaces
     | Fixed_point_number
     | STRING
-    | comment
+    | ESCAPED_LINE_COMMENT
+    | Block_comment
     | TICK_QUOTE
     | TICK_BACKSLASH_TICK_QUOTE
     | TICK_TICK
@@ -508,41 +517,7 @@ escaped_macro_definition_body_alt1
     | CLOSE_CURLY
     | OPEN_BRACKET
     | CLOSE_BRACKET
-  )*? ESCAPED_CR Spaces* (CR | EOF)
-  ;
-
-escaped_macro_definition_body_alt2
-  : (
-    unterminated_string
-    | Macro_identifier
-    | Macro_Escaped_identifier
-    | escaped_identifier
-    | Simple_identifier
-    | integral_number
-    | TEXT_CR
-    | pound_delay
-    | pound_pound_delay
-    | ESCAPED_CR
-    | OPEN_PARENS
-    | CLOSE_PARENS
-    | COMMA
-    | ASSIGN_OP
-    | DOUBLE_QUOTE
-    | TICK_VARIABLE
-    | directive_in_macro
-    | Spaces
-    | Fixed_point_number
-    | STRING
-    | comment
-    | TICK_QUOTE
-    | TICK_BACKSLASH_TICK_QUOTE
-    | TICK_TICK
-    | Special
-    | OPEN_CURLY
-    | CLOSE_CURLY
-    | OPEN_BRACKET
-    | CLOSE_BRACKET
-  )*? (CR Spaces* | EOF)
+  )*?
   ;
 
 simple_macro_definition_body

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -94,6 +94,8 @@ void SV3_1aPpTreeShapeListener::enterComment(
         m_pp->append(ctx->Block_comment()->getText());
       } else if (ctx->One_line_comment()) {
         m_pp->append(ctx->One_line_comment()->getText());
+      } else if (ctx->ESCAPED_LINE_COMMENT()) {
+        m_pp->append(ctx->ESCAPED_LINE_COMMENT()->getText());
       }
     }
   }
@@ -172,6 +174,9 @@ void SV3_1aPpTreeShapeListener::exitComment(
                    VObjectType::ppComment);
       } else if (ctx->One_line_comment()) {
         addVObject(ctx, ctx->One_line_comment()->getText(),
+                   VObjectType::ppComment);
+      } else if (ctx->ESCAPED_LINE_COMMENT()) {
+        addVObject(ctx, ctx->ESCAPED_LINE_COMMENT()->getText(),
                    VObjectType::ppComment);
       }
     } else {


### PR DESCRIPTION
## Fix handling of line comments in multi-line macros

Grammar for multiline macros was over aggressive causing out of order enter/leave calls for the listener. The problem stemmed from the ambiguity between escaped carriage return and line comment both expecting a new line at end (except one was escaped and other wasn't). Lexer, however, didn't have the knowledge of this difference and so the tokens generated caused the parser to over consume for the multi-line macro.

To resolve, introducing a new token to represent a escaped line comment and use it in place of regular line comment within multi-line macros. The only difference between the two is the former being terminated by an escaped newline rather than merely a newline.

Resolve Issue #4047 