### PR TITLE
SourceCompile: don't throw on an oversized `timescale value

### DIFF
--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -28,6 +28,7 @@
 
 #include <cctype>
 #include <cstdint>
+#include <cstdlib>
 #include <regex>
 #include <string>
 #include <string_view>
@@ -697,7 +698,11 @@ void SV3_1aTreeShapeListener::enterTimescale_directive(
   if (std::regex_match(value, base_match, base_regex)) {
     std::ssub_match base1_sub_match = base_match[1];
     std::string base1 = base1_sub_match.str();
-    compUnitTimeInfo.m_timeUnitValue = std::stoi(base1);
+    // Use non-throwing atoi (as the preprocessor-side sibling does): the regex
+    // group is unbounded digits, so std::stoi would throw std::out_of_range on
+    // a value exceeding int range and crash the parser. An overflowed value is
+    // still != 1/10/100 and is reported below.
+    compUnitTimeInfo.m_timeUnitValue = atoi(base1.c_str());
     if ((compUnitTimeInfo.m_timeUnitValue != 1) &&
         (compUnitTimeInfo.m_timeUnitValue != 10) &&
         (compUnitTimeInfo.m_timeUnitValue != 100)) {
@@ -706,7 +711,7 @@ void SV3_1aTreeShapeListener::enterTimescale_directive(
     compUnitTimeInfo.m_timeUnit = TimeInfo::unitFromString(base_match[2].str());
     std::ssub_match base2_sub_match = base_match[3];
     std::string base2 = base2_sub_match.str();
-    compUnitTimeInfo.m_timePrecisionValue = std::stoi(base2);
+    compUnitTimeInfo.m_timePrecisionValue = atoi(base2.c_str());
     if ((compUnitTimeInfo.m_timePrecisionValue != 1) &&
         (compUnitTimeInfo.m_timePrecisionValue != 10) &&
         (compUnitTimeInfo.m_timePrecisionValue != 100)) {


### PR DESCRIPTION
### Problem
`SV3_1aTreeShapeListener::enterTimescale_directive` parses the `` `timescale `` unit/precision values with `std::stoi`, which throws `std::out_of_range` on a value exceeding `int` range — crashing the parser with an uncaught exception.

### Details
The grammar's `Integral_number` allows an unbounded digit string, and the regex group `([0-9]+)` captures it verbatim, so a directive like `` `timescale 3000000000 s / 1 s `` (any size/precision `> INT_MAX`) makes `std::stoi(base1)` / `std::stoi(base2)` throw. The parse-tree walk (`ParseTreeWalker::walk`, `ParseFile.cpp:529/568`) is not wrapped in a `try`/`catch` on this path — the only catch blocks handle `antlr4::ParseCancellationException` around the parse itself — so the exception unwinds to `std::terminate`.

The preprocessor-side sibling (`SV3_1aPpTreeShapeListener::enterTimescale_directive`, lines 1041/1045) already parses the same values with non-throwing `atoi`.

### Fix
Use non-throwing `atoi` for both the time-unit and precision values, matching the Pp-side sibling. An overflowed value is still `!= 1/10/100`, so it is reported through the existing `PA_TIMESCALE_INVALID_VALUE` diagnostic instead of crashing.

### Testing
Verified by static reasoning (`std::stoi` overflow semantics). Happy to add an end-to-end parse test for an oversized `` `timescale `` value if you'd like — kept this to the minimal sibling-matching fix.
