### PR TITLE
Fold interface-port localparam generate bound nested in a generate block

### DIFF
--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -1186,30 +1186,40 @@ UHDM::any *CompileHelper::resolveInterfacePortMember(
     DesignComponent *component, std::string_view baseName,
     std::string_view memberName, CompileDesign *compileDesign,
     const FileContent *fC, NodeId locId) {
-  if (component == nullptr) return nullptr;
-  for (Signal *port : component->getPorts()) {
-    if (port->getName() != baseName) continue;
-    if (!port->isInterface()) return nullptr;
-    DesignComponent *ifaceDef = port->getInterfaceDef();
-    if (ifaceDef == nullptr) {
-      const std::string tn = port->getInterfaceTypeName();
-      if (!tn.empty()) {
-        Design *des = compileDesign->getCompiler()->getDesign();
-        ifaceDef = des->getComponentDefinition(tn);
-        if (ifaceDef == nullptr)
-          ifaceDef = des->getComponentDefinition(StrCat("work@", tn));
+  // Walk up the enclosing-scope chain: when the read sits inside a nested
+  // generate block (`generate if (ALIGNED) begin: aligned for (i<sub.BYT) ...`),
+  // `component` is the gen-scope definition, which has no ports — the interface
+  // port `sub` lives on the enclosing MODULE definition (the degu SoC
+  // logsize2byteena aligned/unaligned byte-enable loops).
+  for (const ValuedComponentI *scope = component; scope;
+       scope = scope->getParentScope()) {
+    const DesignComponent *dc =
+        valuedcomponenti_cast<const DesignComponent *>(scope);
+    if (dc == nullptr) continue;
+    for (Signal *port : const_cast<DesignComponent *>(dc)->getPorts()) {
+      if (port->getName() != baseName) continue;
+      if (!port->isInterface()) return nullptr;
+      DesignComponent *ifaceDef = port->getInterfaceDef();
+      if (ifaceDef == nullptr) {
+        const std::string tn = port->getInterfaceTypeName();
+        if (!tn.empty()) {
+          Design *des = compileDesign->getCompiler()->getDesign();
+          ifaceDef = des->getComponentDefinition(tn);
+          if (ifaceDef == nullptr)
+            ifaceDef = des->getComponentDefinition(StrCat("work@", tn));
+        }
       }
-    }
-    if (ifaceDef) {
-      // Evaluate the interface's param/localparam (e.g. `BYT = DAT/8`) in the
-      // interface definition's own context (default/overridden params).
-      if (any *v = getValue(memberName, ifaceDef, compileDesign, Reduce::Yes,
-                            nullptr, fC->getFileId(), fC->Line(locId), nullptr,
-                            true)) {
-        if (v->UhdmType() == uhdmconstant) return v;
+      if (ifaceDef) {
+        // Evaluate the interface's param/localparam (e.g. `BYT = DAT/8`) in the
+        // interface definition's own context (default/overridden params).
+        if (any *v = getValue(memberName, ifaceDef, compileDesign, Reduce::Yes,
+                              nullptr, fC->getFileId(), fC->Line(locId), nullptr,
+                              true)) {
+          if (v->UhdmType() == uhdmconstant) return v;
+        }
       }
+      return nullptr;
     }
-    return nullptr;
   }
   return nullptr;
 }

--- a/tests/GenForIfaceLocalparamNestedGen/GenForIfaceLocalparamNestedGen.log
+++ b/tests/GenForIfaceLocalparamNestedGen/GenForIfaceLocalparamNestedGen.log
@@ -1,0 +1,2450 @@
+[INF:CM0023] Creating log file "${SURELOG_DIR}/build/regression/GenForIfaceLocalparamNestedGen/slpp_all/surelog.log".
+[NTE:PP0128] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:5:52: Non ASCII character detected, replaced by space.
+[WRN:PA0205] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:9:1: No timescale set for "p".
+[WRN:PA0205] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:14:1: No timescale set for "bus_if".
+[WRN:PA0205] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:18:1: No timescale set for "child".
+[WRN:PA0205] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:27:1: No timescale set for "top".
+[INF:CP0300] Compilation...
+[INF:CP0301] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:9:1: Compile package "p".
+[INF:CP0304] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:14:1: Compile interface "work@bus_if".
+[INF:CP0303] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:18:1: Compile module "work@child".
+[INF:CP0303] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:27:1: Compile module "work@top".
+[INF:EL0526] Design Elaboration...
+[INF:CP0335] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:20:26: Compile generate block "work@top.c.aligned".
+[INF:CP0335] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:21:44: Compile generate block "work@top.c.aligned.g[0]".
+[INF:CP0335] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:21:44: Compile generate block "work@top.c.aligned.g[1]".
+[INF:CP0335] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:21:44: Compile generate block "work@top.c.aligned.g[2]".
+[INF:CP0335] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:21:44: Compile generate block "work@top.c.aligned.g[3]".
+[NTE:EL0503] ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv:27:1: Top level module "work@top".
+[NTE:EL0508] Nb Top level modules: 1.
+[NTE:EL0509] Max instance depth: 2.
+[NTE:EL0510] Nb instances: 2.
+[NTE:EL0511] Nb leaf instances: 0.
+[INF:UH0706] Creating UHDM Model...
+=== UHDM Object Stats Begin (Non-Elaborated Model) ===
+begin                                                  1
+bit_select                                             8
+bit_typespec                                           2
+constant                                             160
+cont_assign                                            5
+design                                                 1
+gen_if                                                 1
+gen_region                                             1
+gen_scope                                             10
+gen_scope_array                                       10
+hier_path                                             19
+import_typespec                                        1
+int_typespec                                          25
+interface_inst                                         4
+interface_typespec                                     3
+logic_net                                              9
+logic_typespec                                        12
+logic_var                                              2
+module_inst                                           11
+named_begin                                            1
+operation                                            156
+package                                                2
+param_assign                                          12
+parameter                                             25
+port                                                  10
+range                                                 17
+ref_module                                             2
+ref_obj                                               66
+ref_typespec                                         258
+string_typespec                                      131
+struct_typespec                                       30
+tagged_pattern                                       131
+typespec_member                                       30
+=== UHDM Object Stats End ===
+[INF:UH0707] Elaborating UHDM...
+=== UHDM Object Stats Begin (Elaborated Model) ===
+begin                                                  1
+bit_select                                            16
+bit_typespec                                           2
+constant                                             160
+cont_assign                                           10
+design                                                 1
+gen_if                                                 1
+gen_region                                             1
+gen_scope                                             15
+gen_scope_array                                       15
+hier_path                                             24
+import_typespec                                        1
+int_typespec                                          25
+interface_inst                                         4
+interface_typespec                                     3
+logic_net                                              9
+logic_typespec                                        12
+logic_var                                              2
+module_inst                                           11
+named_begin                                            1
+operation                                            156
+package                                                2
+param_assign                                          12
+parameter                                             25
+port                                                  14
+range                                                 17
+ref_module                                             2
+ref_obj                                               87
+ref_typespec                                         266
+string_typespec                                      131
+struct_typespec                                       30
+tagged_pattern                                       131
+typespec_member                                       30
+=== UHDM Object Stats End ===
+[INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/GenForIfaceLocalparamNestedGen/slpp_all/surelog.uhdm ...
+[INF:UH0709] Writing UHDM Html Coverage: ${SURELOG_DIR}/build/regression/GenForIfaceLocalparamNestedGen/slpp_all/checker/surelog.chk.html ...
+[INF:UH0710] Loading UHDM DB: ${SURELOG_DIR}/build/regression/GenForIfaceLocalparamNestedGen/slpp_all/surelog.uhdm ...
+[INF:UH0711] Decompiling UHDM...
+====== UHDM =======
+design: (work@top)
+|vpiElaborated:1
+|vpiName:work@top
+|uhdmallPackages:
+\_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiParent:
+  \_design: (work@top)
+  |vpiName:p
+  |vpiFullName:p::
+  |vpiParameter:
+  \_parameter: (p::CFG_DEF), line:12:20, endln:12:27
+    |vpiParent:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+    |vpiTypespec:
+    \_ref_typespec: (p::CFG_DEF)
+      |vpiParent:
+      \_parameter: (p::CFG_DEF), line:12:20, endln:12:27
+      |vpiFullName:p::CFG_DEF
+      |vpiActual:
+      \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiLocalParam:1
+    |vpiName:CFG_DEF
+    |vpiFullName:p::CFG_DEF
+  |vpiParamAssign:
+  \_param_assign: , line:12:20, endln:12:48
+    |vpiParent:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+    |vpiRhs:
+    \_operation: , line:12:30, endln:12:48
+      |vpiParent:
+      \_param_assign: , line:12:20, endln:12:48
+      |vpiOpType:75
+      |vpiOperand:
+      \_tagged_pattern: , line:12:37, endln:12:47
+        |vpiParent:
+        \_operation: , line:12:30, endln:12:48
+        |vpiPattern:
+        \_operation: , line:12:37, endln:12:47
+          |vpiParent:
+          \_operation: , line:12:30, endln:12:48
+          |vpiOpType:75
+          |vpiOperand:
+          \_tagged_pattern: , line:12:44, endln:12:46
+            |vpiParent:
+            \_operation: , line:12:37, endln:12:47
+            |vpiPattern:
+            \_constant: , line:12:44, endln:12:46
+              |vpiDecompile:32
+              |vpiSize:64
+              |UINT:32
+              |vpiConstType:9
+            |vpiTypespec:
+            \_ref_typespec: (p)
+              |vpiParent:
+              \_tagged_pattern: , line:12:44, endln:12:46
+              |vpiFullName:p
+              |vpiActual:
+              \_string_typespec: (DAT), line:12:39, endln:12:42
+        |vpiTypespec:
+        \_ref_typespec: (p)
+          |vpiParent:
+          \_tagged_pattern: , line:12:37, endln:12:47
+          |vpiFullName:p
+          |vpiActual:
+          \_string_typespec: (BUS), line:12:32, endln:12:35
+    |vpiLhs:
+    \_parameter: (p::CFG_DEF), line:12:20, endln:12:27
+  |vpiTypedef:
+  \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiParent:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+    |vpiName:p::bus_t
+    |vpiInstance:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+    |vpiPacked:1
+    |vpiTypespecMember:
+    \_typespec_member: (DAT), line:10:40, endln:10:43
+      |vpiParent:
+      \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+      |vpiName:DAT
+      |vpiTypespec:
+      \_ref_typespec: (p::p::bus_t::DAT)
+        |vpiParent:
+        \_typespec_member: (DAT), line:10:40, endln:10:43
+        |vpiFullName:p::p::bus_t::DAT
+        |vpiActual:
+        \_int_typespec: , line:10:27, endln:10:39
+      |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+      |vpiRefLineNo:10
+      |vpiRefColumnNo:27
+      |vpiRefEndLineNo:10
+      |vpiRefEndColumnNo:39
+  |vpiTypedef:
+  \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiParent:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+    |vpiName:p::cfg_t
+    |vpiInstance:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+    |vpiPacked:1
+    |vpiTypespecMember:
+    \_typespec_member: (BUS), line:11:33, endln:11:36
+      |vpiParent:
+      \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+      |vpiName:BUS
+      |vpiTypespec:
+      \_ref_typespec: (p::p::cfg_t::BUS)
+        |vpiParent:
+        \_typespec_member: (BUS), line:11:33, endln:11:36
+        |vpiFullName:p::p::cfg_t::BUS
+        |vpiActual:
+        \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+      |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+      |vpiRefLineNo:11
+      |vpiRefColumnNo:27
+      |vpiRefEndLineNo:11
+      |vpiRefEndColumnNo:32
+  |vpiDefName:p
+|uhdmtopPackages:
+\_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiParent:
+  \_design: (work@top)
+  |vpiName:p
+  |vpiFullName:p::
+  |vpiParameter:
+  \_parameter: (p::CFG_DEF), line:12:20, endln:12:27
+    |vpiParent:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+    |vpiTypespec:
+    \_ref_typespec: (p::CFG_DEF)
+      |vpiParent:
+      \_parameter: (p::CFG_DEF), line:12:20, endln:12:27
+      |vpiFullName:p::CFG_DEF
+      |vpiActual:
+      \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiLocalParam:1
+    |vpiName:CFG_DEF
+    |vpiFullName:p::CFG_DEF
+  |vpiParamAssign:
+  \_param_assign: , line:12:20, endln:12:48
+    |vpiParent:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+    |vpiRhs:
+    \_operation: , line:12:30, endln:12:48
+      |vpiParent:
+      \_param_assign: , line:12:20, endln:12:48
+      |vpiOpType:75
+      |vpiOperand:
+      \_tagged_pattern: , line:12:37, endln:12:47
+        |vpiParent:
+        \_operation: , line:12:30, endln:12:48
+        |vpiPattern:
+        \_operation: , line:12:37, endln:12:47
+          |vpiParent:
+          \_operation: , line:12:30, endln:12:48
+          |vpiOpType:75
+          |vpiOperand:
+          \_tagged_pattern: , line:12:44, endln:12:46
+            |vpiParent:
+            \_operation: , line:12:37, endln:12:47
+            |vpiPattern:
+            \_constant: , line:12:44, endln:12:46
+              |vpiDecompile:32
+              |vpiSize:64
+              |UINT:32
+              |vpiConstType:9
+            |vpiTypespec:
+            \_ref_typespec: (p)
+              |vpiParent:
+              \_tagged_pattern: , line:12:44, endln:12:46
+              |vpiFullName:p
+              |vpiActual:
+              \_string_typespec: (DAT), line:12:39, endln:12:42
+        |vpiTypespec:
+        \_ref_typespec: (p)
+          |vpiParent:
+          \_tagged_pattern: , line:12:37, endln:12:47
+          |vpiFullName:p
+          |vpiActual:
+          \_string_typespec: (BUS), line:12:32, endln:12:35
+    |vpiLhs:
+    \_parameter: (p::CFG_DEF), line:12:20, endln:12:27
+  |vpiTypedef:
+  \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiName:p::bus_t
+    |vpiInstance:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+    |vpiPacked:1
+    |vpiTypespecMember:
+    \_typespec_member: (DAT), line:10:40, endln:10:43
+      |vpiParent:
+      \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+      |vpiName:DAT
+      |vpiTypespec:
+      \_ref_typespec: (work@top.p::bus_t.DAT)
+        |vpiParent:
+        \_typespec_member: (DAT), line:10:40, endln:10:43
+        |vpiFullName:work@top.p::bus_t.DAT
+        |vpiActual:
+        \_int_typespec: , line:10:27, endln:10:39
+      |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+      |vpiRefLineNo:10
+      |vpiRefColumnNo:27
+      |vpiRefEndLineNo:10
+      |vpiRefEndColumnNo:39
+  |vpiTypedef:
+  \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiName:p::cfg_t
+    |vpiInstance:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+    |vpiPacked:1
+    |vpiTypespecMember:
+    \_typespec_member: (BUS), line:11:33, endln:11:36
+      |vpiParent:
+      \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+      |vpiName:BUS
+      |vpiTypespec:
+      \_ref_typespec: (work@top.p::cfg_t.BUS)
+        |vpiParent:
+        \_typespec_member: (BUS), line:11:33, endln:11:36
+        |vpiFullName:work@top.p::cfg_t.BUS
+        |vpiActual:
+        \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+      |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+      |vpiRefLineNo:11
+      |vpiRefColumnNo:27
+      |vpiRefEndLineNo:11
+      |vpiRefEndColumnNo:32
+  |vpiDefName:p
+  |vpiTop:1
+|uhdmallInterfaces:
+\_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:14:1, endln:17:13
+  |vpiParent:
+  \_design: (work@top)
+  |vpiFullName:work@bus_if
+  |vpiParameter:
+  \_parameter: (work@bus_if.CFG), line:14:39, endln:14:42
+    |vpiParent:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:14:1, endln:17:13
+    |vpiTypespec:
+    \_ref_typespec: (work@bus_if.CFG)
+      |vpiParent:
+      \_parameter: (work@bus_if.CFG), line:14:39, endln:14:42
+      |vpiFullName:work@bus_if.CFG
+      |vpiActual:
+      \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiName:CFG
+    |vpiFullName:work@bus_if.CFG
+  |vpiParameter:
+  \_parameter: (work@bus_if.BYT), line:15:27, endln:15:30
+    |vpiParent:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:14:1, endln:17:13
+    |vpiTypespec:
+    \_ref_typespec: (work@bus_if.BYT)
+      |vpiParent:
+      \_parameter: (work@bus_if.BYT), line:15:27, endln:15:30
+      |vpiFullName:work@bus_if.BYT
+      |vpiActual:
+      \_int_typespec: , line:15:14, endln:15:26
+    |vpiLocalParam:1
+    |vpiName:BYT
+    |vpiFullName:work@bus_if.BYT
+  |vpiParamAssign:
+  \_param_assign: , line:14:39, endln:14:55
+    |vpiParent:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:14:1, endln:17:13
+    |vpiRhs:
+    \_operation: , line:14:45, endln:14:48
+      |vpiParent:
+      \_param_assign: , line:14:39, endln:14:55
+      |vpiOpType:75
+      |vpiOperand:
+      \_tagged_pattern: , line:12:37, endln:12:47
+        |vpiParent:
+        \_operation: , line:14:45, endln:14:48
+        |vpiPattern:
+        \_operation: , line:12:37, endln:12:47
+          |vpiParent:
+          \_tagged_pattern: , line:12:37, endln:12:47
+          |vpiOpType:75
+          |vpiOperand:
+          \_tagged_pattern: , line:12:44, endln:12:46
+            |vpiParent:
+            \_operation: , line:12:37, endln:12:47
+            |vpiPattern:
+            \_constant: , line:12:44, endln:12:46
+              |vpiParent:
+              \_operation: , line:12:37, endln:12:47
+              |vpiDecompile:32
+              |vpiSize:64
+              |UINT:32
+              |vpiConstType:9
+            |vpiTypespec:
+            \_ref_typespec: (work@bus_if)
+              |vpiParent:
+              \_tagged_pattern: , line:12:44, endln:12:46
+              |vpiFullName:work@bus_if
+              |vpiActual:
+              \_string_typespec: (DAT), line:12:39, endln:12:42
+        |vpiTypespec:
+        \_ref_typespec: (work@bus_if)
+          |vpiParent:
+          \_tagged_pattern: , line:12:37, endln:12:47
+          |vpiFullName:work@bus_if
+          |vpiActual:
+          \_string_typespec: (BUS), line:12:32, endln:12:35
+    |vpiLhs:
+    \_parameter: (work@bus_if.CFG), line:14:39, endln:14:42
+  |vpiParamAssign:
+  \_param_assign: , line:15:27, endln:15:46
+    |vpiParent:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:14:1, endln:17:13
+    |vpiRhs:
+    \_operation: , line:15:33, endln:15:46
+      |vpiParent:
+      \_param_assign: , line:15:27, endln:15:46
+      |vpiOpType:12
+      |vpiOperand:
+      \_hier_path: (CFG.BUS.DAT), line:15:33, endln:15:44
+        |vpiParent:
+        \_operation: , line:15:33, endln:15:46
+        |vpiActual:
+        \_ref_obj: (CFG), line:15:37, endln:15:40
+          |vpiParent:
+          \_hier_path: (CFG.BUS.DAT), line:15:33, endln:15:44
+          |vpiName:CFG
+        |vpiActual:
+        \_ref_obj: (BUS), line:15:37, endln:15:40
+          |vpiParent:
+          \_hier_path: (CFG.BUS.DAT), line:15:33, endln:15:44
+          |vpiName:BUS
+        |vpiActual:
+        \_ref_obj: (DAT), line:15:41, endln:15:44
+          |vpiParent:
+          \_hier_path: (CFG.BUS.DAT), line:15:33, endln:15:44
+          |vpiName:DAT
+        |vpiName:CFG.BUS.DAT
+      |vpiOperand:
+      \_constant: , line:15:45, endln:15:46
+        |vpiParent:
+        \_operation: , line:15:33, endln:15:46
+        |vpiDecompile:8
+        |vpiSize:64
+        |UINT:8
+        |vpiConstType:9
+    |vpiLhs:
+    \_parameter: (work@bus_if.BYT), line:15:27, endln:15:30
+  |vpiDefName:work@bus_if
+  |vpiNet:
+  \_logic_net: (work@bus_if.ben), line:16:19, endln:16:22
+    |vpiParent:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:14:1, endln:17:13
+    |vpiTypespec:
+    \_ref_typespec: (work@bus_if.ben)
+      |vpiParent:
+      \_logic_net: (work@bus_if.ben), line:16:19, endln:16:22
+      |vpiFullName:work@bus_if.ben
+      |vpiActual:
+      \_logic_typespec: , line:16:3, endln:16:18
+    |vpiName:ben
+    |vpiFullName:work@bus_if.ben
+    |vpiNetType:36
+|uhdmallModules:
+\_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:18:1, endln:26:10
+  |vpiParent:
+  \_design: (work@top)
+  |vpiFullName:work@child
+  |vpiParameter:
+  \_parameter: (work@child.ALIGNED), line:18:30, endln:18:37
+    |vpiParent:
+    \_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:18:1, endln:26:10
+    |UINT:1
+    |vpiTypespec:
+    \_ref_typespec: (work@child.ALIGNED)
+      |vpiParent:
+      \_parameter: (work@child.ALIGNED), line:18:30, endln:18:37
+      |vpiFullName:work@child.ALIGNED
+      |vpiActual:
+      \_bit_typespec: , line:18:26, endln:18:29
+    |vpiName:ALIGNED
+    |vpiFullName:work@child.ALIGNED
+  |vpiParamAssign:
+  \_param_assign: , line:18:30, endln:18:41
+    |vpiParent:
+    \_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:18:1, endln:26:10
+    |vpiRhs:
+    \_constant: , line:18:40, endln:18:41
+      |vpiParent:
+      \_param_assign: , line:18:30, endln:18:41
+      |vpiDecompile:1
+      |vpiSize:64
+      |UINT:1
+      |vpiTypespec:
+      \_ref_typespec: (work@child)
+        |vpiParent:
+        \_constant: , line:18:40, endln:18:41
+        |vpiFullName:work@child
+        |vpiActual:
+        \_bit_typespec: , line:18:26, endln:18:29
+      |vpiConstType:9
+    |vpiLhs:
+    \_parameter: (work@child.ALIGNED), line:18:30, endln:18:37
+  |vpiDefName:work@child
+  |vpiNet:
+  \_logic_net: (work@child.o), line:18:75, endln:18:76
+    |vpiParent:
+    \_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:18:1, endln:26:10
+    |vpiName:o
+    |vpiFullName:work@child.o
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@child.sub), line:18:51, endln:18:54
+    |vpiParent:
+    \_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:18:1, endln:26:10
+    |vpiName:sub
+    |vpiFullName:work@child.sub
+  |vpiPort:
+  \_port: (sub), line:18:51, endln:18:54
+    |vpiParent:
+    \_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:18:1, endln:26:10
+    |vpiName:sub
+    |vpiDirection:3
+    |vpiLowConn:
+    \_ref_obj: (work@child.sub.sub), line:18:51, endln:18:54
+      |vpiParent:
+      \_port: (sub), line:18:51, endln:18:54
+      |vpiName:sub
+      |vpiFullName:work@child.sub.sub
+      |vpiActual:
+      \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:14:1, endln:17:13
+    |vpiTypedef:
+    \_ref_typespec: (work@child.sub)
+      |vpiParent:
+      \_port: (sub), line:18:51, endln:18:54
+      |vpiFullName:work@child.sub
+      |vpiActual:
+      \_interface_typespec: (bus_if), line:18:44, endln:18:50
+  |vpiPort:
+  \_port: (o), line:18:75, endln:18:76
+    |vpiParent:
+    \_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:18:1, endln:26:10
+    |vpiName:o
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@child.o.o), line:18:75, endln:18:76
+      |vpiParent:
+      \_port: (o), line:18:75, endln:18:76
+      |vpiName:o
+      |vpiFullName:work@child.o.o
+      |vpiActual:
+      \_logic_net: (work@child.o), line:18:75, endln:18:76
+    |vpiTypedef:
+    \_ref_typespec: (work@child.o)
+      |vpiParent:
+      \_port: (o), line:18:75, endln:18:76
+      |vpiFullName:work@child.o
+      |vpiActual:
+      \_logic_typespec: , line:18:63, endln:18:74
+  |vpiGenStmt:
+  \_gen_region: 
+    |vpiParent:
+    \_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:18:1, endln:26:10
+    |vpiStmt:
+    \_begin: (work@child)
+      |vpiParent:
+      \_gen_region: 
+      |vpiFullName:work@child
+      |vpiStmt:
+      \_gen_if: , line:20:5, endln:20:7
+        |vpiParent:
+        \_begin: (work@child)
+        |vpiCondition:
+        \_operation: , line:20:9, endln:20:24
+          |vpiParent:
+          \_gen_if: , line:20:5, endln:20:7
+          |vpiOpType:14
+          |vpiOperand:
+          \_ref_obj: (work@child.ALIGNED), line:20:9, endln:20:16
+            |vpiParent:
+            \_operation: , line:20:9, endln:20:24
+            |vpiName:ALIGNED
+            |vpiFullName:work@child.ALIGNED
+          |vpiOperand:
+          \_constant: , line:20:20, endln:20:24
+            |vpiParent:
+            \_operation: , line:20:9, endln:20:24
+            |vpiDecompile:1'b1
+            |vpiSize:1
+            |BIN:1
+            |vpiConstType:3
+        |vpiStmt:
+        \_named_begin: (work@child.aligned)
+          |vpiParent:
+          \_gen_if: , line:20:5, endln:20:7
+          |vpiName:aligned
+          |vpiFullName:work@child.aligned
+|uhdmallModules:
+\_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+  |vpiParent:
+  \_design: (work@top)
+  |vpiFullName:work@top
+  |vpiParameter:
+  \_parameter: (work@top.CFG_DEF), line:12:20, endln:12:27
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF)
+      |vpiParent:
+      \_parameter: (work@top.CFG_DEF), line:12:20, endln:12:27
+      |vpiFullName:work@top.CFG_DEF
+      |vpiActual:
+      \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiLocalParam:1
+    |vpiName:CFG_DEF
+    |vpiFullName:work@top.CFG_DEF
+    |vpiImported:p
+  |vpiParamAssign:
+  \_param_assign: , line:12:20, endln:12:48
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiRhs:
+    \_operation: , line:12:30, endln:12:48
+      |vpiParent:
+      \_param_assign: , line:12:20, endln:12:48
+      |vpiOpType:75
+      |vpiOperand:
+      \_tagged_pattern: , line:12:37, endln:12:47
+        |vpiParent:
+        \_operation: , line:12:30, endln:12:48
+        |vpiPattern:
+        \_operation: , line:12:37, endln:12:47
+          |vpiParent:
+          \_tagged_pattern: , line:12:37, endln:12:47
+          |vpiOpType:75
+          |vpiOperand:
+          \_tagged_pattern: , line:12:44, endln:12:46
+            |vpiParent:
+            \_operation: , line:12:37, endln:12:47
+            |vpiPattern:
+            \_constant: , line:12:44, endln:12:46
+              |vpiParent:
+              \_tagged_pattern: , line:12:44, endln:12:46
+              |vpiDecompile:32
+              |vpiSize:64
+              |UINT:32
+              |vpiConstType:9
+            |vpiTypespec:
+            \_ref_typespec: (work@top)
+              |vpiParent:
+              \_tagged_pattern: , line:12:44, endln:12:46
+              |vpiFullName:work@top
+              |vpiActual:
+              \_string_typespec: (DAT), line:12:39, endln:12:42
+        |vpiTypespec:
+        \_ref_typespec: (work@top)
+          |vpiParent:
+          \_tagged_pattern: , line:12:37, endln:12:47
+          |vpiFullName:work@top
+          |vpiActual:
+          \_string_typespec: (BUS), line:12:32, endln:12:35
+    |vpiLhs:
+    \_parameter: (work@top.CFG_DEF), line:12:20, endln:12:27
+      |vpiParent:
+      \_param_assign: , line:12:20, endln:12:48
+      |vpiTypespec:
+      \_ref_typespec: (work@top.CFG_DEF)
+        |vpiParent:
+        \_parameter: (work@top.CFG_DEF), line:12:20, endln:12:27
+        |vpiFullName:work@top.CFG_DEF
+        |vpiActual:
+        \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+      |vpiLocalParam:1
+      |vpiName:CFG_DEF
+      |vpiFullName:work@top.CFG_DEF
+      |vpiImported:p
+  |vpiTypedef:
+  \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+  |vpiTypedef:
+  \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+  |vpiTypedef:
+  \_import_typespec: (p), line:28:10, endln:28:14
+  |vpiDefName:work@top
+  |vpiNet:
+  \_logic_net: (work@top.ben_i), line:27:31, endln:27:36
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiName:ben_i
+    |vpiFullName:work@top.ben_i
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.o), line:27:57, endln:27:58
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiName:o
+    |vpiFullName:work@top.o
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.sub), line:31:32, endln:31:35
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiName:sub
+    |vpiFullName:work@top.sub
+    |vpiNetType:1
+  |vpiPort:
+  \_port: (ben_i), line:27:31, endln:27:36
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiName:ben_i
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@top.ben_i.ben_i), line:27:31, endln:27:36
+      |vpiParent:
+      \_port: (ben_i), line:27:31, endln:27:36
+      |vpiName:ben_i
+      |vpiFullName:work@top.ben_i.ben_i
+      |vpiActual:
+      \_logic_net: (work@top.ben_i), line:27:31, endln:27:36
+    |vpiTypedef:
+    \_ref_typespec: (work@top.ben_i)
+      |vpiParent:
+      \_port: (ben_i), line:27:31, endln:27:36
+      |vpiFullName:work@top.ben_i
+      |vpiActual:
+      \_logic_typespec: , line:27:19, endln:27:30
+  |vpiPort:
+  \_port: (o), line:27:57, endln:27:58
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiName:o
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@top.o.o), line:27:57, endln:27:58
+      |vpiParent:
+      \_port: (o), line:27:57, endln:27:58
+      |vpiName:o
+      |vpiFullName:work@top.o.o
+      |vpiActual:
+      \_logic_net: (work@top.o), line:27:57, endln:27:58
+    |vpiTypedef:
+    \_ref_typespec: (work@top.o)
+      |vpiParent:
+      \_port: (o), line:27:57, endln:27:58
+      |vpiFullName:work@top.o
+      |vpiActual:
+      \_logic_typespec: , line:27:45, endln:27:56
+  |vpiContAssign:
+  \_cont_assign: , line:30:10, endln:30:25
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiRhs:
+    \_ref_obj: (work@top.ben_i), line:30:20, endln:30:25
+      |vpiParent:
+      \_cont_assign: , line:30:10, endln:30:25
+      |vpiName:ben_i
+      |vpiFullName:work@top.ben_i
+      |vpiActual:
+      \_logic_net: (work@top.ben_i), line:27:31, endln:27:36
+    |vpiLhs:
+    \_hier_path: (sub.ben), line:30:10, endln:30:17
+      |vpiParent:
+      \_cont_assign: , line:30:10, endln:30:25
+      |vpiActual:
+      \_ref_obj: (sub), line:30:14, endln:30:17
+        |vpiParent:
+        \_hier_path: (sub.ben), line:30:10, endln:30:17
+        |vpiName:sub
+      |vpiActual:
+      \_ref_obj: (ben), line:30:14, endln:30:17
+        |vpiParent:
+        \_hier_path: (sub.ben), line:30:10, endln:30:17
+        |vpiName:ben
+      |vpiName:sub.ben
+  |vpiRefModule:
+  \_ref_module: work@bus_if (sub), line:29:21, endln:29:24
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiName:sub
+    |vpiDefName:work@bus_if
+    |vpiActual:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:14:1, endln:17:13
+  |vpiRefModule:
+  \_ref_module: work@child (c), line:31:24, endln:31:25
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiName:c
+    |vpiDefName:work@child
+    |vpiActual:
+    \_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:18:1, endln:26:10
+    |vpiPort:
+    \_port: (sub), line:31:27, endln:31:36
+      |vpiParent:
+      \_ref_module: work@child (c), line:31:24, endln:31:25
+      |vpiName:sub
+      |vpiHighConn:
+      \_ref_obj: (work@top.c.sub.sub), line:31:32, endln:31:35
+        |vpiParent:
+        \_port: (sub), line:31:27, endln:31:36
+        |vpiName:sub
+        |vpiFullName:work@top.c.sub.sub
+        |vpiActual:
+        \_logic_net: (work@top.sub), line:31:32, endln:31:35
+    |vpiPort:
+    \_port: (o), line:31:38, endln:31:43
+      |vpiParent:
+      \_ref_module: work@child (c), line:31:24, endln:31:25
+      |vpiName:o
+      |vpiHighConn:
+      \_ref_obj: (work@top.c.o.o), line:31:41, endln:31:42
+        |vpiParent:
+        \_port: (o), line:31:38, endln:31:43
+        |vpiName:o
+        |vpiFullName:work@top.c.o.o
+        |vpiActual:
+        \_logic_net: (work@top.o), line:27:57, endln:27:58
+|uhdmtopModules:
+\_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+  |vpiParent:
+  \_design: (work@top)
+  |vpiName:work@top
+  |vpiParameter:
+  \_parameter: (work@top.CFG_DEF), line:12:20, endln:12:27
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF)
+      |vpiParent:
+      \_parameter: (work@top.CFG_DEF), line:12:20, endln:12:27
+      |vpiFullName:work@top.CFG_DEF
+      |vpiActual:
+      \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiLocalParam:1
+    |vpiName:CFG_DEF
+    |vpiFullName:work@top.CFG_DEF
+    |vpiImported:p
+  |vpiParamAssign:
+  \_param_assign: , line:12:20, endln:12:48
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiRhs:
+    \_operation: , line:12:30, endln:12:48
+      |vpiParent:
+      \_param_assign: , line:12:20, endln:12:48
+      |vpiOpType:75
+      |vpiOperand:
+      \_operation: , line:12:37, endln:12:47
+        |vpiParent:
+        \_operation: , line:12:30, endln:12:48
+        |vpiTypespec:
+        \_ref_typespec: 
+          |vpiActual:
+          \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+        |vpiOpType:75
+        |vpiOperand:
+        \_constant: , line:12:44, endln:12:46
+          |vpiParent:
+          \_operation: , line:12:37, endln:12:47
+          |vpiDecompile:32
+          |vpiSize:64
+          |UINT:32
+          |vpiConstType:9
+    |vpiLhs:
+    \_parameter: (work@top.CFG_DEF), line:12:20, endln:12:27
+  |vpiTypedef:
+  \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+  |vpiTypedef:
+  \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+  |vpiTypedef:
+  \_import_typespec: (p), line:28:10, endln:28:14
+  |vpiDefName:work@top
+  |vpiTop:1
+  |vpiNet:
+  \_logic_net: (work@top.ben_i), line:27:31, endln:27:36
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.ben_i)
+      |vpiParent:
+      \_logic_net: (work@top.ben_i), line:27:31, endln:27:36
+      |vpiFullName:work@top.ben_i
+      |vpiActual:
+      \_logic_typespec: , line:27:19, endln:27:30
+    |vpiName:ben_i
+    |vpiFullName:work@top.ben_i
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.o), line:27:57, endln:27:58
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.o)
+      |vpiParent:
+      \_logic_net: (work@top.o), line:27:57, endln:27:58
+      |vpiFullName:work@top.o
+      |vpiActual:
+      \_logic_typespec: , line:27:45, endln:27:56
+    |vpiName:o
+    |vpiFullName:work@top.o
+    |vpiNetType:36
+  |vpiTopModule:1
+  |vpiPort:
+  \_port: (ben_i), line:27:31, endln:27:36
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiName:ben_i
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@top.ben_i), line:27:31, endln:27:36
+      |vpiParent:
+      \_port: (ben_i), line:27:31, endln:27:36
+      |vpiName:ben_i
+      |vpiFullName:work@top.ben_i
+      |vpiActual:
+      \_logic_net: (work@top.ben_i), line:27:31, endln:27:36
+    |vpiTypedef:
+    \_ref_typespec: (work@top.ben_i)
+      |vpiParent:
+      \_port: (ben_i), line:27:31, endln:27:36
+      |vpiFullName:work@top.ben_i
+      |vpiActual:
+      \_logic_typespec: , line:27:19, endln:27:30
+    |vpiInstance:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+  |vpiPort:
+  \_port: (o), line:27:57, endln:27:58
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiName:o
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@top.o), line:27:57, endln:27:58
+      |vpiParent:
+      \_port: (o), line:27:57, endln:27:58
+      |vpiName:o
+      |vpiFullName:work@top.o
+      |vpiActual:
+      \_logic_net: (work@top.o), line:27:57, endln:27:58
+    |vpiTypedef:
+    \_ref_typespec: (work@top.o)
+      |vpiParent:
+      \_port: (o), line:27:57, endln:27:58
+      |vpiFullName:work@top.o
+      |vpiActual:
+      \_logic_typespec: , line:27:45, endln:27:56
+    |vpiInstance:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+  |vpiInterface:
+  \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:29:3, endln:29:28
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiName:sub
+    |vpiFullName:work@top.sub
+    |vpiVariables:
+    \_logic_var: (work@top.sub.ben), line:16:19, endln:16:22
+      |vpiParent:
+      \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:29:3, endln:29:28
+      |vpiTypespec:
+      \_ref_typespec: (work@top.sub.ben)
+        |vpiParent:
+        \_logic_var: (work@top.sub.ben), line:16:19, endln:16:22
+        |vpiFullName:work@top.sub.ben
+        |vpiActual:
+        \_logic_typespec: , line:16:3, endln:16:18
+      |vpiName:ben
+      |vpiFullName:work@top.sub.ben
+      |vpiVisibility:1
+    |vpiParameter:
+    \_parameter: (work@top.sub.CFG), line:14:39, endln:14:42
+      |vpiParent:
+      \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:29:3, endln:29:28
+      |vpiTypespec:
+      \_ref_typespec: (work@top.sub.CFG)
+        |vpiParent:
+        \_parameter: (work@top.sub.CFG), line:14:39, endln:14:42
+        |vpiFullName:work@top.sub.CFG
+        |vpiActual:
+        \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+      |vpiName:CFG
+      |vpiFullName:work@top.sub.CFG
+    |vpiParameter:
+    \_parameter: (work@top.sub.BYT), line:15:27, endln:15:30
+      |vpiParent:
+      \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:29:3, endln:29:28
+      |vpiTypespec:
+      \_ref_typespec: (work@top.sub.BYT)
+        |vpiParent:
+        \_parameter: (work@top.sub.BYT), line:15:27, endln:15:30
+        |vpiFullName:work@top.sub.BYT
+        |vpiActual:
+        \_int_typespec: , line:15:14, endln:15:26
+      |vpiLocalParam:1
+      |vpiName:BYT
+      |vpiFullName:work@top.sub.BYT
+    |vpiParamAssign:
+    \_param_assign: , line:14:39, endln:14:55
+      |vpiParent:
+      \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:29:3, endln:29:28
+      |vpiOverriden:1
+      |vpiRhs:
+      \_operation: , line:29:12, endln:29:19
+        |vpiParent:
+        \_param_assign: , line:14:39, endln:14:55
+        |vpiTypespec:
+        \_ref_typespec: (work@top.sub)
+          |vpiParent:
+          \_operation: , line:29:12, endln:29:19
+          |vpiFullName:work@top.sub
+          |vpiActual:
+          \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+        |vpiOpType:75
+        |vpiOperand:
+        \_operation: , line:12:37, endln:12:47
+          |vpiParent:
+          \_operation: , line:29:12, endln:29:19
+          |vpiSize:32
+          |vpiTypespec:
+          \_ref_typespec: (work@top.sub)
+            |vpiParent:
+            \_operation: , line:12:37, endln:12:47
+            |vpiFullName:work@top.sub
+            |vpiActual:
+            \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+          |vpiOpType:75
+          |vpiOperand:
+          \_constant: , line:12:44, endln:12:46
+            |vpiParent:
+            \_operation: , line:12:37, endln:12:47
+            |vpiDecompile:32
+            |vpiSize:64
+            |UINT:32
+            |vpiConstType:9
+      |vpiLhs:
+      \_parameter: (work@top.sub.CFG), line:14:39, endln:14:42
+    |vpiParamAssign:
+    \_param_assign: , line:15:27, endln:15:46
+      |vpiParent:
+      \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:29:3, endln:29:28
+      |vpiRhs:
+      \_constant: , line:15:33, endln:15:46
+        |vpiParent:
+        \_param_assign: , line:15:27, endln:15:46
+        |vpiDecompile:4
+        |vpiSize:32
+        |INT:4
+        |vpiTypespec:
+        \_ref_typespec: (work@top.sub)
+          |vpiParent:
+          \_constant: , line:15:33, endln:15:46
+          |vpiFullName:work@top.sub
+          |vpiActual:
+          \_int_typespec: , line:15:14, endln:15:26
+        |vpiConstType:7
+      |vpiLhs:
+      \_parameter: (work@top.sub.BYT), line:15:27, endln:15:30
+    |vpiDefName:work@bus_if
+    |vpiDefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiDefLineNo:14
+    |vpiInstance:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+  |vpiModule:
+  \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:3, endln:31:45
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiName:c
+    |vpiFullName:work@top.c
+    |vpiParameter:
+    \_parameter: (work@top.c.ALIGNED), line:18:30, endln:18:37
+      |vpiParent:
+      \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:3, endln:31:45
+      |UINT:1
+      |vpiTypespec:
+      \_ref_typespec: (work@top.c.ALIGNED)
+        |vpiParent:
+        \_parameter: (work@top.c.ALIGNED), line:18:30, endln:18:37
+        |vpiFullName:work@top.c.ALIGNED
+        |vpiActual:
+        \_bit_typespec: , line:18:26, endln:18:29
+      |vpiName:ALIGNED
+      |vpiFullName:work@top.c.ALIGNED
+    |vpiParamAssign:
+    \_param_assign: , line:18:30, endln:18:41
+      |vpiParent:
+      \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:3, endln:31:45
+      |vpiOverriden:1
+      |vpiRhs:
+      \_constant: , line:18:40, endln:18:41
+        |vpiParent:
+        \_param_assign: , line:18:30, endln:18:41
+        |vpiDecompile:1
+        |vpiSize:1
+        |UINT:1
+        |vpiTypespec:
+        \_ref_typespec: (work@top.c)
+          |vpiParent:
+          \_constant: , line:18:40, endln:18:41
+          |vpiFullName:work@top.c
+          |vpiActual:
+          \_bit_typespec: , line:18:26, endln:18:29
+        |vpiConstType:9
+      |vpiLhs:
+      \_parameter: (work@top.c.ALIGNED), line:18:30, endln:18:37
+    |vpiDefName:work@child
+    |vpiDefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiDefLineNo:18
+    |vpiNet:
+    \_logic_net: (work@top.c.o), line:18:75, endln:18:76
+      |vpiParent:
+      \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:3, endln:31:45
+      |vpiTypespec:
+      \_ref_typespec: (work@top.c.o)
+        |vpiParent:
+        \_logic_net: (work@top.c.o), line:18:75, endln:18:76
+        |vpiFullName:work@top.c.o
+        |vpiActual:
+        \_logic_typespec: , line:18:63, endln:18:74
+      |vpiName:o
+      |vpiFullName:work@top.c.o
+      |vpiNetType:36
+    |vpiInstance:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiPort:
+    \_port: (sub), line:18:51, endln:18:54
+      |vpiParent:
+      \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:3, endln:31:45
+      |vpiName:sub
+      |vpiDirection:3
+      |vpiHighConn:
+      \_ref_obj: (work@top.sub), line:31:32, endln:31:35
+        |vpiParent:
+        \_port: (sub), line:18:51, endln:18:54
+        |vpiName:sub
+        |vpiFullName:work@top.sub
+        |vpiActual:
+        \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:29:3, endln:29:28
+      |vpiLowConn:
+      \_ref_obj: (work@top.c.sub), line:31:28, endln:31:31
+        |vpiParent:
+        \_port: (sub), line:18:51, endln:18:54
+        |vpiFullName:work@top.c.sub
+        |vpiActual:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:0
+      |vpiTypedef:
+      \_ref_typespec: (work@top.c.sub)
+        |vpiParent:
+        \_port: (sub), line:18:51, endln:18:54
+        |vpiFullName:work@top.c.sub
+        |vpiActual:
+        \_interface_typespec: (bus_if), line:18:44, endln:18:50
+      |vpiInstance:
+      \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:3, endln:31:45
+    |vpiPort:
+    \_port: (o), line:18:75, endln:18:76
+      |vpiParent:
+      \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:3, endln:31:45
+      |vpiName:o
+      |vpiDirection:2
+      |vpiHighConn:
+      \_ref_obj: (work@top.o), line:31:41, endln:31:42
+        |vpiParent:
+        \_port: (o), line:18:75, endln:18:76
+        |vpiName:o
+        |vpiFullName:work@top.o
+        |vpiActual:
+        \_logic_net: (work@top.o), line:27:57, endln:27:58
+      |vpiLowConn:
+      \_ref_obj: (work@top.c.o), line:31:39, endln:31:40
+        |vpiParent:
+        \_port: (o), line:18:75, endln:18:76
+        |vpiName:o
+        |vpiFullName:work@top.c.o
+        |vpiActual:
+        \_logic_net: (work@top.c.o), line:18:75, endln:18:76
+      |vpiTypedef:
+      \_ref_typespec: (work@top.c.o)
+        |vpiParent:
+        \_port: (o), line:18:75, endln:18:76
+        |vpiFullName:work@top.c.o
+        |vpiActual:
+        \_logic_typespec: , line:18:63, endln:18:74
+      |vpiInstance:
+      \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:3, endln:31:45
+    |vpiInterface:
+    \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:0
+      |vpiParent:
+      \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:3, endln:31:45
+      |vpiName:sub
+      |vpiFullName:work@top.c.sub
+      |vpiVariables:
+      \_logic_var: (work@top.c.sub.ben), line:16:19, endln:16:22
+        |vpiParent:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:0
+        |vpiTypespec:
+        \_ref_typespec: (work@top.c.sub.ben)
+          |vpiParent:
+          \_logic_var: (work@top.c.sub.ben), line:16:19, endln:16:22
+          |vpiFullName:work@top.c.sub.ben
+          |vpiActual:
+          \_logic_typespec: , line:16:3, endln:16:18
+        |vpiName:ben
+        |vpiFullName:work@top.c.sub.ben
+        |vpiVisibility:1
+      |vpiParameter:
+      \_parameter: (work@top.c.sub.CFG), line:14:39, endln:14:42
+        |vpiParent:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:0
+        |vpiTypespec:
+        \_ref_typespec: (work@top.c.sub.CFG)
+          |vpiParent:
+          \_parameter: (work@top.c.sub.CFG), line:14:39, endln:14:42
+          |vpiFullName:work@top.c.sub.CFG
+          |vpiActual:
+          \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+        |vpiName:CFG
+        |vpiFullName:work@top.c.sub.CFG
+      |vpiParameter:
+      \_parameter: (work@top.c.sub.BYT), line:15:27, endln:15:30
+        |vpiParent:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:0
+        |vpiTypespec:
+        \_ref_typespec: (work@top.c.sub.BYT)
+          |vpiParent:
+          \_parameter: (work@top.c.sub.BYT), line:15:27, endln:15:30
+          |vpiFullName:work@top.c.sub.BYT
+          |vpiActual:
+          \_int_typespec: , line:15:14, endln:15:26
+        |vpiLocalParam:1
+        |vpiName:BYT
+        |vpiFullName:work@top.c.sub.BYT
+      |vpiParameter:
+      \_parameter: (work@top.c.sub.CFG), line:14:39, endln:14:42
+        |vpiParent:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:0
+        |vpiTypespec:
+        \_ref_typespec: (work@top.c.sub.CFG)
+          |vpiParent:
+          \_parameter: (work@top.c.sub.CFG), line:14:39, endln:14:42
+          |vpiFullName:work@top.c.sub.CFG
+          |vpiActual:
+          \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+        |vpiName:CFG
+        |vpiFullName:work@top.c.sub.CFG
+      |vpiParameter:
+      \_parameter: (work@top.c.sub.BYT), line:15:27, endln:15:30
+        |vpiParent:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:0
+        |vpiTypespec:
+        \_ref_typespec: (work@top.c.sub.BYT)
+          |vpiParent:
+          \_parameter: (work@top.c.sub.BYT), line:15:27, endln:15:30
+          |vpiFullName:work@top.c.sub.BYT
+          |vpiActual:
+          \_int_typespec: , line:15:14, endln:15:26
+        |vpiLocalParam:1
+        |vpiName:BYT
+        |vpiFullName:work@top.c.sub.BYT
+      |vpiDefName:work@bus_if
+    |vpiInterface:
+    \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:0
+    |vpiGenScopeArray:
+    \_gen_scope_array: (work@top.c.aligned), line:20:26, endln:24:8
+      |vpiParent:
+      \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:3, endln:31:45
+      |vpiName:aligned
+      |vpiFullName:work@top.c.aligned
+      |vpiGenScope:
+      \_gen_scope: (work@top.c.aligned), line:20:26, endln:24:8
+        |vpiParent:
+        \_gen_scope_array: (work@top.c.aligned), line:20:26, endln:24:8
+        |vpiFullName:work@top.c.aligned
+        |vpiGenScopeArray:
+        \_gen_scope_array: (work@top.c.aligned.g[0]), line:21:44, endln:23:10
+          |vpiParent:
+          \_gen_scope: (work@top.c.aligned), line:20:26, endln:24:8
+          |vpiName:g[0]
+          |vpiFullName:work@top.c.aligned.g[0]
+          |vpiGenScope:
+          \_gen_scope: (work@top.c.aligned.g[0]), line:21:44, endln:23:10
+            |vpiParent:
+            \_gen_scope_array: (work@top.c.aligned.g[0]), line:21:44, endln:23:10
+            |vpiFullName:work@top.c.aligned.g[0]
+            |vpiParameter:
+            \_parameter: (work@top.c.aligned.g[0].i), line:21:0
+              |vpiParent:
+              \_gen_scope: (work@top.c.aligned.g[0]), line:21:44, endln:23:10
+              |UINT:0
+              |vpiTypespec:
+              \_ref_typespec: (work@top.c.aligned.g[0].i)
+                |vpiParent:
+                \_parameter: (work@top.c.aligned.g[0].i), line:21:0
+                |vpiFullName:work@top.c.aligned.g[0].i
+                |vpiActual:
+                \_int_typespec: 
+              |vpiLocalParam:1
+              |vpiName:i
+              |vpiFullName:work@top.c.aligned.g[0].i
+            |vpiContAssign:
+            \_cont_assign: , line:22:16, endln:22:33
+              |vpiParent:
+              \_gen_scope: (work@top.c.aligned.g[0]), line:21:44, endln:23:10
+              |vpiRhs:
+              \_hier_path: (sub.ben[i]), line:22:23, endln:22:33
+                |vpiParent:
+                \_cont_assign: , line:22:16, endln:22:33
+                |vpiActual:
+                \_ref_obj: (sub), line:22:23, endln:22:26
+                  |vpiParent:
+                  \_hier_path: (sub.ben[i]), line:22:23, endln:22:33
+                  |vpiName:sub
+                  |vpiActual:
+                  \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:0
+                |vpiActual:
+                \_bit_select: (work@top.c.aligned.g[0].sub.ben[i].ben), line:22:31, endln:22:32
+                  |vpiParent:
+                  \_hier_path: (sub.ben[i]), line:22:23, endln:22:33
+                  |vpiName:ben
+                  |vpiFullName:work@top.c.aligned.g[0].sub.ben[i].ben
+                  |vpiActual:
+                  \_logic_var: (work@top.c.sub.ben), line:16:19, endln:16:22
+                  |vpiIndex:
+                  \_ref_obj: (work@top.c.aligned.g[0].sub.ben[i].i), line:22:31, endln:22:32
+                    |vpiParent:
+                    \_bit_select: (work@top.c.aligned.g[0].sub.ben[i].ben), line:22:31, endln:22:32
+                    |vpiName:i
+                    |vpiFullName:work@top.c.aligned.g[0].sub.ben[i].i
+                    |vpiActual:
+                    \_parameter: (work@top.c.aligned.g[0].i), line:21:0
+                |vpiName:sub.ben[i]
+              |vpiLhs:
+              \_bit_select: (work@top.c.o), line:22:16, endln:22:20
+                |vpiParent:
+                \_cont_assign: , line:22:16, endln:22:33
+                |vpiName:o
+                |vpiFullName:work@top.c.o
+                |vpiActual:
+                \_logic_net: (work@top.c.o), line:18:75, endln:18:76
+                |vpiIndex:
+                \_ref_obj: (work@top.c.aligned.g[0].i), line:22:18, endln:22:19
+                  |vpiParent:
+                  \_bit_select: (work@top.c.o), line:22:16, endln:22:20
+                  |vpiName:i
+                  |vpiFullName:work@top.c.aligned.g[0].i
+                  |vpiActual:
+                  \_parameter: (work@top.c.aligned.g[0].i), line:21:0
+        |vpiGenScopeArray:
+        \_gen_scope_array: (work@top.c.aligned.g[1]), line:21:44, endln:23:10
+          |vpiParent:
+          \_gen_scope: (work@top.c.aligned), line:20:26, endln:24:8
+          |vpiName:g[1]
+          |vpiFullName:work@top.c.aligned.g[1]
+          |vpiGenScope:
+          \_gen_scope: (work@top.c.aligned.g[1]), line:21:44, endln:23:10
+            |vpiParent:
+            \_gen_scope_array: (work@top.c.aligned.g[1]), line:21:44, endln:23:10
+            |vpiFullName:work@top.c.aligned.g[1]
+            |vpiParameter:
+            \_parameter: (work@top.c.aligned.g[1].i), line:21:0
+              |vpiParent:
+              \_gen_scope: (work@top.c.aligned.g[1]), line:21:44, endln:23:10
+              |UINT:1
+              |vpiTypespec:
+              \_ref_typespec: (work@top.c.aligned.g[1].i)
+                |vpiParent:
+                \_parameter: (work@top.c.aligned.g[1].i), line:21:0
+                |vpiFullName:work@top.c.aligned.g[1].i
+                |vpiActual:
+                \_int_typespec: 
+              |vpiLocalParam:1
+              |vpiName:i
+              |vpiFullName:work@top.c.aligned.g[1].i
+            |vpiContAssign:
+            \_cont_assign: , line:22:16, endln:22:33
+              |vpiParent:
+              \_gen_scope: (work@top.c.aligned.g[1]), line:21:44, endln:23:10
+              |vpiRhs:
+              \_hier_path: (sub.ben[i]), line:22:23, endln:22:33
+                |vpiParent:
+                \_cont_assign: , line:22:16, endln:22:33
+                |vpiActual:
+                \_ref_obj: (sub), line:22:23, endln:22:26
+                  |vpiParent:
+                  \_hier_path: (sub.ben[i]), line:22:23, endln:22:33
+                  |vpiName:sub
+                  |vpiActual:
+                  \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:0
+                |vpiActual:
+                \_bit_select: (work@top.c.aligned.g[1].sub.ben[i].ben), line:22:31, endln:22:32
+                  |vpiParent:
+                  \_hier_path: (sub.ben[i]), line:22:23, endln:22:33
+                  |vpiName:ben
+                  |vpiFullName:work@top.c.aligned.g[1].sub.ben[i].ben
+                  |vpiActual:
+                  \_logic_var: (work@top.c.sub.ben), line:16:19, endln:16:22
+                  |vpiIndex:
+                  \_ref_obj: (work@top.c.aligned.g[1].sub.ben[i].i), line:22:31, endln:22:32
+                    |vpiParent:
+                    \_bit_select: (work@top.c.aligned.g[1].sub.ben[i].ben), line:22:31, endln:22:32
+                    |vpiName:i
+                    |vpiFullName:work@top.c.aligned.g[1].sub.ben[i].i
+                    |vpiActual:
+                    \_parameter: (work@top.c.aligned.g[1].i), line:21:0
+                |vpiName:sub.ben[i]
+              |vpiLhs:
+              \_bit_select: (work@top.c.o), line:22:16, endln:22:20
+                |vpiParent:
+                \_cont_assign: , line:22:16, endln:22:33
+                |vpiName:o
+                |vpiFullName:work@top.c.o
+                |vpiActual:
+                \_logic_net: (work@top.c.o), line:18:75, endln:18:76
+                |vpiIndex:
+                \_ref_obj: (work@top.c.aligned.g[1].i), line:22:18, endln:22:19
+                  |vpiParent:
+                  \_bit_select: (work@top.c.o), line:22:16, endln:22:20
+                  |vpiName:i
+                  |vpiFullName:work@top.c.aligned.g[1].i
+                  |vpiActual:
+                  \_parameter: (work@top.c.aligned.g[1].i), line:21:0
+        |vpiGenScopeArray:
+        \_gen_scope_array: (work@top.c.aligned.g[2]), line:21:44, endln:23:10
+          |vpiParent:
+          \_gen_scope: (work@top.c.aligned), line:20:26, endln:24:8
+          |vpiName:g[2]
+          |vpiFullName:work@top.c.aligned.g[2]
+          |vpiGenScope:
+          \_gen_scope: (work@top.c.aligned.g[2]), line:21:44, endln:23:10
+            |vpiParent:
+            \_gen_scope_array: (work@top.c.aligned.g[2]), line:21:44, endln:23:10
+            |vpiFullName:work@top.c.aligned.g[2]
+            |vpiParameter:
+            \_parameter: (work@top.c.aligned.g[2].i), line:21:0
+              |vpiParent:
+              \_gen_scope: (work@top.c.aligned.g[2]), line:21:44, endln:23:10
+              |UINT:2
+              |vpiTypespec:
+              \_ref_typespec: (work@top.c.aligned.g[2].i)
+                |vpiParent:
+                \_parameter: (work@top.c.aligned.g[2].i), line:21:0
+                |vpiFullName:work@top.c.aligned.g[2].i
+                |vpiActual:
+                \_int_typespec: 
+              |vpiLocalParam:1
+              |vpiName:i
+              |vpiFullName:work@top.c.aligned.g[2].i
+            |vpiContAssign:
+            \_cont_assign: , line:22:16, endln:22:33
+              |vpiParent:
+              \_gen_scope: (work@top.c.aligned.g[2]), line:21:44, endln:23:10
+              |vpiRhs:
+              \_hier_path: (sub.ben[i]), line:22:23, endln:22:33
+                |vpiParent:
+                \_cont_assign: , line:22:16, endln:22:33
+                |vpiActual:
+                \_ref_obj: (sub), line:22:23, endln:22:26
+                  |vpiParent:
+                  \_hier_path: (sub.ben[i]), line:22:23, endln:22:33
+                  |vpiName:sub
+                  |vpiActual:
+                  \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:0
+                |vpiActual:
+                \_bit_select: (work@top.c.aligned.g[2].sub.ben[i].ben), line:22:31, endln:22:32
+                  |vpiParent:
+                  \_hier_path: (sub.ben[i]), line:22:23, endln:22:33
+                  |vpiName:ben
+                  |vpiFullName:work@top.c.aligned.g[2].sub.ben[i].ben
+                  |vpiActual:
+                  \_logic_var: (work@top.c.sub.ben), line:16:19, endln:16:22
+                  |vpiIndex:
+                  \_ref_obj: (work@top.c.aligned.g[2].sub.ben[i].i), line:22:31, endln:22:32
+                    |vpiParent:
+                    \_bit_select: (work@top.c.aligned.g[2].sub.ben[i].ben), line:22:31, endln:22:32
+                    |vpiName:i
+                    |vpiFullName:work@top.c.aligned.g[2].sub.ben[i].i
+                    |vpiActual:
+                    \_parameter: (work@top.c.aligned.g[2].i), line:21:0
+                |vpiName:sub.ben[i]
+              |vpiLhs:
+              \_bit_select: (work@top.c.o), line:22:16, endln:22:20
+                |vpiParent:
+                \_cont_assign: , line:22:16, endln:22:33
+                |vpiName:o
+                |vpiFullName:work@top.c.o
+                |vpiActual:
+                \_logic_net: (work@top.c.o), line:18:75, endln:18:76
+                |vpiIndex:
+                \_ref_obj: (work@top.c.aligned.g[2].i), line:22:18, endln:22:19
+                  |vpiParent:
+                  \_bit_select: (work@top.c.o), line:22:16, endln:22:20
+                  |vpiName:i
+                  |vpiFullName:work@top.c.aligned.g[2].i
+                  |vpiActual:
+                  \_parameter: (work@top.c.aligned.g[2].i), line:21:0
+        |vpiGenScopeArray:
+        \_gen_scope_array: (work@top.c.aligned.g[3]), line:21:44, endln:23:10
+          |vpiParent:
+          \_gen_scope: (work@top.c.aligned), line:20:26, endln:24:8
+          |vpiName:g[3]
+          |vpiFullName:work@top.c.aligned.g[3]
+          |vpiGenScope:
+          \_gen_scope: (work@top.c.aligned.g[3]), line:21:44, endln:23:10
+            |vpiParent:
+            \_gen_scope_array: (work@top.c.aligned.g[3]), line:21:44, endln:23:10
+            |vpiFullName:work@top.c.aligned.g[3]
+            |vpiParameter:
+            \_parameter: (work@top.c.aligned.g[3].i), line:21:0
+              |vpiParent:
+              \_gen_scope: (work@top.c.aligned.g[3]), line:21:44, endln:23:10
+              |UINT:3
+              |vpiTypespec:
+              \_ref_typespec: (work@top.c.aligned.g[3].i)
+                |vpiParent:
+                \_parameter: (work@top.c.aligned.g[3].i), line:21:0
+                |vpiFullName:work@top.c.aligned.g[3].i
+                |vpiActual:
+                \_int_typespec: 
+              |vpiLocalParam:1
+              |vpiName:i
+              |vpiFullName:work@top.c.aligned.g[3].i
+            |vpiContAssign:
+            \_cont_assign: , line:22:16, endln:22:33
+              |vpiParent:
+              \_gen_scope: (work@top.c.aligned.g[3]), line:21:44, endln:23:10
+              |vpiRhs:
+              \_hier_path: (sub.ben[i]), line:22:23, endln:22:33
+                |vpiParent:
+                \_cont_assign: , line:22:16, endln:22:33
+                |vpiActual:
+                \_ref_obj: (sub), line:22:23, endln:22:26
+                  |vpiParent:
+                  \_hier_path: (sub.ben[i]), line:22:23, endln:22:33
+                  |vpiName:sub
+                  |vpiActual:
+                  \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:31:0
+                |vpiActual:
+                \_bit_select: (work@top.c.aligned.g[3].sub.ben[i].ben), line:22:31, endln:22:32
+                  |vpiParent:
+                  \_hier_path: (sub.ben[i]), line:22:23, endln:22:33
+                  |vpiName:ben
+                  |vpiFullName:work@top.c.aligned.g[3].sub.ben[i].ben
+                  |vpiActual:
+                  \_logic_var: (work@top.c.sub.ben), line:16:19, endln:16:22
+                  |vpiIndex:
+                  \_ref_obj: (work@top.c.aligned.g[3].sub.ben[i].i), line:22:31, endln:22:32
+                    |vpiParent:
+                    \_bit_select: (work@top.c.aligned.g[3].sub.ben[i].ben), line:22:31, endln:22:32
+                    |vpiName:i
+                    |vpiFullName:work@top.c.aligned.g[3].sub.ben[i].i
+                    |vpiActual:
+                    \_parameter: (work@top.c.aligned.g[3].i), line:21:0
+                |vpiName:sub.ben[i]
+              |vpiLhs:
+              \_bit_select: (work@top.c.o), line:22:16, endln:22:20
+                |vpiParent:
+                \_cont_assign: , line:22:16, endln:22:33
+                |vpiName:o
+                |vpiFullName:work@top.c.o
+                |vpiActual:
+                \_logic_net: (work@top.c.o), line:18:75, endln:18:76
+                |vpiIndex:
+                \_ref_obj: (work@top.c.aligned.g[3].i), line:22:18, endln:22:19
+                  |vpiParent:
+                  \_bit_select: (work@top.c.o), line:22:16, endln:22:20
+                  |vpiName:i
+                  |vpiFullName:work@top.c.aligned.g[3].i
+                  |vpiActual:
+                  \_parameter: (work@top.c.aligned.g[3].i), line:21:0
+  |vpiContAssign:
+  \_cont_assign: , line:30:10, endln:30:25
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:27:1, endln:32:10
+    |vpiRhs:
+    \_ref_obj: (work@top.ben_i), line:30:20, endln:30:25
+      |vpiParent:
+      \_cont_assign: , line:30:10, endln:30:25
+      |vpiName:ben_i
+      |vpiFullName:work@top.ben_i
+      |vpiActual:
+      \_logic_net: (work@top.ben_i), line:27:31, endln:27:36
+    |vpiLhs:
+    \_hier_path: (sub.ben), line:30:10, endln:30:17
+      |vpiParent:
+      \_cont_assign: , line:30:10, endln:30:25
+      |vpiActual:
+      \_ref_obj: (sub), line:30:14, endln:30:17
+        |vpiParent:
+        \_hier_path: (sub.ben), line:30:10, endln:30:17
+        |vpiName:sub
+        |vpiActual:
+        \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:29:3, endln:29:28
+      |vpiActual:
+      \_ref_obj: (ben), line:30:14, endln:30:17
+        |vpiParent:
+        \_hier_path: (sub.ben), line:30:10, endln:30:17
+        |vpiName:ben
+        |vpiActual:
+        \_logic_var: (work@top.sub.ben), line:16:19, endln:16:22
+      |vpiName:sub.ben
+\_weaklyReferenced:
+\_int_typespec: , line:10:27, endln:10:39
+  |vpiParent:
+  \_typespec_member: (DAT), line:10:40, endln:10:43
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+\_string_typespec: (DAT), line:12:39, endln:12:42
+  |vpiParent:
+  \_tagged_pattern: , line:12:44, endln:12:46
+  |vpiName:DAT
+\_string_typespec: (BUS), line:12:32, endln:12:35
+  |vpiParent:
+  \_tagged_pattern: , line:12:37, endln:12:47
+  |vpiName:BUS
+\_int_typespec: , line:10:27, endln:10:39
+  |vpiParent:
+  \_typespec_member: (DAT), line:10:40, endln:10:43
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+\_string_typespec: (DAT), line:12:39, endln:12:42
+  |vpiParent:
+  \_tagged_pattern: , line:12:44, endln:12:46
+  |vpiName:DAT
+\_string_typespec: (BUS), line:12:32, endln:12:35
+  |vpiParent:
+  \_tagged_pattern: , line:12:37, endln:12:47
+  |vpiName:BUS
+\_string_typespec: (BUS), line:12:32, endln:12:35
+  |vpiParent:
+  \_ref_typespec: (work@bus_if)
+  |vpiName:BUS
+\_string_typespec: (DAT), line:12:39, endln:12:42
+  |vpiParent:
+  \_ref_typespec: (work@bus_if)
+  |vpiName:DAT
+\_int_typespec: , line:15:14, endln:15:26
+  |vpiParent:
+  \_parameter: (work@bus_if.BYT), line:15:27, endln:15:30
+\_bit_typespec: , line:18:26, endln:18:29
+  |vpiParent:
+  \_parameter: (work@child.ALIGNED), line:18:30, endln:18:37
+\_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (BUS), line:11:33, endln:11:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiName:BUS
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS)
+      |vpiParent:
+      \_typespec_member: (BUS), line:11:33, endln:11:36
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.BUS
+      |vpiActual:
+      \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:11
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:11
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS)
+  |vpiName:p::bus_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DAT), line:10:40, endln:10:43
+    |vpiParent:
+    \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiName:DAT
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS.p::bus_t.DAT)
+      |vpiParent:
+      \_typespec_member: (DAT), line:10:40, endln:10:43
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.BUS.p::bus_t.DAT
+      |vpiActual:
+      \_int_typespec: , line:10:27, endln:10:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:10
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:10
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:10:27, endln:10:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS.p::bus_t.DAT)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+\_string_typespec: (BUS), line:12:32, endln:12:35
+  |vpiParent:
+  \_ref_typespec: (work@top)
+  |vpiName:BUS
+\_string_typespec: (DAT), line:12:39, endln:12:42
+  |vpiParent:
+  \_ref_typespec: (work@top)
+  |vpiName:DAT
+\_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (BUS), line:11:33, endln:11:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiName:BUS
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS)
+      |vpiParent:
+      \_typespec_member: (BUS), line:11:33, endln:11:36
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.BUS
+      |vpiActual:
+      \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:11
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:11
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS)
+  |vpiName:p::bus_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DAT), line:10:40, endln:10:43
+    |vpiParent:
+    \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiName:DAT
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS.p::bus_t.DAT)
+      |vpiParent:
+      \_typespec_member: (DAT), line:10:40, endln:10:43
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.BUS.p::bus_t.DAT
+      |vpiActual:
+      \_int_typespec: , line:10:27, endln:10:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:10
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:10
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:10:27, endln:10:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS.p::bus_t.DAT)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+\_logic_typespec: , line:27:19, endln:27:30
+  |vpiRange:
+  \_range: , line:27:25, endln:27:30
+    |vpiParent:
+    \_logic_typespec: , line:27:19, endln:27:30
+    |vpiLeftRange:
+    \_constant: , line:27:26, endln:27:27
+      |vpiParent:
+      \_range: , line:27:25, endln:27:30
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:27:28, endln:27:29
+      |vpiParent:
+      \_range: , line:27:25, endln:27:30
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:27:45, endln:27:56
+  |vpiRange:
+  \_range: , line:27:51, endln:27:56
+    |vpiParent:
+    \_logic_typespec: , line:27:45, endln:27:56
+    |vpiLeftRange:
+    \_constant: , line:27:52, endln:27:53
+      |vpiParent:
+      \_range: , line:27:51, endln:27:56
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:27:54, endln:27:55
+      |vpiParent:
+      \_range: , line:27:51, endln:27:56
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS)
+  |vpiName:p::bus_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DAT), line:10:40, endln:10:43
+    |vpiParent:
+    \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiName:DAT
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS.p::bus_t.DAT)
+      |vpiParent:
+      \_typespec_member: (DAT), line:10:40, endln:10:43
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.BUS.p::bus_t.DAT
+      |vpiActual:
+      \_int_typespec: , line:10:27, endln:10:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:10
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:10
+    |vpiRefEndColumnNo:39
+\_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS)
+  |vpiParent:
+  \_typespec_member: (BUS), line:11:33, endln:11:36
+  |vpiFullName:work@top.CFG_DEF.p::cfg_t.BUS
+  |vpiActual:
+  \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+\_typespec_member: (BUS), line:11:33, endln:11:36
+  |vpiParent:
+  \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+  |vpiName:BUS
+  |vpiTypespec:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS)
+  |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+  |vpiRefLineNo:11
+  |vpiRefColumnNo:27
+  |vpiRefEndLineNo:11
+  |vpiRefEndColumnNo:32
+\_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (BUS), line:11:33, endln:11:36
+\_ref_typespec: (work@top.CFG_DEF)
+  |vpiParent:
+  \_parameter: (work@top.CFG_DEF), line:12:20, endln:12:27
+  |vpiFullName:work@top.CFG_DEF
+  |vpiActual:
+  \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+\_parameter: (work@top.CFG_DEF), line:12:20, endln:12:27
+  |vpiParent:
+  \_param_assign: , line:12:20, endln:12:48
+  |vpiTypespec:
+  \_ref_typespec: (work@top.CFG_DEF)
+  |vpiLocalParam:1
+  |vpiName:CFG_DEF
+  |vpiFullName:work@top.CFG_DEF
+  |vpiImported:p
+\_int_typespec: , line:10:27, endln:10:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS.p::bus_t.DAT)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+\_operation: , line:12:30, endln:12:48
+  |vpiParent:
+  \_param_assign: , line:12:20, endln:12:48
+  |vpiTypespec:
+  \_ref_typespec: 
+    |vpiActual:
+    \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+  |vpiOpType:75
+  |vpiOperand:
+  \_operation: , line:12:37, endln:12:47
+\_logic_typespec: , line:27:19, endln:27:30
+  |vpiParent:
+  \_logic_net: (work@top.ben_i), line:27:31, endln:27:36
+  |vpiRange:
+  \_range: , line:27:25, endln:27:30
+    |vpiParent:
+    \_logic_typespec: , line:27:19, endln:27:30
+    |vpiLeftRange:
+    \_constant: , line:27:26, endln:27:27
+      |vpiParent:
+      \_range: , line:27:25, endln:27:30
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:27:28, endln:27:29
+      |vpiParent:
+      \_range: , line:27:25, endln:27:30
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:27:45, endln:27:56
+  |vpiParent:
+  \_logic_net: (work@top.o), line:27:57, endln:27:58
+  |vpiRange:
+  \_range: , line:27:51, endln:27:56
+    |vpiParent:
+    \_logic_typespec: , line:27:45, endln:27:56
+    |vpiLeftRange:
+    \_constant: , line:27:52, endln:27:53
+      |vpiParent:
+      \_range: , line:27:51, endln:27:56
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:27:54, endln:27:55
+      |vpiParent:
+      \_range: , line:27:51, endln:27:56
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+  |vpiParent:
+  \_ref_typespec: (work@top.sub)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (BUS), line:11:33, endln:11:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiName:BUS
+    |vpiTypespec:
+    \_ref_typespec: (work@top.sub.p::cfg_t.BUS)
+      |vpiParent:
+      \_typespec_member: (BUS), line:11:33, endln:11:36
+      |vpiFullName:work@top.sub.p::cfg_t.BUS
+      |vpiActual:
+      \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:11
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:11
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+  |vpiParent:
+  \_ref_typespec: (work@top.sub.p::cfg_t.BUS)
+  |vpiName:p::bus_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DAT), line:10:40, endln:10:43
+    |vpiParent:
+    \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiName:DAT
+    |vpiTypespec:
+    \_ref_typespec: (work@top.sub.p::cfg_t.BUS.p::bus_t.DAT)
+      |vpiParent:
+      \_typespec_member: (DAT), line:10:40, endln:10:43
+      |vpiFullName:work@top.sub.p::cfg_t.BUS.p::bus_t.DAT
+      |vpiActual:
+      \_int_typespec: , line:10:27, endln:10:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:10
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:10
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:10:27, endln:10:39
+  |vpiParent:
+  \_ref_typespec: (work@top.sub.p::cfg_t.BUS.p::bus_t.DAT)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+\_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+  |vpiParent:
+  \_ref_typespec: (work@top.sub)
+  |vpiName:p::bus_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DAT), line:10:40, endln:10:43
+    |vpiParent:
+    \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiName:DAT
+    |vpiTypespec:
+    \_ref_typespec: (work@top.sub.p::bus_t.DAT)
+      |vpiParent:
+      \_typespec_member: (DAT), line:10:40, endln:10:43
+      |vpiFullName:work@top.sub.p::bus_t.DAT
+      |vpiActual:
+      \_int_typespec: , line:10:27, endln:10:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:10
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:10
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:10:27, endln:10:39
+  |vpiParent:
+  \_ref_typespec: (work@top.sub.p::bus_t.DAT)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+\_logic_typespec: , line:16:3, endln:16:18
+  |vpiParent:
+  \_logic_var: (work@top.sub.ben), line:16:19, endln:16:22
+  |vpiRange:
+  \_range: , line:16:9, endln:16:18
+    |vpiParent:
+    \_logic_typespec: , line:16:3, endln:16:18
+    |vpiLeftRange:
+    \_constant: , line:16:10, endln:16:13
+      |vpiParent:
+      \_range: , line:16:9, endln:16:18
+      |vpiDecompile:3
+      |vpiSize:64
+      |INT:3
+      |vpiConstType:7
+    |vpiRightRange:
+    \_constant: , line:16:16, endln:16:17
+      |vpiParent:
+      \_range: , line:16:9, endln:16:18
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_interface_typespec: (bus_if), line:18:44, endln:18:50
+  |vpiName:bus_if
+\_logic_typespec: , line:16:3, endln:16:18
+  |vpiParent:
+  \_logic_var: (work@top.c.sub.ben), line:16:19, endln:16:22
+  |vpiRange:
+  \_range: , line:16:9, endln:16:18
+    |vpiParent:
+    \_logic_typespec: , line:16:3, endln:16:18
+    |vpiLeftRange:
+    \_constant: , line:16:10, endln:16:13
+      |vpiParent:
+      \_range: , line:16:9, endln:16:18
+      |vpiDecompile:3
+      |vpiSize:64
+      |INT:3
+      |vpiConstType:7
+    |vpiRightRange:
+    \_constant: , line:16:16, endln:16:17
+      |vpiParent:
+      \_range: , line:16:9, endln:16:18
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:18:63, endln:18:74
+  |vpiRange:
+  \_range: , line:18:69, endln:18:74
+    |vpiParent:
+    \_logic_typespec: , line:18:63, endln:18:74
+    |vpiLeftRange:
+    \_constant: , line:18:70, endln:18:71
+      |vpiParent:
+      \_range: , line:18:69, endln:18:74
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:18:72, endln:18:73
+      |vpiParent:
+      \_range: , line:18:69, endln:18:74
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:18:63, endln:18:74
+  |vpiParent:
+  \_logic_net: (work@top.c.o), line:18:75, endln:18:76
+  |vpiRange:
+  \_range: , line:18:69, endln:18:74
+    |vpiParent:
+    \_logic_typespec: , line:18:63, endln:18:74
+    |vpiLeftRange:
+    \_constant: , line:18:70, endln:18:71
+      |vpiParent:
+      \_range: , line:18:69, endln:18:74
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:18:72, endln:18:73
+      |vpiParent:
+      \_range: , line:18:69, endln:18:74
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_operation: , line:12:37, endln:12:47
+  |vpiParent:
+  \_operation: , line:14:45, endln:14:48
+  |vpiSize:32
+  |vpiTypespec:
+  \_ref_typespec: 
+    |vpiActual:
+    \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+  |vpiOpType:75
+  |vpiOperand:
+  \_constant: , line:12:44, endln:12:46
+\_operation: , line:14:45, endln:14:48
+  |vpiParent:
+  \_param_assign: , line:14:39, endln:14:55
+  |vpiTypespec:
+  \_ref_typespec: 
+    |vpiActual:
+    \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+  |vpiOpType:75
+  |vpiOperand:
+  \_operation: , line:12:37, endln:12:47
+\_logic_typespec: , line:16:3, endln:16:18
+  |vpiRange:
+  \_range: , line:16:9, endln:16:18
+    |vpiParent:
+    \_logic_typespec: , line:16:3, endln:16:18
+    |vpiLeftRange:
+    \_operation: , line:16:10, endln:16:15
+      |vpiParent:
+      \_range: , line:16:9, endln:16:18
+      |vpiOpType:11
+      |vpiOperand:
+      \_ref_obj: (BYT), line:16:10, endln:16:13
+        |vpiParent:
+        \_operation: , line:16:10, endln:16:15
+        |vpiName:BYT
+      |vpiOperand:
+      \_constant: , line:16:14, endln:16:15
+        |vpiParent:
+        \_operation: , line:16:10, endln:16:15
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
+        |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:16:16, endln:16:17
+      |vpiParent:
+      \_range: , line:16:9, endln:16:18
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_interface_typespec: (bus_if), line:18:44, endln:18:50
+  |vpiName:bus_if
+\_logic_typespec: , line:18:63, endln:18:74
+  |vpiRange:
+  \_range: , line:18:69, endln:18:74
+    |vpiParent:
+    \_logic_typespec: , line:18:63, endln:18:74
+    |vpiLeftRange:
+    \_constant: , line:18:70, endln:18:71
+      |vpiParent:
+      \_range: , line:18:69, endln:18:74
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:18:72, endln:18:73
+      |vpiParent:
+      \_range: , line:18:69, endln:18:74
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:27:19, endln:27:30
+  |vpiRange:
+  \_range: , line:27:25, endln:27:30
+    |vpiParent:
+    \_logic_typespec: , line:27:19, endln:27:30
+    |vpiLeftRange:
+    \_constant: , line:27:26, endln:27:27
+      |vpiParent:
+      \_range: , line:27:25, endln:27:30
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:27:28, endln:27:29
+      |vpiParent:
+      \_range: , line:27:25, endln:27:30
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:27:45, endln:27:56
+  |vpiRange:
+  \_range: , line:27:51, endln:27:56
+    |vpiParent:
+    \_logic_typespec: , line:27:45, endln:27:56
+    |vpiLeftRange:
+    \_constant: , line:27:52, endln:27:53
+      |vpiParent:
+      \_range: , line:27:51, endln:27:56
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:27:54, endln:27:55
+      |vpiParent:
+      \_range: , line:27:51, endln:27:56
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (BUS), line:11:33, endln:11:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiName:BUS
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS)
+      |vpiParent:
+      \_typespec_member: (BUS), line:11:33, endln:11:36
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.BUS
+      |vpiActual:
+      \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:11
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:11
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS)
+  |vpiName:p::bus_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DAT), line:10:40, endln:10:43
+    |vpiParent:
+    \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiName:DAT
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS.p::bus_t.DAT)
+      |vpiParent:
+      \_typespec_member: (DAT), line:10:40, endln:10:43
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.BUS.p::bus_t.DAT
+      |vpiActual:
+      \_int_typespec: , line:10:27, endln:10:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:10
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:10
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:10:27, endln:10:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.BUS.p::bus_t.DAT)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+\_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+  |vpiParent:
+  \_ref_typespec: (work@top.sub.CFG)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (BUS), line:11:33, endln:11:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiName:BUS
+    |vpiTypespec:
+    \_ref_typespec: (work@top.sub.CFG.p::cfg_t.BUS)
+      |vpiParent:
+      \_typespec_member: (BUS), line:11:33, endln:11:36
+      |vpiFullName:work@top.sub.CFG.p::cfg_t.BUS
+      |vpiActual:
+      \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:11
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:11
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+  |vpiParent:
+  \_ref_typespec: (work@top.sub.CFG.p::cfg_t.BUS)
+  |vpiName:p::bus_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DAT), line:10:40, endln:10:43
+    |vpiParent:
+    \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiName:DAT
+    |vpiTypespec:
+    \_ref_typespec: (work@top.sub.CFG.p::cfg_t.BUS.p::bus_t.DAT)
+      |vpiParent:
+      \_typespec_member: (DAT), line:10:40, endln:10:43
+      |vpiFullName:work@top.sub.CFG.p::cfg_t.BUS.p::bus_t.DAT
+      |vpiActual:
+      \_int_typespec: , line:10:27, endln:10:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:10
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:10
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:10:27, endln:10:39
+  |vpiParent:
+  \_ref_typespec: (work@top.sub.CFG.p::cfg_t.BUS.p::bus_t.DAT)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+\_int_typespec: , line:15:14, endln:15:26
+  |vpiParent:
+  \_ref_typespec: (work@top.sub.BYT)
+\_bit_typespec: , line:18:26, endln:18:29
+  |vpiParent:
+  \_ref_typespec: (work@top.c.ALIGNED)
+\_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.CFG)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (BUS), line:11:33, endln:11:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiName:BUS
+    |vpiTypespec:
+    \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.BUS)
+      |vpiParent:
+      \_typespec_member: (BUS), line:11:33, endln:11:36
+      |vpiFullName:work@top.c.sub.CFG.p::cfg_t.BUS
+      |vpiActual:
+      \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:11
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:11
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.BUS)
+  |vpiName:p::bus_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DAT), line:10:40, endln:10:43
+    |vpiParent:
+    \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiName:DAT
+    |vpiTypespec:
+    \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.BUS.p::bus_t.DAT)
+      |vpiParent:
+      \_typespec_member: (DAT), line:10:40, endln:10:43
+      |vpiFullName:work@top.c.sub.CFG.p::cfg_t.BUS.p::bus_t.DAT
+      |vpiActual:
+      \_int_typespec: , line:10:27, endln:10:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:10
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:10
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:10:27, endln:10:39
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.BUS.p::bus_t.DAT)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+\_int_typespec: , line:15:14, endln:15:26
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.BYT)
+\_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.CFG)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (BUS), line:11:33, endln:11:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:11:11, endln:11:39
+    |vpiName:BUS
+    |vpiTypespec:
+    \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.BUS)
+      |vpiParent:
+      \_typespec_member: (BUS), line:11:33, endln:11:36
+      |vpiFullName:work@top.c.sub.CFG.p::cfg_t.BUS
+      |vpiActual:
+      \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:11
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:11
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.BUS)
+  |vpiName:p::bus_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DAT), line:10:40, endln:10:43
+    |vpiParent:
+    \_struct_typespec: (p::bus_t), line:10:11, endln:10:46
+    |vpiName:DAT
+    |vpiTypespec:
+    \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.BUS.p::bus_t.DAT)
+      |vpiParent:
+      \_typespec_member: (DAT), line:10:40, endln:10:43
+      |vpiFullName:work@top.c.sub.CFG.p::cfg_t.BUS.p::bus_t.DAT
+      |vpiActual:
+      \_int_typespec: , line:10:27, endln:10:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv
+    |vpiRefLineNo:10
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:10
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:10:27, endln:10:39
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.BUS.p::bus_t.DAT)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv, line:9:1, endln:13:11
+\_int_typespec: , line:15:14, endln:15:26
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.BYT)
+\_int_typespec: 
+\_int_typespec: 
+\_int_typespec: 
+\_int_typespec: 
+===================
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
+[WARNING] : 4
+[   NOTE] : 6
+
+============================== Begin RoundTrip Results ==============================
+[roundtrip]: ${SURELOG_DIR}/tests/GenForIfaceLocalparamNestedGen/dut.sv | ${SURELOG_DIR}/build/regression/GenForIfaceLocalparamNestedGen/roundtrip/dut_000.sv | 17 | 32 |
+============================== End RoundTrip Results ==============================

--- a/tests/GenForIfaceLocalparamNestedGen/GenForIfaceLocalparamNestedGen.sl
+++ b/tests/GenForIfaceLocalparamNestedGen/GenForIfaceLocalparamNestedGen.sl
@@ -1,0 +1,1 @@
+-parse -mt 0 -d uhdm -d coveruhdm -elabuhdm -nobuiltin dut.sv

--- a/tests/GenForIfaceLocalparamNestedGen/dut.sv
+++ b/tests/GenForIfaceLocalparamNestedGen/dut.sv
@@ -1,0 +1,32 @@
+// Regression: a generate-for bounded by an interface localparam read through
+// the interface port (`sub.BYT`), but NESTED inside another generate block
+// (`generate if (ALIGNED) begin: aligned ... end`).  When nested, the compile
+// context is the gen-scope definition (which has no ports), so the interface
+// port lives on the ENCLOSING module definition — resolveInterfacePortMember
+// must walk up the parent-scope chain to find it.  Mirrors the jeras/rp32
+// tcb_lite_lib_logsize2byteena aligned/unaligned byte-enable loops; without the
+// walk the loops drop and the SoC read/write data path is undriven (X).
+package p;
+  typedef struct packed { int unsigned DAT; } bus_t;
+  typedef struct packed { bus_t BUS; } cfg_t;
+  localparam cfg_t CFG_DEF = '{BUS: '{DAT: 32}};
+endpackage
+interface bus_if #(parameter p::cfg_t CFG = p::CFG_DEF);
+  localparam int unsigned BYT = CFG.BUS.DAT/8;    // = 4, via a struct-param field
+  logic [BYT-1:0] ben;
+endinterface
+module child #(parameter bit ALIGNED = 1) (bus_if sub, output logic [3:0] o);
+  generate
+    if (ALIGNED == 1'b1) begin : aligned
+      for (genvar i = 0; i < sub.BYT; i++) begin : g
+        assign o[i] = sub.ben[i];
+      end
+    end
+  endgenerate
+endmodule
+module top (input logic [3:0] ben_i, output logic [3:0] o);
+  import p::*;
+  bus_if #(CFG_DEF) sub ();
+  assign sub.ben = ben_i;
+  child #(.ALIGNED(1)) c (.sub(sub), .o(o));
+endmodule


### PR DESCRIPTION
Extends resolveInterfacePortMember (interface-port localparam value read, e.g. a generate-for bound `i < sub.CFG_BUS_BYT`) to walk UP the enclosing-scope chain.  When the read sits inside a nested generate block — `generate if (ALIGNED) begin: aligned for (i=0; i<sub.BYT; i++) ... end` — the compile `component` is the gen-scope definition, which has no ports; the interface port `sub` lives on the enclosing MODULE definition.  Walking getParentScope() finds it, so the bound folds and the loop unrolls.

This is the jeras/rp32 tcb_lite_lib_logsize2byteena aligned/unaligned byte-enable and read/write-data reshaping loops; without the walk they dropped and the degu SoC fetch/read data path (`sub_rdt`/`man_wdt`/`man.req.byt`) was undriven (X).

New regression: tests/GenForIfaceLocalparamNestedGen (asserts
work@top.c.aligned.g[0..3] elaborate).  Full regression: 785 PASS, 0 failures.