### PR TITLE
grammar: accept hierarchical_identifier as bind target

### DIFF
--- a/grammar/SV3_1aParser.g4
+++ b/grammar/SV3_1aParser.g4
@@ -422,11 +422,19 @@ parameter_override
   ;
 
 bind_directive
-  : BIND identifier (
-    COLON? identifier constant_bit_select (
-      COMMA identifier constant_bit_select
-    )*
-  )? bind_instantiation
+  : BIND (
+      // bind <hierarchical_id> bind_instantiation
+      // (IEEE 1800-2017 23.11 form 2: bind_target_instance).
+      // Hierarchical paths like `$root.top.foo_i` or `top.foo_i`.
+      hierarchical_identifier
+    | // bind <module_id> [: <inst_list>] bind_instantiation
+      // (form 1: bind_target_scope [: bind_target_instance_list]).
+      identifier (
+        COLON identifier constant_bit_select (
+          COMMA identifier constant_bit_select
+        )*
+      )?
+  ) bind_instantiation
   ;
 
 bind_instantiation

--- a/tests/BindHierPath/BindHierPath.log
+++ b/tests/BindHierPath/BindHierPath.log
@@ -1,0 +1,745 @@
+[INF:CM0023] Creating log file "${SURELOG_DIR}/build/regression/BindHierPath/slpp_all/surelog.log".
+AST_DEBUG_BEGIN
+LIB:  work
+FILE: ${SURELOG_DIR}/tests/BindHierPath/dut.sv
+n<> u<0> t<_INVALID_> f<0> l<0:0>
+n<> u<1> t<Null_rule> p<153> s<152> l<10:1> el<9:2>
+n<module> u<2> t<Module_keyword> p<29> s<3> l<10:1> el<10:7>
+n<foo> u<3> t<StringConst> p<29> s<28> l<10:8> el<10:11>
+n<> u<4> t<PortDir_Inp> p<9> s<8> l<10:13> el<10:18>
+n<> u<5> t<IntVec_TypeLogic> p<6> l<10:19> el<10:24>
+n<> u<6> t<Data_type> p<7> c<5> l<10:19> el<10:24>
+n<> u<7> t<Data_type_or_implicit> p<8> c<6> l<10:19> el<10:24>
+n<> u<8> t<Net_port_type> p<9> c<7> l<10:19> el<10:24>
+n<> u<9> t<Net_port_header> p<11> c<4> s<10> l<10:13> el<10:24>
+n<a> u<10> t<StringConst> p<11> l<10:25> el<10:26>
+n<> u<11> t<Ansi_port_declaration> p<28> c<9> s<19> l<10:13> el<10:26>
+n<> u<12> t<PortDir_Inp> p<17> s<16> l<10:28> el<10:33>
+n<> u<13> t<IntVec_TypeLogic> p<14> l<10:34> el<10:39>
+n<> u<14> t<Data_type> p<15> c<13> l<10:34> el<10:39>
+n<> u<15> t<Data_type_or_implicit> p<16> c<14> l<10:34> el<10:39>
+n<> u<16> t<Net_port_type> p<17> c<15> l<10:34> el<10:39>
+n<> u<17> t<Net_port_header> p<19> c<12> s<18> l<10:28> el<10:39>
+n<b> u<18> t<StringConst> p<19> l<10:40> el<10:41>
+n<> u<19> t<Ansi_port_declaration> p<28> c<17> s<27> l<10:28> el<10:41>
+n<> u<20> t<PortDir_Out> p<25> s<24> l<10:43> el<10:49>
+n<> u<21> t<IntVec_TypeLogic> p<22> l<10:50> el<10:55>
+n<> u<22> t<Data_type> p<23> c<21> l<10:50> el<10:55>
+n<> u<23> t<Data_type_or_implicit> p<24> c<22> l<10:50> el<10:55>
+n<> u<24> t<Net_port_type> p<25> c<23> l<10:50> el<10:55>
+n<> u<25> t<Net_port_header> p<27> c<20> s<26> l<10:43> el<10:55>
+n<c> u<26> t<StringConst> p<27> l<10:56> el<10:57>
+n<> u<27> t<Ansi_port_declaration> p<28> c<25> l<10:43> el<10:57>
+n<> u<28> t<List_of_port_declarations> p<29> c<11> l<10:12> el<10:58>
+n<> u<29> t<Module_ansi_header> p<31> c<2> s<30> l<10:1> el<10:59>
+n<> u<30> t<ENDMODULE> p<31> l<11:1> el<11:10>
+n<> u<31> t<Module_declaration> p<32> c<29> l<10:1> el<11:10>
+n<> u<32> t<Description> p<152> c<31> s<78> l<10:1> el<11:10>
+n<module> u<33> t<Module_keyword> p<54> s<34> l<13:1> el<13:7>
+n<bar> u<34> t<StringConst> p<54> s<53> l<13:8> el<13:11>
+n<> u<35> t<PortDir_Inp> p<38> s<37> l<13:13> el<13:18>
+n<> u<36> t<Data_type_or_implicit> p<37> l<13:19> el<13:19>
+n<> u<37> t<Net_port_type> p<38> c<36> l<13:19> el<13:19>
+n<> u<38> t<Net_port_header> p<40> c<35> s<39> l<13:13> el<13:18>
+n<a> u<39> t<StringConst> p<40> l<13:19> el<13:20>
+n<> u<40> t<Ansi_port_declaration> p<53> c<38> s<46> l<13:13> el<13:20>
+n<> u<41> t<PortDir_Inp> p<44> s<43> l<13:22> el<13:27>
+n<> u<42> t<Data_type_or_implicit> p<43> l<13:28> el<13:28>
+n<> u<43> t<Net_port_type> p<44> c<42> l<13:28> el<13:28>
+n<> u<44> t<Net_port_header> p<46> c<41> s<45> l<13:22> el<13:27>
+n<b> u<45> t<StringConst> p<46> l<13:28> el<13:29>
+n<> u<46> t<Ansi_port_declaration> p<53> c<44> s<52> l<13:22> el<13:29>
+n<> u<47> t<PortDir_Out> p<50> s<49> l<13:31> el<13:37>
+n<> u<48> t<Data_type_or_implicit> p<49> l<13:38> el<13:38>
+n<> u<49> t<Net_port_type> p<50> c<48> l<13:38> el<13:38>
+n<> u<50> t<Net_port_header> p<52> c<47> s<51> l<13:31> el<13:37>
+n<c> u<51> t<StringConst> p<52> l<13:38> el<13:39>
+n<> u<52> t<Ansi_port_declaration> p<53> c<50> l<13:31> el<13:39>
+n<> u<53> t<List_of_port_declarations> p<54> c<40> l<13:12> el<13:40>
+n<> u<54> t<Module_ansi_header> p<77> c<33> s<75> l<13:1> el<13:41>
+n<c> u<55> t<StringConst> p<56> l<14:10> el<14:11>
+n<> u<56> t<Ps_or_hierarchical_identifier> p<59> c<55> s<58> l<14:10> el<14:11>
+n<> u<57> t<Constant_bit_select> p<58> l<14:12> el<14:12>
+n<> u<58> t<Constant_select> p<59> c<57> l<14:12> el<14:12>
+n<> u<59> t<Net_lvalue> p<70> c<56> s<69> l<14:10> el<14:11>
+n<a> u<60> t<StringConst> p<61> l<14:14> el<14:15>
+n<> u<61> t<Primary_literal> p<62> c<60> l<14:14> el<14:15>
+n<> u<62> t<Primary> p<63> c<61> l<14:14> el<14:15>
+n<> u<63> t<Expression> p<69> c<62> s<68> l<14:14> el<14:15>
+n<b> u<64> t<StringConst> p<65> l<14:18> el<14:19>
+n<> u<65> t<Primary_literal> p<66> c<64> l<14:18> el<14:19>
+n<> u<66> t<Primary> p<67> c<65> l<14:18> el<14:19>
+n<> u<67> t<Expression> p<69> c<66> l<14:18> el<14:19>
+n<> u<68> t<BinOp_BitwXor> p<69> s<67> l<14:16> el<14:17>
+n<> u<69> t<Expression> p<70> c<63> l<14:14> el<14:19>
+n<> u<70> t<Net_assignment> p<71> c<59> l<14:10> el<14:19>
+n<> u<71> t<List_of_net_assignments> p<72> c<70> l<14:10> el<14:19>
+n<> u<72> t<Continuous_assign> p<73> c<71> l<14:3> el<14:20>
+n<> u<73> t<Module_common_item> p<74> c<72> l<14:3> el<14:20>
+n<> u<74> t<Module_or_generate_item> p<75> c<73> l<14:3> el<14:20>
+n<> u<75> t<Non_port_module_item> p<77> c<74> s<76> l<14:3> el<14:20>
+n<> u<76> t<ENDMODULE> p<77> l<15:1> el<15:10>
+n<> u<77> t<Module_declaration> p<78> c<54> l<13:1> el<15:10>
+n<> u<78> t<Description> p<152> c<77> s<136> l<13:1> el<15:10>
+n<module> u<79> t<Module_keyword> p<83> s<80> l<17:1> el<17:7>
+n<top> u<80> t<StringConst> p<83> s<82> l<17:8> el<17:11>
+n<> u<81> t<Port> p<82> l<17:13> el<17:13>
+n<> u<82> t<List_of_ports> p<83> c<81> l<17:12> el<17:14>
+n<> u<83> t<Module_nonansi_header> p<135> c<79> s<100> l<17:1> el<17:15>
+n<> u<84> t<IntVec_TypeLogic> p<85> l<18:3> el<18:8>
+n<> u<85> t<Data_type> p<93> c<84> s<92> l<18:3> el<18:8>
+n<u> u<86> t<StringConst> p<87> l<18:9> el<18:10>
+n<> u<87> t<Variable_decl_assignment> p<92> c<86> s<89> l<18:9> el<18:10>
+n<v> u<88> t<StringConst> p<89> l<18:12> el<18:13>
+n<> u<89> t<Variable_decl_assignment> p<92> c<88> s<91> l<18:12> el<18:13>
+n<w> u<90> t<StringConst> p<91> l<18:15> el<18:16>
+n<> u<91> t<Variable_decl_assignment> p<92> c<90> l<18:15> el<18:16>
+n<> u<92> t<List_of_variable_decl_assignments> p<93> c<87> l<18:9> el<18:16>
+n<> u<93> t<Variable_declaration> p<94> c<85> l<18:3> el<18:17>
+n<> u<94> t<Data_declaration> p<95> c<93> l<18:3> el<18:17>
+n<> u<95> t<Package_or_generate_item_declaration> p<96> c<94> l<18:3> el<18:17>
+n<> u<96> t<Module_or_generate_item_declaration> p<97> c<95> l<18:3> el<18:17>
+n<> u<97> t<Module_common_item> p<98> c<96> l<18:3> el<18:17>
+n<> u<98> t<Module_or_generate_item> p<99> c<97> l<18:3> el<18:17>
+n<> u<99> t<Non_port_module_item> p<100> c<98> l<18:3> el<18:17>
+n<> u<100> t<Module_item> p<135> c<99> s<133> l<18:3> el<18:17>
+n<foo> u<101> t<StringConst> p<130> s<129> l<19:3> el<19:6>
+n<foo_i> u<102> t<StringConst> p<103> l<19:7> el<19:12>
+n<> u<103> t<Name_of_instance> p<129> c<102> s<128> l<19:7> el<19:12>
+n<a> u<104> t<StringConst> p<111> s<109> l<19:15> el<19:16>
+n<u> u<105> t<StringConst> p<106> l<19:18> el<19:19>
+n<> u<106> t<Primary_literal> p<107> c<105> l<19:18> el<19:19>
+n<> u<107> t<Primary> p<108> c<106> l<19:18> el<19:19>
+n<> u<108> t<Expression> p<111> c<107> s<110> l<19:18> el<19:19>
+n<> u<109> t<OPEN_PARENS> p<111> s<108> l<19:17> el<19:18>
+n<> u<110> t<CLOSE_PARENS> p<111> l<19:19> el<19:20>
+n<> u<111> t<Named_port_connection> p<128> c<104> s<119> l<19:14> el<19:20>
+n<b> u<112> t<StringConst> p<119> s<117> l<19:23> el<19:24>
+n<v> u<113> t<StringConst> p<114> l<19:26> el<19:27>
+n<> u<114> t<Primary_literal> p<115> c<113> l<19:26> el<19:27>
+n<> u<115> t<Primary> p<116> c<114> l<19:26> el<19:27>
+n<> u<116> t<Expression> p<119> c<115> s<118> l<19:26> el<19:27>
+n<> u<117> t<OPEN_PARENS> p<119> s<116> l<19:25> el<19:26>
+n<> u<118> t<CLOSE_PARENS> p<119> l<19:27> el<19:28>
+n<> u<119> t<Named_port_connection> p<128> c<112> s<127> l<19:22> el<19:28>
+n<c> u<120> t<StringConst> p<127> s<125> l<19:31> el<19:32>
+n<w> u<121> t<StringConst> p<122> l<19:34> el<19:35>
+n<> u<122> t<Primary_literal> p<123> c<121> l<19:34> el<19:35>
+n<> u<123> t<Primary> p<124> c<122> l<19:34> el<19:35>
+n<> u<124> t<Expression> p<127> c<123> s<126> l<19:34> el<19:35>
+n<> u<125> t<OPEN_PARENS> p<127> s<124> l<19:33> el<19:34>
+n<> u<126> t<CLOSE_PARENS> p<127> l<19:35> el<19:36>
+n<> u<127> t<Named_port_connection> p<128> c<120> l<19:30> el<19:36>
+n<> u<128> t<List_of_port_connections> p<129> c<111> l<19:14> el<19:36>
+n<> u<129> t<Hierarchical_instance> p<130> c<103> l<19:7> el<19:37>
+n<> u<130> t<Module_instantiation> p<131> c<101> l<19:3> el<19:38>
+n<> u<131> t<Module_or_generate_item> p<132> c<130> l<19:3> el<19:38>
+n<> u<132> t<Non_port_module_item> p<133> c<131> l<19:3> el<19:38>
+n<> u<133> t<Module_item> p<135> c<132> s<134> l<19:3> el<19:38>
+n<> u<134> t<ENDMODULE> p<135> l<20:1> el<20:10>
+n<> u<135> t<Module_declaration> p<136> c<83> l<17:1> el<20:10>
+n<> u<136> t<Description> p<152> c<135> s<151> l<17:1> el<20:10>
+n<> u<137> t<Dollar_root_keyword> p<140> s<138> l<23:6> el<23:12>
+n<top> u<138> t<StringConst> p<140> s<139> l<23:12> el<23:15>
+n<foo_i> u<139> t<StringConst> p<140> l<23:16> el<23:21>
+n<> u<140> t<Hierarchical_identifier> p<150> c<137> s<149> l<23:6> el<23:21>
+n<bar> u<141> t<StringConst> p<148> s<147> l<23:22> el<23:25>
+n<bound_i> u<142> t<StringConst> p<143> l<23:26> el<23:33>
+n<> u<143> t<Name_of_instance> p<147> c<142> s<146> l<23:26> el<23:33>
+n<> u<144> t<DOTSTAR> p<145> l<23:35> el<23:37>
+n<> u<145> t<Named_port_connection> p<146> c<144> l<23:35> el<23:37>
+n<> u<146> t<List_of_port_connections> p<147> c<145> l<23:35> el<23:37>
+n<> u<147> t<Hierarchical_instance> p<148> c<143> l<23:26> el<23:38>
+n<> u<148> t<Module_instantiation> p<149> c<141> l<23:22> el<23:39>
+n<> u<149> t<Bind_instantiation> p<150> c<148> l<23:22> el<23:39>
+n<> u<150> t<Bind_directive> p<151> c<140> l<23:1> el<23:39>
+n<> u<151> t<Description> p<152> c<150> l<23:1> el<23:39>
+n<> u<152> t<Source_text> p<153> c<32> l<10:1> el<23:39>
+n<> u<153> t<Top_level_rule> c<1> l<10:1> el<24:1>
+AST_DEBUG_END
+[WRN:PA0205] ${SURELOG_DIR}/tests/BindHierPath/dut.sv:10:1: No timescale set for "foo".
+[WRN:PA0205] ${SURELOG_DIR}/tests/BindHierPath/dut.sv:13:1: No timescale set for "bar".
+[WRN:PA0205] ${SURELOG_DIR}/tests/BindHierPath/dut.sv:17:1: No timescale set for "top".
+[INF:CP0300] Compilation...
+[INF:CP0303] ${SURELOG_DIR}/tests/BindHierPath/dut.sv:13:1: Compile module "work@bar".
+[INF:CP0303] ${SURELOG_DIR}/tests/BindHierPath/dut.sv:10:1: Compile module "work@foo".
+[INF:CP0303] ${SURELOG_DIR}/tests/BindHierPath/dut.sv:17:1: Compile module "work@top".
+[NTE:CP0309] ${SURELOG_DIR}/tests/BindHierPath/dut.sv:13:38: Implicit port type (wire) for "c".
+[INF:EL0526] Design Elaboration...
+[NTE:EL0503] ${SURELOG_DIR}/tests/BindHierPath/dut.sv:17:1: Top level module "work@top".
+[NTE:EL0508] Nb Top level modules: 1.
+[NTE:EL0509] Max instance depth: 2.
+[NTE:EL0510] Nb instances: 2.
+[NTE:EL0511] Nb leaf instances: 1.
+[INF:UH0706] Creating UHDM Model...
+=== UHDM Object Stats Begin (Non-Elaborated Model) ===
+cont_assign                                            1
+design                                                 1
+logic_net                                             12
+logic_typespec                                        16
+logic_var                                              3
+module_inst                                            6
+operation                                              1
+port                                                  12
+ref_module                                             1
+ref_obj                                               18
+ref_typespec                                          18
+=== UHDM Object Stats End ===
+[INF:UH0707] Elaborating UHDM...
+=== UHDM Object Stats Begin (Elaborated Model) ===
+cont_assign                                            1
+design                                                 1
+logic_net                                             12
+logic_typespec                                        16
+logic_var                                              3
+module_inst                                            6
+operation                                              1
+port                                                  15
+ref_module                                             1
+ref_obj                                               24
+ref_typespec                                          21
+=== UHDM Object Stats End ===
+[INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/BindHierPath/slpp_all/surelog.uhdm ...
+[INF:UH0709] Writing UHDM Html Coverage: ${SURELOG_DIR}/build/regression/BindHierPath/slpp_all/checker/surelog.chk.html ...
+[INF:UH0710] Loading UHDM DB: ${SURELOG_DIR}/build/regression/BindHierPath/slpp_all/surelog.uhdm ...
+[INF:UH0711] Decompiling UHDM...
+====== UHDM =======
+design: (work@top)
+|vpiElaborated:1
+|vpiName:work@top
+|uhdmallModules:
+\_module_inst: work@bar (work@bar), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:13:1, endln:15:10
+  |vpiParent:
+  \_design: (work@top)
+  |vpiFullName:work@bar
+  |vpiDefName:work@bar
+  |vpiNet:
+  \_logic_net: (work@bar.a), line:13:19, endln:13:20
+    |vpiParent:
+    \_module_inst: work@bar (work@bar), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:13:1, endln:15:10
+    |vpiName:a
+    |vpiFullName:work@bar.a
+  |vpiNet:
+  \_logic_net: (work@bar.b), line:13:28, endln:13:29
+    |vpiParent:
+    \_module_inst: work@bar (work@bar), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:13:1, endln:15:10
+    |vpiName:b
+    |vpiFullName:work@bar.b
+  |vpiNet:
+  \_logic_net: (work@bar.c), line:13:38, endln:13:39
+    |vpiParent:
+    \_module_inst: work@bar (work@bar), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:13:1, endln:15:10
+    |vpiName:c
+    |vpiFullName:work@bar.c
+  |vpiPort:
+  \_port: (a), line:13:19, endln:13:20
+    |vpiParent:
+    \_module_inst: work@bar (work@bar), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:13:1, endln:15:10
+    |vpiName:a
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@bar.a.a), line:13:19, endln:13:20
+      |vpiParent:
+      \_port: (a), line:13:19, endln:13:20
+      |vpiName:a
+      |vpiFullName:work@bar.a.a
+      |vpiActual:
+      \_logic_net: (work@bar.a), line:13:19, endln:13:20
+    |vpiTypedef:
+    \_ref_typespec: (work@bar.a)
+      |vpiParent:
+      \_port: (a), line:13:19, endln:13:20
+      |vpiFullName:work@bar.a
+      |vpiActual:
+      \_logic_typespec: , line:13:19, endln:13:19
+  |vpiPort:
+  \_port: (b), line:13:28, endln:13:29
+    |vpiParent:
+    \_module_inst: work@bar (work@bar), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:13:1, endln:15:10
+    |vpiName:b
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@bar.b.b), line:13:28, endln:13:29
+      |vpiParent:
+      \_port: (b), line:13:28, endln:13:29
+      |vpiName:b
+      |vpiFullName:work@bar.b.b
+      |vpiActual:
+      \_logic_net: (work@bar.b), line:13:28, endln:13:29
+    |vpiTypedef:
+    \_ref_typespec: (work@bar.b)
+      |vpiParent:
+      \_port: (b), line:13:28, endln:13:29
+      |vpiFullName:work@bar.b
+      |vpiActual:
+      \_logic_typespec: , line:13:28, endln:13:28
+  |vpiPort:
+  \_port: (c), line:13:38, endln:13:39
+    |vpiParent:
+    \_module_inst: work@bar (work@bar), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:13:1, endln:15:10
+    |vpiName:c
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@bar.c.c), line:13:38, endln:13:39
+      |vpiParent:
+      \_port: (c), line:13:38, endln:13:39
+      |vpiName:c
+      |vpiFullName:work@bar.c.c
+      |vpiActual:
+      \_logic_net: (work@bar.c), line:13:38, endln:13:39
+    |vpiTypedef:
+    \_ref_typespec: (work@bar.c)
+      |vpiParent:
+      \_port: (c), line:13:38, endln:13:39
+      |vpiFullName:work@bar.c
+      |vpiActual:
+      \_logic_typespec: , line:13:38, endln:13:38
+  |vpiContAssign:
+  \_cont_assign: , line:14:10, endln:14:19
+    |vpiParent:
+    \_module_inst: work@bar (work@bar), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:13:1, endln:15:10
+    |vpiRhs:
+    \_operation: , line:14:14, endln:14:19
+      |vpiParent:
+      \_cont_assign: , line:14:10, endln:14:19
+      |vpiOpType:30
+      |vpiOperand:
+      \_ref_obj: (work@bar.a), line:14:14, endln:14:15
+        |vpiParent:
+        \_operation: , line:14:14, endln:14:19
+        |vpiName:a
+        |vpiFullName:work@bar.a
+        |vpiActual:
+        \_logic_net: (work@bar.a), line:13:19, endln:13:20
+      |vpiOperand:
+      \_ref_obj: (work@bar.b), line:14:18, endln:14:19
+        |vpiParent:
+        \_operation: , line:14:14, endln:14:19
+        |vpiName:b
+        |vpiFullName:work@bar.b
+        |vpiActual:
+        \_logic_net: (work@bar.b), line:13:28, endln:13:29
+    |vpiLhs:
+    \_ref_obj: (work@bar.c), line:14:10, endln:14:11
+      |vpiParent:
+      \_cont_assign: , line:14:10, endln:14:19
+      |vpiName:c
+      |vpiFullName:work@bar.c
+      |vpiActual:
+      \_logic_net: (work@bar.c), line:13:38, endln:13:39
+|uhdmallModules:
+\_module_inst: work@foo (work@foo), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:10:1, endln:11:10
+  |vpiParent:
+  \_design: (work@top)
+  |vpiFullName:work@foo
+  |vpiDefName:work@foo
+  |vpiNet:
+  \_logic_net: (work@foo.a), line:10:25, endln:10:26
+    |vpiParent:
+    \_module_inst: work@foo (work@foo), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:10:1, endln:11:10
+    |vpiName:a
+    |vpiFullName:work@foo.a
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@foo.b), line:10:40, endln:10:41
+    |vpiParent:
+    \_module_inst: work@foo (work@foo), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:10:1, endln:11:10
+    |vpiName:b
+    |vpiFullName:work@foo.b
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@foo.c), line:10:56, endln:10:57
+    |vpiParent:
+    \_module_inst: work@foo (work@foo), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:10:1, endln:11:10
+    |vpiName:c
+    |vpiFullName:work@foo.c
+    |vpiNetType:36
+  |vpiPort:
+  \_port: (a), line:10:25, endln:10:26
+    |vpiParent:
+    \_module_inst: work@foo (work@foo), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:10:1, endln:11:10
+    |vpiName:a
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@foo.a.a), line:10:25, endln:10:26
+      |vpiParent:
+      \_port: (a), line:10:25, endln:10:26
+      |vpiName:a
+      |vpiFullName:work@foo.a.a
+      |vpiActual:
+      \_logic_net: (work@foo.a), line:10:25, endln:10:26
+    |vpiTypedef:
+    \_ref_typespec: (work@foo.a)
+      |vpiParent:
+      \_port: (a), line:10:25, endln:10:26
+      |vpiFullName:work@foo.a
+      |vpiActual:
+      \_logic_typespec: , line:10:19, endln:10:24
+  |vpiPort:
+  \_port: (b), line:10:40, endln:10:41
+    |vpiParent:
+    \_module_inst: work@foo (work@foo), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:10:1, endln:11:10
+    |vpiName:b
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@foo.b.b), line:10:40, endln:10:41
+      |vpiParent:
+      \_port: (b), line:10:40, endln:10:41
+      |vpiName:b
+      |vpiFullName:work@foo.b.b
+      |vpiActual:
+      \_logic_net: (work@foo.b), line:10:40, endln:10:41
+    |vpiTypedef:
+    \_ref_typespec: (work@foo.b)
+      |vpiParent:
+      \_port: (b), line:10:40, endln:10:41
+      |vpiFullName:work@foo.b
+      |vpiActual:
+      \_logic_typespec: , line:10:34, endln:10:39
+  |vpiPort:
+  \_port: (c), line:10:56, endln:10:57
+    |vpiParent:
+    \_module_inst: work@foo (work@foo), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:10:1, endln:11:10
+    |vpiName:c
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@foo.c.c), line:10:56, endln:10:57
+      |vpiParent:
+      \_port: (c), line:10:56, endln:10:57
+      |vpiName:c
+      |vpiFullName:work@foo.c.c
+      |vpiActual:
+      \_logic_net: (work@foo.c), line:10:56, endln:10:57
+    |vpiTypedef:
+    \_ref_typespec: (work@foo.c)
+      |vpiParent:
+      \_port: (c), line:10:56, endln:10:57
+      |vpiFullName:work@foo.c
+      |vpiActual:
+      \_logic_typespec: , line:10:50, endln:10:55
+|uhdmallModules:
+\_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:17:1, endln:20:10
+  |vpiParent:
+  \_design: (work@top)
+  |vpiFullName:work@top
+  |vpiDefName:work@top
+  |vpiNet:
+  \_logic_net: (work@top.u), line:18:9, endln:18:10
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:17:1, endln:20:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.u)
+      |vpiParent:
+      \_logic_net: (work@top.u), line:18:9, endln:18:10
+      |vpiFullName:work@top.u
+      |vpiActual:
+      \_logic_typespec: , line:18:3, endln:18:8
+    |vpiName:u
+    |vpiFullName:work@top.u
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.v), line:18:12, endln:18:13
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:17:1, endln:20:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.v)
+      |vpiParent:
+      \_logic_net: (work@top.v), line:18:12, endln:18:13
+      |vpiFullName:work@top.v
+      |vpiActual:
+      \_logic_typespec: , line:18:3, endln:18:8
+    |vpiName:v
+    |vpiFullName:work@top.v
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.w), line:18:15, endln:18:16
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:17:1, endln:20:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.w)
+      |vpiParent:
+      \_logic_net: (work@top.w), line:18:15, endln:18:16
+      |vpiFullName:work@top.w
+      |vpiActual:
+      \_logic_typespec: , line:18:3, endln:18:8
+    |vpiName:w
+    |vpiFullName:work@top.w
+    |vpiNetType:36
+  |vpiRefModule:
+  \_ref_module: work@foo (foo_i), line:19:7, endln:19:12
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:17:1, endln:20:10
+    |vpiName:foo_i
+    |vpiDefName:work@foo
+    |vpiActual:
+    \_module_inst: work@foo (work@foo), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:10:1, endln:11:10
+    |vpiPort:
+    \_port: (a), line:19:14, endln:19:20
+      |vpiParent:
+      \_ref_module: work@foo (foo_i), line:19:7, endln:19:12
+      |vpiName:a
+      |vpiHighConn:
+      \_ref_obj: (work@top.foo_i.a.u), line:19:18, endln:19:19
+        |vpiParent:
+        \_port: (a), line:19:14, endln:19:20
+        |vpiName:u
+        |vpiFullName:work@top.foo_i.a.u
+        |vpiActual:
+        \_logic_net: (work@top.u), line:18:9, endln:18:10
+    |vpiPort:
+    \_port: (b), line:19:22, endln:19:28
+      |vpiParent:
+      \_ref_module: work@foo (foo_i), line:19:7, endln:19:12
+      |vpiName:b
+      |vpiHighConn:
+      \_ref_obj: (work@top.foo_i.b.v), line:19:26, endln:19:27
+        |vpiParent:
+        \_port: (b), line:19:22, endln:19:28
+        |vpiName:v
+        |vpiFullName:work@top.foo_i.b.v
+        |vpiActual:
+        \_logic_net: (work@top.v), line:18:12, endln:18:13
+    |vpiPort:
+    \_port: (c), line:19:30, endln:19:36
+      |vpiParent:
+      \_ref_module: work@foo (foo_i), line:19:7, endln:19:12
+      |vpiName:c
+      |vpiHighConn:
+      \_ref_obj: (work@top.foo_i.c.w), line:19:34, endln:19:35
+        |vpiParent:
+        \_port: (c), line:19:30, endln:19:36
+        |vpiName:w
+        |vpiFullName:work@top.foo_i.c.w
+        |vpiActual:
+        \_logic_net: (work@top.w), line:18:15, endln:18:16
+|uhdmtopModules:
+\_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:17:1, endln:20:10
+  |vpiParent:
+  \_design: (work@top)
+  |vpiName:work@top
+  |vpiVariables:
+  \_logic_var: (work@top.u), line:18:9, endln:18:10
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:17:1, endln:20:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.u)
+      |vpiParent:
+      \_logic_var: (work@top.u), line:18:9, endln:18:10
+      |vpiFullName:work@top.u
+      |vpiActual:
+      \_logic_typespec: , line:18:3, endln:18:8
+    |vpiName:u
+    |vpiFullName:work@top.u
+    |vpiVisibility:1
+  |vpiVariables:
+  \_logic_var: (work@top.v), line:18:12, endln:18:13
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:17:1, endln:20:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.v)
+      |vpiParent:
+      \_logic_var: (work@top.v), line:18:12, endln:18:13
+      |vpiFullName:work@top.v
+      |vpiActual:
+      \_logic_typespec: , line:18:3, endln:18:8
+    |vpiName:v
+    |vpiFullName:work@top.v
+    |vpiVisibility:1
+  |vpiVariables:
+  \_logic_var: (work@top.w), line:18:15, endln:18:16
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:17:1, endln:20:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.w)
+      |vpiParent:
+      \_logic_var: (work@top.w), line:18:15, endln:18:16
+      |vpiFullName:work@top.w
+      |vpiActual:
+      \_logic_typespec: , line:18:3, endln:18:8
+    |vpiName:w
+    |vpiFullName:work@top.w
+    |vpiVisibility:1
+  |vpiDefName:work@top
+  |vpiTop:1
+  |vpiTopModule:1
+  |vpiModule:
+  \_module_inst: work@foo (work@top.foo_i), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:19:3, endln:19:38
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:17:1, endln:20:10
+    |vpiName:foo_i
+    |vpiFullName:work@top.foo_i
+    |vpiDefName:work@foo
+    |vpiDefFile:${SURELOG_DIR}/tests/BindHierPath/dut.sv
+    |vpiDefLineNo:10
+    |vpiNet:
+    \_logic_net: (work@top.foo_i.a), line:10:25, endln:10:26
+      |vpiParent:
+      \_module_inst: work@foo (work@top.foo_i), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:19:3, endln:19:38
+      |vpiTypespec:
+      \_ref_typespec: (work@top.foo_i.a)
+        |vpiParent:
+        \_logic_net: (work@top.foo_i.a), line:10:25, endln:10:26
+        |vpiFullName:work@top.foo_i.a
+        |vpiActual:
+        \_logic_typespec: , line:10:19, endln:10:24
+      |vpiName:a
+      |vpiFullName:work@top.foo_i.a
+      |vpiNetType:36
+    |vpiNet:
+    \_logic_net: (work@top.foo_i.b), line:10:40, endln:10:41
+      |vpiParent:
+      \_module_inst: work@foo (work@top.foo_i), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:19:3, endln:19:38
+      |vpiTypespec:
+      \_ref_typespec: (work@top.foo_i.b)
+        |vpiParent:
+        \_logic_net: (work@top.foo_i.b), line:10:40, endln:10:41
+        |vpiFullName:work@top.foo_i.b
+        |vpiActual:
+        \_logic_typespec: , line:10:34, endln:10:39
+      |vpiName:b
+      |vpiFullName:work@top.foo_i.b
+      |vpiNetType:36
+    |vpiNet:
+    \_logic_net: (work@top.foo_i.c), line:10:56, endln:10:57
+      |vpiParent:
+      \_module_inst: work@foo (work@top.foo_i), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:19:3, endln:19:38
+      |vpiTypespec:
+      \_ref_typespec: (work@top.foo_i.c)
+        |vpiParent:
+        \_logic_net: (work@top.foo_i.c), line:10:56, endln:10:57
+        |vpiFullName:work@top.foo_i.c
+        |vpiActual:
+        \_logic_typespec: , line:10:50, endln:10:55
+      |vpiName:c
+      |vpiFullName:work@top.foo_i.c
+      |vpiNetType:36
+    |vpiInstance:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:17:1, endln:20:10
+    |vpiPort:
+    \_port: (a), line:10:25, endln:10:26
+      |vpiParent:
+      \_module_inst: work@foo (work@top.foo_i), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:19:3, endln:19:38
+      |vpiName:a
+      |vpiDirection:1
+      |vpiHighConn:
+      \_ref_obj: (work@top.u), line:19:18, endln:19:19
+        |vpiParent:
+        \_port: (a), line:10:25, endln:10:26
+        |vpiName:u
+        |vpiFullName:work@top.u
+        |vpiActual:
+        \_logic_var: (work@top.u), line:18:9, endln:18:10
+      |vpiLowConn:
+      \_ref_obj: (work@top.foo_i.a), line:19:15, endln:19:16
+        |vpiParent:
+        \_port: (a), line:10:25, endln:10:26
+        |vpiName:a
+        |vpiFullName:work@top.foo_i.a
+        |vpiActual:
+        \_logic_net: (work@top.foo_i.a), line:10:25, endln:10:26
+      |vpiTypedef:
+      \_ref_typespec: (work@top.foo_i.a)
+        |vpiParent:
+        \_port: (a), line:10:25, endln:10:26
+        |vpiFullName:work@top.foo_i.a
+        |vpiActual:
+        \_logic_typespec: , line:10:19, endln:10:24
+      |vpiInstance:
+      \_module_inst: work@foo (work@top.foo_i), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:19:3, endln:19:38
+    |vpiPort:
+    \_port: (b), line:10:40, endln:10:41
+      |vpiParent:
+      \_module_inst: work@foo (work@top.foo_i), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:19:3, endln:19:38
+      |vpiName:b
+      |vpiDirection:1
+      |vpiHighConn:
+      \_ref_obj: (work@top.v), line:19:26, endln:19:27
+        |vpiParent:
+        \_port: (b), line:10:40, endln:10:41
+        |vpiName:v
+        |vpiFullName:work@top.v
+        |vpiActual:
+        \_logic_var: (work@top.v), line:18:12, endln:18:13
+      |vpiLowConn:
+      \_ref_obj: (work@top.foo_i.b), line:19:23, endln:19:24
+        |vpiParent:
+        \_port: (b), line:10:40, endln:10:41
+        |vpiName:b
+        |vpiFullName:work@top.foo_i.b
+        |vpiActual:
+        \_logic_net: (work@top.foo_i.b), line:10:40, endln:10:41
+      |vpiTypedef:
+      \_ref_typespec: (work@top.foo_i.b)
+        |vpiParent:
+        \_port: (b), line:10:40, endln:10:41
+        |vpiFullName:work@top.foo_i.b
+        |vpiActual:
+        \_logic_typespec: , line:10:34, endln:10:39
+      |vpiInstance:
+      \_module_inst: work@foo (work@top.foo_i), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:19:3, endln:19:38
+    |vpiPort:
+    \_port: (c), line:10:56, endln:10:57
+      |vpiParent:
+      \_module_inst: work@foo (work@top.foo_i), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:19:3, endln:19:38
+      |vpiName:c
+      |vpiDirection:2
+      |vpiHighConn:
+      \_ref_obj: (work@top.w), line:19:34, endln:19:35
+        |vpiParent:
+        \_port: (c), line:10:56, endln:10:57
+        |vpiName:w
+        |vpiFullName:work@top.w
+        |vpiActual:
+        \_logic_var: (work@top.w), line:18:15, endln:18:16
+      |vpiLowConn:
+      \_ref_obj: (work@top.foo_i.c), line:19:31, endln:19:32
+        |vpiParent:
+        \_port: (c), line:10:56, endln:10:57
+        |vpiName:c
+        |vpiFullName:work@top.foo_i.c
+        |vpiActual:
+        \_logic_net: (work@top.foo_i.c), line:10:56, endln:10:57
+      |vpiTypedef:
+      \_ref_typespec: (work@top.foo_i.c)
+        |vpiParent:
+        \_port: (c), line:10:56, endln:10:57
+        |vpiFullName:work@top.foo_i.c
+        |vpiActual:
+        \_logic_typespec: , line:10:50, endln:10:55
+      |vpiInstance:
+      \_module_inst: work@foo (work@top.foo_i), file:${SURELOG_DIR}/tests/BindHierPath/dut.sv, line:19:3, endln:19:38
+\_weaklyReferenced:
+\_logic_typespec: , line:18:3, endln:18:8
+  |vpiParent:
+  \_logic_var: (work@top.w), line:18:15, endln:18:16
+\_logic_typespec: , line:10:19, endln:10:24
+\_logic_typespec: , line:10:34, endln:10:39
+\_logic_typespec: , line:10:50, endln:10:55
+\_logic_typespec: , line:10:19, endln:10:24
+  |vpiParent:
+  \_logic_net: (work@top.foo_i.a), line:10:25, endln:10:26
+\_logic_typespec: , line:10:34, endln:10:39
+  |vpiParent:
+  \_logic_net: (work@top.foo_i.b), line:10:40, endln:10:41
+\_logic_typespec: , line:10:50, endln:10:55
+  |vpiParent:
+  \_logic_net: (work@top.foo_i.c), line:10:56, endln:10:57
+\_logic_typespec: , line:13:19, endln:13:19
+\_logic_typespec: , line:13:28, endln:13:28
+\_logic_typespec: , line:13:38, endln:13:38
+\_logic_typespec: , line:10:19, endln:10:24
+\_logic_typespec: , line:10:34, endln:10:39
+\_logic_typespec: , line:10:50, endln:10:55
+\_logic_typespec: , line:18:3, endln:18:8
+\_logic_typespec: , line:18:3, endln:18:8
+\_logic_typespec: , line:18:3, endln:18:8
+===================
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
+[WARNING] : 3
+[   NOTE] : 6
+
+============================== Begin RoundTrip Results ==============================
+[roundtrip]: ${SURELOG_DIR}/tests/BindHierPath/dut.sv | ${SURELOG_DIR}/build/regression/BindHierPath/roundtrip/dut_000.sv | 5 | 20 |
+============================== End RoundTrip Results ==============================

--- a/tests/BindHierPath/BindHierPath.sl
+++ b/tests/BindHierPath/BindHierPath.sl
@@ -1,0 +1,1 @@
+-parse -d uhdm -d coveruhdm -elabuhdm -d ast dut.sv -nobuiltin

--- a/tests/BindHierPath/dut.sv
+++ b/tests/BindHierPath/dut.sv
@@ -1,0 +1,23 @@
+// Test for `bind <hierarchical_identifier>` syntax (IEEE 1800-2017
+// 23.11 form 2: bind_target_instance).  Surelog used to reject
+// `bind $root.top.foo_i ...` and `bind top.foo_i ...` with
+// "no viable alternative at input 'bind \$root'".  The
+// bind_directive rule now accepts hierarchical_identifier as the
+// target, matching the LRM.
+//
+// Sourced from yosys/tests/bind/hier.sv.
+
+module foo (input logic a, input logic b, output logic c);
+endmodule
+
+module bar (input a, input b, output c);
+  assign c = a ^ b;
+endmodule
+
+module top ();
+  logic u, v, w;
+  foo foo_i (.a (u), .b (v), .c (w));
+endmodule
+
+// Hierarchical target with $root prefix.
+bind $root.top.foo_i bar bound_i (.*);


### PR DESCRIPTION
The bind_directive rule only matched `bind <identifier> ...` — bind to a module type.  IEEE 1800-2017 §23.11 also allows the second form, `bind bind_target_instance bind_instantiation`, where the target is a hierarchical_identifier with an optional bit-select (e.g. `bind $root.top.foo_i bar bound_i (.*)` or
`bind top.foo_i bar bound_i (.*)`).  Surelog rejected these with "no viable alternative at input 'bind \$root'".

Extend bind_directive to accept either a hierarchical_identifier (form 2) or an identifier with an optional `:`-prefixed instance list (form 1).  The two alternatives are LL(1)-distinguishable because hierarchical_identifier requires at least one `.identifier` after the first identifier (or the `$root.` prefix), so a bare identifier still goes through the form-1 path.

Adds tests/BindHierPath/ covering the `$root.top.foo_i` form (sourced from yosys/tests/bind/hier.sv).