### PR TITLE
DesignCompile: guard divide-by-zero and 32-bit shift UB in pattern expansion

### DIFF
--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -5009,10 +5009,15 @@ int32_t CompileHelper::adjustOpSize(const typespec* tps, expr* cop,
         fileSystem->toPathId(rtps->VpiFile(),
                              compileDesign->getCompiler()->getSymbolTable()),
         rtps->VpiLineNo(), true);
-    int32_t ncsize = fullSize / innerSize;
-    // Fix the size of the member:
-    adjustUnsized(any_cast<constant*>(cop), ncsize);
-    cop->VpiSize(ncsize);
+    // innerSize is a Bits() result and can be 0 when the width is unresolvable
+    // (e.g. a cyclic or too-deeply-nested type trips loop detection); guard the
+    // division to avoid a divide-by-zero crash and leave the size unchanged.
+    if (innerSize != 0) {
+      int32_t ncsize = fullSize / innerSize;
+      // Fix the size of the member:
+      adjustUnsized(any_cast<constant*>(cop), ncsize);
+      cop->VpiSize(ncsize);
+    }
   } else {
     int32_t ncsize = Bits(
         rtps, invalidValue, component, compileDesign, Reduce::Yes, instance,
@@ -5132,7 +5137,7 @@ UHDM::expr* CompileHelper::expandPatternAssignment(const typespec* tps,
                   }
                 }
                 values[valIndex] =
-                    (defaultval & (1 << (csize - 1 - i))) ? 1 : 0;
+                    (defaultval & ((uint64_t)1 << (csize - 1 - i))) ? 1 : 0;
                 valIndex++;
               }
             }
@@ -5186,7 +5191,8 @@ UHDM::expr* CompileHelper::expandPatternAssignment(const typespec* tps,
                     }
                   }
                   if (found) {
-                    values[valIndex] = (val & (1 << (csize - 1 - i))) ? 1 : 0;
+                    values[valIndex] =
+                        (val & ((uint64_t)1 << (csize - 1 - i))) ? 1 : 0;
                   }
                   valIndex++;
                 }


### PR DESCRIPTION
### Problem
Two defects in assignment-pattern (`'{...}`) expansion in `CompileHelper.cpp`:

1. **Divide-by-zero (crash).** For a logic-typed pattern target:
   ```cpp
   uint64_t innerSize = Bits(rtps, invalidValue, ..., /*sizeMode=*/true);
   int32_t ncsize = fullSize / innerSize;
   ```
   `Bits()` returns `0` when the width is unresolvable — e.g. loop detection fires for a cyclic or too-deeply-nested type (`Bits` → `loopDetected()` → returns `0` and latches `m_unwind`). Both `Bits` calls use the same typespec, so under loop-unwind both return `0`, giving `0 / 0` → SIGFPE. The loop-detection path returns `0` **without** setting `invalidValue`, so the later `invalidValue` check cannot catch it.

2. **32-bit shift UB (silent miscompute).** For a struct-typed pattern, `(defaultval & (1 << (csize - 1 - i)))` (and the `val` variant) shift the 32-bit `int` literal `1` by `csize - 1 - i`. The adjacent guards only reject `shift < 0 || shift >= 64`, so they permit shifts of 32..63 — reachable for a struct member wider than 32 bits (e.g. `logic [63:0]`). Shifting an `int` by ≥ 32 is undefined behavior (on x86 the count is masked to 5 bits, testing the wrong bit). The sibling loops in the same function already use `1ULL` / `(uint64_t)1`.

### Fix
1. Only divide when `innerSize != 0`, leaving the size unchanged otherwise (consistent with the function's other early-outs on unresolvable sizes).
2. Shift a 64-bit `1` (`(uint64_t)1 << …`) at both sites, matching the sibling loops.

### Testing
Static reasoning. Fix-only: (1) needs a pathological cyclic/deeply-nested type width to drive `Bits()` to `0` during elaboration; (2) is UB (UBSan-detected) rather than a hard crash. Happy to add elaboration tests if you'd like.

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
