### PR TITLE
CompileStmt: guard empty statement vector in class constructor compilation

### DIFF
--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -2259,7 +2259,7 @@ bool CompileHelper::compileClassConstructorDeclaration(
       if (Statement) {
         VectorOfany* sts = compileStmt(component, fC, Statement, compileDesign,
                                        Reduce::No, func);
-        if (sts) {
+        if (sts && !sts->empty()) {
           any* st = (*sts)[0];
           st->VpiParent(func);
           func->Stmt(st);


### PR DESCRIPTION
## Problem
A class constructor whose body contains a single type declaration segfaults during elaboration:
```systemverilog
class C;
  function new(int x);
    typedef int T;
  endfunction
endclass
```
`surelog -parse f.sv` → `Segmentation fault`.

## Root cause
In `CompileHelper::compileClassConstructorDeclaration`, the single-statement branch indexes `(*sts)[0]` after only checking the vector pointer for null, not for emptiness:
```cpp
VectorOfany* sts = compileStmt(component, fC, Statement, compileDesign, Reduce::No, func);
if (sts) {
  any* st = (*sts)[0];   // out of bounds on an empty vector
```
`compileStmt` returns a non-null but **empty** vector for a bare type declaration — `compileDataDeclaration`'s type-declaration case returns `s.MakeAnyVec()` with the comment "Type declaration are not executable statements." With a constructor port list (`new(int x)`), the constructor's single body statement is the typedef, so `(*sts)[0]` dereferences the empty vector's null `data()`.

## Fix
Check the vector is non-empty before indexing, matching the `if (!sts->empty())` guard already used elsewhere in this file:
```cpp
if (sts && !sts->empty()) {
```

## Test
Not a `*_test.cpp` unit test (the crash is in class elaboration); reproducible end-to-end with the 5-line snippet above (segfault before the fix, clean after).
