### PR TITLE
DesignCompile: guard null-deref and 32-bit shift UB in constant parameter compilation

### DIFF
--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -3626,7 +3626,8 @@ bool CompileHelper::compileParameterDeclaration(
         UHDM::any* expr = compileExpression(
             component, fC, actual_value, compileDesign,
             isMultiDimension ? Reduce::No : reduce, param, nullptr);
-        UHDM::UHDM_OBJECT_TYPE exprtype = expr->UhdmType();
+        UHDM::UHDM_OBJECT_TYPE exprtype =
+            expr ? expr->UhdmType() : UHDM::uhdmconstant;
         if (expr) {
           expr = defaultPatternAssignment(ts, expr, component, compileDesign,
                                           instance);
@@ -3653,7 +3654,7 @@ bool CompileHelper::compileParameterDeclaration(
           adjustSize(ts, component, compileDesign, instance, c);
           Value* val = m_exprBuilder.fromVpiValue(c->VpiValue(), size);
           component->setValue(the_name, val, m_exprBuilder);
-        } else if ((reduce == Reduce::Yes) && (!isMultiDimension)) {
+        } else if (expr && (reduce == Reduce::Yes) && (!isMultiDimension)) {
           UHDM::expr* the_expr = (UHDM::expr*)expr;
           if (the_expr->Typespec() == nullptr) {
             ref_typespec* tsRef = s.MakeRef_typespec();
@@ -4028,7 +4029,7 @@ UHDM::constant* CompileHelper::adjustSize(const UHDM::typespec* ts,
           }
         } else if (ttype == uhdmint_typespec) {
           if (constantIsSigned) {
-            uint64_t msb = val & 1 << (orig_size - 1);
+            uint64_t msb = val & ((uint64_t)1 << (orig_size - 1));
             if (msb) {
               // 2's complement
               std::string v = std::string(c->VpiValue());


### PR DESCRIPTION
## Problem
Two defects in `CompileHelper::compileParameterDeclaration` / `adjustSize` when compiling a constant parameter at package or `$unit` scope.

### 1. Null-pointer dereference (crash)
In `compileParameterDeclaration`:
```cpp
UHDM::any* expr = compileExpression(
    component, fC, actual_value, compileDesign,
    isMultiDimension ? Reduce::No : reduce, param, nullptr);
UHDM::UHDM_OBJECT_TYPE exprtype = expr->UhdmType();   // deref
if (expr) {                                           // null check, one line too late
```
`expr` is dereferenced on the line *before* the author's own `if (expr)` null check. `compileExpression` legitimately returns `nullptr` when the right-hand side is a `data_type` rather than a value — `CompileExpression.cpp` has `case VObjectType::paData_type: ... return nullptr;` ("When trying to evaluate type parameters"). A `constant_param_expression` may grammatically be a `data_type`, so an ordinary (non-type) parameter with a data-type RHS reaches this path and crashes.

There is a second unguarded use of the same possibly-null `expr` further down:
```cpp
} else if ((reduce == Reduce::Yes) && (!isMultiDimension)) {   // no `expr &&`
  UHDM::expr* the_expr = (UHDM::expr*)expr;
  if (the_expr->Typespec() == nullptr) {                       // deref of null
```
The sibling branches all correctly gate on `expr && ...`; these two are the outliers.

Trigger (parseable SystemVerilog):
```systemverilog
package pkg;
  localparam p = int;   // data_type as the RHS of an ordinary parameter
endpackage
```

### 2. 32-bit shift undefined behavior
In `adjustSize` (called from the same block):
```cpp
uint64_t msb = val & 1 << (orig_size - 1);
```
`1` is a 32-bit `int` and `orig_size` is the constant's bit width (`c->VpiSize()`), which the grammar leaves unbounded. For a width `>= 33` (e.g. a wide signed based literal), `1 << (orig_size - 1)` shifts by `>= 32`, which is undefined behavior (and already sign-overflows at 32). The sibling constant code and `expandPatternAssignment` already use `(uint64_t)1 << ...`.

## Fix
- Guard the dereference at the point of use, matching the existing `expr && ...` idiom:
  ```cpp
  UHDM::UHDM_OBJECT_TYPE exprtype = expr ? expr->UhdmType() : UHDM::uhdmconstant;
  ...
  } else if (expr && (reduce == Reduce::Yes) && (!isMultiDimension)) {
  ```
  With `expr` null, control now falls through to the existing `else if (Value* val = m_exprBuilder.evalExpr(...))` branch (which reports the error), instead of dereferencing null.
- Promote the shift operand to 64-bit: `val & ((uint64_t)1 << (orig_size - 1))`, matching the file's own idiom.

## Test
Not added: `compileParameterDeclaration`/`adjustSize` require a full design-compile context (FileContent, parse-tree NodeIds, `CompileDesign`) that the low-level `CompileHelper_test.cpp` unit harness (which drives individual methods with hand-built UHDM objects) cannot construct. Happy to add an end-to-end regression case under `tests/` if you'd prefer.
