### PR TITLE
ElaborationStep: guard null getSimpleVarFromTypespec in makeVar_ SimpleType branch

### DIFF
--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -1845,24 +1845,29 @@ any* ElaborationStep::makeVar_(DesignComponent* component, Signal* sig,
       UHDM::typespec* spec = sit->getTypespec();
       spec = m_helper.elabTypespec(component, spec, m_compileDesign, nullptr,
                                    instance);
-      variables* var = m_helper.getSimpleVarFromTypespec(spec, packedDimensions,
-                                                         m_compileDesign);
-      var->VpiConstantVariable(sig->isConst());
-      var->VpiSigned(sig->isSigned());
-      var->VpiName(signame);
-      if (var->Typespec() == nullptr) {
-        ref_typespec* specRef = s.MakeRef_typespec();
-        specRef->VpiParent(var);
-        var->Typespec(specRef);
+      // getSimpleVarFromTypespec returns null for typespecs it does not handle
+      // (e.g. a typedef of chandle/event/interface); guard the dereference and
+      // let the fallback below build a variable, matching the sibling call
+      // sites (e.g. the Parameter branch and CompileType).
+      if (variables* var = m_helper.getSimpleVarFromTypespec(
+              spec, packedDimensions, m_compileDesign)) {
+        var->VpiConstantVariable(sig->isConst());
+        var->VpiSigned(sig->isSigned());
+        var->VpiName(signame);
+        if (var->Typespec() == nullptr) {
+          ref_typespec* specRef = s.MakeRef_typespec();
+          specRef->VpiParent(var);
+          var->Typespec(specRef);
+        }
+        var->Typespec()->Actual_typespec(spec);
+        if (assignExp != nullptr) {
+          var->Expr(assignExp);
+          assignExp->VpiParent(var);
+        }
+        obj = var;
+        found = true;
+        break;
       }
-      var->Typespec()->Actual_typespec(spec);
-      if (assignExp != nullptr) {
-        var->Expr(assignExp);
-        assignExp->VpiParent(var);
-      }
-      obj = var;
-      found = true;
-      break;
     } else if (/*const ClassDefinition* cl = */ datatype_cast<
                const ClassDefinition*>(dtype)) {
       class_var* stv = s.MakeClass_var();


### PR DESCRIPTION
## Problem
Elaborating a signal whose type is a typedef of `chandle` (or `event`, an interface, a packed array, ...) segfaults during design elaboration:
```systemverilog
module top;
  typedef chandle ct;
  ct v;
endmodule
```
`surelog -parse -elabuhdm -d uhdm top.sv` → `Segmentation fault (core dumped)`.

## Root cause
In `ElaborationStep::makeVar_`, the `SimpleType` branch dereferences the result of `getSimpleVarFromTypespec` without a null check:
```cpp
variables* var = m_helper.getSimpleVarFromTypespec(spec, packedDimensions, m_compileDesign);
var->VpiConstantVariable(sig->isConst());   // segfault when var == nullptr
```
`getSimpleVarFromTypespec` (`CompileType.cpp`) has a `default: break;` and returns null for any typespec it doesn't handle — including `chandle_typespec`, `event_typespec`, `interface_typespec`, `packed_array_typespec` and `unsupported_typespec`. A bare `chandle c;` takes a different path, but a *typedef* of `chandle` flows through this `SimpleType` branch, so `var` is null and the dereference crashes. It is reached via `NetlistElaboration::elabSignal` → `makeVar_` with no upstream guard.

The sibling call sites already null-check this exact call — the `Parameter` branch a few lines below (`if (variables* var = m_helper.getSimpleVarFromTypespec(...))`) and `CompileType.cpp`.

## Fix
Guard the dereference with the same `if (variables* var = ...)` idiom. When the result is null, `found` stays false and the existing fallback in `makeVar_` builds a variable, so the typedef elaborates as a plain variable (graceful) instead of crashing.

## Test
Not a `*_test.cpp` unit test — `makeVar_` needs full netlist-elaboration context. Reproducible end-to-end with the 3-line module above (segfault before the fix, clean UHDM after).

## Note
The same `getSimpleVarFromTypespec` result is dereferenced without a null check at a handful of other call sites (in `NetlistElaboration.cpp` and `CompileType.cpp`) where sibling sites do guard it. I scoped this PR to the reproduced crash but am happy to harden those in a follow-up if you'd like.
