### PR TITLE
Expression: guard modulo by zero to avoid SIGFPE in constant folding

### DIFF
--- a/src/Expression/ExprBuilder_test.cpp
+++ b/src/Expression/ExprBuilder_test.cpp
@@ -152,5 +152,24 @@ TEST(ExprBuilderTest, ExprFromParseTree2) {
     EXPECT_EQ(val->getValueUL(), 16);
   }
 }
+
+TEST(ExprBuilderTest, ModuloByZeroDoesNotCrash) {
+  ExprBuilder builder;
+  ParserHarness harness;
+  auto fC = harness.parse(
+      "module top();"
+      "parameter p = 4 % 0;"
+      "endmodule");
+  NodeId root = fC->getRootNode();
+  std::vector<NodeId> assigns =
+      fC->sl_collect_all(root, VObjectType::paParam_assignment);
+  for (NodeId param_assign : assigns) {
+    NodeId param = fC->Child(param_assign);
+    NodeId rhs = fC->Sibling(param);
+    // Modulo by zero must not crash (SIGFPE); it yields an invalid value.
+    std::unique_ptr<Value> val(builder.evalExpr(fC.get(), rhs));
+    EXPECT_FALSE(val->isValid());
+  }
+}
 }  // namespace
 }  // namespace SURELOG

--- a/src/Expression/Value.cpp
+++ b/src/Expression/Value.cpp
@@ -610,6 +610,14 @@ void SValue::mod(const Value* a, const Value* b) {
   const SValue* aval = (const SValue*)a;
   const SValue* bval = (const SValue*)b;
   m_size = (aval->m_size > bval->m_size) ? aval->m_size : bval->m_size;
+  if (bval->m_value.s_int == 0) {
+    // Modulo by zero: mirror div() and produce an invalid value instead of
+    // executing a hardware modulo, which raises SIGFPE.
+    m_valid = 0;
+    m_value.s_int = 0;
+    m_negative = 0;
+    return;
+  }
   switch (aval->getType()) {
     case Value::Type::Scalar:
       m_negative = 0;
@@ -1540,6 +1548,15 @@ void LValue::mod(const Value* a, const Value* b) {
   m_valueArray[0].m_size =
       (a->getSize(0) > b->getSize(0)) ? a->getSize(0) : b->getSize(0);
   if (!m_valid) return;
+  if (!b->getValueL(0)) {
+    // Modulo by zero: mirror div() and produce an invalid value instead of
+    // executing a hardware modulo, which raises SIGFPE.
+    m_valueArray[0].m_value.s_int = 0;
+    m_valid = 0;
+    m_negative = 0;
+    m_type = Value::Type::Unsigned;
+    return;
+  }
   switch (a->getType()) {
     case Value::Type::Scalar:
       m_negative = 0;


### PR DESCRIPTION
## Problem
Constant-folding a modulo by zero crashes Surelog with SIGFPE. A parameter such as
```systemverilog
module top();
  parameter p = 4 % 0;
endmodule
```
(or any constant-folded `%` with a zero right-hand side — parameter/localparam values, enum values, range or replication counts, etc.) aborts the process during expression evaluation, before any semantic zero-divisor diagnostic.

## Root cause
`Value::div` guards against a zero divisor but `Value::mod` does not. In both value representations, `div` checks the divisor and marks the result invalid on zero:
- `LValue::div`: `if (b->getValueL(0)) { ...divide... } else { m_valid = 0; ... }`
- `SValue::div`: `if (bval->m_value.s_int == 0) { m_valid = 0; ... } else { ...divide... }`

The `mod` twins have no such check and execute a hardware modulo directly:
- `LValue::mod` (`Value.cpp`): `m_valueArray[0].m_value.u_int = a->getValueUL(0) % b->getValueUL(0);`
- `SValue::mod` (`Value.cpp`): `m_value.u_int = aval->m_value.u_int % bval->m_value.u_int;`

`mod` computes `m_valid = a->isValid() && b->isValid()`, but a literal `0` is a *valid* value, so the `if (!m_valid) return;` early-out does not fire and execution reaches `% 0`, raising SIGFPE (default action: terminate). `ExprBuilder::evalExpr`'s `paBinOp_Percent` case calls `value->mod(valueL, valueR)` with no divisor check, and `evalExpr` is invoked throughout compilation and elaboration (parameter values, enum values, sized ranges, general constant evaluation). There is no `try`/`catch` on this path (and none could intercept SIGFPE), and no SIGFPE handler exists.

## Fix
Add the same zero-divisor guard `div` already has to both `mod` implementations, producing an invalid value instead of dividing:
- `LValue::mod`: `if (!b->getValueL(0)) { ...m_valid = 0; return; }` (mirrors `LValue::div`).
- `SValue::mod`: `if (bval->m_value.s_int == 0) { m_valid = 0; ...; return; }` (mirrors `SValue::div`).

## Test
`ExprBuilderTest.ModuloByZeroDoesNotCrash` (cloned from the existing `ExprFromParseTree2`): folds `parameter p = 4 % 0;` via `ExprBuilder::evalExpr`. Before the fix this SIGFPEs the test binary; after, the value is simply invalid (`isValid() == false`).
