### PR TITLE
Fold interface-param struct-field generate condition (sub.CFG.HSK.DLY)

### DIFF
--- a/include/Surelog/DesignCompile/CompileHelper.h
+++ b/include/Surelog/DesignCompile/CompileHelper.h
@@ -624,8 +624,7 @@ class CompileHelper final {
   // TYPE definition, since the interface instance isn't bound yet at
   // generate-elaboration time.  Returns a UHDM constant, or nullptr.
   UHDM::any* resolveInterfacePortMember(DesignComponent* component,
-                                        std::string_view baseName,
-                                        std::string_view memberName,
+                                        UHDM::hier_path* path,
                                         CompileDesign* compileDesign,
                                         const FileContent* fC, NodeId locId);
 

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -1183,9 +1183,13 @@ any *CompileHelper::getValue(std::string_view name, DesignComponent *component,
 }
 
 UHDM::any *CompileHelper::resolveInterfacePortMember(
-    DesignComponent *component, std::string_view baseName,
-    std::string_view memberName, CompileDesign *compileDesign,
-    const FileContent *fC, NodeId locId) {
+    DesignComponent *component, UHDM::hier_path *path,
+    CompileDesign *compileDesign, const FileContent *fC, NodeId locId) {
+  if (path == nullptr || path->Path_elems() == nullptr ||
+      path->Path_elems()->size() < 2)
+    return nullptr;
+  const std::string baseName =
+      std::string(path->Path_elems()->at(0)->VpiName());
   // Walk up the enclosing-scope chain: when the read sits inside a nested
   // generate block (`generate if (ALIGNED) begin: aligned for (i<sub.BYT) ...`),
   // `component` is the gen-scope definition, which has no ports — the interface
@@ -1209,14 +1213,41 @@ UHDM::any *CompileHelper::resolveInterfacePortMember(
             ifaceDef = des->getComponentDefinition(StrCat("work@", tn));
         }
       }
-      if (ifaceDef) {
-        // Evaluate the interface's param/localparam (e.g. `BYT = DAT/8`) in the
-        // interface definition's own context (default/overridden params).
-        if (any *v = getValue(memberName, ifaceDef, compileDesign, Reduce::Yes,
-                              nullptr, fC->getFileId(), fC->Line(locId), nullptr,
-                              true)) {
+      if (ifaceDef == nullptr) return nullptr;
+      UHDM::VectorOfany &elems = *path->Path_elems();
+      if (elems.size() == 2) {
+        // `sub.BYT`: a single param/localparam read — evaluate the member in
+        // the interface definition's own context (default/overridden params).
+        if (any *v = getValue(std::string(elems.at(1)->VpiName()), ifaceDef,
+                              compileDesign, Reduce::Yes, nullptr,
+                              fC->getFileId(), fC->Line(locId), nullptr, true)) {
           if (v->UhdmType() == uhdmconstant) return v;
         }
+        return nullptr;
+      }
+      // `sub.CFG.HSK.DLY`: a nested struct-PARAMETER field chain (`CFG` is a
+      // struct param of the interface, `.HSK.DLY` walks its members).  Build a
+      // sub-path from the member elements (dropping the interface-port base) and
+      // decode it in the interface definition, where the struct-param-field
+      // navigation resolves it to a constant.  Needed for the degu SoC
+      // demultiplexer / register generate conditions `if (sub.CFG.HSK.DLY==N)`.
+      UHDM::Serializer &s = compileDesign->getSerializer();
+      UHDM::hier_path *sub = s.MakeHier_path();
+      UHDM::VectorOfany *sub_elems = s.MakeAnyVec();
+      std::string sub_name;
+      for (size_t i = 1; i < elems.size(); i++) {
+        sub_elems->push_back(elems.at(i));
+        if (i > 1) sub_name += ".";
+        sub_name += std::string(elems.at(i)->VpiName());
+      }
+      sub->Path_elems(sub_elems);
+      sub->VpiName(sub_name);
+      sub->VpiFullName(sub_name);
+      bool invalid = false;
+      if (any *v = decodeHierPath(sub, invalid, ifaceDef, compileDesign,
+                                  Reduce::Yes, nullptr, fC->getFileId(),
+                                  fC->Line(locId), nullptr, true, false)) {
+        if (!invalid && v->UhdmType() == uhdmconstant) return v;
       }
       return nullptr;
     }
@@ -1522,18 +1553,16 @@ UHDM::any *CompileHelper::compileSelectExpression(
       // byte-enable loops).  The interface INSTANCE isn't bound to the port yet
       // at generate-elaboration time, so resolve the member from the port's
       // interface TYPE definition and return its constant; otherwise the bound
-      // stays a non-constant hier_path and the loop silently drops.  Only a
-      // plain 2-level `base.member` (no selects/brackets) qualifies.
+      // stays a non-constant hier_path and the loop/branch silently drops.  A
+      // plain dotted `base.member[.field...]` (no array selects/brackets)
+      // qualifies — either a direct localparam (`sub.BYT`) or a nested
+      // struct-parameter field chain (`sub.CFG.HSK.DLY`).
       if (reduce == Reduce::Yes && component &&
-          hname.find('[') == std::string::npos) {
-        const size_t dot = hname.find('.');
-        if (dot != std::string::npos &&
-            hname.find('.', dot + 1) == std::string::npos) {
-          if (any *v = resolveInterfacePortMember(
-                  component, hname.substr(0, dot), hname.substr(dot + 1),
-                  compileDesign, fC, Bit_select)) {
-            result = v;
-          }
+          hname.find('[') == std::string::npos &&
+          hname.find('.') != std::string::npos) {
+        if (any *v = resolveInterfacePortMember(component, path, compileDesign,
+                                                fC, Bit_select)) {
+          result = v;
         }
       }
       break;

--- a/tests/GenIfIfaceParamStructField/GenIfIfaceParamStructField.log
+++ b/tests/GenIfIfaceParamStructField/GenIfIfaceParamStructField.log
@@ -1,0 +1,2924 @@
+[INF:CM0023] Creating log file "${SURELOG_DIR}/build/regression/GenIfIfaceParamStructField/slpp_all/surelog.log".
+[NTE:PP0128] ${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv:2:24: Non ASCII character detected, replaced by space.
+[WRN:PA0205] ${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv:3:1: No timescale set for "p".
+[WRN:PA0205] ${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv:8:1: No timescale set for "bus_if".
+[WRN:PA0205] ${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv:13:1: No timescale set for "child".
+[WRN:PA0205] ${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv:24:1: No timescale set for "top".
+[INF:CP0300] Compilation...
+[INF:CP0301] ${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv:3:1: Compile package "p".
+[INF:CP0304] ${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv:8:1: Compile interface "work@bus_if".
+[INF:CP0303] ${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv:13:1: Compile module "work@child".
+[INF:CP0303] ${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv:24:1: Compile module "work@top".
+[INF:EL0526] Design Elaboration...
+[INF:CP0335] ${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv:17:14: Compile generate block "work@top.c.genblk1".
+[INF:CP0335] ${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv:18:7: Compile generate block "work@top.c.genblk1.genblk1".
+[NTE:EL0503] ${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv:24:1: Top level module "work@top".
+[NTE:EL0508] Nb Top level modules: 1.
+[NTE:EL0509] Max instance depth: 2.
+[NTE:EL0510] Nb instances: 2.
+[NTE:EL0511] Nb leaf instances: 0.
+[INF:UH0706] Creating UHDM Model...
+=== UHDM Object Stats Begin (Non-Elaborated Model) ===
+always                                                 2
+assignment                                             4
+begin                                                  4
+constant                                              90
+cont_assign                                            6
+design                                                 1
+event_control                                          2
+gen_if                                                 1
+gen_if_else                                            1
+gen_region                                             1
+gen_scope                                              3
+gen_scope_array                                        3
+hier_path                                             29
+if_else                                                2
+if_stmt                                                2
+import_typespec                                        1
+int_typespec                                          16
+interface_inst                                         4
+interface_typespec                                     3
+logic_net                                             17
+logic_typespec                                        26
+logic_var                                             10
+module_inst                                           11
+operation                                             86
+package                                                2
+param_assign                                           8
+parameter                                             14
+port                                                  13
+range                                                 18
+ref_module                                             2
+ref_obj                                               81
+ref_typespec                                         175
+string_typespec                                       71
+struct_typespec                                       30
+tagged_pattern                                        71
+typespec_member                                       30
+=== UHDM Object Stats End ===
+[INF:UH0707] Elaborating UHDM...
+=== UHDM Object Stats Begin (Elaborated Model) ===
+always                                                 3
+assignment                                             6
+begin                                                  4
+constant                                              91
+cont_assign                                           11
+design                                                 1
+event_control                                          3
+gen_if                                                 1
+gen_if_else                                            1
+gen_region                                             1
+gen_scope                                              4
+gen_scope_array                                        4
+hier_path                                             41
+if_else                                                3
+if_stmt                                                3
+import_typespec                                        1
+int_typespec                                          16
+interface_inst                                         4
+interface_typespec                                     3
+logic_net                                             17
+logic_typespec                                        26
+logic_var                                             10
+module_inst                                           11
+operation                                             89
+package                                                2
+param_assign                                           8
+parameter                                             14
+port                                                  19
+range                                                 18
+ref_module                                             2
+ref_obj                                              117
+ref_typespec                                         181
+string_typespec                                       71
+struct_typespec                                       30
+tagged_pattern                                        71
+typespec_member                                       30
+=== UHDM Object Stats End ===
+[INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/GenIfIfaceParamStructField/slpp_all/surelog.uhdm ...
+[INF:UH0709] Writing UHDM Html Coverage: ${SURELOG_DIR}/build/regression/GenIfIfaceParamStructField/slpp_all/checker/surelog.chk.html ...
+[INF:UH0710] Loading UHDM DB: ${SURELOG_DIR}/build/regression/GenIfIfaceParamStructField/slpp_all/surelog.uhdm ...
+[INF:UH0711] Decompiling UHDM...
+====== UHDM =======
+design: (work@top)
+|vpiElaborated:1
+|vpiName:work@top
+|uhdmallPackages:
+\_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiParent:
+  \_design: (work@top)
+  |vpiName:p
+  |vpiFullName:p::
+  |vpiParameter:
+  \_parameter: (p::CFG_DEF), line:6:20, endln:6:27
+    |vpiParent:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+    |vpiTypespec:
+    \_ref_typespec: (p::CFG_DEF)
+      |vpiParent:
+      \_parameter: (p::CFG_DEF), line:6:20, endln:6:27
+      |vpiFullName:p::CFG_DEF
+      |vpiActual:
+      \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiLocalParam:1
+    |vpiName:CFG_DEF
+    |vpiFullName:p::CFG_DEF
+  |vpiParamAssign:
+  \_param_assign: , line:6:20, endln:6:47
+    |vpiParent:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+    |vpiRhs:
+    \_operation: , line:6:30, endln:6:47
+      |vpiParent:
+      \_param_assign: , line:6:20, endln:6:47
+      |vpiOpType:75
+      |vpiOperand:
+      \_tagged_pattern: , line:6:37, endln:6:46
+        |vpiParent:
+        \_operation: , line:6:30, endln:6:47
+        |vpiPattern:
+        \_operation: , line:6:37, endln:6:46
+          |vpiParent:
+          \_operation: , line:6:30, endln:6:47
+          |vpiOpType:75
+          |vpiOperand:
+          \_tagged_pattern: , line:6:44, endln:6:45
+            |vpiParent:
+            \_operation: , line:6:37, endln:6:46
+            |vpiPattern:
+            \_constant: , line:6:44, endln:6:45
+              |vpiDecompile:1
+              |vpiSize:64
+              |UINT:1
+              |vpiConstType:9
+            |vpiTypespec:
+            \_ref_typespec: (p)
+              |vpiParent:
+              \_tagged_pattern: , line:6:44, endln:6:45
+              |vpiFullName:p
+              |vpiActual:
+              \_string_typespec: (DLY), line:6:39, endln:6:42
+        |vpiTypespec:
+        \_ref_typespec: (p)
+          |vpiParent:
+          \_tagged_pattern: , line:6:37, endln:6:46
+          |vpiFullName:p
+          |vpiActual:
+          \_string_typespec: (HSK), line:6:32, endln:6:35
+    |vpiLhs:
+    \_parameter: (p::CFG_DEF), line:6:20, endln:6:27
+  |vpiTypedef:
+  \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiParent:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+    |vpiName:p::cfg_t
+    |vpiInstance:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+    |vpiPacked:1
+    |vpiTypespecMember:
+    \_typespec_member: (HSK), line:5:33, endln:5:36
+      |vpiParent:
+      \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+      |vpiName:HSK
+      |vpiTypespec:
+      \_ref_typespec: (p::p::cfg_t::HSK)
+        |vpiParent:
+        \_typespec_member: (HSK), line:5:33, endln:5:36
+        |vpiFullName:p::p::cfg_t::HSK
+        |vpiActual:
+        \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+      |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+      |vpiRefLineNo:5
+      |vpiRefColumnNo:27
+      |vpiRefEndLineNo:5
+      |vpiRefEndColumnNo:32
+  |vpiTypedef:
+  \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiParent:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+    |vpiName:p::hsk_t
+    |vpiInstance:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+    |vpiPacked:1
+    |vpiTypespecMember:
+    \_typespec_member: (DLY), line:4:40, endln:4:43
+      |vpiParent:
+      \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+      |vpiName:DLY
+      |vpiTypespec:
+      \_ref_typespec: (p::p::hsk_t::DLY)
+        |vpiParent:
+        \_typespec_member: (DLY), line:4:40, endln:4:43
+        |vpiFullName:p::p::hsk_t::DLY
+        |vpiActual:
+        \_int_typespec: , line:4:27, endln:4:39
+      |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+      |vpiRefLineNo:4
+      |vpiRefColumnNo:27
+      |vpiRefEndLineNo:4
+      |vpiRefEndColumnNo:39
+  |vpiDefName:p
+|uhdmtopPackages:
+\_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiParent:
+  \_design: (work@top)
+  |vpiName:p
+  |vpiFullName:p::
+  |vpiParameter:
+  \_parameter: (p::CFG_DEF), line:6:20, endln:6:27
+    |vpiParent:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+    |vpiTypespec:
+    \_ref_typespec: (p::CFG_DEF)
+      |vpiParent:
+      \_parameter: (p::CFG_DEF), line:6:20, endln:6:27
+      |vpiFullName:p::CFG_DEF
+      |vpiActual:
+      \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiLocalParam:1
+    |vpiName:CFG_DEF
+    |vpiFullName:p::CFG_DEF
+  |vpiParamAssign:
+  \_param_assign: , line:6:20, endln:6:47
+    |vpiParent:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+    |vpiRhs:
+    \_operation: , line:6:30, endln:6:47
+      |vpiParent:
+      \_param_assign: , line:6:20, endln:6:47
+      |vpiOpType:75
+      |vpiOperand:
+      \_tagged_pattern: , line:6:37, endln:6:46
+        |vpiParent:
+        \_operation: , line:6:30, endln:6:47
+        |vpiPattern:
+        \_operation: , line:6:37, endln:6:46
+          |vpiParent:
+          \_operation: , line:6:30, endln:6:47
+          |vpiOpType:75
+          |vpiOperand:
+          \_tagged_pattern: , line:6:44, endln:6:45
+            |vpiParent:
+            \_operation: , line:6:37, endln:6:46
+            |vpiPattern:
+            \_constant: , line:6:44, endln:6:45
+              |vpiDecompile:1
+              |vpiSize:64
+              |UINT:1
+              |vpiConstType:9
+            |vpiTypespec:
+            \_ref_typespec: (p)
+              |vpiParent:
+              \_tagged_pattern: , line:6:44, endln:6:45
+              |vpiFullName:p
+              |vpiActual:
+              \_string_typespec: (DLY), line:6:39, endln:6:42
+        |vpiTypespec:
+        \_ref_typespec: (p)
+          |vpiParent:
+          \_tagged_pattern: , line:6:37, endln:6:46
+          |vpiFullName:p
+          |vpiActual:
+          \_string_typespec: (HSK), line:6:32, endln:6:35
+    |vpiLhs:
+    \_parameter: (p::CFG_DEF), line:6:20, endln:6:27
+  |vpiTypedef:
+  \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:p::cfg_t
+    |vpiInstance:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+    |vpiPacked:1
+    |vpiTypespecMember:
+    \_typespec_member: (HSK), line:5:33, endln:5:36
+      |vpiParent:
+      \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+      |vpiName:HSK
+      |vpiTypespec:
+      \_ref_typespec: (work@top.p::cfg_t.HSK)
+        |vpiParent:
+        \_typespec_member: (HSK), line:5:33, endln:5:36
+        |vpiFullName:work@top.p::cfg_t.HSK
+        |vpiActual:
+        \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+      |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+      |vpiRefLineNo:5
+      |vpiRefColumnNo:27
+      |vpiRefEndLineNo:5
+      |vpiRefEndColumnNo:32
+  |vpiTypedef:
+  \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:p::hsk_t
+    |vpiInstance:
+    \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+    |vpiPacked:1
+    |vpiTypespecMember:
+    \_typespec_member: (DLY), line:4:40, endln:4:43
+      |vpiParent:
+      \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+      |vpiName:DLY
+      |vpiTypespec:
+      \_ref_typespec: (work@top.p::hsk_t.DLY)
+        |vpiParent:
+        \_typespec_member: (DLY), line:4:40, endln:4:43
+        |vpiFullName:work@top.p::hsk_t.DLY
+        |vpiActual:
+        \_int_typespec: , line:4:27, endln:4:39
+      |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+      |vpiRefLineNo:4
+      |vpiRefColumnNo:27
+      |vpiRefEndLineNo:4
+      |vpiRefEndColumnNo:39
+  |vpiDefName:p
+  |vpiTop:1
+|uhdmallInterfaces:
+\_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:8:1, endln:12:13
+  |vpiParent:
+  \_design: (work@top)
+  |vpiFullName:work@bus_if
+  |vpiParameter:
+  \_parameter: (work@bus_if.CFG), line:8:39, endln:8:42
+    |vpiParent:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:8:1, endln:12:13
+    |vpiTypespec:
+    \_ref_typespec: (work@bus_if.CFG)
+      |vpiParent:
+      \_parameter: (work@bus_if.CFG), line:8:39, endln:8:42
+      |vpiFullName:work@bus_if.CFG
+      |vpiActual:
+      \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiName:CFG
+    |vpiFullName:work@bus_if.CFG
+  |vpiParamAssign:
+  \_param_assign: , line:8:39, endln:8:55
+    |vpiParent:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:8:1, endln:12:13
+    |vpiRhs:
+    \_operation: , line:8:45, endln:8:48
+      |vpiParent:
+      \_param_assign: , line:8:39, endln:8:55
+      |vpiOpType:75
+      |vpiOperand:
+      \_tagged_pattern: , line:6:37, endln:6:46
+        |vpiParent:
+        \_operation: , line:8:45, endln:8:48
+        |vpiPattern:
+        \_operation: , line:6:37, endln:6:46
+          |vpiParent:
+          \_tagged_pattern: , line:6:37, endln:6:46
+          |vpiOpType:75
+          |vpiOperand:
+          \_tagged_pattern: , line:6:44, endln:6:45
+            |vpiParent:
+            \_operation: , line:6:37, endln:6:46
+            |vpiPattern:
+            \_constant: , line:6:44, endln:6:45
+              |vpiParent:
+              \_operation: , line:6:37, endln:6:46
+              |vpiDecompile:1
+              |vpiSize:64
+              |UINT:1
+              |vpiConstType:9
+            |vpiTypespec:
+            \_ref_typespec: (work@bus_if)
+              |vpiParent:
+              \_tagged_pattern: , line:6:44, endln:6:45
+              |vpiFullName:work@bus_if
+              |vpiActual:
+              \_string_typespec: (DLY), line:6:39, endln:6:42
+        |vpiTypespec:
+        \_ref_typespec: (work@bus_if)
+          |vpiParent:
+          \_tagged_pattern: , line:6:37, endln:6:46
+          |vpiFullName:work@bus_if
+          |vpiActual:
+          \_string_typespec: (HSK), line:6:32, endln:6:35
+    |vpiLhs:
+    \_parameter: (work@bus_if.CFG), line:8:39, endln:8:42
+  |vpiDefName:work@bus_if
+  |vpiNet:
+  \_logic_net: (work@bus_if.clk), line:9:9, endln:9:12
+    |vpiParent:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:8:1, endln:12:13
+    |vpiTypespec:
+    \_ref_typespec: (work@bus_if.clk)
+      |vpiParent:
+      \_logic_net: (work@bus_if.clk), line:9:9, endln:9:12
+      |vpiFullName:work@bus_if.clk
+      |vpiActual:
+      \_logic_typespec: , line:9:3, endln:9:8
+    |vpiName:clk
+    |vpiFullName:work@bus_if.clk
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@bus_if.rst), line:9:14, endln:9:17
+    |vpiParent:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:8:1, endln:12:13
+    |vpiTypespec:
+    \_ref_typespec: (work@bus_if.rst)
+      |vpiParent:
+      \_logic_net: (work@bus_if.rst), line:9:14, endln:9:17
+      |vpiFullName:work@bus_if.rst
+      |vpiActual:
+      \_logic_typespec: , line:9:3, endln:9:8
+    |vpiName:rst
+    |vpiFullName:work@bus_if.rst
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@bus_if.trn), line:9:19, endln:9:22
+    |vpiParent:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:8:1, endln:12:13
+    |vpiTypespec:
+    \_ref_typespec: (work@bus_if.trn)
+      |vpiParent:
+      \_logic_net: (work@bus_if.trn), line:9:19, endln:9:22
+      |vpiFullName:work@bus_if.trn
+      |vpiActual:
+      \_logic_typespec: , line:9:3, endln:9:8
+    |vpiName:trn
+    |vpiFullName:work@bus_if.trn
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@bus_if.sel), line:10:15, endln:10:18
+    |vpiParent:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:8:1, endln:12:13
+    |vpiTypespec:
+    \_ref_typespec: (work@bus_if.sel)
+      |vpiParent:
+      \_logic_net: (work@bus_if.sel), line:10:15, endln:10:18
+      |vpiFullName:work@bus_if.sel
+      |vpiActual:
+      \_logic_typespec: , line:10:3, endln:10:14
+    |vpiName:sel
+    |vpiFullName:work@bus_if.sel
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@bus_if.rsp_sel), line:11:15, endln:11:22
+    |vpiParent:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:8:1, endln:12:13
+    |vpiTypespec:
+    \_ref_typespec: (work@bus_if.rsp_sel)
+      |vpiParent:
+      \_logic_net: (work@bus_if.rsp_sel), line:11:15, endln:11:22
+      |vpiFullName:work@bus_if.rsp_sel
+      |vpiActual:
+      \_logic_typespec: , line:11:3, endln:11:14
+    |vpiName:rsp_sel
+    |vpiFullName:work@bus_if.rsp_sel
+    |vpiNetType:36
+|uhdmallModules:
+\_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:13:1, endln:23:10
+  |vpiParent:
+  \_design: (work@top)
+  |vpiFullName:work@child
+  |vpiDefName:work@child
+  |vpiNet:
+  \_logic_net: (work@child.sub), line:13:22, endln:13:25
+    |vpiParent:
+    \_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:13:1, endln:23:10
+    |vpiName:sub
+    |vpiFullName:work@child.sub
+  |vpiPort:
+  \_port: (sub), line:13:22, endln:13:25
+    |vpiParent:
+    \_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:13:1, endln:23:10
+    |vpiName:sub
+    |vpiDirection:3
+    |vpiLowConn:
+    \_ref_obj: (work@child.sub.sub), line:13:22, endln:13:25
+      |vpiParent:
+      \_port: (sub), line:13:22, endln:13:25
+      |vpiName:sub
+      |vpiFullName:work@child.sub.sub
+      |vpiActual:
+      \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:8:1, endln:12:13
+    |vpiTypedef:
+    \_ref_typespec: (work@child.sub)
+      |vpiParent:
+      \_port: (sub), line:13:22, endln:13:25
+      |vpiFullName:work@child.sub
+      |vpiActual:
+      \_interface_typespec: (bus_if), line:13:15, endln:13:21
+  |vpiGenStmt:
+  \_gen_region: 
+    |vpiParent:
+    \_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:13:1, endln:23:10
+    |vpiStmt:
+    \_begin: (work@child)
+      |vpiParent:
+      \_gen_region: 
+      |vpiFullName:work@child
+      |vpiStmt:
+      \_gen_if_else: , line:15:5, endln:21:8
+        |vpiParent:
+        \_begin: (work@child)
+        |vpiCondition:
+        \_operation: , line:15:9, endln:15:29
+          |vpiParent:
+          \_gen_if_else: , line:15:5, endln:21:8
+          |vpiOpType:14
+          |vpiOperand:
+          \_hier_path: (sub.CFG.HSK.DLY), line:15:9, endln:15:24
+            |vpiParent:
+            \_operation: , line:15:9, endln:15:29
+            |vpiActual:
+            \_ref_obj: (sub), line:15:13, endln:15:16
+              |vpiParent:
+              \_hier_path: (sub.CFG.HSK.DLY), line:15:9, endln:15:24
+              |vpiName:sub
+            |vpiActual:
+            \_ref_obj: (CFG), line:15:13, endln:15:16
+              |vpiParent:
+              \_hier_path: (sub.CFG.HSK.DLY), line:15:9, endln:15:24
+              |vpiName:CFG
+            |vpiActual:
+            \_ref_obj: (HSK), line:15:17, endln:15:20
+              |vpiParent:
+              \_hier_path: (sub.CFG.HSK.DLY), line:15:9, endln:15:24
+              |vpiName:HSK
+            |vpiActual:
+            \_ref_obj: (DLY), line:15:21, endln:15:24
+              |vpiParent:
+              \_hier_path: (sub.CFG.HSK.DLY), line:15:9, endln:15:24
+              |vpiName:DLY
+            |vpiName:sub.CFG.HSK.DLY
+          |vpiOperand:
+          \_constant: , line:15:28, endln:15:29
+            |vpiParent:
+            \_operation: , line:15:9, endln:15:29
+            |vpiDecompile:0
+            |vpiSize:64
+            |UINT:0
+            |vpiConstType:9
+        |vpiStmt:
+        \_begin: (work@child)
+          |vpiParent:
+          \_gen_if_else: , line:15:5, endln:21:8
+          |vpiFullName:work@child
+          |vpiStmt:
+          \_cont_assign: , line:16:14, endln:16:35
+            |vpiParent:
+            \_begin: (work@child)
+            |vpiRhs:
+            \_hier_path: (sub.sel), line:16:28, endln:16:35
+              |vpiParent:
+              \_cont_assign: , line:16:14, endln:16:35
+              |vpiActual:
+              \_ref_obj: (sub), line:16:28, endln:16:31
+                |vpiParent:
+                \_hier_path: (sub.sel), line:16:28, endln:16:35
+                |vpiName:sub
+              |vpiActual:
+              \_ref_obj: (work@child.sel), line:16:32, endln:16:35
+                |vpiParent:
+                \_hier_path: (sub.sel), line:16:28, endln:16:35
+                |vpiName:sel
+                |vpiFullName:work@child.sel
+              |vpiName:sub.sel
+            |vpiLhs:
+            \_hier_path: (sub.rsp_sel), line:16:14, endln:16:25
+              |vpiParent:
+              \_cont_assign: , line:16:14, endln:16:35
+              |vpiActual:
+              \_ref_obj: (sub), line:16:18, endln:16:25
+                |vpiParent:
+                \_hier_path: (sub.rsp_sel), line:16:14, endln:16:25
+                |vpiName:sub
+              |vpiActual:
+              \_ref_obj: (rsp_sel), line:16:18, endln:16:25
+                |vpiParent:
+                \_hier_path: (sub.rsp_sel), line:16:14, endln:16:25
+                |vpiName:rsp_sel
+              |vpiName:sub.rsp_sel
+        |vpiElseStmt:
+        \_begin: (work@child)
+          |vpiParent:
+          \_gen_if_else: , line:15:5, endln:21:8
+          |vpiFullName:work@child
+          |vpiStmt:
+          \_gen_if: , line:17:14, endln:17:16
+            |vpiParent:
+            \_begin: (work@child)
+            |vpiCondition:
+            \_operation: , line:17:18, endln:17:38
+              |vpiParent:
+              \_gen_if: , line:17:14, endln:17:16
+              |vpiOpType:14
+              |vpiOperand:
+              \_hier_path: (sub.CFG.HSK.DLY), line:17:18, endln:17:33
+                |vpiParent:
+                \_operation: , line:17:18, endln:17:38
+                |vpiActual:
+                \_ref_obj: (sub), line:17:22, endln:17:25
+                  |vpiParent:
+                  \_hier_path: (sub.CFG.HSK.DLY), line:17:18, endln:17:33
+                  |vpiName:sub
+                |vpiActual:
+                \_ref_obj: (CFG), line:17:22, endln:17:25
+                  |vpiParent:
+                  \_hier_path: (sub.CFG.HSK.DLY), line:17:18, endln:17:33
+                  |vpiName:CFG
+                |vpiActual:
+                \_ref_obj: (HSK), line:17:26, endln:17:29
+                  |vpiParent:
+                  \_hier_path: (sub.CFG.HSK.DLY), line:17:18, endln:17:33
+                  |vpiName:HSK
+                |vpiActual:
+                \_ref_obj: (DLY), line:17:30, endln:17:33
+                  |vpiParent:
+                  \_hier_path: (sub.CFG.HSK.DLY), line:17:18, endln:17:33
+                  |vpiName:DLY
+                |vpiName:sub.CFG.HSK.DLY
+              |vpiOperand:
+              \_constant: , line:17:37, endln:17:38
+                |vpiParent:
+                \_operation: , line:17:18, endln:17:38
+                |vpiDecompile:1
+                |vpiSize:64
+                |UINT:1
+                |vpiConstType:9
+            |vpiStmt:
+            \_begin: (work@child)
+              |vpiParent:
+              \_gen_if: , line:17:14, endln:17:16
+              |vpiFullName:work@child
+              |vpiStmt:
+              \_always: , line:18:7, endln:20:50
+                |vpiParent:
+                \_begin: (work@child)
+                |vpiStmt:
+                \_event_control: , line:18:17, endln:18:54
+                  |vpiParent:
+                  \_always: , line:18:7, endln:20:50
+                  |vpiCondition:
+                  \_operation: , line:18:19, endln:18:53
+                    |vpiParent:
+                    \_event_control: , line:18:17, endln:18:54
+                    |vpiOpType:35
+                    |vpiOperand:
+                    \_operation: , line:18:19, endln:18:34
+                      |vpiParent:
+                      \_operation: , line:18:19, endln:18:53
+                      |vpiOpType:39
+                      |vpiOperand:
+                      \_hier_path: (sub.clk), line:18:27, endln:18:34
+                        |vpiParent:
+                        \_operation: , line:18:19, endln:18:34
+                        |vpiActual:
+                        \_ref_obj: (sub), line:18:27, endln:18:30
+                          |vpiParent:
+                          \_hier_path: (sub.clk), line:18:27, endln:18:34
+                          |vpiName:sub
+                        |vpiActual:
+                        \_ref_obj: (work@child.clk), line:18:31, endln:18:34
+                          |vpiParent:
+                          \_hier_path: (sub.clk), line:18:27, endln:18:34
+                          |vpiName:clk
+                          |vpiFullName:work@child.clk
+                        |vpiName:sub.clk
+                    |vpiOperand:
+                    \_operation: , line:18:38, endln:18:53
+                      |vpiParent:
+                      \_operation: , line:18:19, endln:18:53
+                      |vpiOpType:39
+                      |vpiOperand:
+                      \_hier_path: (sub.rst), line:18:46, endln:18:53
+                        |vpiParent:
+                        \_operation: , line:18:38, endln:18:53
+                        |vpiActual:
+                        \_ref_obj: (sub), line:18:46, endln:18:49
+                          |vpiParent:
+                          \_hier_path: (sub.rst), line:18:46, endln:18:53
+                          |vpiName:sub
+                        |vpiActual:
+                        \_ref_obj: (work@child.rst), line:18:50, endln:18:53
+                          |vpiParent:
+                          \_hier_path: (sub.rst), line:18:46, endln:18:53
+                          |vpiName:rst
+                          |vpiFullName:work@child.rst
+                        |vpiName:sub.rst
+                  |vpiStmt:
+                  \_if_else: , line:19:9, endln:20:50
+                    |vpiParent:
+                    \_event_control: , line:18:17, endln:18:54
+                    |vpiCondition:
+                    \_hier_path: (sub.rst), line:19:13, endln:19:20
+                      |vpiParent:
+                      \_event_control: , line:18:17, endln:18:54
+                      |vpiActual:
+                      \_ref_obj: (sub), line:19:13, endln:19:16
+                        |vpiParent:
+                        \_hier_path: (sub.rst), line:19:13, endln:19:20
+                        |vpiName:sub
+                      |vpiActual:
+                      \_ref_obj: (work@child.rst), line:19:17, endln:19:20
+                        |vpiParent:
+                        \_hier_path: (sub.rst), line:19:13, endln:19:20
+                        |vpiName:rst
+                        |vpiFullName:work@child.rst
+                      |vpiName:sub.rst
+                    |vpiStmt:
+                    \_assignment: , line:19:22, endln:19:39
+                      |vpiParent:
+                      \_if_else: , line:19:9, endln:20:50
+                      |vpiOpType:82
+                      |vpiRhs:
+                      \_constant: , line:19:37, endln:19:39
+                        |vpiDecompile:'0
+                        |vpiSize:-1
+                        |BIN:0
+                        |vpiConstType:3
+                      |vpiLhs:
+                      \_hier_path: (sub.rsp_sel), line:19:22, endln:19:33
+                        |vpiParent:
+                        \_assignment: , line:19:22, endln:19:39
+                        |vpiActual:
+                        \_ref_obj: (sub), line:19:26, endln:19:33
+                          |vpiParent:
+                          \_hier_path: (sub.rsp_sel), line:19:22, endln:19:33
+                          |vpiName:sub
+                        |vpiActual:
+                        \_ref_obj: (rsp_sel), line:19:26, endln:19:33
+                          |vpiParent:
+                          \_hier_path: (sub.rsp_sel), line:19:22, endln:19:33
+                          |vpiName:rsp_sel
+                        |vpiName:sub.rsp_sel
+                    |vpiElseStmt:
+                    \_if_stmt: , line:20:14, endln:20:50
+                      |vpiParent:
+                      \_if_else: , line:19:9, endln:20:50
+                      |vpiCondition:
+                      \_hier_path: (sub.trn), line:20:18, endln:20:25
+                        |vpiParent:
+                        \_if_else: , line:19:9, endln:20:50
+                        |vpiActual:
+                        \_ref_obj: (sub), line:20:18, endln:20:21
+                          |vpiParent:
+                          \_hier_path: (sub.trn), line:20:18, endln:20:25
+                          |vpiName:sub
+                        |vpiActual:
+                        \_ref_obj: (work@child.trn), line:20:22, endln:20:25
+                          |vpiParent:
+                          \_hier_path: (sub.trn), line:20:18, endln:20:25
+                          |vpiName:trn
+                          |vpiFullName:work@child.trn
+                        |vpiName:sub.trn
+                      |vpiStmt:
+                      \_assignment: , line:20:27, endln:20:49
+                        |vpiParent:
+                        \_if_stmt: , line:20:14, endln:20:50
+                        |vpiOpType:82
+                        |vpiRhs:
+                        \_hier_path: (sub.sel), line:20:42, endln:20:49
+                          |vpiParent:
+                          \_assignment: , line:20:27, endln:20:49
+                          |vpiActual:
+                          \_ref_obj: (sub), line:20:42, endln:20:45
+                            |vpiParent:
+                            \_hier_path: (sub.sel), line:20:42, endln:20:49
+                            |vpiName:sub
+                          |vpiActual:
+                          \_ref_obj: (work@child.sel), line:20:46, endln:20:49
+                            |vpiParent:
+                            \_hier_path: (sub.sel), line:20:42, endln:20:49
+                            |vpiName:sel
+                            |vpiFullName:work@child.sel
+                          |vpiName:sub.sel
+                        |vpiLhs:
+                        \_hier_path: (sub.rsp_sel), line:20:27, endln:20:38
+                          |vpiParent:
+                          \_assignment: , line:20:27, endln:20:49
+                          |vpiActual:
+                          \_ref_obj: (sub), line:20:31, endln:20:38
+                            |vpiParent:
+                            \_hier_path: (sub.rsp_sel), line:20:27, endln:20:38
+                            |vpiName:sub
+                          |vpiActual:
+                          \_ref_obj: (rsp_sel), line:20:31, endln:20:38
+                            |vpiParent:
+                            \_hier_path: (sub.rsp_sel), line:20:27, endln:20:38
+                            |vpiName:rsp_sel
+                          |vpiName:sub.rsp_sel
+                |vpiAlwaysType:3
+|uhdmallModules:
+\_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+  |vpiParent:
+  \_design: (work@top)
+  |vpiFullName:work@top
+  |vpiParameter:
+  \_parameter: (work@top.CFG_DEF), line:6:20, endln:6:27
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF)
+      |vpiParent:
+      \_parameter: (work@top.CFG_DEF), line:6:20, endln:6:27
+      |vpiFullName:work@top.CFG_DEF
+      |vpiActual:
+      \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiLocalParam:1
+    |vpiName:CFG_DEF
+    |vpiFullName:work@top.CFG_DEF
+    |vpiImported:p
+  |vpiParamAssign:
+  \_param_assign: , line:6:20, endln:6:47
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiRhs:
+    \_operation: , line:6:30, endln:6:47
+      |vpiParent:
+      \_param_assign: , line:6:20, endln:6:47
+      |vpiOpType:75
+      |vpiOperand:
+      \_tagged_pattern: , line:6:37, endln:6:46
+        |vpiParent:
+        \_operation: , line:6:30, endln:6:47
+        |vpiPattern:
+        \_operation: , line:6:37, endln:6:46
+          |vpiParent:
+          \_tagged_pattern: , line:6:37, endln:6:46
+          |vpiOpType:75
+          |vpiOperand:
+          \_tagged_pattern: , line:6:44, endln:6:45
+            |vpiParent:
+            \_operation: , line:6:37, endln:6:46
+            |vpiPattern:
+            \_constant: , line:6:44, endln:6:45
+              |vpiParent:
+              \_tagged_pattern: , line:6:44, endln:6:45
+              |vpiDecompile:1
+              |vpiSize:64
+              |UINT:1
+              |vpiConstType:9
+            |vpiTypespec:
+            \_ref_typespec: (work@top)
+              |vpiParent:
+              \_tagged_pattern: , line:6:44, endln:6:45
+              |vpiFullName:work@top
+              |vpiActual:
+              \_string_typespec: (DLY), line:6:39, endln:6:42
+        |vpiTypespec:
+        \_ref_typespec: (work@top)
+          |vpiParent:
+          \_tagged_pattern: , line:6:37, endln:6:46
+          |vpiFullName:work@top
+          |vpiActual:
+          \_string_typespec: (HSK), line:6:32, endln:6:35
+    |vpiLhs:
+    \_parameter: (work@top.CFG_DEF), line:6:20, endln:6:27
+      |vpiParent:
+      \_param_assign: , line:6:20, endln:6:47
+      |vpiTypespec:
+      \_ref_typespec: (work@top.CFG_DEF)
+        |vpiParent:
+        \_parameter: (work@top.CFG_DEF), line:6:20, endln:6:27
+        |vpiFullName:work@top.CFG_DEF
+        |vpiActual:
+        \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+      |vpiLocalParam:1
+      |vpiName:CFG_DEF
+      |vpiFullName:work@top.CFG_DEF
+      |vpiImported:p
+  |vpiTypedef:
+  \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+  |vpiTypedef:
+  \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+  |vpiTypedef:
+  \_import_typespec: (p), line:25:10, endln:25:14
+  |vpiDefName:work@top
+  |vpiNet:
+  \_logic_net: (work@top.clk), line:24:25, endln:24:28
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:clk
+    |vpiFullName:work@top.clk
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.rst), line:24:42, endln:24:45
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:rst
+    |vpiFullName:work@top.rst
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.trn), line:24:59, endln:24:62
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:trn
+    |vpiFullName:work@top.trn
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.sel), line:24:82, endln:24:85
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:sel
+    |vpiFullName:work@top.sel
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.o), line:24:106, endln:24:107
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:o
+    |vpiFullName:work@top.o
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.sub), line:29:17, endln:29:20
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:sub
+    |vpiFullName:work@top.sub
+    |vpiNetType:1
+  |vpiPort:
+  \_port: (clk), line:24:25, endln:24:28
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:clk
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@top.clk.clk), line:24:25, endln:24:28
+      |vpiParent:
+      \_port: (clk), line:24:25, endln:24:28
+      |vpiName:clk
+      |vpiFullName:work@top.clk.clk
+      |vpiActual:
+      \_logic_net: (work@top.clk), line:24:25, endln:24:28
+    |vpiTypedef:
+    \_ref_typespec: (work@top.clk)
+      |vpiParent:
+      \_port: (clk), line:24:25, endln:24:28
+      |vpiFullName:work@top.clk
+      |vpiActual:
+      \_logic_typespec: , line:24:19, endln:24:24
+  |vpiPort:
+  \_port: (rst), line:24:42, endln:24:45
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:rst
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@top.rst.rst), line:24:42, endln:24:45
+      |vpiParent:
+      \_port: (rst), line:24:42, endln:24:45
+      |vpiName:rst
+      |vpiFullName:work@top.rst.rst
+      |vpiActual:
+      \_logic_net: (work@top.rst), line:24:42, endln:24:45
+    |vpiTypedef:
+    \_ref_typespec: (work@top.rst)
+      |vpiParent:
+      \_port: (rst), line:24:42, endln:24:45
+      |vpiFullName:work@top.rst
+      |vpiActual:
+      \_logic_typespec: , line:24:36, endln:24:41
+  |vpiPort:
+  \_port: (trn), line:24:59, endln:24:62
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:trn
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@top.trn.trn), line:24:59, endln:24:62
+      |vpiParent:
+      \_port: (trn), line:24:59, endln:24:62
+      |vpiName:trn
+      |vpiFullName:work@top.trn.trn
+      |vpiActual:
+      \_logic_net: (work@top.trn), line:24:59, endln:24:62
+    |vpiTypedef:
+    \_ref_typespec: (work@top.trn)
+      |vpiParent:
+      \_port: (trn), line:24:59, endln:24:62
+      |vpiFullName:work@top.trn
+      |vpiActual:
+      \_logic_typespec: , line:24:53, endln:24:58
+  |vpiPort:
+  \_port: (sel), line:24:82, endln:24:85
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:sel
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@top.sel.sel), line:24:82, endln:24:85
+      |vpiParent:
+      \_port: (sel), line:24:82, endln:24:85
+      |vpiName:sel
+      |vpiFullName:work@top.sel.sel
+      |vpiActual:
+      \_logic_net: (work@top.sel), line:24:82, endln:24:85
+    |vpiTypedef:
+    \_ref_typespec: (work@top.sel)
+      |vpiParent:
+      \_port: (sel), line:24:82, endln:24:85
+      |vpiFullName:work@top.sel
+      |vpiActual:
+      \_logic_typespec: , line:24:70, endln:24:81
+  |vpiPort:
+  \_port: (o), line:24:106, endln:24:107
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:o
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@top.o.o), line:24:106, endln:24:107
+      |vpiParent:
+      \_port: (o), line:24:106, endln:24:107
+      |vpiName:o
+      |vpiFullName:work@top.o.o
+      |vpiActual:
+      \_logic_net: (work@top.o), line:24:106, endln:24:107
+    |vpiTypedef:
+    \_ref_typespec: (work@top.o)
+      |vpiParent:
+      \_port: (o), line:24:106, endln:24:107
+      |vpiFullName:work@top.o
+      |vpiActual:
+      \_logic_typespec: , line:24:94, endln:24:105
+  |vpiContAssign:
+  \_cont_assign: , line:27:10, endln:27:23
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiRhs:
+    \_ref_obj: (work@top.clk), line:27:20, endln:27:23
+      |vpiParent:
+      \_cont_assign: , line:27:10, endln:27:23
+      |vpiName:clk
+      |vpiFullName:work@top.clk
+      |vpiActual:
+      \_logic_net: (work@top.clk), line:24:25, endln:24:28
+    |vpiLhs:
+    \_hier_path: (sub.clk), line:27:10, endln:27:17
+      |vpiParent:
+      \_cont_assign: , line:27:10, endln:27:23
+      |vpiActual:
+      \_ref_obj: (sub), line:27:14, endln:27:17
+        |vpiParent:
+        \_hier_path: (sub.clk), line:27:10, endln:27:17
+        |vpiName:sub
+      |vpiActual:
+      \_ref_obj: (clk), line:27:14, endln:27:17
+        |vpiParent:
+        \_hier_path: (sub.clk), line:27:10, endln:27:17
+        |vpiName:clk
+      |vpiName:sub.clk
+  |vpiContAssign:
+  \_cont_assign: , line:27:32, endln:27:45
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiRhs:
+    \_ref_obj: (work@top.rst), line:27:42, endln:27:45
+      |vpiParent:
+      \_cont_assign: , line:27:32, endln:27:45
+      |vpiName:rst
+      |vpiFullName:work@top.rst
+      |vpiActual:
+      \_logic_net: (work@top.rst), line:24:42, endln:24:45
+    |vpiLhs:
+    \_hier_path: (sub.rst), line:27:32, endln:27:39
+      |vpiParent:
+      \_cont_assign: , line:27:32, endln:27:45
+      |vpiActual:
+      \_ref_obj: (sub), line:27:36, endln:27:39
+        |vpiParent:
+        \_hier_path: (sub.rst), line:27:32, endln:27:39
+        |vpiName:sub
+      |vpiActual:
+      \_ref_obj: (rst), line:27:36, endln:27:39
+        |vpiParent:
+        \_hier_path: (sub.rst), line:27:32, endln:27:39
+        |vpiName:rst
+      |vpiName:sub.rst
+  |vpiContAssign:
+  \_cont_assign: , line:27:54, endln:27:67
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiRhs:
+    \_ref_obj: (work@top.trn), line:27:64, endln:27:67
+      |vpiParent:
+      \_cont_assign: , line:27:54, endln:27:67
+      |vpiName:trn
+      |vpiFullName:work@top.trn
+      |vpiActual:
+      \_logic_net: (work@top.trn), line:24:59, endln:24:62
+    |vpiLhs:
+    \_hier_path: (sub.trn), line:27:54, endln:27:61
+      |vpiParent:
+      \_cont_assign: , line:27:54, endln:27:67
+      |vpiActual:
+      \_ref_obj: (sub), line:27:58, endln:27:61
+        |vpiParent:
+        \_hier_path: (sub.trn), line:27:54, endln:27:61
+        |vpiName:sub
+      |vpiActual:
+      \_ref_obj: (trn), line:27:58, endln:27:61
+        |vpiParent:
+        \_hier_path: (sub.trn), line:27:54, endln:27:61
+        |vpiName:trn
+      |vpiName:sub.trn
+  |vpiContAssign:
+  \_cont_assign: , line:27:76, endln:27:89
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiRhs:
+    \_ref_obj: (work@top.sel), line:27:86, endln:27:89
+      |vpiParent:
+      \_cont_assign: , line:27:76, endln:27:89
+      |vpiName:sel
+      |vpiFullName:work@top.sel
+      |vpiActual:
+      \_logic_net: (work@top.sel), line:24:82, endln:24:85
+    |vpiLhs:
+    \_hier_path: (sub.sel), line:27:76, endln:27:83
+      |vpiParent:
+      \_cont_assign: , line:27:76, endln:27:89
+      |vpiActual:
+      \_ref_obj: (sub), line:27:80, endln:27:83
+        |vpiParent:
+        \_hier_path: (sub.sel), line:27:76, endln:27:83
+        |vpiName:sub
+      |vpiActual:
+      \_ref_obj: (sel), line:27:80, endln:27:83
+        |vpiParent:
+        \_hier_path: (sub.sel), line:27:76, endln:27:83
+        |vpiName:sel
+      |vpiName:sub.sel
+  |vpiContAssign:
+  \_cont_assign: , line:28:10, endln:28:25
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiRhs:
+    \_hier_path: (sub.rsp_sel), line:28:14, endln:28:25
+      |vpiParent:
+      \_cont_assign: , line:28:10, endln:28:25
+      |vpiActual:
+      \_ref_obj: (sub), line:28:14, endln:28:17
+        |vpiParent:
+        \_hier_path: (sub.rsp_sel), line:28:14, endln:28:25
+        |vpiName:sub
+      |vpiActual:
+      \_ref_obj: (work@top.rsp_sel), line:28:18, endln:28:25
+        |vpiParent:
+        \_hier_path: (sub.rsp_sel), line:28:14, endln:28:25
+        |vpiName:rsp_sel
+        |vpiFullName:work@top.rsp_sel
+      |vpiName:sub.rsp_sel
+    |vpiLhs:
+    \_ref_obj: (work@top.o), line:28:10, endln:28:11
+      |vpiParent:
+      \_cont_assign: , line:28:10, endln:28:25
+      |vpiName:o
+      |vpiFullName:work@top.o
+      |vpiActual:
+      \_logic_net: (work@top.o), line:24:106, endln:24:107
+  |vpiRefModule:
+  \_ref_module: work@bus_if (sub), line:26:21, endln:26:24
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:sub
+    |vpiDefName:work@bus_if
+    |vpiActual:
+    \_interface_inst: work@bus_if (work@bus_if), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:8:1, endln:12:13
+  |vpiRefModule:
+  \_ref_module: work@child (c), line:29:9, endln:29:10
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:c
+    |vpiDefName:work@child
+    |vpiActual:
+    \_module_inst: work@child (work@child), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:13:1, endln:23:10
+    |vpiPort:
+    \_port: (sub), line:29:12, endln:29:21
+      |vpiParent:
+      \_ref_module: work@child (c), line:29:9, endln:29:10
+      |vpiName:sub
+      |vpiHighConn:
+      \_ref_obj: (work@top.c.sub.sub), line:29:17, endln:29:20
+        |vpiParent:
+        \_port: (sub), line:29:12, endln:29:21
+        |vpiName:sub
+        |vpiFullName:work@top.c.sub.sub
+        |vpiActual:
+        \_logic_net: (work@top.sub), line:29:17, endln:29:20
+|uhdmtopModules:
+\_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+  |vpiParent:
+  \_design: (work@top)
+  |vpiName:work@top
+  |vpiParameter:
+  \_parameter: (work@top.CFG_DEF), line:6:20, endln:6:27
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF)
+      |vpiParent:
+      \_parameter: (work@top.CFG_DEF), line:6:20, endln:6:27
+      |vpiFullName:work@top.CFG_DEF
+      |vpiActual:
+      \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiLocalParam:1
+    |vpiName:CFG_DEF
+    |vpiFullName:work@top.CFG_DEF
+    |vpiImported:p
+  |vpiParamAssign:
+  \_param_assign: , line:6:20, endln:6:47
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiRhs:
+    \_operation: , line:6:30, endln:6:47
+      |vpiParent:
+      \_param_assign: , line:6:20, endln:6:47
+      |vpiOpType:75
+      |vpiOperand:
+      \_operation: , line:6:37, endln:6:46
+        |vpiParent:
+        \_operation: , line:6:30, endln:6:47
+        |vpiTypespec:
+        \_ref_typespec: 
+          |vpiActual:
+          \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+        |vpiOpType:75
+        |vpiOperand:
+        \_constant: , line:6:44, endln:6:45
+          |vpiParent:
+          \_operation: , line:6:37, endln:6:46
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
+    |vpiLhs:
+    \_parameter: (work@top.CFG_DEF), line:6:20, endln:6:27
+  |vpiTypedef:
+  \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+  |vpiTypedef:
+  \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+  |vpiTypedef:
+  \_import_typespec: (p), line:25:10, endln:25:14
+  |vpiDefName:work@top
+  |vpiTop:1
+  |vpiNet:
+  \_logic_net: (work@top.clk), line:24:25, endln:24:28
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.clk)
+      |vpiParent:
+      \_logic_net: (work@top.clk), line:24:25, endln:24:28
+      |vpiFullName:work@top.clk
+      |vpiActual:
+      \_logic_typespec: , line:24:19, endln:24:24
+    |vpiName:clk
+    |vpiFullName:work@top.clk
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.rst), line:24:42, endln:24:45
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.rst)
+      |vpiParent:
+      \_logic_net: (work@top.rst), line:24:42, endln:24:45
+      |vpiFullName:work@top.rst
+      |vpiActual:
+      \_logic_typespec: , line:24:36, endln:24:41
+    |vpiName:rst
+    |vpiFullName:work@top.rst
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.trn), line:24:59, endln:24:62
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.trn)
+      |vpiParent:
+      \_logic_net: (work@top.trn), line:24:59, endln:24:62
+      |vpiFullName:work@top.trn
+      |vpiActual:
+      \_logic_typespec: , line:24:53, endln:24:58
+    |vpiName:trn
+    |vpiFullName:work@top.trn
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.sel), line:24:82, endln:24:85
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.sel)
+      |vpiParent:
+      \_logic_net: (work@top.sel), line:24:82, endln:24:85
+      |vpiFullName:work@top.sel
+      |vpiActual:
+      \_logic_typespec: , line:24:70, endln:24:81
+    |vpiName:sel
+    |vpiFullName:work@top.sel
+    |vpiNetType:36
+  |vpiNet:
+  \_logic_net: (work@top.o), line:24:106, endln:24:107
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiTypespec:
+    \_ref_typespec: (work@top.o)
+      |vpiParent:
+      \_logic_net: (work@top.o), line:24:106, endln:24:107
+      |vpiFullName:work@top.o
+      |vpiActual:
+      \_logic_typespec: , line:24:94, endln:24:105
+    |vpiName:o
+    |vpiFullName:work@top.o
+    |vpiNetType:36
+  |vpiTopModule:1
+  |vpiPort:
+  \_port: (clk), line:24:25, endln:24:28
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:clk
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@top.clk), line:24:25, endln:24:28
+      |vpiParent:
+      \_port: (clk), line:24:25, endln:24:28
+      |vpiName:clk
+      |vpiFullName:work@top.clk
+      |vpiActual:
+      \_logic_net: (work@top.clk), line:24:25, endln:24:28
+    |vpiTypedef:
+    \_ref_typespec: (work@top.clk)
+      |vpiParent:
+      \_port: (clk), line:24:25, endln:24:28
+      |vpiFullName:work@top.clk
+      |vpiActual:
+      \_logic_typespec: , line:24:19, endln:24:24
+    |vpiInstance:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+  |vpiPort:
+  \_port: (rst), line:24:42, endln:24:45
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:rst
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@top.rst), line:24:42, endln:24:45
+      |vpiParent:
+      \_port: (rst), line:24:42, endln:24:45
+      |vpiName:rst
+      |vpiFullName:work@top.rst
+      |vpiActual:
+      \_logic_net: (work@top.rst), line:24:42, endln:24:45
+    |vpiTypedef:
+    \_ref_typespec: (work@top.rst)
+      |vpiParent:
+      \_port: (rst), line:24:42, endln:24:45
+      |vpiFullName:work@top.rst
+      |vpiActual:
+      \_logic_typespec: , line:24:36, endln:24:41
+    |vpiInstance:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+  |vpiPort:
+  \_port: (trn), line:24:59, endln:24:62
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:trn
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@top.trn), line:24:59, endln:24:62
+      |vpiParent:
+      \_port: (trn), line:24:59, endln:24:62
+      |vpiName:trn
+      |vpiFullName:work@top.trn
+      |vpiActual:
+      \_logic_net: (work@top.trn), line:24:59, endln:24:62
+    |vpiTypedef:
+    \_ref_typespec: (work@top.trn)
+      |vpiParent:
+      \_port: (trn), line:24:59, endln:24:62
+      |vpiFullName:work@top.trn
+      |vpiActual:
+      \_logic_typespec: , line:24:53, endln:24:58
+    |vpiInstance:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+  |vpiPort:
+  \_port: (sel), line:24:82, endln:24:85
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:sel
+    |vpiDirection:1
+    |vpiLowConn:
+    \_ref_obj: (work@top.sel), line:24:82, endln:24:85
+      |vpiParent:
+      \_port: (sel), line:24:82, endln:24:85
+      |vpiName:sel
+      |vpiFullName:work@top.sel
+      |vpiActual:
+      \_logic_net: (work@top.sel), line:24:82, endln:24:85
+    |vpiTypedef:
+    \_ref_typespec: (work@top.sel)
+      |vpiParent:
+      \_port: (sel), line:24:82, endln:24:85
+      |vpiFullName:work@top.sel
+      |vpiActual:
+      \_logic_typespec: , line:24:70, endln:24:81
+    |vpiInstance:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+  |vpiPort:
+  \_port: (o), line:24:106, endln:24:107
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:o
+    |vpiDirection:2
+    |vpiLowConn:
+    \_ref_obj: (work@top.o), line:24:106, endln:24:107
+      |vpiParent:
+      \_port: (o), line:24:106, endln:24:107
+      |vpiName:o
+      |vpiFullName:work@top.o
+      |vpiActual:
+      \_logic_net: (work@top.o), line:24:106, endln:24:107
+    |vpiTypedef:
+    \_ref_typespec: (work@top.o)
+      |vpiParent:
+      \_port: (o), line:24:106, endln:24:107
+      |vpiFullName:work@top.o
+      |vpiActual:
+      \_logic_typespec: , line:24:94, endln:24:105
+    |vpiInstance:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+  |vpiInterface:
+  \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:sub
+    |vpiFullName:work@top.sub
+    |vpiVariables:
+    \_logic_var: (work@top.sub.clk), line:9:9, endln:9:12
+      |vpiParent:
+      \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+      |vpiTypespec:
+      \_ref_typespec: (work@top.sub.clk)
+        |vpiParent:
+        \_logic_var: (work@top.sub.clk), line:9:9, endln:9:12
+        |vpiFullName:work@top.sub.clk
+        |vpiActual:
+        \_logic_typespec: , line:9:3, endln:9:8
+      |vpiName:clk
+      |vpiFullName:work@top.sub.clk
+      |vpiVisibility:1
+    |vpiVariables:
+    \_logic_var: (work@top.sub.rst), line:9:14, endln:9:17
+      |vpiParent:
+      \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+      |vpiTypespec:
+      \_ref_typespec: (work@top.sub.rst)
+        |vpiParent:
+        \_logic_var: (work@top.sub.rst), line:9:14, endln:9:17
+        |vpiFullName:work@top.sub.rst
+        |vpiActual:
+        \_logic_typespec: , line:9:3, endln:9:8
+      |vpiName:rst
+      |vpiFullName:work@top.sub.rst
+      |vpiVisibility:1
+    |vpiVariables:
+    \_logic_var: (work@top.sub.trn), line:9:19, endln:9:22
+      |vpiParent:
+      \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+      |vpiTypespec:
+      \_ref_typespec: (work@top.sub.trn)
+        |vpiParent:
+        \_logic_var: (work@top.sub.trn), line:9:19, endln:9:22
+        |vpiFullName:work@top.sub.trn
+        |vpiActual:
+        \_logic_typespec: , line:9:3, endln:9:8
+      |vpiName:trn
+      |vpiFullName:work@top.sub.trn
+      |vpiVisibility:1
+    |vpiVariables:
+    \_logic_var: (work@top.sub.sel), line:10:15, endln:10:18
+      |vpiParent:
+      \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+      |vpiTypespec:
+      \_ref_typespec: (work@top.sub.sel)
+        |vpiParent:
+        \_logic_var: (work@top.sub.sel), line:10:15, endln:10:18
+        |vpiFullName:work@top.sub.sel
+        |vpiActual:
+        \_logic_typespec: , line:10:3, endln:10:14
+      |vpiName:sel
+      |vpiFullName:work@top.sub.sel
+      |vpiVisibility:1
+    |vpiVariables:
+    \_logic_var: (work@top.sub.rsp_sel), line:11:15, endln:11:22
+      |vpiParent:
+      \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+      |vpiTypespec:
+      \_ref_typespec: (work@top.sub.rsp_sel)
+        |vpiParent:
+        \_logic_var: (work@top.sub.rsp_sel), line:11:15, endln:11:22
+        |vpiFullName:work@top.sub.rsp_sel
+        |vpiActual:
+        \_logic_typespec: , line:11:3, endln:11:14
+      |vpiName:rsp_sel
+      |vpiFullName:work@top.sub.rsp_sel
+      |vpiVisibility:1
+    |vpiParameter:
+    \_parameter: (work@top.sub.CFG), line:8:39, endln:8:42
+      |vpiParent:
+      \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+      |vpiTypespec:
+      \_ref_typespec: (work@top.sub.CFG)
+        |vpiParent:
+        \_parameter: (work@top.sub.CFG), line:8:39, endln:8:42
+        |vpiFullName:work@top.sub.CFG
+        |vpiActual:
+        \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+      |vpiName:CFG
+      |vpiFullName:work@top.sub.CFG
+    |vpiParamAssign:
+    \_param_assign: , line:8:39, endln:8:55
+      |vpiParent:
+      \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+      |vpiOverriden:1
+      |vpiRhs:
+      \_operation: , line:26:12, endln:26:19
+        |vpiParent:
+        \_param_assign: , line:8:39, endln:8:55
+        |vpiTypespec:
+        \_ref_typespec: (work@top.sub)
+          |vpiParent:
+          \_operation: , line:26:12, endln:26:19
+          |vpiFullName:work@top.sub
+          |vpiActual:
+          \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+        |vpiOpType:75
+        |vpiOperand:
+        \_operation: , line:6:37, endln:6:46
+          |vpiParent:
+          \_operation: , line:26:12, endln:26:19
+          |vpiSize:32
+          |vpiTypespec:
+          \_ref_typespec: (work@top.sub)
+            |vpiParent:
+            \_operation: , line:6:37, endln:6:46
+            |vpiFullName:work@top.sub
+            |vpiActual:
+            \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+          |vpiOpType:75
+          |vpiOperand:
+          \_constant: , line:6:44, endln:6:45
+            |vpiParent:
+            \_operation: , line:6:37, endln:6:46
+            |vpiDecompile:1
+            |vpiSize:64
+            |UINT:1
+            |vpiConstType:9
+      |vpiLhs:
+      \_parameter: (work@top.sub.CFG), line:8:39, endln:8:42
+    |vpiDefName:work@bus_if
+    |vpiDefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiDefLineNo:8
+    |vpiInstance:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+  |vpiModule:
+  \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:3, endln:29:23
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiName:c
+    |vpiFullName:work@top.c
+    |vpiDefName:work@child
+    |vpiDefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiDefLineNo:13
+    |vpiInstance:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiPort:
+    \_port: (sub), line:13:22, endln:13:25
+      |vpiParent:
+      \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:3, endln:29:23
+      |vpiName:sub
+      |vpiDirection:3
+      |vpiHighConn:
+      \_ref_obj: (work@top.sub), line:29:17, endln:29:20
+        |vpiParent:
+        \_port: (sub), line:13:22, endln:13:25
+        |vpiName:sub
+        |vpiFullName:work@top.sub
+        |vpiActual:
+        \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+      |vpiLowConn:
+      \_ref_obj: (work@top.c.sub), line:29:13, endln:29:16
+        |vpiParent:
+        \_port: (sub), line:13:22, endln:13:25
+        |vpiFullName:work@top.c.sub
+        |vpiActual:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+      |vpiTypedef:
+      \_ref_typespec: (work@top.c.sub)
+        |vpiParent:
+        \_port: (sub), line:13:22, endln:13:25
+        |vpiFullName:work@top.c.sub
+        |vpiActual:
+        \_interface_typespec: (bus_if), line:13:15, endln:13:21
+      |vpiInstance:
+      \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:3, endln:29:23
+    |vpiInterface:
+    \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+      |vpiParent:
+      \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:3, endln:29:23
+      |vpiName:sub
+      |vpiFullName:work@top.c.sub
+      |vpiVariables:
+      \_logic_var: (work@top.c.sub.clk), line:9:9, endln:9:12
+        |vpiParent:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+        |vpiTypespec:
+        \_ref_typespec: (work@top.c.sub.clk)
+          |vpiParent:
+          \_logic_var: (work@top.c.sub.clk), line:9:9, endln:9:12
+          |vpiFullName:work@top.c.sub.clk
+          |vpiActual:
+          \_logic_typespec: , line:9:3, endln:9:8
+        |vpiName:clk
+        |vpiFullName:work@top.c.sub.clk
+        |vpiVisibility:1
+      |vpiVariables:
+      \_logic_var: (work@top.c.sub.rst), line:9:14, endln:9:17
+        |vpiParent:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+        |vpiTypespec:
+        \_ref_typespec: (work@top.c.sub.rst)
+          |vpiParent:
+          \_logic_var: (work@top.c.sub.rst), line:9:14, endln:9:17
+          |vpiFullName:work@top.c.sub.rst
+          |vpiActual:
+          \_logic_typespec: , line:9:3, endln:9:8
+        |vpiName:rst
+        |vpiFullName:work@top.c.sub.rst
+        |vpiVisibility:1
+      |vpiVariables:
+      \_logic_var: (work@top.c.sub.trn), line:9:19, endln:9:22
+        |vpiParent:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+        |vpiTypespec:
+        \_ref_typespec: (work@top.c.sub.trn)
+          |vpiParent:
+          \_logic_var: (work@top.c.sub.trn), line:9:19, endln:9:22
+          |vpiFullName:work@top.c.sub.trn
+          |vpiActual:
+          \_logic_typespec: , line:9:3, endln:9:8
+        |vpiName:trn
+        |vpiFullName:work@top.c.sub.trn
+        |vpiVisibility:1
+      |vpiVariables:
+      \_logic_var: (work@top.c.sub.sel), line:10:15, endln:10:18
+        |vpiParent:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+        |vpiTypespec:
+        \_ref_typespec: (work@top.c.sub.sel)
+          |vpiParent:
+          \_logic_var: (work@top.c.sub.sel), line:10:15, endln:10:18
+          |vpiFullName:work@top.c.sub.sel
+          |vpiActual:
+          \_logic_typespec: , line:10:3, endln:10:14
+        |vpiName:sel
+        |vpiFullName:work@top.c.sub.sel
+        |vpiVisibility:1
+      |vpiVariables:
+      \_logic_var: (work@top.c.sub.rsp_sel), line:11:15, endln:11:22
+        |vpiParent:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+        |vpiTypespec:
+        \_ref_typespec: (work@top.c.sub.rsp_sel)
+          |vpiParent:
+          \_logic_var: (work@top.c.sub.rsp_sel), line:11:15, endln:11:22
+          |vpiFullName:work@top.c.sub.rsp_sel
+          |vpiActual:
+          \_logic_typespec: , line:11:3, endln:11:14
+        |vpiName:rsp_sel
+        |vpiFullName:work@top.c.sub.rsp_sel
+        |vpiVisibility:1
+      |vpiParameter:
+      \_parameter: (work@top.c.sub.CFG), line:8:39, endln:8:42
+        |vpiParent:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+        |vpiTypespec:
+        \_ref_typespec: (work@top.c.sub.CFG)
+          |vpiParent:
+          \_parameter: (work@top.c.sub.CFG), line:8:39, endln:8:42
+          |vpiFullName:work@top.c.sub.CFG
+          |vpiActual:
+          \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+        |vpiName:CFG
+        |vpiFullName:work@top.c.sub.CFG
+      |vpiParameter:
+      \_parameter: (work@top.c.sub.CFG), line:8:39, endln:8:42
+        |vpiParent:
+        \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+        |vpiTypespec:
+        \_ref_typespec: (work@top.c.sub.CFG)
+          |vpiParent:
+          \_parameter: (work@top.c.sub.CFG), line:8:39, endln:8:42
+          |vpiFullName:work@top.c.sub.CFG
+          |vpiActual:
+          \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+        |vpiName:CFG
+        |vpiFullName:work@top.c.sub.CFG
+      |vpiDefName:work@bus_if
+    |vpiInterface:
+    \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+    |vpiGenScopeArray:
+    \_gen_scope_array: (work@top.c.genblk1), line:18:7, endln:20:50
+      |vpiParent:
+      \_module_inst: work@child (work@top.c), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:3, endln:29:23
+      |vpiName:genblk1
+      |vpiFullName:work@top.c.genblk1
+      |vpiGenScope:
+      \_gen_scope: (work@top.c.genblk1), line:18:7, endln:20:50
+        |vpiParent:
+        \_gen_scope_array: (work@top.c.genblk1), line:18:7, endln:20:50
+        |vpiFullName:work@top.c.genblk1
+        |vpiProcess:
+        \_always: , line:18:7, endln:20:50
+          |vpiParent:
+          \_gen_scope: (work@top.c.genblk1), line:18:7, endln:20:50
+          |vpiStmt:
+          \_event_control: , line:18:17, endln:18:54
+            |vpiParent:
+            \_always: , line:18:7, endln:20:50
+            |vpiCondition:
+            \_operation: , line:18:19, endln:18:53
+              |vpiParent:
+              \_event_control: , line:18:17, endln:18:54
+              |vpiOpType:35
+              |vpiOperand:
+              \_operation: , line:18:19, endln:18:34
+                |vpiParent:
+                \_operation: , line:18:19, endln:18:53
+                |vpiOpType:39
+                |vpiOperand:
+                \_hier_path: (sub.clk), line:18:27, endln:18:34
+                  |vpiParent:
+                  \_operation: , line:18:19, endln:18:34
+                  |vpiActual:
+                  \_ref_obj: (sub), line:18:27, endln:18:30
+                    |vpiParent:
+                    \_hier_path: (sub.clk), line:18:27, endln:18:34
+                    |vpiName:sub
+                    |vpiActual:
+                    \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+                  |vpiActual:
+                  \_ref_obj: (work@top.c.genblk1.clk), line:18:31, endln:18:34
+                    |vpiParent:
+                    \_hier_path: (sub.clk), line:18:27, endln:18:34
+                    |vpiName:clk
+                    |vpiFullName:work@top.c.genblk1.clk
+                    |vpiActual:
+                    \_logic_var: (work@top.c.sub.clk), line:9:9, endln:9:12
+                  |vpiName:sub.clk
+              |vpiOperand:
+              \_operation: , line:18:38, endln:18:53
+                |vpiParent:
+                \_operation: , line:18:19, endln:18:53
+                |vpiOpType:39
+                |vpiOperand:
+                \_hier_path: (sub.rst), line:18:46, endln:18:53
+                  |vpiParent:
+                  \_operation: , line:18:38, endln:18:53
+                  |vpiActual:
+                  \_ref_obj: (sub), line:18:46, endln:18:49
+                    |vpiParent:
+                    \_hier_path: (sub.rst), line:18:46, endln:18:53
+                    |vpiName:sub
+                    |vpiActual:
+                    \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+                  |vpiActual:
+                  \_ref_obj: (work@top.c.genblk1.rst), line:18:50, endln:18:53
+                    |vpiParent:
+                    \_hier_path: (sub.rst), line:18:46, endln:18:53
+                    |vpiName:rst
+                    |vpiFullName:work@top.c.genblk1.rst
+                    |vpiActual:
+                    \_logic_var: (work@top.c.sub.rst), line:9:14, endln:9:17
+                  |vpiName:sub.rst
+            |vpiStmt:
+            \_if_else: , line:19:9, endln:20:50
+              |vpiParent:
+              \_event_control: , line:18:17, endln:18:54
+              |vpiCondition:
+              \_hier_path: (sub.rst), line:19:13, endln:19:20
+                |vpiParent:
+                \_if_else: , line:19:9, endln:20:50
+                |vpiActual:
+                \_ref_obj: (sub), line:19:13, endln:19:16
+                  |vpiParent:
+                  \_hier_path: (sub.rst), line:19:13, endln:19:20
+                  |vpiName:sub
+                  |vpiActual:
+                  \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+                |vpiActual:
+                \_ref_obj: (work@top.c.genblk1.rst), line:19:17, endln:19:20
+                  |vpiParent:
+                  \_hier_path: (sub.rst), line:19:13, endln:19:20
+                  |vpiName:rst
+                  |vpiFullName:work@top.c.genblk1.rst
+                  |vpiActual:
+                  \_logic_var: (work@top.c.sub.rst), line:9:14, endln:9:17
+                |vpiName:sub.rst
+              |vpiStmt:
+              \_assignment: , line:19:22, endln:19:39
+                |vpiParent:
+                \_if_else: , line:19:9, endln:20:50
+                |vpiOpType:82
+                |vpiRhs:
+                \_constant: , line:19:37, endln:19:39
+                  |vpiParent:
+                  \_assignment: , line:19:22, endln:19:39
+                  |vpiDecompile:'0
+                  |vpiSize:-1
+                  |BIN:0
+                  |vpiConstType:3
+                |vpiLhs:
+                \_hier_path: (sub.rsp_sel), line:19:22, endln:19:33
+                  |vpiParent:
+                  \_assignment: , line:19:22, endln:19:39
+                  |vpiActual:
+                  \_ref_obj: (sub), line:19:26, endln:19:33
+                    |vpiParent:
+                    \_hier_path: (sub.rsp_sel), line:19:22, endln:19:33
+                    |vpiName:sub
+                    |vpiActual:
+                    \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+                  |vpiActual:
+                  \_ref_obj: (rsp_sel), line:19:26, endln:19:33
+                    |vpiParent:
+                    \_hier_path: (sub.rsp_sel), line:19:22, endln:19:33
+                    |vpiName:rsp_sel
+                    |vpiActual:
+                    \_logic_var: (work@top.c.sub.rsp_sel), line:11:15, endln:11:22
+                  |vpiName:sub.rsp_sel
+              |vpiElseStmt:
+              \_if_stmt: , line:20:14, endln:20:50
+                |vpiParent:
+                \_if_else: , line:19:9, endln:20:50
+                |vpiCondition:
+                \_hier_path: (sub.trn), line:20:18, endln:20:25
+                  |vpiParent:
+                  \_if_stmt: , line:20:14, endln:20:50
+                  |vpiActual:
+                  \_ref_obj: (sub), line:20:18, endln:20:21
+                    |vpiParent:
+                    \_hier_path: (sub.trn), line:20:18, endln:20:25
+                    |vpiName:sub
+                    |vpiActual:
+                    \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+                  |vpiActual:
+                  \_ref_obj: (work@top.c.genblk1.trn), line:20:22, endln:20:25
+                    |vpiParent:
+                    \_hier_path: (sub.trn), line:20:18, endln:20:25
+                    |vpiName:trn
+                    |vpiFullName:work@top.c.genblk1.trn
+                    |vpiActual:
+                    \_logic_var: (work@top.c.sub.trn), line:9:19, endln:9:22
+                  |vpiName:sub.trn
+                |vpiStmt:
+                \_assignment: , line:20:27, endln:20:49
+                  |vpiParent:
+                  \_if_stmt: , line:20:14, endln:20:50
+                  |vpiOpType:82
+                  |vpiRhs:
+                  \_hier_path: (sub.sel), line:20:42, endln:20:49
+                    |vpiParent:
+                    \_assignment: , line:20:27, endln:20:49
+                    |vpiActual:
+                    \_ref_obj: (sub), line:20:42, endln:20:45
+                      |vpiParent:
+                      \_hier_path: (sub.sel), line:20:42, endln:20:49
+                      |vpiName:sub
+                      |vpiActual:
+                      \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+                    |vpiActual:
+                    \_ref_obj: (work@top.c.genblk1.sel), line:20:46, endln:20:49
+                      |vpiParent:
+                      \_hier_path: (sub.sel), line:20:42, endln:20:49
+                      |vpiName:sel
+                      |vpiFullName:work@top.c.genblk1.sel
+                      |vpiActual:
+                      \_logic_var: (work@top.c.sub.sel), line:10:15, endln:10:18
+                    |vpiName:sub.sel
+                  |vpiLhs:
+                  \_hier_path: (sub.rsp_sel), line:20:27, endln:20:38
+                    |vpiParent:
+                    \_assignment: , line:20:27, endln:20:49
+                    |vpiActual:
+                    \_ref_obj: (sub), line:20:31, endln:20:38
+                      |vpiParent:
+                      \_hier_path: (sub.rsp_sel), line:20:27, endln:20:38
+                      |vpiName:sub
+                      |vpiActual:
+                      \_interface_inst: work@bus_if (work@top.c.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:29:0
+                    |vpiActual:
+                    \_ref_obj: (rsp_sel), line:20:31, endln:20:38
+                      |vpiParent:
+                      \_hier_path: (sub.rsp_sel), line:20:27, endln:20:38
+                      |vpiName:rsp_sel
+                      |vpiActual:
+                      \_logic_var: (work@top.c.sub.rsp_sel), line:11:15, endln:11:22
+                    |vpiName:sub.rsp_sel
+          |vpiAlwaysType:3
+  |vpiContAssign:
+  \_cont_assign: , line:27:10, endln:27:23
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiRhs:
+    \_ref_obj: (work@top.clk), line:27:20, endln:27:23
+      |vpiParent:
+      \_cont_assign: , line:27:10, endln:27:23
+      |vpiName:clk
+      |vpiFullName:work@top.clk
+      |vpiActual:
+      \_logic_net: (work@top.clk), line:24:25, endln:24:28
+    |vpiLhs:
+    \_hier_path: (sub.clk), line:27:10, endln:27:17
+      |vpiParent:
+      \_cont_assign: , line:27:10, endln:27:23
+      |vpiActual:
+      \_ref_obj: (sub), line:27:14, endln:27:17
+        |vpiParent:
+        \_hier_path: (sub.clk), line:27:10, endln:27:17
+        |vpiName:sub
+        |vpiActual:
+        \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+      |vpiActual:
+      \_ref_obj: (clk), line:27:14, endln:27:17
+        |vpiParent:
+        \_hier_path: (sub.clk), line:27:10, endln:27:17
+        |vpiName:clk
+        |vpiActual:
+        \_logic_var: (work@top.sub.clk), line:9:9, endln:9:12
+      |vpiName:sub.clk
+  |vpiContAssign:
+  \_cont_assign: , line:27:32, endln:27:45
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiRhs:
+    \_ref_obj: (work@top.rst), line:27:42, endln:27:45
+      |vpiParent:
+      \_cont_assign: , line:27:32, endln:27:45
+      |vpiName:rst
+      |vpiFullName:work@top.rst
+      |vpiActual:
+      \_logic_net: (work@top.rst), line:24:42, endln:24:45
+    |vpiLhs:
+    \_hier_path: (sub.rst), line:27:32, endln:27:39
+      |vpiParent:
+      \_cont_assign: , line:27:32, endln:27:45
+      |vpiActual:
+      \_ref_obj: (sub), line:27:36, endln:27:39
+        |vpiParent:
+        \_hier_path: (sub.rst), line:27:32, endln:27:39
+        |vpiName:sub
+        |vpiActual:
+        \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+      |vpiActual:
+      \_ref_obj: (rst), line:27:36, endln:27:39
+        |vpiParent:
+        \_hier_path: (sub.rst), line:27:32, endln:27:39
+        |vpiName:rst
+        |vpiActual:
+        \_logic_var: (work@top.sub.rst), line:9:14, endln:9:17
+      |vpiName:sub.rst
+  |vpiContAssign:
+  \_cont_assign: , line:27:54, endln:27:67
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiRhs:
+    \_ref_obj: (work@top.trn), line:27:64, endln:27:67
+      |vpiParent:
+      \_cont_assign: , line:27:54, endln:27:67
+      |vpiName:trn
+      |vpiFullName:work@top.trn
+      |vpiActual:
+      \_logic_net: (work@top.trn), line:24:59, endln:24:62
+    |vpiLhs:
+    \_hier_path: (sub.trn), line:27:54, endln:27:61
+      |vpiParent:
+      \_cont_assign: , line:27:54, endln:27:67
+      |vpiActual:
+      \_ref_obj: (sub), line:27:58, endln:27:61
+        |vpiParent:
+        \_hier_path: (sub.trn), line:27:54, endln:27:61
+        |vpiName:sub
+        |vpiActual:
+        \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+      |vpiActual:
+      \_ref_obj: (trn), line:27:58, endln:27:61
+        |vpiParent:
+        \_hier_path: (sub.trn), line:27:54, endln:27:61
+        |vpiName:trn
+        |vpiActual:
+        \_logic_var: (work@top.sub.trn), line:9:19, endln:9:22
+      |vpiName:sub.trn
+  |vpiContAssign:
+  \_cont_assign: , line:27:76, endln:27:89
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiRhs:
+    \_ref_obj: (work@top.sel), line:27:86, endln:27:89
+      |vpiParent:
+      \_cont_assign: , line:27:76, endln:27:89
+      |vpiName:sel
+      |vpiFullName:work@top.sel
+      |vpiActual:
+      \_logic_net: (work@top.sel), line:24:82, endln:24:85
+    |vpiLhs:
+    \_hier_path: (sub.sel), line:27:76, endln:27:83
+      |vpiParent:
+      \_cont_assign: , line:27:76, endln:27:89
+      |vpiActual:
+      \_ref_obj: (sub), line:27:80, endln:27:83
+        |vpiParent:
+        \_hier_path: (sub.sel), line:27:76, endln:27:83
+        |vpiName:sub
+        |vpiActual:
+        \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+      |vpiActual:
+      \_ref_obj: (sel), line:27:80, endln:27:83
+        |vpiParent:
+        \_hier_path: (sub.sel), line:27:76, endln:27:83
+        |vpiName:sel
+        |vpiActual:
+        \_logic_var: (work@top.sub.sel), line:10:15, endln:10:18
+      |vpiName:sub.sel
+  |vpiContAssign:
+  \_cont_assign: , line:28:10, endln:28:25
+    |vpiParent:
+    \_module_inst: work@top (work@top), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:24:1, endln:30:10
+    |vpiRhs:
+    \_hier_path: (sub.rsp_sel), line:28:14, endln:28:25
+      |vpiParent:
+      \_cont_assign: , line:28:10, endln:28:25
+      |vpiActual:
+      \_ref_obj: (sub), line:28:14, endln:28:17
+        |vpiParent:
+        \_hier_path: (sub.rsp_sel), line:28:14, endln:28:25
+        |vpiName:sub
+        |vpiActual:
+        \_interface_inst: work@bus_if (work@top.sub), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:26:3, endln:26:28
+      |vpiActual:
+      \_ref_obj: (work@top.rsp_sel), line:28:18, endln:28:25
+        |vpiParent:
+        \_hier_path: (sub.rsp_sel), line:28:14, endln:28:25
+        |vpiName:rsp_sel
+        |vpiFullName:work@top.rsp_sel
+        |vpiActual:
+        \_logic_var: (work@top.sub.rsp_sel), line:11:15, endln:11:22
+      |vpiName:sub.rsp_sel
+    |vpiLhs:
+    \_ref_obj: (work@top.o), line:28:10, endln:28:11
+      |vpiParent:
+      \_cont_assign: , line:28:10, endln:28:25
+      |vpiName:o
+      |vpiFullName:work@top.o
+      |vpiActual:
+      \_logic_net: (work@top.o), line:24:106, endln:24:107
+\_weaklyReferenced:
+\_int_typespec: , line:4:27, endln:4:39
+  |vpiParent:
+  \_typespec_member: (DLY), line:4:40, endln:4:43
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+\_string_typespec: (DLY), line:6:39, endln:6:42
+  |vpiParent:
+  \_tagged_pattern: , line:6:44, endln:6:45
+  |vpiName:DLY
+\_string_typespec: (HSK), line:6:32, endln:6:35
+  |vpiParent:
+  \_tagged_pattern: , line:6:37, endln:6:46
+  |vpiName:HSK
+\_int_typespec: , line:4:27, endln:4:39
+  |vpiParent:
+  \_typespec_member: (DLY), line:4:40, endln:4:43
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+\_string_typespec: (DLY), line:6:39, endln:6:42
+  |vpiParent:
+  \_tagged_pattern: , line:6:44, endln:6:45
+  |vpiName:DLY
+\_string_typespec: (HSK), line:6:32, endln:6:35
+  |vpiParent:
+  \_tagged_pattern: , line:6:37, endln:6:46
+  |vpiName:HSK
+\_string_typespec: (HSK), line:6:32, endln:6:35
+  |vpiParent:
+  \_ref_typespec: (work@bus_if)
+  |vpiName:HSK
+\_string_typespec: (DLY), line:6:39, endln:6:42
+  |vpiParent:
+  \_ref_typespec: (work@bus_if)
+  |vpiName:DLY
+\_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (HSK), line:5:33, endln:5:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiName:HSK
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK)
+      |vpiParent:
+      \_typespec_member: (HSK), line:5:33, endln:5:36
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.HSK
+      |vpiActual:
+      \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:5
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:5
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK)
+  |vpiName:p::hsk_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DLY), line:4:40, endln:4:43
+    |vpiParent:
+    \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiName:DLY
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK.p::hsk_t.DLY)
+      |vpiParent:
+      \_typespec_member: (DLY), line:4:40, endln:4:43
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.HSK.p::hsk_t.DLY
+      |vpiActual:
+      \_int_typespec: , line:4:27, endln:4:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:4
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:4
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:4:27, endln:4:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK.p::hsk_t.DLY)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+\_string_typespec: (HSK), line:6:32, endln:6:35
+  |vpiParent:
+  \_ref_typespec: (work@top)
+  |vpiName:HSK
+\_string_typespec: (DLY), line:6:39, endln:6:42
+  |vpiParent:
+  \_ref_typespec: (work@top)
+  |vpiName:DLY
+\_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (HSK), line:5:33, endln:5:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiName:HSK
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK)
+      |vpiParent:
+      \_typespec_member: (HSK), line:5:33, endln:5:36
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.HSK
+      |vpiActual:
+      \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:5
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:5
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK)
+  |vpiName:p::hsk_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DLY), line:4:40, endln:4:43
+    |vpiParent:
+    \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiName:DLY
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK.p::hsk_t.DLY)
+      |vpiParent:
+      \_typespec_member: (DLY), line:4:40, endln:4:43
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.HSK.p::hsk_t.DLY
+      |vpiActual:
+      \_int_typespec: , line:4:27, endln:4:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:4
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:4
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:4:27, endln:4:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK.p::hsk_t.DLY)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+\_logic_typespec: , line:24:19, endln:24:24
+\_logic_typespec: , line:24:36, endln:24:41
+\_logic_typespec: , line:24:53, endln:24:58
+\_logic_typespec: , line:24:70, endln:24:81
+  |vpiRange:
+  \_range: , line:24:76, endln:24:81
+    |vpiParent:
+    \_logic_typespec: , line:24:70, endln:24:81
+    |vpiLeftRange:
+    \_constant: , line:24:77, endln:24:78
+      |vpiParent:
+      \_range: , line:24:76, endln:24:81
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:24:79, endln:24:80
+      |vpiParent:
+      \_range: , line:24:76, endln:24:81
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:24:94, endln:24:105
+  |vpiRange:
+  \_range: , line:24:100, endln:24:105
+    |vpiParent:
+    \_logic_typespec: , line:24:94, endln:24:105
+    |vpiLeftRange:
+    \_constant: , line:24:101, endln:24:102
+      |vpiParent:
+      \_range: , line:24:100, endln:24:105
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:24:103, endln:24:104
+      |vpiParent:
+      \_range: , line:24:100, endln:24:105
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK)
+  |vpiName:p::hsk_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DLY), line:4:40, endln:4:43
+    |vpiParent:
+    \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiName:DLY
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK.p::hsk_t.DLY)
+      |vpiParent:
+      \_typespec_member: (DLY), line:4:40, endln:4:43
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.HSK.p::hsk_t.DLY
+      |vpiActual:
+      \_int_typespec: , line:4:27, endln:4:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:4
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:4
+    |vpiRefEndColumnNo:39
+\_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK)
+  |vpiParent:
+  \_typespec_member: (HSK), line:5:33, endln:5:36
+  |vpiFullName:work@top.CFG_DEF.p::cfg_t.HSK
+  |vpiActual:
+  \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+\_typespec_member: (HSK), line:5:33, endln:5:36
+  |vpiParent:
+  \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+  |vpiName:HSK
+  |vpiTypespec:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK)
+  |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+  |vpiRefLineNo:5
+  |vpiRefColumnNo:27
+  |vpiRefEndLineNo:5
+  |vpiRefEndColumnNo:32
+\_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (HSK), line:5:33, endln:5:36
+\_ref_typespec: (work@top.CFG_DEF)
+  |vpiParent:
+  \_parameter: (work@top.CFG_DEF), line:6:20, endln:6:27
+  |vpiFullName:work@top.CFG_DEF
+  |vpiActual:
+  \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+\_parameter: (work@top.CFG_DEF), line:6:20, endln:6:27
+  |vpiParent:
+  \_param_assign: , line:6:20, endln:6:47
+  |vpiTypespec:
+  \_ref_typespec: (work@top.CFG_DEF)
+  |vpiLocalParam:1
+  |vpiName:CFG_DEF
+  |vpiFullName:work@top.CFG_DEF
+  |vpiImported:p
+\_int_typespec: , line:4:27, endln:4:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK.p::hsk_t.DLY)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+\_operation: , line:6:30, endln:6:47
+  |vpiParent:
+  \_param_assign: , line:6:20, endln:6:47
+  |vpiTypespec:
+  \_ref_typespec: 
+    |vpiActual:
+    \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+  |vpiOpType:75
+  |vpiOperand:
+  \_operation: , line:6:37, endln:6:46
+\_logic_typespec: , line:24:19, endln:24:24
+  |vpiParent:
+  \_logic_net: (work@top.clk), line:24:25, endln:24:28
+\_logic_typespec: , line:24:36, endln:24:41
+  |vpiParent:
+  \_logic_net: (work@top.rst), line:24:42, endln:24:45
+\_logic_typespec: , line:24:53, endln:24:58
+  |vpiParent:
+  \_logic_net: (work@top.trn), line:24:59, endln:24:62
+\_logic_typespec: , line:24:70, endln:24:81
+  |vpiParent:
+  \_logic_net: (work@top.sel), line:24:82, endln:24:85
+  |vpiRange:
+  \_range: , line:24:76, endln:24:81
+    |vpiParent:
+    \_logic_typespec: , line:24:70, endln:24:81
+    |vpiLeftRange:
+    \_constant: , line:24:77, endln:24:78
+      |vpiParent:
+      \_range: , line:24:76, endln:24:81
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:24:79, endln:24:80
+      |vpiParent:
+      \_range: , line:24:76, endln:24:81
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:24:94, endln:24:105
+  |vpiRange:
+  \_range: , line:24:100, endln:24:105
+    |vpiParent:
+    \_logic_typespec: , line:24:94, endln:24:105
+    |vpiLeftRange:
+    \_constant: , line:24:101, endln:24:102
+      |vpiParent:
+      \_range: , line:24:100, endln:24:105
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:24:103, endln:24:104
+      |vpiParent:
+      \_range: , line:24:100, endln:24:105
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+  |vpiParent:
+  \_ref_typespec: (work@top.sub)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (HSK), line:5:33, endln:5:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiName:HSK
+    |vpiTypespec:
+    \_ref_typespec: (work@top.sub.p::cfg_t.HSK)
+      |vpiParent:
+      \_typespec_member: (HSK), line:5:33, endln:5:36
+      |vpiFullName:work@top.sub.p::cfg_t.HSK
+      |vpiActual:
+      \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:5
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:5
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+  |vpiParent:
+  \_ref_typespec: (work@top.sub.p::cfg_t.HSK)
+  |vpiName:p::hsk_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DLY), line:4:40, endln:4:43
+    |vpiParent:
+    \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiName:DLY
+    |vpiTypespec:
+    \_ref_typespec: (work@top.sub.p::cfg_t.HSK.p::hsk_t.DLY)
+      |vpiParent:
+      \_typespec_member: (DLY), line:4:40, endln:4:43
+      |vpiFullName:work@top.sub.p::cfg_t.HSK.p::hsk_t.DLY
+      |vpiActual:
+      \_int_typespec: , line:4:27, endln:4:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:4
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:4
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:4:27, endln:4:39
+  |vpiParent:
+  \_ref_typespec: (work@top.sub.p::cfg_t.HSK.p::hsk_t.DLY)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+\_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+  |vpiParent:
+  \_ref_typespec: (work@top.sub)
+  |vpiName:p::hsk_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DLY), line:4:40, endln:4:43
+    |vpiParent:
+    \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiName:DLY
+    |vpiTypespec:
+    \_ref_typespec: (work@top.sub.p::hsk_t.DLY)
+      |vpiParent:
+      \_typespec_member: (DLY), line:4:40, endln:4:43
+      |vpiFullName:work@top.sub.p::hsk_t.DLY
+      |vpiActual:
+      \_int_typespec: , line:4:27, endln:4:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:4
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:4
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:4:27, endln:4:39
+  |vpiParent:
+  \_ref_typespec: (work@top.sub.p::hsk_t.DLY)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+\_logic_typespec: , line:9:3, endln:9:8
+  |vpiParent:
+  \_logic_var: (work@top.sub.trn), line:9:19, endln:9:22
+\_logic_typespec: , line:10:3, endln:10:14
+  |vpiParent:
+  \_logic_var: (work@top.sub.sel), line:10:15, endln:10:18
+  |vpiRange:
+  \_range: , line:10:9, endln:10:14
+    |vpiParent:
+    \_logic_typespec: , line:10:3, endln:10:14
+    |vpiLeftRange:
+    \_constant: , line:10:10, endln:10:11
+      |vpiParent:
+      \_range: , line:10:9, endln:10:14
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:10:12, endln:10:13
+      |vpiParent:
+      \_range: , line:10:9, endln:10:14
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:11:3, endln:11:14
+  |vpiParent:
+  \_logic_var: (work@top.sub.rsp_sel), line:11:15, endln:11:22
+  |vpiRange:
+  \_range: , line:11:9, endln:11:14
+    |vpiParent:
+    \_logic_typespec: , line:11:3, endln:11:14
+    |vpiLeftRange:
+    \_constant: , line:11:10, endln:11:11
+      |vpiParent:
+      \_range: , line:11:9, endln:11:14
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:11:12, endln:11:13
+      |vpiParent:
+      \_range: , line:11:9, endln:11:14
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_interface_typespec: (bus_if), line:13:15, endln:13:21
+  |vpiName:bus_if
+\_logic_typespec: , line:9:3, endln:9:8
+  |vpiParent:
+  \_logic_var: (work@top.c.sub.trn), line:9:19, endln:9:22
+\_logic_typespec: , line:10:3, endln:10:14
+  |vpiParent:
+  \_logic_var: (work@top.c.sub.sel), line:10:15, endln:10:18
+  |vpiRange:
+  \_range: , line:10:9, endln:10:14
+    |vpiParent:
+    \_logic_typespec: , line:10:3, endln:10:14
+    |vpiLeftRange:
+    \_constant: , line:10:10, endln:10:11
+      |vpiParent:
+      \_range: , line:10:9, endln:10:14
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:10:12, endln:10:13
+      |vpiParent:
+      \_range: , line:10:9, endln:10:14
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:11:3, endln:11:14
+  |vpiParent:
+  \_logic_var: (work@top.c.sub.rsp_sel), line:11:15, endln:11:22
+  |vpiRange:
+  \_range: , line:11:9, endln:11:14
+    |vpiParent:
+    \_logic_typespec: , line:11:3, endln:11:14
+    |vpiLeftRange:
+    \_constant: , line:11:10, endln:11:11
+      |vpiParent:
+      \_range: , line:11:9, endln:11:14
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:11:12, endln:11:13
+      |vpiParent:
+      \_range: , line:11:9, endln:11:14
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_operation: , line:6:37, endln:6:46
+  |vpiParent:
+  \_operation: , line:8:45, endln:8:48
+  |vpiSize:32
+  |vpiTypespec:
+  \_ref_typespec: 
+    |vpiActual:
+    \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+  |vpiOpType:75
+  |vpiOperand:
+  \_constant: , line:6:44, endln:6:45
+\_operation: , line:8:45, endln:8:48
+  |vpiParent:
+  \_param_assign: , line:8:39, endln:8:55
+  |vpiTypespec:
+  \_ref_typespec: 
+    |vpiActual:
+    \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+  |vpiOpType:75
+  |vpiOperand:
+  \_operation: , line:6:37, endln:6:46
+\_logic_typespec: , line:9:3, endln:9:8
+\_logic_typespec: , line:9:3, endln:9:8
+\_logic_typespec: , line:9:3, endln:9:8
+\_logic_typespec: , line:10:3, endln:10:14
+  |vpiRange:
+  \_range: , line:10:9, endln:10:14
+    |vpiParent:
+    \_logic_typespec: , line:10:3, endln:10:14
+    |vpiLeftRange:
+    \_constant: , line:10:10, endln:10:11
+      |vpiParent:
+      \_range: , line:10:9, endln:10:14
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:10:12, endln:10:13
+      |vpiParent:
+      \_range: , line:10:9, endln:10:14
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:11:3, endln:11:14
+  |vpiRange:
+  \_range: , line:11:9, endln:11:14
+    |vpiParent:
+    \_logic_typespec: , line:11:3, endln:11:14
+    |vpiLeftRange:
+    \_constant: , line:11:10, endln:11:11
+      |vpiParent:
+      \_range: , line:11:9, endln:11:14
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:11:12, endln:11:13
+      |vpiParent:
+      \_range: , line:11:9, endln:11:14
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_interface_typespec: (bus_if), line:13:15, endln:13:21
+  |vpiName:bus_if
+\_logic_typespec: , line:24:19, endln:24:24
+\_logic_typespec: , line:24:36, endln:24:41
+\_logic_typespec: , line:24:53, endln:24:58
+\_logic_typespec: , line:24:70, endln:24:81
+  |vpiRange:
+  \_range: , line:24:76, endln:24:81
+    |vpiParent:
+    \_logic_typespec: , line:24:70, endln:24:81
+    |vpiLeftRange:
+    \_constant: , line:24:77, endln:24:78
+      |vpiParent:
+      \_range: , line:24:76, endln:24:81
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:24:79, endln:24:80
+      |vpiParent:
+      \_range: , line:24:76, endln:24:81
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_logic_typespec: , line:24:94, endln:24:105
+  |vpiRange:
+  \_range: , line:24:100, endln:24:105
+    |vpiParent:
+    \_logic_typespec: , line:24:94, endln:24:105
+    |vpiLeftRange:
+    \_constant: , line:24:101, endln:24:102
+      |vpiParent:
+      \_range: , line:24:100, endln:24:105
+      |vpiDecompile:3
+      |vpiSize:64
+      |UINT:3
+      |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:24:103, endln:24:104
+      |vpiParent:
+      \_range: , line:24:100, endln:24:105
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+\_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (HSK), line:5:33, endln:5:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiName:HSK
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK)
+      |vpiParent:
+      \_typespec_member: (HSK), line:5:33, endln:5:36
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.HSK
+      |vpiActual:
+      \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:5
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:5
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK)
+  |vpiName:p::hsk_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DLY), line:4:40, endln:4:43
+    |vpiParent:
+    \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiName:DLY
+    |vpiTypespec:
+    \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK.p::hsk_t.DLY)
+      |vpiParent:
+      \_typespec_member: (DLY), line:4:40, endln:4:43
+      |vpiFullName:work@top.CFG_DEF.p::cfg_t.HSK.p::hsk_t.DLY
+      |vpiActual:
+      \_int_typespec: , line:4:27, endln:4:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:4
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:4
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:4:27, endln:4:39
+  |vpiParent:
+  \_ref_typespec: (work@top.CFG_DEF.p::cfg_t.HSK.p::hsk_t.DLY)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+\_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+  |vpiParent:
+  \_ref_typespec: (work@top.sub.CFG)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (HSK), line:5:33, endln:5:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiName:HSK
+    |vpiTypespec:
+    \_ref_typespec: (work@top.sub.CFG.p::cfg_t.HSK)
+      |vpiParent:
+      \_typespec_member: (HSK), line:5:33, endln:5:36
+      |vpiFullName:work@top.sub.CFG.p::cfg_t.HSK
+      |vpiActual:
+      \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:5
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:5
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+  |vpiParent:
+  \_ref_typespec: (work@top.sub.CFG.p::cfg_t.HSK)
+  |vpiName:p::hsk_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DLY), line:4:40, endln:4:43
+    |vpiParent:
+    \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiName:DLY
+    |vpiTypespec:
+    \_ref_typespec: (work@top.sub.CFG.p::cfg_t.HSK.p::hsk_t.DLY)
+      |vpiParent:
+      \_typespec_member: (DLY), line:4:40, endln:4:43
+      |vpiFullName:work@top.sub.CFG.p::cfg_t.HSK.p::hsk_t.DLY
+      |vpiActual:
+      \_int_typespec: , line:4:27, endln:4:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:4
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:4
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:4:27, endln:4:39
+  |vpiParent:
+  \_ref_typespec: (work@top.sub.CFG.p::cfg_t.HSK.p::hsk_t.DLY)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+\_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.CFG)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (HSK), line:5:33, endln:5:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiName:HSK
+    |vpiTypespec:
+    \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.HSK)
+      |vpiParent:
+      \_typespec_member: (HSK), line:5:33, endln:5:36
+      |vpiFullName:work@top.c.sub.CFG.p::cfg_t.HSK
+      |vpiActual:
+      \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:5
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:5
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.HSK)
+  |vpiName:p::hsk_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DLY), line:4:40, endln:4:43
+    |vpiParent:
+    \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiName:DLY
+    |vpiTypespec:
+    \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.HSK.p::hsk_t.DLY)
+      |vpiParent:
+      \_typespec_member: (DLY), line:4:40, endln:4:43
+      |vpiFullName:work@top.c.sub.CFG.p::cfg_t.HSK.p::hsk_t.DLY
+      |vpiActual:
+      \_int_typespec: , line:4:27, endln:4:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:4
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:4
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:4:27, endln:4:39
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.HSK.p::hsk_t.DLY)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+\_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.CFG)
+  |vpiName:p::cfg_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (HSK), line:5:33, endln:5:36
+    |vpiParent:
+    \_struct_typespec: (p::cfg_t), line:5:11, endln:5:39
+    |vpiName:HSK
+    |vpiTypespec:
+    \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.HSK)
+      |vpiParent:
+      \_typespec_member: (HSK), line:5:33, endln:5:36
+      |vpiFullName:work@top.c.sub.CFG.p::cfg_t.HSK
+      |vpiActual:
+      \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:5
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:5
+    |vpiRefEndColumnNo:32
+\_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.HSK)
+  |vpiName:p::hsk_t
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+  |vpiPacked:1
+  |vpiTypespecMember:
+  \_typespec_member: (DLY), line:4:40, endln:4:43
+    |vpiParent:
+    \_struct_typespec: (p::hsk_t), line:4:11, endln:4:46
+    |vpiName:DLY
+    |vpiTypespec:
+    \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.HSK.p::hsk_t.DLY)
+      |vpiParent:
+      \_typespec_member: (DLY), line:4:40, endln:4:43
+      |vpiFullName:work@top.c.sub.CFG.p::cfg_t.HSK.p::hsk_t.DLY
+      |vpiActual:
+      \_int_typespec: , line:4:27, endln:4:39
+    |vpiRefFile:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv
+    |vpiRefLineNo:4
+    |vpiRefColumnNo:27
+    |vpiRefEndLineNo:4
+    |vpiRefEndColumnNo:39
+\_int_typespec: , line:4:27, endln:4:39
+  |vpiParent:
+  \_ref_typespec: (work@top.c.sub.CFG.p::cfg_t.HSK.p::hsk_t.DLY)
+  |vpiInstance:
+  \_package: p (p::), file:${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv, line:3:1, endln:7:11
+===================
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
+[WARNING] : 4
+[   NOTE] : 6
+
+============================== Begin RoundTrip Results ==============================
+[roundtrip]: ${SURELOG_DIR}/tests/GenIfIfaceParamStructField/dut.sv | ${SURELOG_DIR}/build/regression/GenIfIfaceParamStructField/roundtrip/dut_000.sv | 18 | 30 |
+============================== End RoundTrip Results ==============================

--- a/tests/GenIfIfaceParamStructField/GenIfIfaceParamStructField.sl
+++ b/tests/GenIfIfaceParamStructField/GenIfIfaceParamStructField.sl
@@ -1,0 +1,1 @@
+-parse -mt 0 -d uhdm -d coveruhdm -elabuhdm -nobuiltin dut.sv

--- a/tests/GenIfIfaceParamStructField/dut.sv
+++ b/tests/GenIfIfaceParamStructField/dut.sv
@@ -1,0 +1,30 @@
+// generate-if condition reading a 4-level interface-param struct field
+// `sub.CFG.HSK.DLY` — the jeras/rp32 demultiplexer rsp_sel / register modules.
+package p;
+  typedef struct packed { int unsigned DLY; } hsk_t;
+  typedef struct packed { hsk_t HSK; } cfg_t;
+  localparam cfg_t CFG_DEF = '{HSK: '{DLY: 1}};
+endpackage
+interface bus_if #(parameter p::cfg_t CFG = p::CFG_DEF);
+  logic clk, rst, trn;
+  logic [3:0] sel;
+  logic [3:0] rsp_sel;
+endinterface
+module child (bus_if sub);
+  generate
+    if (sub.CFG.HSK.DLY == 0) begin
+      assign sub.rsp_sel = sub.sel;
+    end else if (sub.CFG.HSK.DLY == 1) begin
+      always_ff @(posedge sub.clk or posedge sub.rst)
+        if (sub.rst) sub.rsp_sel <= '0;
+        else if (sub.trn) sub.rsp_sel <= sub.sel;
+    end
+  endgenerate
+endmodule
+module top (input logic clk, input logic rst, input logic trn, input logic [3:0] sel, output logic [3:0] o);
+  import p::*;
+  bus_if #(CFG_DEF) sub ();
+  assign sub.clk = clk; assign sub.rst = rst; assign sub.trn = trn; assign sub.sel = sel;
+  assign o = sub.rsp_sel;
+  child c (.sub(sub));
+endmodule


### PR DESCRIPTION
Extends resolveInterfacePortMember to resolve a NESTED struct-parameter field read through an interface port, `sub.CFG.HSK.DLY` — where `CFG` is a struct parameter of the interface and `.HSK.DLY` walks its members.  Previously only a direct 2-level `sub.<localparam>` was handled; a deeper path stayed a non-constant hier_path, so a generate condition `if (sub.CFG.HSK.DLY == N)` (or `case (sub.CFG.BUS.MOD)`) could not fold and the branch was dropped.

For a multi-level member the helper now builds a sub-path from the member elements (dropping the interface-port base) and decodes it via decodeHierPath in the interface DEFINITION's context, where the struct-parameter-field navigation resolves it to a constant.  The interface instance is not bound to the port at generate-elaboration time, so the type-definition params (default/overridden) are used.

This drives the jeras/rp32 demultiplexer response select (`rsp_sel`, guarded by `if (sub.CFG.HSK.DLY == 0/1)`) and clears the EL0545 "Invalid generate case stmt value" on tcb_lite_lib_register_request's `case (sub.CFG.BUS.MOD)` — the degu SoC now elaborates without error.

New regression: tests/GenIfIfaceParamStructField.  Full regression: 787 PASS, 0 fails.