### PR TITLE
PreprocessFile: guard empty formal argument in evaluateMacro_

### DIFF
--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -894,6 +894,11 @@ std::pair<bool, std::string> PreprocessFile::evaluateMacro_(
   for (uint32_t i = 0; i < formal_args.size(); i++) {
     std::vector<std::string> formal_arg_default;
     StringUtils::tokenize(formal_args[i], "=", formal_arg_default);
+    if (formal_arg_default.empty()) {
+      // Empty formal argument (e.g. produced by a malformed default value);
+      // nothing to substitute, so skip it instead of indexing an empty vector.
+      continue;
+    }
     const std::string formal =
         std::regex_replace(formal_arg_default[0], ws_re, "");
     bool empty_actual = true;


### PR DESCRIPTION
## Problem
Instantiating a macro whose formal-argument list contains an argument that tokenizes to empty segfaults the preprocessor:
```systemverilog
`define M(a=(,),b) hello
`M(1,2)
```
`surelog -parse f.sv` → `Segmentation fault (core dumped)`.

## Root cause
In `PreprocessFile::evaluateMacro_`, each formal argument is split on `=` and then indexed without a size check:
```cpp
StringUtils::tokenize(formal_args[i], "=", formal_arg_default);
const std::string formal =
    std::regex_replace(formal_arg_default[0], ws_re, "");   // OOB on empty vector
```
`StringUtils::tokenize` returns an empty vector for empty input (`StringUtils.cpp`: `if (str.empty()) return result;`), so when `formal_args[i]` is the empty string, `formal_arg_default` is empty and `formal_arg_default[0]` dereferences the empty vector (the reference is then handed to `std::regex_replace`, which reads it → SIGSEGV). This is the same unchecked `tokenize(...); parts[0]` idiom fixed in #4108.

A `(,)` default value is grammatically valid (`paired_parens` admits a bare comma), and `recordMacro` strips only the first `(` and first `)` from the raw argument text `(a=(,),b)`, collapsing it to `a=(,,b)`; comma-tokenizing that yields `["a=(", "", "b)"]`, so `formal_args[1]` is empty. The crash is deferred to the instantiation site (`` `M(1,2) `` → `getMacro` → `evaluateMacro_`), with no `try`/`catch` on the path (it is a null dereference, not an exception).

## Fix
Guard the index and skip an empty formal argument (there is nothing to substitute for it):
```cpp
StringUtils::tokenize(formal_args[i], "=", formal_arg_default);
if (formal_arg_default.empty()) {
  continue;
}
```

## Test
Not a `*_test.cpp` unit test here (the crash is in the instantiation path); reproducible end-to-end with the 2-line source above — segfault before the fix, clean preprocessing after.
