### PR TITLE
CommandLine: parse numeric arguments without throwing

### DIFF
--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -49,6 +49,7 @@
 #include "Surelog/ErrorReporting/ErrorDefinition.h"
 #include "Surelog/ErrorReporting/Location.h"
 #include "Surelog/SourceCompile/SymbolTable.h"
+#include "Surelog/Utils/NumUtils.h"
 #include "Surelog/Utils/StringUtils.h"
 #include "Surelog/surelog-version.h"
 
@@ -593,9 +594,10 @@ void CommandLineParser::processArgs_(const std::vector<std::string>& args,
     std::string arg(undecorateArg(args[i]));
     if (arg == "-cmd_ign") {
       // ignore command and drop <N> following arguments
-      if (i < args.size() - 2) {
-        const int32_t argcount = std::stoi(args[i + 2]);
-        if (argcount < 0 || argcount > 100) {  // just a sane limit
+      if (i + 2 < args.size()) {
+        int32_t argcount = 0;
+        if (NumUtils::parseInt32(args[i + 2], &argcount) == nullptr ||
+            argcount < 0 || argcount > 100) {  // just a sane limit
           std::cerr << "Illegal argument count for -cmd_ign (" << args[i + 2]
                     << ")" << std::endl;
           return;
@@ -942,8 +944,9 @@ bool CommandLineParser::parseCommandLine(int32_t argc, const char** argv) {
       } else if (all_arguments[i] == "coverelab") {
         // Ignored!
       } else if (is_number(all_arguments[i])) {
-        int32_t debugLevel = std::stoi(all_arguments[i]);
-        if (debugLevel < 0 || debugLevel > 4) {
+        int32_t debugLevel = 0;
+        if (NumUtils::parseInt32(all_arguments[i], &debugLevel) == nullptr ||
+            debugLevel < 0 || debugLevel > 4) {
           Location loc(m_symbolTable->registerSymbol(all_arguments[i]));
           Error err(ErrorDefinition::CMD_DEBUG_INCORRECT_LEVEL, loc);
           m_errors->addError(err);
@@ -1052,7 +1055,12 @@ bool CommandLineParser::parseCommandLine(int32_t argc, const char** argv) {
         break;
       }
       i++;
-      m_nbLinesForFileSplitting = std::stoi(all_arguments[i]);
+      if (NumUtils::parseUint32(all_arguments[i], &m_nbLinesForFileSplitting) ==
+          nullptr) {
+        Location loc(m_symbolTable->registerSymbol(all_arguments[i]));
+        Error err(ErrorDefinition::CMD_SPLIT_FILE_MISSING_SIZE, loc);
+        m_errors->addError(err);
+      }
     } else if (all_arguments[i] == "-builtin") {
       i++;
     } else if (all_arguments[i] == "-exe") {
@@ -1097,8 +1105,11 @@ bool CommandLineParser::parseCommandLine(int32_t argc, const char** argv) {
         uint32_t concurentThreadsSupported =
             std::thread::hardware_concurrency();
         maxMT = concurentThreadsSupported;
-      } else {
-        maxMT = std::stoi(all_arguments[i]);
+      } else if (NumUtils::parseUint32(all_arguments[i], &maxMT) == nullptr) {
+        Location loc(m_symbolTable->registerSymbol(all_arguments[i]));
+        Error err(ErrorDefinition::CMD_MT_INCORRECT_LEVEL, loc);
+        m_errors->addError(err);
+        maxMT = 0;
       }
       if (maxMT > 512) {
         Location loc(m_symbolTable->registerSymbol(all_arguments[i]));

--- a/src/CommandLine/CommandLineParser_test.cpp
+++ b/src/CommandLine/CommandLineParser_test.cpp
@@ -498,5 +498,35 @@ TEST(CommandLineParserTest, WorkingDirectories4) {
                  [&](const PathId& id) { return fileSystem->toPath(id); });
   EXPECT_EQ(expectedSourceFiles, actualSourceFiles);
 }
+
+TEST(CommandLineParserTest, InvalidNumericArgumentsDoNotCrash) {
+  // Regression: these arguments previously reached an unguarded std::stoi (or,
+  // for a lone -cmd_ign, an unsigned-underflow out-of-bounds vector read) and
+  // terminated the process with an uncaught exception. They must now be handled
+  // gracefully (return without throwing/crashing).
+  const fs::path programPath = FileSystem::getProgramPath().string();
+  const std::vector<std::vector<std::string>> argSets{
+      {programPath.string(), "-mt", "auto"},
+      {programPath.string(), "-mt", "99999999999"},
+      {programPath.string(), "-split", "foo"},
+      {programPath.string(), "-d", "."},
+      {programPath.string(), "-cmd_ign", "cmd", "notanumber"},
+      {programPath.string(), "-cmd_ign"},
+  };
+
+  std::unique_ptr<TestFileSystem> fileSystem(new TestFileSystem());
+  for (const std::vector<std::string>& args : argSets) {
+    std::vector<const char*> cargs;
+    cargs.reserve(args.size());
+    std::transform(args.begin(), args.end(), std::back_inserter(cargs),
+                   [](const std::string& arg) { return arg.c_str(); });
+    std::unique_ptr<SymbolTable> symbolTable(new SymbolTable);
+    std::unique_ptr<ErrorContainer> errors(
+        new ErrorContainer(symbolTable.get()));
+    std::unique_ptr<CommandLineParser> clp(
+        new CommandLineParser(errors.get(), symbolTable.get()));
+    clp->parseCommandLine(cargs.size(), cargs.data());
+  }
+}
 }  // namespace
 }  // namespace SURELOG


### PR DESCRIPTION
### Problem
Several numeric command-line arguments are parsed with an unguarded `std::stoi`, which throws (`std::invalid_argument` / `std::out_of_range`) on non-numeric or oversized input. There is no `try`/`catch` on the command-line path (`main` → `parseCommandLine`), so a trivial typo terminates Surelog with an uncaught C++ exception instead of a diagnostic. A separate unsigned-underflow also causes an out-of-bounds read in `-cmd_ign`.

Reproducers (all currently crash):
- `surelog -mt auto file.sv` / `surelog -mt 99999999999 file.sv`
- `surelog -split foo file.sv`
- `surelog -d .` / `surelog -d 99999999999999999999`
- `surelog -cmd_ign cmd notanumber` (throw), and `surelog -cmd_ign` alone (see below)

### Details
- `-mt`/`-mp`/`--threads` (`maxMT = std::stoi(...)`) and `-split` (`m_nbLinesForFileSplitting = std::stoi(...)`) have no numeric guard.
- `-d` gates on `is_number()`, but `is_number` is `find_first_not_of("-.0123456789") == npos`, which accepts `"."`, `"-"`, and `> INT_MAX` digit strings, so `std::stoi` still throws.
- `-cmd_ign` (`processArgs_`): `if (i < args.size() - 2)` computes an **unsigned** subtraction — for a lone `-cmd_ign` token (`args.size() == 1`), `1 - 2` wraps to `SIZE_MAX`, the guard passes, and `args[i + 1]`/`args[i + 2]` read a 1-element vector out of bounds. The count is then `std::stoi(args[i + 2])`, which also throws on a non-numeric value.

### Fix
Route all four numeric parses through the codebase's own non-throwing `NumUtils::parseInt32`/`parseUint32` (from_chars-based; returns `nullptr` on failure), emitting the handler's existing diagnostic (`CMD_MT_INCORRECT_LEVEL`, `CMD_SPLIT_FILE_MISSING_SIZE`, `CMD_DEBUG_INCORRECT_LEVEL`, or the `-cmd_ign` cerr message) on failure. Also fix the `-cmd_ign` guard to `i + 2 < args.size()` to avoid the unsigned underflow.

### Test
`InvalidNumericArgumentsDoNotCrash` in `CommandLineParser_test.cpp` runs `parseCommandLine` over each of the above argument sets and requires it to return without throwing (each previously terminated the process).
