### PR TITLE
Expression: fix out-of-bounds access in fromString for malformed literal

### DIFF
--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -1028,15 +1028,19 @@ Value* ExprBuilder::fromString(std::string_view value) {
     uint32_t i = 0;
     for (i = 0; i < value.size(); i++) {
       if (value[i] == '\'') {
-        base = value[i + 1];
-        if (base == 's' || base == 'S') base = value[i + 2];
+        if (i + 1 < value.size()) base = value[i + 1];
+        if ((base == 's' || base == 'S') && i + 2 < value.size())
+          base = value[i + 2];
         break;
       }
     }
+    // Guard against a malformed literal whose apostrophe is at/near the end
+    // (e.g. "4'"): std::string_view::substr(pos) throws std::out_of_range when
+    // pos > size().
     if (value.find_first_of("sS") != std::string::npos) {
-      sval = value.substr(i + 3);
+      if (i + 3 <= value.size()) sval = value.substr(i + 3);
     } else {
-      sval = value.substr(i + 2);
+      if (i + 2 <= value.size()) sval = value.substr(i + 2);
     }
     sval = StringUtils::replaceAll(sval, "_", "");
     // No check for validity of sval being a legal parse-able value.

--- a/src/Expression/ExprBuilder_test.cpp
+++ b/src/Expression/ExprBuilder_test.cpp
@@ -93,6 +93,20 @@ TEST(ExprBuilderTest, BuildFrom) {
     EXPECT_EQ(v6->uhdmValue(), "UINT:11");
   }
 }
+TEST(ExprBuilderTest, FromStringMalformedLiteralDoesNotCrash) {
+  // Malformed based-literals whose apostrophe is at or near the end previously
+  // read/substr'd past the end of the string_view and crashed with
+  // std::out_of_range; they must now be handled without crashing.
+  ExprBuilder builder;
+  std::unique_ptr<Value> v1(builder.fromString("4'"));
+  EXPECT_NE(v1, nullptr);
+  std::unique_ptr<Value> v2(builder.fromString("'"));
+  EXPECT_NE(v2, nullptr);
+  std::unique_ptr<Value> v3(builder.fromString("4's"));
+  EXPECT_NE(v3, nullptr);
+  std::unique_ptr<Value> v4(builder.fromString("'s"));
+  EXPECT_NE(v4, nullptr);
+}
 TEST(ExprBuilderTest, ExprFromParseTree1) {
   ExprBuilder builder;
   ParserHarness harness;


### PR DESCRIPTION
### Problem
`ExprBuilder::fromString` reads and `substr`s past the end of its `std::string_view` for a malformed based-literal whose apostrophe is at or near the end (e.g. `4'`), throwing `std::out_of_range` and crashing.

### Details
After locating the apostrophe at index `i`, the code does:
```cpp
base = value[i + 1];
if (base == 's' || base == 'S') base = value[i + 2];
...
if (value.find_first_of("sS") != std::string::npos) sval = value.substr(i + 3);
else                                                 sval = value.substr(i + 2);
```
For `value == "4'"` (size 2), the apostrophe is the last char (`i == 1`), so `value.substr(i + 2) == value.substr(3)` and `std::string_view::substr(pos)` throws `std::out_of_range` when `pos > size()`. `value[i + 1]`/`value[i + 2]` are also past-the-end reads. `4's` (signed prefix, no digits) hits the same on `substr(i + 3)`.

This is reachable from a command-line parameter override: `surelog -Px=4' top.sv`. The `-P` value is stored verbatim, and `DesignElaboration::elaborateInstance_` calls `m_exprBuilder.fromString(value)` for every override **before** any parameter-existence check, with no `try`/`catch` on that path — so the throw reaches `std::terminate`.

### Fix
Bounds-check the offsets before the reads/`substr` (`i + 1`/`i + 2` against `size()`, `i + 2`/`i + 3` against `size()`), leaving `sval` empty for a malformed literal. The op still returns a value; it just no longer reads out of bounds.

### Test
`FromStringMalformedLiteralDoesNotCrash` in `ExprBuilder_test.cpp` calls `fromString` on `4'`, `'`, `4's`, and `'s` (each previously crashed) and checks it returns without crashing.
