### PR TITLE
PreprocessFile: preserve interior whitespace in macro default arguments

### DIFF
--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -927,8 +927,14 @@ std::pair<bool, std::string> PreprocessFile::evaluateMacro_(
                                         actual_args[i]);
       StringUtils::replaceInTokenVector(body_tokens, formal, actual_args[i]);
     } else if (formal_arg_default.size() == 2) {
-      const std::string default_val =
-          std::regex_replace(formal_arg_default[1], ws_re, "");
+      // Trim leading/trailing whitespace but PRESERVE interior whitespace —
+      // a default like `function automatic [31:0] f` is multi-token and
+      // collapsing it to `functionautomatic[31:0]f` produces a syntax error
+      // at the use site (yosys/tests/simple/macro_arg_spaces.sv).  The
+      // formal name (line 898 above) is a single identifier so stripping
+      // ws there is fine.
+      const std::string default_val(
+          StringUtils::trim(formal_arg_default[1]));
       StringUtils::replaceInTokenVector(body_tokens, {"``", formal, "``"},
                                         default_val);
       StringUtils::replaceInTokenVector(body_tokens, "``" + formal + "``",

--- a/tests/MacroArgDefaultSpaces/MacroArgDefaultSpaces.log
+++ b/tests/MacroArgDefaultSpaces/MacroArgDefaultSpaces.log
@@ -1,0 +1,1510 @@
+[INF:CM0023] Creating log file "${SURELOG_DIR}/build/regression/MacroArgDefaultSpaces/slpp_all/surelog.log".
+AST_DEBUG_BEGIN
+LIB:  work
+FILE: ${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv
+n<> u<0> t<_INVALID_> f<0> l<0:0>
+n<> u<1> t<Null_rule> p<288> s<287> l<5:1> el<4:2>
+n<module> u<2> t<Module_keyword> p<49> s<3> l<5:1> el<5:7>
+n<macro_arg_spaces_top> u<3> t<StringConst> p<49> s<48> l<5:8> el<5:28>
+n<> u<4> t<PortDir_Inp> p<18> s<17> l<6:2> el<6:7>
+n<> u<5> t<NetType_Wire> p<17> s<16> l<6:8> el<6:12>
+n<31> u<6> t<IntConst> p<7> l<6:14> el<6:16>
+n<> u<7> t<Primary_literal> p<8> c<6> l<6:14> el<6:16>
+n<> u<8> t<Constant_primary> p<9> c<7> l<6:14> el<6:16>
+n<> u<9> t<Constant_expression> p<14> c<8> s<13> l<6:14> el<6:16>
+n<0> u<10> t<IntConst> p<11> l<6:17> el<6:18>
+n<> u<11> t<Primary_literal> p<12> c<10> l<6:17> el<6:18>
+n<> u<12> t<Constant_primary> p<13> c<11> l<6:17> el<6:18>
+n<> u<13> t<Constant_expression> p<14> c<12> l<6:17> el<6:18>
+n<> u<14> t<Constant_range> p<15> c<9> l<6:14> el<6:18>
+n<> u<15> t<Packed_dimension> p<16> c<14> l<6:13> el<6:19>
+n<> u<16> t<Data_type_or_implicit> p<17> c<15> l<6:13> el<6:19>
+n<> u<17> t<Net_port_type> p<18> c<5> l<6:8> el<6:19>
+n<> u<18> t<Net_port_header> p<20> c<4> s<19> l<6:2> el<6:19>
+n<i> u<19> t<StringConst> p<20> l<6:20> el<6:21>
+n<> u<20> t<Ansi_port_declaration> p<48> c<18> s<37> l<6:2> el<6:21>
+n<> u<21> t<PortDir_Out> p<35> s<34> l<7:2> el<7:8>
+n<> u<22> t<NetType_Wire> p<34> s<33> l<7:9> el<7:13>
+n<31> u<23> t<IntConst> p<24> l<7:15> el<7:17>
+n<> u<24> t<Primary_literal> p<25> c<23> l<7:15> el<7:17>
+n<> u<25> t<Constant_primary> p<26> c<24> l<7:15> el<7:17>
+n<> u<26> t<Constant_expression> p<31> c<25> s<30> l<7:15> el<7:17>
+n<0> u<27> t<IntConst> p<28> l<7:18> el<7:19>
+n<> u<28> t<Primary_literal> p<29> c<27> l<7:18> el<7:19>
+n<> u<29> t<Constant_primary> p<30> c<28> l<7:18> el<7:19>
+n<> u<30> t<Constant_expression> p<31> c<29> l<7:18> el<7:19>
+n<> u<31> t<Constant_range> p<32> c<26> l<7:15> el<7:19>
+n<> u<32> t<Packed_dimension> p<33> c<31> l<7:14> el<7:20>
+n<> u<33> t<Data_type_or_implicit> p<34> c<32> l<7:14> el<7:20>
+n<> u<34> t<Net_port_type> p<35> c<22> l<7:9> el<7:20>
+n<> u<35> t<Net_port_header> p<37> c<21> s<36> l<7:2> el<7:20>
+n<x> u<36> t<StringConst> p<37> l<7:21> el<7:22>
+n<> u<37> t<Ansi_port_declaration> p<48> c<35> s<42> l<7:2> el<7:22>
+n<> u<38> t<Data_type_or_implicit> p<39> l<7:24> el<7:24>
+n<> u<39> t<Net_port_type> p<40> c<38> l<7:24> el<7:24>
+n<> u<40> t<Net_port_header> p<42> c<39> s<41> l<7:24> el<7:24>
+n<y> u<41> t<StringConst> p<42> l<7:24> el<7:25>
+n<> u<42> t<Ansi_port_declaration> p<48> c<40> s<47> l<7:24> el<7:25>
+n<> u<43> t<Data_type_or_implicit> p<44> l<7:27> el<7:27>
+n<> u<44> t<Net_port_type> p<45> c<43> l<7:27> el<7:27>
+n<> u<45> t<Net_port_header> p<47> c<44> s<46> l<7:27> el<7:27>
+n<z> u<46> t<StringConst> p<47> l<7:27> el<7:28>
+n<> u<47> t<Ansi_port_declaration> p<48> c<45> l<7:27> el<7:28>
+n<> u<48> t<List_of_port_declarations> p<49> c<20> l<5:28> el<8:2>
+n<> u<49> t<Module_ansi_header> p<285> c<2> s<107> l<5:1> el<8:3>
+n<> u<50> t<Lifetime_Automatic> p<102> s<101> l<13:10> el<13:19>
+n<31> u<51> t<IntConst> p<52> l<13:21> el<13:23>
+n<> u<52> t<Primary_literal> p<53> c<51> l<13:21> el<13:23>
+n<> u<53> t<Constant_primary> p<54> c<52> l<13:21> el<13:23>
+n<> u<54> t<Constant_expression> p<59> c<53> s<58> l<13:21> el<13:23>
+n<0> u<55> t<IntConst> p<56> l<13:24> el<13:25>
+n<> u<56> t<Primary_literal> p<57> c<55> l<13:24> el<13:25>
+n<> u<57> t<Constant_primary> p<58> c<56> l<13:24> el<13:25>
+n<> u<58> t<Constant_expression> p<59> c<57> l<13:24> el<13:25>
+n<> u<59> t<Constant_range> p<60> c<54> l<13:21> el<13:25>
+n<> u<60> t<Packed_dimension> p<61> c<59> l<13:20> el<13:26>
+n<> u<61> t<Function_data_type_or_implicit> p<101> c<60> s<62> l<13:20> el<13:26>
+n<a> u<62> t<StringConst> p<101> s<78> l<13:27> el<13:28>
+n<> u<63> t<TfPortDir_Inp> p<77> s<74> l<14:2> el<14:7>
+n<31> u<64> t<IntConst> p<65> l<14:9> el<14:11>
+n<> u<65> t<Primary_literal> p<66> c<64> l<14:9> el<14:11>
+n<> u<66> t<Constant_primary> p<67> c<65> l<14:9> el<14:11>
+n<> u<67> t<Constant_expression> p<72> c<66> s<71> l<14:9> el<14:11>
+n<0> u<68> t<IntConst> p<69> l<14:12> el<14:13>
+n<> u<69> t<Primary_literal> p<70> c<68> l<14:12> el<14:13>
+n<> u<70> t<Constant_primary> p<71> c<69> l<14:12> el<14:13>
+n<> u<71> t<Constant_expression> p<72> c<70> l<14:12> el<14:13>
+n<> u<72> t<Constant_range> p<73> c<67> l<14:9> el<14:13>
+n<> u<73> t<Packed_dimension> p<74> c<72> l<14:8> el<14:14>
+n<> u<74> t<Data_type_or_implicit> p<77> c<73> s<76> l<14:8> el<14:14>
+n<i> u<75> t<StringConst> p<76> l<14:15> el<14:16>
+n<> u<76> t<List_of_tf_variable_identifiers> p<77> c<75> l<14:15> el<14:16>
+n<> u<77> t<Tf_port_declaration> p<78> c<63> l<14:2> el<14:17>
+n<> u<78> t<Tf_item_declaration> p<101> c<77> s<99> l<14:2> el<14:17>
+n<a> u<79> t<StringConst> p<80> l<15:2> el<15:3>
+n<> u<80> t<Ps_or_hierarchical_identifier> p<83> c<79> s<82> l<15:2> el<15:3>
+n<> u<81> t<Bit_select> p<82> l<15:4> el<15:4>
+n<> u<82> t<Select> p<83> c<81> l<15:4> el<15:4>
+n<> u<83> t<Variable_lvalue> p<95> c<80> s<84> l<15:2> el<15:3>
+n<> u<84> t<AssignOp_Assign> p<95> s<94> l<15:4> el<15:5>
+n<i> u<85> t<StringConst> p<86> l<15:6> el<15:7>
+n<> u<86> t<Primary_literal> p<87> c<85> l<15:6> el<15:7>
+n<> u<87> t<Primary> p<88> c<86> l<15:6> el<15:7>
+n<> u<88> t<Expression> p<94> c<87> s<93> l<15:6> el<15:7>
+n<2> u<89> t<IntConst> p<90> l<15:10> el<15:11>
+n<> u<90> t<Primary_literal> p<91> c<89> l<15:10> el<15:11>
+n<> u<91> t<Primary> p<92> c<90> l<15:10> el<15:11>
+n<> u<92> t<Expression> p<94> c<91> l<15:10> el<15:11>
+n<> u<93> t<BinOp_Mult> p<94> s<92> l<15:8> el<15:9>
+n<> u<94> t<Expression> p<95> c<88> l<15:6> el<15:11>
+n<> u<95> t<Operator_assignment> p<96> c<83> l<15:2> el<15:11>
+n<> u<96> t<Blocking_assignment> p<97> c<95> l<15:2> el<15:11>
+n<> u<97> t<Statement_item> p<98> c<96> l<15:2> el<15:12>
+n<> u<98> t<Statement> p<99> c<97> l<15:2> el<15:12>
+n<> u<99> t<Function_statement_or_null> p<101> c<98> s<100> l<15:2> el<15:12>
+n<> u<100> t<ENDFUNCTION> p<101> l<16:1> el<16:12>
+n<> u<101> t<Function_body_declaration> p<102> c<61> l<13:20> el<16:12>
+n<> u<102> t<Function_declaration> p<103> c<50> l<13:1> el<16:12>
+n<> u<103> t<Package_or_generate_item_declaration> p<104> c<102> l<13:1> el<16:12>
+n<> u<104> t<Module_or_generate_item_declaration> p<105> c<103> l<13:1> el<16:12>
+n<> u<105> t<Module_common_item> p<106> c<104> l<13:1> el<16:12>
+n<> u<106> t<Module_or_generate_item> p<107> c<105> l<13:1> el<16:12>
+n<> u<107> t<Non_port_module_item> p<285> c<106> s<165> l<13:1> el<16:12>
+n<> u<108> t<Lifetime_Automatic> p<160> s<159> l<18:10> el<18:19>
+n<31> u<109> t<IntConst> p<110> l<18:21> el<18:23>
+n<> u<110> t<Primary_literal> p<111> c<109> l<18:21> el<18:23>
+n<> u<111> t<Constant_primary> p<112> c<110> l<18:21> el<18:23>
+n<> u<112> t<Constant_expression> p<117> c<111> s<116> l<18:21> el<18:23>
+n<0> u<113> t<IntConst> p<114> l<18:24> el<18:25>
+n<> u<114> t<Primary_literal> p<115> c<113> l<18:24> el<18:25>
+n<> u<115> t<Constant_primary> p<116> c<114> l<18:24> el<18:25>
+n<> u<116> t<Constant_expression> p<117> c<115> l<18:24> el<18:25>
+n<> u<117> t<Constant_range> p<118> c<112> l<18:21> el<18:25>
+n<> u<118> t<Packed_dimension> p<119> c<117> l<18:20> el<18:26>
+n<> u<119> t<Function_data_type_or_implicit> p<159> c<118> s<120> l<18:20> el<18:26>
+n<f> u<120> t<StringConst> p<159> s<136> l<18:27> el<18:28>
+n<> u<121> t<TfPortDir_Inp> p<135> s<132> l<19:2> el<19:7>
+n<31> u<122> t<IntConst> p<123> l<19:9> el<19:11>
+n<> u<123> t<Primary_literal> p<124> c<122> l<19:9> el<19:11>
+n<> u<124> t<Constant_primary> p<125> c<123> l<19:9> el<19:11>
+n<> u<125> t<Constant_expression> p<130> c<124> s<129> l<19:9> el<19:11>
+n<0> u<126> t<IntConst> p<127> l<19:12> el<19:13>
+n<> u<127> t<Primary_literal> p<128> c<126> l<19:12> el<19:13>
+n<> u<128> t<Constant_primary> p<129> c<127> l<19:12> el<19:13>
+n<> u<129> t<Constant_expression> p<130> c<128> l<19:12> el<19:13>
+n<> u<130> t<Constant_range> p<131> c<125> l<19:9> el<19:13>
+n<> u<131> t<Packed_dimension> p<132> c<130> l<19:8> el<19:14>
+n<> u<132> t<Data_type_or_implicit> p<135> c<131> s<134> l<19:8> el<19:14>
+n<i> u<133> t<StringConst> p<134> l<19:15> el<19:16>
+n<> u<134> t<List_of_tf_variable_identifiers> p<135> c<133> l<19:15> el<19:16>
+n<> u<135> t<Tf_port_declaration> p<136> c<121> l<19:2> el<19:17>
+n<> u<136> t<Tf_item_declaration> p<159> c<135> s<157> l<19:2> el<19:17>
+n<f> u<137> t<StringConst> p<138> l<20:2> el<20:3>
+n<> u<138> t<Ps_or_hierarchical_identifier> p<141> c<137> s<140> l<20:2> el<20:3>
+n<> u<139> t<Bit_select> p<140> l<20:4> el<20:4>
+n<> u<140> t<Select> p<141> c<139> l<20:4> el<20:4>
+n<> u<141> t<Variable_lvalue> p<153> c<138> s<142> l<20:2> el<20:3>
+n<> u<142> t<AssignOp_Assign> p<153> s<152> l<20:4> el<20:5>
+n<i> u<143> t<StringConst> p<144> l<20:6> el<20:7>
+n<> u<144> t<Primary_literal> p<145> c<143> l<20:6> el<20:7>
+n<> u<145> t<Primary> p<146> c<144> l<20:6> el<20:7>
+n<> u<146> t<Expression> p<152> c<145> s<151> l<20:6> el<20:7>
+n<3> u<147> t<IntConst> p<148> l<20:10> el<20:11>
+n<> u<148> t<Primary_literal> p<149> c<147> l<20:10> el<20:11>
+n<> u<149> t<Primary> p<150> c<148> l<20:10> el<20:11>
+n<> u<150> t<Expression> p<152> c<149> l<20:10> el<20:11>
+n<> u<151> t<BinOp_Mult> p<152> s<150> l<20:8> el<20:9>
+n<> u<152> t<Expression> p<153> c<146> l<20:6> el<20:11>
+n<> u<153> t<Operator_assignment> p<154> c<141> l<20:2> el<20:11>
+n<> u<154> t<Blocking_assignment> p<155> c<153> l<20:2> el<20:11>
+n<> u<155> t<Statement_item> p<156> c<154> l<20:2> el<20:12>
+n<> u<156> t<Statement> p<157> c<155> l<20:2> el<20:12>
+n<> u<157> t<Function_statement_or_null> p<159> c<156> s<158> l<20:2> el<20:12>
+n<> u<158> t<ENDFUNCTION> p<159> l<21:1> el<21:12>
+n<> u<159> t<Function_body_declaration> p<160> c<119> l<18:20> el<21:12>
+n<> u<160> t<Function_declaration> p<161> c<108> l<18:1> el<21:12>
+n<> u<161> t<Package_or_generate_item_declaration> p<162> c<160> l<18:1> el<21:12>
+n<> u<162> t<Module_or_generate_item_declaration> p<163> c<161> l<18:1> el<21:12>
+n<> u<163> t<Module_common_item> p<164> c<162> l<18:1> el<21:12>
+n<> u<164> t<Module_or_generate_item> p<165> c<163> l<18:1> el<21:12>
+n<> u<165> t<Non_port_module_item> p<285> c<164> s<223> l<18:1> el<21:12>
+n<> u<166> t<Lifetime_Automatic> p<218> s<217> l<23:10> el<23:19>
+n<31> u<167> t<IntConst> p<168> l<23:21> el<23:23>
+n<> u<168> t<Primary_literal> p<169> c<167> l<23:21> el<23:23>
+n<> u<169> t<Constant_primary> p<170> c<168> l<23:21> el<23:23>
+n<> u<170> t<Constant_expression> p<175> c<169> s<174> l<23:21> el<23:23>
+n<0> u<171> t<IntConst> p<172> l<23:24> el<23:25>
+n<> u<172> t<Primary_literal> p<173> c<171> l<23:24> el<23:25>
+n<> u<173> t<Constant_primary> p<174> c<172> l<23:24> el<23:25>
+n<> u<174> t<Constant_expression> p<175> c<173> l<23:24> el<23:25>
+n<> u<175> t<Constant_range> p<176> c<170> l<23:21> el<23:25>
+n<> u<176> t<Packed_dimension> p<177> c<175> l<23:20> el<23:26>
+n<> u<177> t<Function_data_type_or_implicit> p<217> c<176> s<178> l<23:20> el<23:26>
+n<b> u<178> t<StringConst> p<217> s<194> l<23:27> el<23:28>
+n<> u<179> t<TfPortDir_Inp> p<193> s<190> l<24:2> el<24:7>
+n<31> u<180> t<IntConst> p<181> l<24:9> el<24:11>
+n<> u<181> t<Primary_literal> p<182> c<180> l<24:9> el<24:11>
+n<> u<182> t<Constant_primary> p<183> c<181> l<24:9> el<24:11>
+n<> u<183> t<Constant_expression> p<188> c<182> s<187> l<24:9> el<24:11>
+n<0> u<184> t<IntConst> p<185> l<24:12> el<24:13>
+n<> u<185> t<Primary_literal> p<186> c<184> l<24:12> el<24:13>
+n<> u<186> t<Constant_primary> p<187> c<185> l<24:12> el<24:13>
+n<> u<187> t<Constant_expression> p<188> c<186> l<24:12> el<24:13>
+n<> u<188> t<Constant_range> p<189> c<183> l<24:9> el<24:13>
+n<> u<189> t<Packed_dimension> p<190> c<188> l<24:8> el<24:14>
+n<> u<190> t<Data_type_or_implicit> p<193> c<189> s<192> l<24:8> el<24:14>
+n<i> u<191> t<StringConst> p<192> l<24:15> el<24:16>
+n<> u<192> t<List_of_tf_variable_identifiers> p<193> c<191> l<24:15> el<24:16>
+n<> u<193> t<Tf_port_declaration> p<194> c<179> l<24:2> el<24:17>
+n<> u<194> t<Tf_item_declaration> p<217> c<193> s<215> l<24:2> el<24:17>
+n<b> u<195> t<StringConst> p<196> l<25:2> el<25:3>
+n<> u<196> t<Ps_or_hierarchical_identifier> p<199> c<195> s<198> l<25:2> el<25:3>
+n<> u<197> t<Bit_select> p<198> l<25:4> el<25:4>
+n<> u<198> t<Select> p<199> c<197> l<25:4> el<25:4>
+n<> u<199> t<Variable_lvalue> p<211> c<196> s<200> l<25:2> el<25:3>
+n<> u<200> t<AssignOp_Assign> p<211> s<210> l<25:4> el<25:5>
+n<i> u<201> t<StringConst> p<202> l<25:6> el<25:7>
+n<> u<202> t<Primary_literal> p<203> c<201> l<25:6> el<25:7>
+n<> u<203> t<Primary> p<204> c<202> l<25:6> el<25:7>
+n<> u<204> t<Expression> p<210> c<203> s<209> l<25:6> el<25:7>
+n<5> u<205> t<IntConst> p<206> l<25:10> el<25:11>
+n<> u<206> t<Primary_literal> p<207> c<205> l<25:10> el<25:11>
+n<> u<207> t<Primary> p<208> c<206> l<25:10> el<25:11>
+n<> u<208> t<Expression> p<210> c<207> l<25:10> el<25:11>
+n<> u<209> t<BinOp_Mult> p<210> s<208> l<25:8> el<25:9>
+n<> u<210> t<Expression> p<211> c<204> l<25:6> el<25:11>
+n<> u<211> t<Operator_assignment> p<212> c<199> l<25:2> el<25:11>
+n<> u<212> t<Blocking_assignment> p<213> c<211> l<25:2> el<25:11>
+n<> u<213> t<Statement_item> p<214> c<212> l<25:2> el<25:12>
+n<> u<214> t<Statement> p<215> c<213> l<25:2> el<25:12>
+n<> u<215> t<Function_statement_or_null> p<217> c<214> s<216> l<25:2> el<25:12>
+n<> u<216> t<ENDFUNCTION> p<217> l<26:1> el<26:12>
+n<> u<217> t<Function_body_declaration> p<218> c<177> l<23:20> el<26:12>
+n<> u<218> t<Function_declaration> p<219> c<166> l<23:1> el<26:12>
+n<> u<219> t<Package_or_generate_item_declaration> p<220> c<218> l<23:1> el<26:12>
+n<> u<220> t<Module_or_generate_item_declaration> p<221> c<219> l<23:1> el<26:12>
+n<> u<221> t<Module_common_item> p<222> c<220> l<23:1> el<26:12>
+n<> u<222> t<Module_or_generate_item> p<223> c<221> l<23:1> el<26:12>
+n<> u<223> t<Non_port_module_item> p<285> c<222> s<243> l<23:1> el<26:12>
+n<x> u<224> t<StringConst> p<225> l<28:8> el<28:9>
+n<> u<225> t<Ps_or_hierarchical_identifier> p<228> c<224> s<227> l<28:8> el<28:9>
+n<> u<226> t<Constant_bit_select> p<227> l<28:10> el<28:10>
+n<> u<227> t<Constant_select> p<228> c<226> l<28:10> el<28:10>
+n<> u<228> t<Net_lvalue> p<238> c<225> s<237> l<28:8> el<28:9>
+n<a> u<229> t<StringConst> p<235> s<234> l<28:12> el<28:13>
+n<i> u<230> t<StringConst> p<231> l<28:14> el<28:15>
+n<> u<231> t<Primary_literal> p<232> c<230> l<28:14> el<28:15>
+n<> u<232> t<Primary> p<233> c<231> l<28:14> el<28:15>
+n<> u<233> t<Expression> p<234> c<232> l<28:14> el<28:15>
+n<> u<234> t<List_of_arguments> p<235> c<233> l<28:14> el<28:15>
+n<> u<235> t<Complex_func_call> p<236> c<229> l<28:12> el<28:16>
+n<> u<236> t<Primary> p<237> c<235> l<28:12> el<28:16>
+n<> u<237> t<Expression> p<238> c<236> l<28:12> el<28:16>
+n<> u<238> t<Net_assignment> p<239> c<228> l<28:8> el<28:16>
+n<> u<239> t<List_of_net_assignments> p<240> c<238> l<28:8> el<28:16>
+n<> u<240> t<Continuous_assign> p<241> c<239> l<28:1> el<28:17>
+n<> u<241> t<Module_common_item> p<242> c<240> l<28:1> el<28:17>
+n<> u<242> t<Module_or_generate_item> p<243> c<241> l<28:1> el<28:17>
+n<> u<243> t<Non_port_module_item> p<285> c<242> s<263> l<28:1> el<28:17>
+n<y> u<244> t<StringConst> p<245> l<29:8> el<29:9>
+n<> u<245> t<Ps_or_hierarchical_identifier> p<248> c<244> s<247> l<29:8> el<29:9>
+n<> u<246> t<Constant_bit_select> p<247> l<29:10> el<29:10>
+n<> u<247> t<Constant_select> p<248> c<246> l<29:10> el<29:10>
+n<> u<248> t<Net_lvalue> p<258> c<245> s<257> l<29:8> el<29:9>
+n<f> u<249> t<StringConst> p<255> s<254> l<29:12> el<29:13>
+n<i> u<250> t<StringConst> p<251> l<29:14> el<29:15>
+n<> u<251> t<Primary_literal> p<252> c<250> l<29:14> el<29:15>
+n<> u<252> t<Primary> p<253> c<251> l<29:14> el<29:15>
+n<> u<253> t<Expression> p<254> c<252> l<29:14> el<29:15>
+n<> u<254> t<List_of_arguments> p<255> c<253> l<29:14> el<29:15>
+n<> u<255> t<Complex_func_call> p<256> c<249> l<29:12> el<29:16>
+n<> u<256> t<Primary> p<257> c<255> l<29:12> el<29:16>
+n<> u<257> t<Expression> p<258> c<256> l<29:12> el<29:16>
+n<> u<258> t<Net_assignment> p<259> c<248> l<29:8> el<29:16>
+n<> u<259> t<List_of_net_assignments> p<260> c<258> l<29:8> el<29:16>
+n<> u<260> t<Continuous_assign> p<261> c<259> l<29:1> el<29:17>
+n<> u<261> t<Module_common_item> p<262> c<260> l<29:1> el<29:17>
+n<> u<262> t<Module_or_generate_item> p<263> c<261> l<29:1> el<29:17>
+n<> u<263> t<Non_port_module_item> p<285> c<262> s<283> l<29:1> el<29:17>
+n<z> u<264> t<StringConst> p<265> l<30:8> el<30:9>
+n<> u<265> t<Ps_or_hierarchical_identifier> p<268> c<264> s<267> l<30:8> el<30:9>
+n<> u<266> t<Constant_bit_select> p<267> l<30:10> el<30:10>
+n<> u<267> t<Constant_select> p<268> c<266> l<30:10> el<30:10>
+n<> u<268> t<Net_lvalue> p<278> c<265> s<277> l<30:8> el<30:9>
+n<b> u<269> t<StringConst> p<275> s<274> l<30:12> el<30:13>
+n<i> u<270> t<StringConst> p<271> l<30:14> el<30:15>
+n<> u<271> t<Primary_literal> p<272> c<270> l<30:14> el<30:15>
+n<> u<272> t<Primary> p<273> c<271> l<30:14> el<30:15>
+n<> u<273> t<Expression> p<274> c<272> l<30:14> el<30:15>
+n<> u<274> t<List_of_arguments> p<275> c<273> l<30:14> el<30:15>
+n<> u<275> t<Complex_func_call> p<276> c<269> l<30:12> el<30:16>
+n<> u<276> t<Primary> p<277> c<275> l<30:12> el<30:16>
+n<> u<277> t<Expression> p<278> c<276> l<30:12> el<30:16>
+n<> u<278> t<Net_assignment> p<279> c<268> l<30:8> el<30:16>
+n<> u<279> t<List_of_net_assignments> p<280> c<278> l<30:8> el<30:16>
+n<> u<280> t<Continuous_assign> p<281> c<279> l<30:1> el<30:17>
+n<> u<281> t<Module_common_item> p<282> c<280> l<30:1> el<30:17>
+n<> u<282> t<Module_or_generate_item> p<283> c<281> l<30:1> el<30:17>
+n<> u<283> t<Non_port_module_item> p<285> c<282> s<284> l<30:1> el<30:17>
+n<> u<284> t<ENDMODULE> p<285> l<32:1> el<32:10>
+n<> u<285> t<Module_declaration> p<286> c<49> l<5:1> el<32:10>
+n<> u<286> t<Description> p<287> c<285> l<5:1> el<32:10>
+n<> u<287> t<Source_text> p<288> c<286> l<5:1> el<32:10>
+n<> u<288> t<Top_level_rule> c<1> l<5:1> el<33:1>
+AST_DEBUG_END
+[WRN:PA0205] ${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv:5:1: No timescale set for "macro_arg_spaces_top".
+[INF:CP0300] Compilation...
+[INF:CP0303] ${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv:5:1: Compile module "work@macro_arg_spaces_top".
+[INF:EL0526] Design Elaboration...
+[NTE:EL0503] ${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv:5:1: Top level module "work@macro_arg_spaces_top".
+[NTE:EL0508] Nb Top level modules: 1.
+[NTE:EL0509] Max instance depth: 1.
+[NTE:EL0510] Nb instances: 1.
+[NTE:EL0511] Nb leaf instances: 1.
+[INF:UH0706] Creating UHDM Model...
+=== UHDM Object Stats Begin (Non-Elaborated Model) ===
+assignment                                             3
+constant                                              45
+cont_assign                                            3
+design                                                 1
+func_call                                              3
+function                                               3
+io_decl                                                3
+logic_net                                              8
+logic_typespec                                        17
+logic_var                                              9
+module_inst                                            7
+operation                                              3
+param_assign                                           6
+parameter                                              6
+port                                                   8
+range                                                 21
+ref_obj                                               20
+ref_typespec                                          27
+=== UHDM Object Stats End ===
+[INF:UH0707] Elaborating UHDM...
+=== UHDM Object Stats Begin (Elaborated Model) ===
+assignment                                             6
+constant                                              45
+cont_assign                                            6
+design                                                 1
+func_call                                              6
+function                                               6
+io_decl                                                6
+logic_net                                              8
+logic_typespec                                        17
+logic_var                                              9
+module_inst                                            7
+operation                                              6
+param_assign                                           6
+parameter                                              6
+port                                                  12
+range                                                 21
+ref_obj                                               36
+ref_typespec                                          37
+=== UHDM Object Stats End ===
+[INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/MacroArgDefaultSpaces/slpp_all/surelog.uhdm ...
+[INF:UH0709] Writing UHDM Html Coverage: ${SURELOG_DIR}/build/regression/MacroArgDefaultSpaces/slpp_all/checker/surelog.chk.html ...
+[INF:UH0710] Loading UHDM DB: ${SURELOG_DIR}/build/regression/MacroArgDefaultSpaces/slpp_all/surelog.uhdm ...
+[INF:UH0711] Decompiling UHDM...
+====== UHDM =======
+design: (work@macro_arg_spaces_top)
+|vpiElaborated:1
+|vpiName:work@macro_arg_spaces_top
+|uhdmallModules:
+\_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+  |vpiParent:
+  \_design: (work@macro_arg_spaces_top)
+  |vpiFullName:work@macro_arg_spaces_top
+  |vpiDefName:work@macro_arg_spaces_top
+  |vpiTaskFunc:
+  \_function: (work@macro_arg_spaces_top.a), line:13:1, endln:16:12
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:a
+    |vpiFullName:work@macro_arg_spaces_top.a
+    |vpiVisibility:1
+    |vpiAutomatic:1
+    |vpiReturn:
+    \_logic_var: (work@macro_arg_spaces_top.a), line:13:20, endln:13:26
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.a), line:13:1, endln:16:12
+      |vpiTypespec:
+      \_ref_typespec: (work@macro_arg_spaces_top.a)
+        |vpiParent:
+        \_logic_var: (work@macro_arg_spaces_top.a), line:13:20, endln:13:26
+        |vpiFullName:work@macro_arg_spaces_top.a
+        |vpiActual:
+        \_logic_typespec: , line:13:20, endln:13:26
+      |vpiFullName:work@macro_arg_spaces_top.a
+    |vpiIODecl:
+    \_io_decl: (i), line:14:15, endln:14:16
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.a), line:13:1, endln:16:12
+      |vpiDirection:1
+      |vpiName:i
+      |vpiTypedef:
+      \_ref_typespec: (work@macro_arg_spaces_top.a.i)
+        |vpiParent:
+        \_io_decl: (i), line:14:15, endln:14:16
+        |vpiFullName:work@macro_arg_spaces_top.a.i
+        |vpiActual:
+        \_logic_typespec: , line:14:8, endln:14:14
+    |vpiStmt:
+    \_assignment: , line:15:2, endln:15:11
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.a), line:13:1, endln:16:12
+      |vpiOpType:82
+      |vpiBlocking:1
+      |vpiRhs:
+      \_operation: , line:15:6, endln:15:11
+        |vpiParent:
+        \_assignment: , line:15:2, endln:15:11
+        |vpiOpType:25
+        |vpiOperand:
+        \_ref_obj: (work@macro_arg_spaces_top.a.i), line:15:6, endln:15:7
+          |vpiParent:
+          \_operation: , line:15:6, endln:15:11
+          |vpiName:i
+          |vpiFullName:work@macro_arg_spaces_top.a.i
+          |vpiActual:
+          \_io_decl: (i), line:14:15, endln:14:16
+        |vpiOperand:
+        \_constant: , line:15:10, endln:15:11
+          |vpiParent:
+          \_operation: , line:15:6, endln:15:11
+          |vpiDecompile:2
+          |vpiSize:64
+          |UINT:2
+          |vpiConstType:9
+      |vpiLhs:
+      \_ref_obj: (work@macro_arg_spaces_top.a.a), line:15:2, endln:15:3
+        |vpiParent:
+        \_assignment: , line:15:2, endln:15:11
+        |vpiName:a
+        |vpiFullName:work@macro_arg_spaces_top.a.a
+        |vpiActual:
+        \_logic_var: (work@macro_arg_spaces_top.a), line:13:20, endln:13:26
+    |vpiInstance:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+  |vpiTaskFunc:
+  \_function: (work@macro_arg_spaces_top.f), line:18:1, endln:21:12
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:f
+    |vpiFullName:work@macro_arg_spaces_top.f
+    |vpiVisibility:1
+    |vpiAutomatic:1
+    |vpiReturn:
+    \_logic_var: (work@macro_arg_spaces_top.f), line:18:20, endln:18:26
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.f), line:18:1, endln:21:12
+      |vpiTypespec:
+      \_ref_typespec: (work@macro_arg_spaces_top.f)
+        |vpiParent:
+        \_logic_var: (work@macro_arg_spaces_top.f), line:18:20, endln:18:26
+        |vpiFullName:work@macro_arg_spaces_top.f
+        |vpiActual:
+        \_logic_typespec: , line:18:20, endln:18:26
+      |vpiFullName:work@macro_arg_spaces_top.f
+    |vpiIODecl:
+    \_io_decl: (i), line:19:15, endln:19:16
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.f), line:18:1, endln:21:12
+      |vpiDirection:1
+      |vpiName:i
+      |vpiTypedef:
+      \_ref_typespec: (work@macro_arg_spaces_top.f.i)
+        |vpiParent:
+        \_io_decl: (i), line:19:15, endln:19:16
+        |vpiFullName:work@macro_arg_spaces_top.f.i
+        |vpiActual:
+        \_logic_typespec: , line:19:8, endln:19:14
+    |vpiStmt:
+    \_assignment: , line:20:2, endln:20:11
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.f), line:18:1, endln:21:12
+      |vpiOpType:82
+      |vpiBlocking:1
+      |vpiRhs:
+      \_operation: , line:20:6, endln:20:11
+        |vpiParent:
+        \_assignment: , line:20:2, endln:20:11
+        |vpiOpType:25
+        |vpiOperand:
+        \_ref_obj: (work@macro_arg_spaces_top.f.i), line:20:6, endln:20:7
+          |vpiParent:
+          \_operation: , line:20:6, endln:20:11
+          |vpiName:i
+          |vpiFullName:work@macro_arg_spaces_top.f.i
+          |vpiActual:
+          \_io_decl: (i), line:19:15, endln:19:16
+        |vpiOperand:
+        \_constant: , line:20:10, endln:20:11
+          |vpiParent:
+          \_operation: , line:20:6, endln:20:11
+          |vpiDecompile:3
+          |vpiSize:64
+          |UINT:3
+          |vpiConstType:9
+      |vpiLhs:
+      \_ref_obj: (work@macro_arg_spaces_top.f.f), line:20:2, endln:20:3
+        |vpiParent:
+        \_assignment: , line:20:2, endln:20:11
+        |vpiName:f
+        |vpiFullName:work@macro_arg_spaces_top.f.f
+        |vpiActual:
+        \_logic_var: (work@macro_arg_spaces_top.f), line:18:20, endln:18:26
+    |vpiInstance:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+  |vpiTaskFunc:
+  \_function: (work@macro_arg_spaces_top.b), line:23:1, endln:26:12
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:b
+    |vpiFullName:work@macro_arg_spaces_top.b
+    |vpiVisibility:1
+    |vpiAutomatic:1
+    |vpiReturn:
+    \_logic_var: (work@macro_arg_spaces_top.b), line:23:20, endln:23:26
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.b), line:23:1, endln:26:12
+      |vpiTypespec:
+      \_ref_typespec: (work@macro_arg_spaces_top.b)
+        |vpiParent:
+        \_logic_var: (work@macro_arg_spaces_top.b), line:23:20, endln:23:26
+        |vpiFullName:work@macro_arg_spaces_top.b
+        |vpiActual:
+        \_logic_typespec: , line:23:20, endln:23:26
+      |vpiFullName:work@macro_arg_spaces_top.b
+    |vpiIODecl:
+    \_io_decl: (i), line:24:15, endln:24:16
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.b), line:23:1, endln:26:12
+      |vpiDirection:1
+      |vpiName:i
+      |vpiTypedef:
+      \_ref_typespec: (work@macro_arg_spaces_top.b.i)
+        |vpiParent:
+        \_io_decl: (i), line:24:15, endln:24:16
+        |vpiFullName:work@macro_arg_spaces_top.b.i
+        |vpiActual:
+        \_logic_typespec: , line:24:8, endln:24:14
+    |vpiStmt:
+    \_assignment: , line:25:2, endln:25:11
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.b), line:23:1, endln:26:12
+      |vpiOpType:82
+      |vpiBlocking:1
+      |vpiRhs:
+      \_operation: , line:25:6, endln:25:11
+        |vpiParent:
+        \_assignment: , line:25:2, endln:25:11
+        |vpiOpType:25
+        |vpiOperand:
+        \_ref_obj: (work@macro_arg_spaces_top.b.i), line:25:6, endln:25:7
+          |vpiParent:
+          \_operation: , line:25:6, endln:25:11
+          |vpiName:i
+          |vpiFullName:work@macro_arg_spaces_top.b.i
+          |vpiActual:
+          \_io_decl: (i), line:24:15, endln:24:16
+        |vpiOperand:
+        \_constant: , line:25:10, endln:25:11
+          |vpiParent:
+          \_operation: , line:25:6, endln:25:11
+          |vpiDecompile:5
+          |vpiSize:64
+          |UINT:5
+          |vpiConstType:9
+      |vpiLhs:
+      \_ref_obj: (work@macro_arg_spaces_top.b.b), line:25:2, endln:25:3
+        |vpiParent:
+        \_assignment: , line:25:2, endln:25:11
+        |vpiName:b
+        |vpiFullName:work@macro_arg_spaces_top.b.b
+        |vpiActual:
+        \_logic_var: (work@macro_arg_spaces_top.b), line:23:20, endln:23:26
+    |vpiInstance:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+  |vpiNet:
+  \_logic_net: (work@macro_arg_spaces_top.i), line:6:20, endln:6:21
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:i
+    |vpiFullName:work@macro_arg_spaces_top.i
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (work@macro_arg_spaces_top.x), line:7:21, endln:7:22
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:x
+    |vpiFullName:work@macro_arg_spaces_top.x
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (work@macro_arg_spaces_top.y), line:7:24, endln:7:25
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:y
+    |vpiFullName:work@macro_arg_spaces_top.y
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (work@macro_arg_spaces_top.z), line:7:27, endln:7:28
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:z
+    |vpiFullName:work@macro_arg_spaces_top.z
+    |vpiNetType:1
+  |vpiPort:
+  \_port: (i), line:6:20, endln:6:21
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:i
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@macro_arg_spaces_top.i.i), line:6:20, endln:6:21
+      |vpiParent:
+      \_port: (i), line:6:20, endln:6:21
+      |vpiName:i
+      |vpiFullName:work@macro_arg_spaces_top.i.i
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.i), line:6:20, endln:6:21
+    |vpiTypedef:
+    \_ref_typespec: (work@macro_arg_spaces_top.i)
+      |vpiParent:
+      \_port: (i), line:6:20, endln:6:21
+      |vpiFullName:work@macro_arg_spaces_top.i
+      |vpiActual:
+      \_logic_typespec: , line:6:8, endln:6:19
+  |vpiPort:
+  \_port: (x), line:7:21, endln:7:22
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:x
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@macro_arg_spaces_top.x.x), line:7:21, endln:7:22
+      |vpiParent:
+      \_port: (x), line:7:21, endln:7:22
+      |vpiName:x
+      |vpiFullName:work@macro_arg_spaces_top.x.x
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.x), line:7:21, endln:7:22
+    |vpiTypedef:
+    \_ref_typespec: (work@macro_arg_spaces_top.x)
+      |vpiParent:
+      \_port: (x), line:7:21, endln:7:22
+      |vpiFullName:work@macro_arg_spaces_top.x
+      |vpiActual:
+      \_logic_typespec: , line:7:9, endln:7:20
+  |vpiPort:
+  \_port: (y), line:7:24, endln:7:25
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:y
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@macro_arg_spaces_top.y.y), line:7:24, endln:7:25
+      |vpiParent:
+      \_port: (y), line:7:24, endln:7:25
+      |vpiName:y
+      |vpiFullName:work@macro_arg_spaces_top.y.y
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.y), line:7:24, endln:7:25
+    |vpiTypedef:
+    \_ref_typespec: (work@macro_arg_spaces_top.y)
+      |vpiParent:
+      \_port: (y), line:7:24, endln:7:25
+      |vpiFullName:work@macro_arg_spaces_top.y
+      |vpiActual:
+      \_logic_typespec: , line:7:9, endln:7:20
+  |vpiPort:
+  \_port: (z), line:7:27, endln:7:28
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:z
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@macro_arg_spaces_top.z.z), line:7:27, endln:7:28
+      |vpiParent:
+      \_port: (z), line:7:27, endln:7:28
+      |vpiName:z
+      |vpiFullName:work@macro_arg_spaces_top.z.z
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.z), line:7:27, endln:7:28
+    |vpiTypedef:
+    \_ref_typespec: (work@macro_arg_spaces_top.z)
+      |vpiParent:
+      \_port: (z), line:7:27, endln:7:28
+      |vpiFullName:work@macro_arg_spaces_top.z
+      |vpiActual:
+      \_logic_typespec: , line:7:9, endln:7:20
+  |vpiContAssign:
+  \_cont_assign: , line:28:8, endln:28:16
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiRhs:
+    \_func_call: (a), line:28:12, endln:28:16
+      |vpiParent:
+      \_cont_assign: , line:28:8, endln:28:16
+      |vpiArgument:
+      \_ref_obj: (work@macro_arg_spaces_top.i), line:28:14, endln:28:15
+        |vpiParent:
+        \_func_call: (a), line:28:12, endln:28:16
+        |vpiTypespec:
+        \_ref_typespec: (work@macro_arg_spaces_top.i)
+          |vpiParent:
+          \_ref_obj: (work@macro_arg_spaces_top.i), line:28:14, endln:28:15
+          |vpiFullName:work@macro_arg_spaces_top.i
+          |vpiActual:
+          \_logic_typespec: , line:14:8, endln:14:14
+        |vpiName:i
+        |vpiFullName:work@macro_arg_spaces_top.i
+        |vpiActual:
+        \_logic_net: (work@macro_arg_spaces_top.i), line:6:20, endln:6:21
+      |vpiName:a
+      |vpiFunction:
+      \_function: (work@macro_arg_spaces_top.a), line:13:1, endln:16:12
+    |vpiLhs:
+    \_ref_obj: (work@macro_arg_spaces_top.x), line:28:8, endln:28:9
+      |vpiParent:
+      \_cont_assign: , line:28:8, endln:28:16
+      |vpiName:x
+      |vpiFullName:work@macro_arg_spaces_top.x
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.x), line:7:21, endln:7:22
+  |vpiContAssign:
+  \_cont_assign: , line:29:8, endln:29:16
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiRhs:
+    \_func_call: (f), line:29:12, endln:29:16
+      |vpiParent:
+      \_cont_assign: , line:29:8, endln:29:16
+      |vpiArgument:
+      \_ref_obj: (work@macro_arg_spaces_top.i), line:29:14, endln:29:15
+        |vpiParent:
+        \_func_call: (f), line:29:12, endln:29:16
+        |vpiTypespec:
+        \_ref_typespec: (work@macro_arg_spaces_top.i)
+          |vpiParent:
+          \_ref_obj: (work@macro_arg_spaces_top.i), line:29:14, endln:29:15
+          |vpiFullName:work@macro_arg_spaces_top.i
+          |vpiActual:
+          \_logic_typespec: , line:19:8, endln:19:14
+        |vpiName:i
+        |vpiFullName:work@macro_arg_spaces_top.i
+        |vpiActual:
+        \_logic_net: (work@macro_arg_spaces_top.i), line:6:20, endln:6:21
+      |vpiName:f
+      |vpiFunction:
+      \_function: (work@macro_arg_spaces_top.f), line:18:1, endln:21:12
+    |vpiLhs:
+    \_ref_obj: (work@macro_arg_spaces_top.y), line:29:8, endln:29:9
+      |vpiParent:
+      \_cont_assign: , line:29:8, endln:29:16
+      |vpiName:y
+      |vpiFullName:work@macro_arg_spaces_top.y
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.y), line:7:24, endln:7:25
+  |vpiContAssign:
+  \_cont_assign: , line:30:8, endln:30:16
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiRhs:
+    \_func_call: (b), line:30:12, endln:30:16
+      |vpiParent:
+      \_cont_assign: , line:30:8, endln:30:16
+      |vpiArgument:
+      \_ref_obj: (work@macro_arg_spaces_top.i), line:30:14, endln:30:15
+        |vpiParent:
+        \_func_call: (b), line:30:12, endln:30:16
+        |vpiTypespec:
+        \_ref_typespec: (work@macro_arg_spaces_top.i)
+          |vpiParent:
+          \_ref_obj: (work@macro_arg_spaces_top.i), line:30:14, endln:30:15
+          |vpiFullName:work@macro_arg_spaces_top.i
+          |vpiActual:
+          \_logic_typespec: , line:24:8, endln:24:14
+        |vpiName:i
+        |vpiFullName:work@macro_arg_spaces_top.i
+        |vpiActual:
+        \_logic_net: (work@macro_arg_spaces_top.i), line:6:20, endln:6:21
+      |vpiName:b
+      |vpiFunction:
+      \_function: (work@macro_arg_spaces_top.b), line:23:1, endln:26:12
+    |vpiLhs:
+    \_ref_obj: (work@macro_arg_spaces_top.z), line:30:8, endln:30:9
+      |vpiParent:
+      \_cont_assign: , line:30:8, endln:30:16
+      |vpiName:z
+      |vpiFullName:work@macro_arg_spaces_top.z
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.z), line:7:27, endln:7:28
+|uhdmtopModules:
+\_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+  |vpiParent:
+  \_design: (work@macro_arg_spaces_top)
+  |vpiName:work@macro_arg_spaces_top
+  |vpiDefName:work@macro_arg_spaces_top
+  |vpiTop:1
+  |vpiTaskFunc:
+  \_function: (work@macro_arg_spaces_top.a), line:13:1, endln:16:12
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:a
+    |vpiFullName:work@macro_arg_spaces_top.a
+    |vpiVisibility:1
+    |vpiAutomatic:1
+    |vpiReturn:
+    \_logic_var: (work@macro_arg_spaces_top.a), line:13:20, endln:13:26
+    |vpiIODecl:
+    \_io_decl: (i), line:14:15, endln:14:16
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.a), line:13:1, endln:16:12
+      |vpiDirection:1
+      |vpiName:i
+      |vpiTypedef:
+      \_ref_typespec: (work@macro_arg_spaces_top.a.i)
+        |vpiParent:
+        \_io_decl: (i), line:14:15, endln:14:16
+        |vpiFullName:work@macro_arg_spaces_top.a.i
+        |vpiActual:
+        \_logic_typespec: , line:14:8, endln:14:14
+    |vpiStmt:
+    \_assignment: , line:15:2, endln:15:11
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.a), line:13:1, endln:16:12
+      |vpiOpType:82
+      |vpiBlocking:1
+      |vpiRhs:
+      \_operation: , line:15:6, endln:15:11
+        |vpiParent:
+        \_assignment: , line:15:2, endln:15:11
+        |vpiOpType:25
+        |vpiOperand:
+        \_ref_obj: (work@macro_arg_spaces_top.a.i), line:15:6, endln:15:7
+          |vpiParent:
+          \_operation: , line:15:6, endln:15:11
+          |vpiName:i
+          |vpiFullName:work@macro_arg_spaces_top.a.i
+          |vpiActual:
+          \_io_decl: (i), line:14:15, endln:14:16
+        |vpiOperand:
+        \_constant: , line:15:10, endln:15:11
+      |vpiLhs:
+      \_ref_obj: (work@macro_arg_spaces_top.a.a), line:15:2, endln:15:3
+        |vpiParent:
+        \_assignment: , line:15:2, endln:15:11
+        |vpiName:a
+        |vpiFullName:work@macro_arg_spaces_top.a.a
+        |vpiActual:
+        \_logic_var: (work@macro_arg_spaces_top.a), line:13:20, endln:13:26
+    |vpiInstance:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+  |vpiTaskFunc:
+  \_function: (work@macro_arg_spaces_top.f), line:18:1, endln:21:12
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:f
+    |vpiFullName:work@macro_arg_spaces_top.f
+    |vpiVisibility:1
+    |vpiAutomatic:1
+    |vpiReturn:
+    \_logic_var: (work@macro_arg_spaces_top.f), line:18:20, endln:18:26
+    |vpiIODecl:
+    \_io_decl: (i), line:19:15, endln:19:16
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.f), line:18:1, endln:21:12
+      |vpiDirection:1
+      |vpiName:i
+      |vpiTypedef:
+      \_ref_typespec: (work@macro_arg_spaces_top.f.i)
+        |vpiParent:
+        \_io_decl: (i), line:19:15, endln:19:16
+        |vpiFullName:work@macro_arg_spaces_top.f.i
+        |vpiActual:
+        \_logic_typespec: , line:19:8, endln:19:14
+    |vpiStmt:
+    \_assignment: , line:20:2, endln:20:11
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.f), line:18:1, endln:21:12
+      |vpiOpType:82
+      |vpiBlocking:1
+      |vpiRhs:
+      \_operation: , line:20:6, endln:20:11
+        |vpiParent:
+        \_assignment: , line:20:2, endln:20:11
+        |vpiOpType:25
+        |vpiOperand:
+        \_ref_obj: (work@macro_arg_spaces_top.f.i), line:20:6, endln:20:7
+          |vpiParent:
+          \_operation: , line:20:6, endln:20:11
+          |vpiName:i
+          |vpiFullName:work@macro_arg_spaces_top.f.i
+          |vpiActual:
+          \_io_decl: (i), line:19:15, endln:19:16
+        |vpiOperand:
+        \_constant: , line:20:10, endln:20:11
+      |vpiLhs:
+      \_ref_obj: (work@macro_arg_spaces_top.f.f), line:20:2, endln:20:3
+        |vpiParent:
+        \_assignment: , line:20:2, endln:20:11
+        |vpiName:f
+        |vpiFullName:work@macro_arg_spaces_top.f.f
+        |vpiActual:
+        \_logic_var: (work@macro_arg_spaces_top.f), line:18:20, endln:18:26
+    |vpiInstance:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+  |vpiTaskFunc:
+  \_function: (work@macro_arg_spaces_top.b), line:23:1, endln:26:12
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:b
+    |vpiFullName:work@macro_arg_spaces_top.b
+    |vpiVisibility:1
+    |vpiAutomatic:1
+    |vpiReturn:
+    \_logic_var: (work@macro_arg_spaces_top.b), line:23:20, endln:23:26
+    |vpiIODecl:
+    \_io_decl: (i), line:24:15, endln:24:16
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.b), line:23:1, endln:26:12
+      |vpiDirection:1
+      |vpiName:i
+      |vpiTypedef:
+      \_ref_typespec: (work@macro_arg_spaces_top.b.i)
+        |vpiParent:
+        \_io_decl: (i), line:24:15, endln:24:16
+        |vpiFullName:work@macro_arg_spaces_top.b.i
+        |vpiActual:
+        \_logic_typespec: , line:24:8, endln:24:14
+    |vpiStmt:
+    \_assignment: , line:25:2, endln:25:11
+      |vpiParent:
+      \_function: (work@macro_arg_spaces_top.b), line:23:1, endln:26:12
+      |vpiOpType:82
+      |vpiBlocking:1
+      |vpiRhs:
+      \_operation: , line:25:6, endln:25:11
+        |vpiParent:
+        \_assignment: , line:25:2, endln:25:11
+        |vpiOpType:25
+        |vpiOperand:
+        \_ref_obj: (work@macro_arg_spaces_top.b.i), line:25:6, endln:25:7
+          |vpiParent:
+          \_operation: , line:25:6, endln:25:11
+          |vpiName:i
+          |vpiFullName:work@macro_arg_spaces_top.b.i
+          |vpiActual:
+          \_io_decl: (i), line:24:15, endln:24:16
+        |vpiOperand:
+        \_constant: , line:25:10, endln:25:11
+      |vpiLhs:
+      \_ref_obj: (work@macro_arg_spaces_top.b.b), line:25:2, endln:25:3
+        |vpiParent:
+        \_assignment: , line:25:2, endln:25:11
+        |vpiName:b
+        |vpiFullName:work@macro_arg_spaces_top.b.b
+        |vpiActual:
+        \_logic_var: (work@macro_arg_spaces_top.b), line:23:20, endln:23:26
+    |vpiInstance:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+  |vpiNet:
+  \_logic_net: (work@macro_arg_spaces_top.i), line:6:20, endln:6:21
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiTypespec:
+    \_ref_typespec: (work@macro_arg_spaces_top.i)
+      |vpiParent:
+      \_logic_net: (work@macro_arg_spaces_top.i), line:6:20, endln:6:21
+      |vpiFullName:work@macro_arg_spaces_top.i
+      |vpiActual:
+      \_logic_typespec: , line:6:8, endln:6:19
+    |vpiName:i
+    |vpiFullName:work@macro_arg_spaces_top.i
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (work@macro_arg_spaces_top.x), line:7:21, endln:7:22
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiTypespec:
+    \_ref_typespec: (work@macro_arg_spaces_top.x)
+      |vpiParent:
+      \_logic_net: (work@macro_arg_spaces_top.x), line:7:21, endln:7:22
+      |vpiFullName:work@macro_arg_spaces_top.x
+      |vpiActual:
+      \_logic_typespec: , line:7:9, endln:7:20
+    |vpiName:x
+    |vpiFullName:work@macro_arg_spaces_top.x
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (work@macro_arg_spaces_top.y), line:7:24, endln:7:25
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiTypespec:
+    \_ref_typespec: (work@macro_arg_spaces_top.y)
+      |vpiParent:
+      \_logic_net: (work@macro_arg_spaces_top.y), line:7:24, endln:7:25
+      |vpiFullName:work@macro_arg_spaces_top.y
+      |vpiActual:
+      \_logic_typespec: , line:7:9, endln:7:20
+    |vpiName:y
+    |vpiFullName:work@macro_arg_spaces_top.y
+    |vpiNetType:1
+  |vpiNet:
+  \_logic_net: (work@macro_arg_spaces_top.z), line:7:27, endln:7:28
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiTypespec:
+    \_ref_typespec: (work@macro_arg_spaces_top.z)
+      |vpiParent:
+      \_logic_net: (work@macro_arg_spaces_top.z), line:7:27, endln:7:28
+      |vpiFullName:work@macro_arg_spaces_top.z
+      |vpiActual:
+      \_logic_typespec: , line:7:9, endln:7:20
+    |vpiName:z
+    |vpiFullName:work@macro_arg_spaces_top.z
+    |vpiNetType:1
+  |vpiTopModule:1
+  |vpiPort:
+  \_port: (i), line:6:20, endln:6:21
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:i
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@macro_arg_spaces_top.i), line:6:20, endln:6:21
+      |vpiParent:
+      \_port: (i), line:6:20, endln:6:21
+      |vpiName:i
+      |vpiFullName:work@macro_arg_spaces_top.i
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.i), line:6:20, endln:6:21
+    |vpiTypedef:
+    \_ref_typespec: (work@macro_arg_spaces_top.i)
+      |vpiParent:
+      \_port: (i), line:6:20, endln:6:21
+      |vpiFullName:work@macro_arg_spaces_top.i
+      |vpiActual:
+      \_logic_typespec: , line:6:8, endln:6:19
+    |vpiInstance:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+  |vpiPort:
+  \_port: (x), line:7:21, endln:7:22
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:x
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@macro_arg_spaces_top.x), line:7:21, endln:7:22
+      |vpiParent:
+      \_port: (x), line:7:21, endln:7:22
+      |vpiName:x
+      |vpiFullName:work@macro_arg_spaces_top.x
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.x), line:7:21, endln:7:22
+    |vpiTypedef:
+    \_ref_typespec: (work@macro_arg_spaces_top.x)
+      |vpiParent:
+      \_port: (x), line:7:21, endln:7:22
+      |vpiFullName:work@macro_arg_spaces_top.x
+      |vpiActual:
+      \_logic_typespec: , line:7:9, endln:7:20
+    |vpiInstance:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+  |vpiPort:
+  \_port: (y), line:7:24, endln:7:25
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:y
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@macro_arg_spaces_top.y), line:7:24, endln:7:25
+      |vpiParent:
+      \_port: (y), line:7:24, endln:7:25
+      |vpiName:y
+      |vpiFullName:work@macro_arg_spaces_top.y
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.y), line:7:24, endln:7:25
+    |vpiTypedef:
+    \_ref_typespec: (work@macro_arg_spaces_top.y)
+      |vpiParent:
+      \_port: (y), line:7:24, endln:7:25
+      |vpiFullName:work@macro_arg_spaces_top.y
+      |vpiActual:
+      \_logic_typespec: , line:7:9, endln:7:20
+    |vpiInstance:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+  |vpiPort:
+  \_port: (z), line:7:27, endln:7:28
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiName:z
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@macro_arg_spaces_top.z), line:7:27, endln:7:28
+      |vpiParent:
+      \_port: (z), line:7:27, endln:7:28
+      |vpiName:z
+      |vpiFullName:work@macro_arg_spaces_top.z
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.z), line:7:27, endln:7:28
+    |vpiTypedef:
+    \_ref_typespec: (work@macro_arg_spaces_top.z)
+      |vpiParent:
+      \_port: (z), line:7:27, endln:7:28
+      |vpiFullName:work@macro_arg_spaces_top.z
+      |vpiActual:
+      \_logic_typespec: , line:7:9, endln:7:20
+    |vpiInstance:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+  |vpiContAssign:
+  \_cont_assign: , line:28:8, endln:28:16
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiRhs:
+    \_func_call: (a), line:28:12, endln:28:16
+      |vpiParent:
+      \_cont_assign: , line:28:8, endln:28:16
+      |vpiArgument:
+      \_ref_obj: (work@macro_arg_spaces_top.i), line:28:14, endln:28:15
+        |vpiParent:
+        \_func_call: (a), line:28:12, endln:28:16
+        |vpiTypespec:
+        \_ref_typespec: (work@macro_arg_spaces_top.i)
+          |vpiParent:
+          \_ref_obj: (work@macro_arg_spaces_top.i), line:28:14, endln:28:15
+          |vpiFullName:work@macro_arg_spaces_top.i
+          |vpiActual:
+          \_logic_typespec: , line:14:8, endln:14:14
+        |vpiName:i
+        |vpiFullName:work@macro_arg_spaces_top.i
+        |vpiActual:
+        \_logic_net: (work@macro_arg_spaces_top.i), line:6:20, endln:6:21
+      |vpiName:a
+      |vpiFunction:
+      \_function: (work@macro_arg_spaces_top.a), line:13:1, endln:16:12
+    |vpiLhs:
+    \_ref_obj: (work@macro_arg_spaces_top.x), line:28:8, endln:28:9
+      |vpiParent:
+      \_cont_assign: , line:28:8, endln:28:16
+      |vpiName:x
+      |vpiFullName:work@macro_arg_spaces_top.x
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.x), line:7:21, endln:7:22
+  |vpiContAssign:
+  \_cont_assign: , line:29:8, endln:29:16
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiRhs:
+    \_func_call: (f), line:29:12, endln:29:16
+      |vpiParent:
+      \_cont_assign: , line:29:8, endln:29:16
+      |vpiArgument:
+      \_ref_obj: (work@macro_arg_spaces_top.i), line:29:14, endln:29:15
+        |vpiParent:
+        \_func_call: (f), line:29:12, endln:29:16
+        |vpiTypespec:
+        \_ref_typespec: (work@macro_arg_spaces_top.i)
+          |vpiParent:
+          \_ref_obj: (work@macro_arg_spaces_top.i), line:29:14, endln:29:15
+          |vpiFullName:work@macro_arg_spaces_top.i
+          |vpiActual:
+          \_logic_typespec: , line:19:8, endln:19:14
+        |vpiName:i
+        |vpiFullName:work@macro_arg_spaces_top.i
+        |vpiActual:
+        \_logic_net: (work@macro_arg_spaces_top.i), line:6:20, endln:6:21
+      |vpiName:f
+      |vpiFunction:
+      \_function: (work@macro_arg_spaces_top.f), line:18:1, endln:21:12
+    |vpiLhs:
+    \_ref_obj: (work@macro_arg_spaces_top.y), line:29:8, endln:29:9
+      |vpiParent:
+      \_cont_assign: , line:29:8, endln:29:16
+      |vpiName:y
+      |vpiFullName:work@macro_arg_spaces_top.y
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.y), line:7:24, endln:7:25
+  |vpiContAssign:
+  \_cont_assign: , line:30:8, endln:30:16
+    |vpiParent:
+    \_module_inst: work@macro_arg_spaces_top (work@macro_arg_spaces_top), file:${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv, line:5:1, endln:32:10
+    |vpiRhs:
+    \_func_call: (b), line:30:12, endln:30:16
+      |vpiParent:
+      \_cont_assign: , line:30:8, endln:30:16
+      |vpiArgument:
+      \_ref_obj: (work@macro_arg_spaces_top.i), line:30:14, endln:30:15
+        |vpiParent:
+        \_func_call: (b), line:30:12, endln:30:16
+        |vpiTypespec:
+        \_ref_typespec: (work@macro_arg_spaces_top.i)
+          |vpiParent:
+          \_ref_obj: (work@macro_arg_spaces_top.i), line:30:14, endln:30:15
+          |vpiFullName:work@macro_arg_spaces_top.i
+          |vpiActual:
+          \_logic_typespec: , line:24:8, endln:24:14
+        |vpiName:i
+        |vpiFullName:work@macro_arg_spaces_top.i
+        |vpiActual:
+        \_logic_net: (work@macro_arg_spaces_top.i), line:6:20, endln:6:21
+      |vpiName:b
+      |vpiFunction:
+      \_function: (work@macro_arg_spaces_top.b), line:23:1, endln:26:12
+    |vpiLhs:
+    \_ref_obj: (work@macro_arg_spaces_top.z), line:30:8, endln:30:9
+      |vpiParent:
+      \_cont_assign: , line:30:8, endln:30:16
+      |vpiName:z
+      |vpiFullName:work@macro_arg_spaces_top.z
+      |vpiActual:
+      \_logic_net: (work@macro_arg_spaces_top.z), line:7:27, endln:7:28
+\_weaklyReferenced:
+\_logic_typespec: , line:13:20, endln:13:26
+  |vpiRange:
+  \_range: , line:13:20, endln:13:26
+    |vpiParent:
+    \_logic_typespec: , line:13:20, endln:13:26
+    |vpiLeftRange:
+    \_constant: , line:13:21, endln:13:23
+      |vpiParent:
+      \_range: , line:13:20, endln:13:26
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:13:24, endln:13:25
+      |vpiParent:
+      \_range: , line:13:20, endln:13:26
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:14:8, endln:14:14
+  |vpiRange:
+  \_range: , line:14:8, endln:14:14
+    |vpiParent:
+    \_logic_typespec: , line:14:8, endln:14:14
+    |vpiLeftRange:
+    \_constant: , line:14:9, endln:14:11
+      |vpiParent:
+      \_range: , line:14:8, endln:14:14
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:14:12, endln:14:13
+      |vpiParent:
+      \_range: , line:14:8, endln:14:14
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:18:20, endln:18:26
+  |vpiRange:
+  \_range: , line:18:20, endln:18:26
+    |vpiParent:
+    \_logic_typespec: , line:18:20, endln:18:26
+    |vpiLeftRange:
+    \_constant: , line:18:21, endln:18:23
+      |vpiParent:
+      \_range: , line:18:20, endln:18:26
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:18:24, endln:18:25
+      |vpiParent:
+      \_range: , line:18:20, endln:18:26
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:19:8, endln:19:14
+  |vpiRange:
+  \_range: , line:19:8, endln:19:14
+    |vpiParent:
+    \_logic_typespec: , line:19:8, endln:19:14
+    |vpiLeftRange:
+    \_constant: , line:19:9, endln:19:11
+      |vpiParent:
+      \_range: , line:19:8, endln:19:14
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:19:12, endln:19:13
+      |vpiParent:
+      \_range: , line:19:8, endln:19:14
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:23:20, endln:23:26
+  |vpiRange:
+  \_range: , line:23:20, endln:23:26
+    |vpiParent:
+    \_logic_typespec: , line:23:20, endln:23:26
+    |vpiLeftRange:
+    \_constant: , line:23:21, endln:23:23
+      |vpiParent:
+      \_range: , line:23:20, endln:23:26
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:23:24, endln:23:25
+      |vpiParent:
+      \_range: , line:23:20, endln:23:26
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:24:8, endln:24:14
+  |vpiRange:
+  \_range: , line:24:8, endln:24:14
+    |vpiParent:
+    \_logic_typespec: , line:24:8, endln:24:14
+    |vpiLeftRange:
+    \_constant: , line:24:9, endln:24:11
+      |vpiParent:
+      \_range: , line:24:8, endln:24:14
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:24:12, endln:24:13
+      |vpiParent:
+      \_range: , line:24:8, endln:24:14
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:6:8, endln:6:19
+  |vpiRange:
+  \_range: , line:6:13, endln:6:19
+    |vpiParent:
+    \_logic_typespec: , line:6:8, endln:6:19
+    |vpiLeftRange:
+    \_constant: , line:6:14, endln:6:16
+      |vpiParent:
+      \_range: , line:6:13, endln:6:19
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:6:17, endln:6:18
+      |vpiParent:
+      \_range: , line:6:13, endln:6:19
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:7:9, endln:7:20
+  |vpiRange:
+  \_range: , line:7:14, endln:7:20
+    |vpiParent:
+    \_logic_typespec: , line:7:9, endln:7:20
+    |vpiLeftRange:
+    \_constant: , line:7:15, endln:7:17
+      |vpiParent:
+      \_range: , line:7:14, endln:7:20
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:7:18, endln:7:19
+      |vpiParent:
+      \_range: , line:7:14, endln:7:20
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:6:8, endln:6:19
+  |vpiParent:
+  \_logic_net: (work@macro_arg_spaces_top.i), line:6:20, endln:6:21
+  |vpiRange:
+  \_range: , line:6:13, endln:6:19
+    |vpiParent:
+    \_logic_typespec: , line:6:8, endln:6:19
+    |vpiLeftRange:
+    \_constant: , line:6:14, endln:6:16
+      |vpiParent:
+      \_range: , line:6:13, endln:6:19
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:6:17, endln:6:18
+      |vpiParent:
+      \_range: , line:6:13, endln:6:19
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:7:9, endln:7:20
+  |vpiRange:
+  \_range: , line:7:14, endln:7:20
+    |vpiParent:
+    \_logic_typespec: , line:7:9, endln:7:20
+    |vpiLeftRange:
+    \_constant: , line:7:15, endln:7:17
+      |vpiParent:
+      \_range: , line:7:14, endln:7:20
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:7:18, endln:7:19
+      |vpiParent:
+      \_range: , line:7:14, endln:7:20
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:6:8, endln:6:19
+  |vpiRange:
+  \_range: , line:6:13, endln:6:19
+    |vpiParent:
+    \_logic_typespec: , line:6:8, endln:6:19
+    |vpiLeftRange:
+    \_constant: , line:6:14, endln:6:16
+      |vpiParent:
+      \_range: , line:6:13, endln:6:19
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:6:17, endln:6:18
+      |vpiParent:
+      \_range: , line:6:13, endln:6:19
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:7:9, endln:7:20
+  |vpiRange:
+  \_range: , line:7:14, endln:7:20
+    |vpiParent:
+    \_logic_typespec: , line:7:9, endln:7:20
+    |vpiLeftRange:
+    \_constant: , line:7:15, endln:7:17
+      |vpiParent:
+      \_range: , line:7:14, endln:7:20
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:7:18, endln:7:19
+      |vpiParent:
+      \_range: , line:7:14, endln:7:20
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:7:9, endln:7:20
+  |vpiRange:
+  \_range: , line:7:14, endln:7:20
+    |vpiParent:
+    \_logic_typespec: , line:7:9, endln:7:20
+    |vpiLeftRange:
+    \_constant: , line:7:15, endln:7:17
+      |vpiParent:
+      \_range: , line:7:14, endln:7:20
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:7:18, endln:7:19
+      |vpiParent:
+      \_range: , line:7:14, endln:7:20
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:7:9, endln:7:20
+  |vpiRange:
+  \_range: , line:7:14, endln:7:20
+    |vpiParent:
+    \_logic_typespec: , line:7:9, endln:7:20
+    |vpiLeftRange:
+    \_constant: , line:7:15, endln:7:17
+      |vpiParent:
+      \_range: , line:7:14, endln:7:20
+      |vpiDecompile:31
+      |vpiSize:64
+      |UINT:31
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:7:18, endln:7:19
+      |vpiParent:
+      \_range: , line:7:14, endln:7:20
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+===================
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
+[WARNING] : 1
+[   NOTE] : 5
+
+============================== Begin RoundTrip Results ==============================
+[roundtrip]: ${SURELOG_DIR}/tests/MacroArgDefaultSpaces/dut.sv | ${SURELOG_DIR}/build/regression/MacroArgDefaultSpaces/roundtrip/dut_000.sv | 11 | 32 |
+============================== End RoundTrip Results ==============================

--- a/tests/MacroArgDefaultSpaces/MacroArgDefaultSpaces.sl
+++ b/tests/MacroArgDefaultSpaces/MacroArgDefaultSpaces.sl
@@ -1,0 +1,1 @@
+-parse -d uhdm -d coveruhdm -elabuhdm -d ast dut.sv -nobuiltin

--- a/tests/MacroArgDefaultSpaces/dut.sv
+++ b/tests/MacroArgDefaultSpaces/dut.sv
@@ -1,0 +1,32 @@
+// Default macro argument with interior whitespace must keep its spaces
+// when the macro is invoked with an empty argument.  See
+// yosys/tests/simple/macro_arg_spaces.sv.
+
+module macro_arg_spaces_top(
+	input wire [31:0] i,
+	output wire [31:0] x, y, z
+);
+
+`define BAR(a) a
+`define FOO(a = function automatic [31:0] f) a
+
+`BAR(function automatic [31:0] a);
+	input [31:0] i;
+	a = i * 2;
+endfunction
+
+`FOO();
+	input [31:0] i;
+	f = i * 3;
+endfunction
+
+`FOO(function automatic [31:0] b);
+	input [31:0] i;
+	b = i * 5;
+endfunction
+
+assign x = a(i);
+assign y = f(i);
+assign z = b(i);
+
+endmodule


### PR DESCRIPTION
`evaluateMacro_` stripped all whitespace from a formal argument's default value via `std::regex_replace(formal_arg_default[1], ws_re, "")` — the same regex that's correctly applied to the formal name on the line above.  For multi-token defaults like
`\`define FOO(a = function automatic [31:0] f) a` the default collapsed to `functionautomatic[31:0]f`, producing a syntax error at the use site `\`FOO()` (yosys/tests/simple/macro_arg_spaces.sv).

Switch the default value to `StringUtils::trim` instead so only the leading/trailing whitespace is removed and the spaces between tokens stay intact.  The formal-name path is unaffected — it's a single identifier.

Test: tests/MacroArgDefaultSpaces/ (yosys macro_arg_spaces.sv verbatim).