### PR TITLE
for regression, allow the path to the surelog folder to contain dot

### DIFF
--- a/tests/regression.tcl
+++ b/tests/regression.tcl
@@ -315,12 +315,12 @@ proc load_tests { } {
     set totaltest 0
     foreach file $fileList {
         if {$VERIFICATION == 0} {
-            regexp {([a-zA-Z0-9_/:-]+)/([a-zA-Z0-9_-]+)\.sl} $file tmp testdir testname
+            regexp {([a-zA-Z0-9_\./:-]+)/([a-zA-Z0-9_-]+)\.sl} $file tmp testdir testname
         } else {
             if {$TESTTARGET == "src" || [regexp {\.json} $TESTTARGET]} {
-                regexp {([a-zA-Z0-9_/:-]+)/([a-zA-Z0-9_\.-]+\.json)} $file tmp testdir testname
+                regexp {([a-zA-Z0-9\._/:-]+)/([a-zA-Z0-9_\.-]+\.json)} $file tmp testdir testname
             } else {
-                regexp {([a-zA-Z0-9_/:-]+)/([a-zA-Z0-9_\.-]+)\.slv} $file tmp testdir testname
+                regexp {([a-zA-Z0-9\._/:-]+)/([a-zA-Z0-9_\.-]+)\.slv} $file tmp testdir testname
             }
         }
         regsub [pwd]/ $testdir "" testdir


### PR DESCRIPTION
Hi,

I was unable to run the regressions because the folder in which surelog was cloned was containing a dot in its name. I suggest by that change to allow the folder to have a dot.

Btw I believe that in tcl regexp, in the square brackets, we do not need to escape the dot. I kept it escaped because it was in the other part of the regexp, to stay consistent. But both should work.

Regards,
  Fabrice