### PR TITLE
CompileHelper: guard null typespec in defaultPatternAssignment pattern op

### DIFF
--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -3363,6 +3363,7 @@ UHDM::any* CompileHelper::defaultPatternAssignment(const UHDM::typespec* tps,
           if (const UHDM::ref_typespec* rt = pattern->Typespec()) {
             ptps = rt->Actual_typespec();
           }
+          if (ptps == nullptr) break;
           if (ptps->VpiName() == "default") {
             UHDM::ExprEval eval;
             expr* expat = (expr*)pattern->Pattern();


### PR DESCRIPTION
## Problem
A struct/array assignment pattern whose member key is a cast expression segfaults during elaboration:
```systemverilog
module top();
  typedef struct packed { int a; } s;
  s x = '{ int'(0): 1 };
endmodule
```
`surelog -parse repro.sv` → `Segmentation fault`.

## Root cause
In `CompileHelper::defaultPatternAssignment`, the `vpiAssignmentPatternOp` case dereferences a possibly-null typespec:
```cpp
const typespec* ptps = nullptr;
if (const UHDM::ref_typespec* rt = pattern->Typespec()) {
  ptps = rt->Actual_typespec();
}
if (ptps->VpiName() == "default") {   // segfault when ptps == nullptr
```
`ptps` stays null when the tagged pattern has no typespec. A `'{key: value}` member sets its typespec only when `compileTypespec` succeeds for the key; for a cast-expression key (`int'(0)`, `byte'(0)`, `4'(0)`), `compileTypespec` returns null, so `pattern->Typespec()` is never set and `ptps` is null at the dereference.

The sibling `vpiCastOp` case a few lines above guards the identical `Typespec() -> Actual_typespec()` pattern with `if (optps == nullptr) break;`; the `vpiAssignmentPatternOp` case is missing it.

## Fix
Add the same null guard before dereferencing `ptps`:
```cpp
if (ptps == nullptr) break;
```
A cast-key pattern is then left unmodified instead of crashing.

## Test
Not a `*_test.cpp` unit test (the crash is in a full-elaboration function); reproducible end-to-end with the 3-line module above (segfault before the fix, clean after).
