### PR TITLE
PreprocessFile: bound the token-paste look-ahead to avoid OOB read

### DIFF
--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -724,7 +724,7 @@ void PreprocessFile::checkMacroArguments_(
     } else if (s1 == "``") {
       if (i > 0) s1 = tokens[i - 1];
       s1 = StringUtils::trim(s1);
-      s2 = tokens[i + 1];
+      s2 = (i + 1 < tokens.size()) ? tokens[i + 1] : std::string();
       s2 = StringUtils::trim(s2);
       check = true;
     }


### PR DESCRIPTION
### Problem
`PreprocessFile` reads a token vector out of bounds when the `` ` `` `` ` `` token-paste operator is the last body token.

### Root cause
In `SourceCompile/PreprocessFile.cpp`, the ``s1 == "``"`` branch guards the previous-token access (`if (i > 0) s1 = tokens[i - 1];`) but reads the next token as `tokens[i + 1]` unconditionally. When the paste operator is the last token, `i + 1 == tokens.size()`, an out-of-bounds `std::vector::operator[]`.

### Fix
Guard `tokens[i + 1]` symmetrically with the `i - 1` case.

### Verification
Static reasoning. (Surelog builds with cmake and large vendored submodules; not built locally.)
