### PR TITLE
SourceCompile: guard unchecked tokenize in SLline directive handling

### DIFF
--- a/src/SourceCompile/AnalyzeFile.cpp
+++ b/src/SourceCompile/AnalyzeFile.cpp
@@ -62,6 +62,10 @@ void AnalyzeFile::checkSLlineDirective_(std::string_view line,
     text = StringUtils::unquoted(text);
     std::vector<std::string_view> parts;
     StringUtils::tokenize(text, "^", parts);
+    // A malformed SLline line may tokenize to fewer than two parts (an empty
+    // remainder yields none, a "^"-less one yields a single part); ignore it
+    // rather than indexing out of bounds.
+    if (parts.size() < 2) return;
     std::string_view symbol = StringUtils::unquoted(parts[0]);
     std::string_view file = StringUtils::unquoted(parts[1]);
     info.m_sectionSymbolId = m_clp->getSymbolTable()->registerSymbol(symbol);

--- a/src/SourceCompile/SV3_1aTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aTreeShapeListener.cpp
@@ -214,6 +214,9 @@ void SV3_1aTreeShapeListener::exitSlline(SV3_1aParser::SllineContext *ctx) {
   std::string text(StringUtils::unquoted(ctx->String()->getText()));
   std::vector<std::string_view> parts;
   StringUtils::tokenize(text, "^", parts);
+  // A malformed SLline String may tokenize to fewer than two parts; ignore it
+  // rather than indexing out of bounds.
+  if (parts.size() < 2) return;
   std::string_view symbol = StringUtils::unquoted(parts[0]);
   std::string_view file = StringUtils::unquoted(parts[1]);
 


### PR DESCRIPTION
## Problem
Two SLline-directive handlers tokenize a string on `^` and then index `parts[0]`/`parts[1]` with no size check. `StringUtils::tokenize` returns an **empty** vector for empty input and a **single-element** vector when the input contains no `^`, so a malformed line reads out of bounds — `parts[0]` on the empty vector dereferences a null `begin()` (segfault), and `parts[1]` on the one-element vector is an out-of-bounds read.

### 1. `AnalyzeFile::checkSLlineDirective_` (reachable via `-split`)
```cpp
ss >> keyword;
if (keyword == "SLline") {
  ...
  ss >> info.m_sectionStartLine;   // fails (no int) -> stream in fail state
  std::string text;
  ss >> text;                      // reads nothing -> text stays empty
  text = StringUtils::unquoted(text);
  std::vector<std::string_view> parts;
  StringUtils::tokenize(text, "^", parts);   // empty text -> empty parts
  std::string_view symbol = StringUtils::unquoted(parts[0]);   // OOB / null deref
  std::string_view file = StringUtils::unquoted(parts[1]);
```
`checkSLlineDirective_` runs on every line of every source file when file splitting is enabled, and matches any line whose first whitespace token is the identifier `SLline`. A file that uses `SLline` as an ordinary identifier crashes:
```systemverilog
module SLline;
endmodule
module top;
  SLline u1();
endmodule
```
`surelog -split 1 file.sv` → on `SLline u1();` the integer extraction fails, `text` is empty, and `parts[0]` dereferences an empty vector.

### 2. `SV3_1aTreeShapeListener::exitSlline`
The same unchecked `parts[0]`/`parts[1]` after tokenizing the `slline` rule's `String` on `^`. The re-emitted `` `line `` string carries no `^`, so `parts` has size 1 and `parts[1]` reads out of bounds. This path is reached with `-outputlineinfo`.

## Fix
Guard both sites with a size check before indexing, matching the defensive style already used elsewhere in these files:
```cpp
StringUtils::tokenize(text, "^", parts);
if (parts.size() < 2) return;   // malformed SLline line; ignore
```

## Test
Not added as a unit test: both handlers run inside the file-analysis / parse-tree-walk pipeline (needing a `CompileSourceFile`/`CommandLineParser` fixture the unit harness doesn't set up). Reproducible end-to-end via the `surelog -split 1 file.sv` case above.
