### PR TITLE
CompileStmt: guard empty statement vector in function body compilation

### DIFF
--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -2537,7 +2537,7 @@ bool CompileHelper::compileFunction(DesignComponent* component,
     if (Statement) {
       VectorOfany* sts = compileStmt(component, fC, Statement, compileDesign,
                                      reduce, func, instance);
-      if (sts) {
+      if (sts && !sts->empty()) {
         any* st = (*sts)[0];
         UHDM_OBJECT_TYPE stmt_type = st->UhdmType();
         if (stmt_type == uhdmparam_assign) {


### PR DESCRIPTION
## Problem

In `CompileHelper::compileFunction`, the "0 or 1 Stmt" single-statement branch
(CompileStmt.cpp, ~2538) does:

```cpp
VectorOfany* sts = compileStmt(component, fC, Statement, compileDesign,
                               reduce, func, instance);
if (sts) {                       // non-null check only
  any* st = (*sts)[0];           // out-of-bounds when sts is empty
  UHDM_OBJECT_TYPE stmt_type = st->UhdmType();   // derefs garbage -> SIGSEGV
```

`compileStmt` returns a **non-null but empty** `VectorOfany` for a bare type
declaration — `compileDataDeclaration`'s `paType_declaration` case returns an
empty list with the comment *"Type declaration are not executable statements."*
In an ANSI-style function (parenthesized port list), a leading `typedef` in the
body is parsed as a bare block-item declaration rather than a pre-collected
tf-item, so it reaches this single-statement branch. With the typedef as the
only body item, `sts` is non-null but empty, `if (sts)` passes, and `(*sts)[0]`
reads past the end; `st->UhdmType()` then dereferences the garbage reference and
segfaults.

## Reproducer (parses cleanly, then crashes during compile)

```systemverilog
module m; function int f(); typedef int T; endfunction endmodule
```

```
$ surelog -parse repro.sv
Segmentation fault (core dumped)
```

Non-ANSI functions (`function int f; typedef int T; endfunction`) do **not**
crash because the typedef is pre-collected as a `tf_item_declaration` and
skipped — which is why the obvious repro hides the bug.

## Fix

```cpp
if (sts && !sts->empty()) {
```

This mirrors the sibling guard just merged in #4118
(`compileClassConstructorDeclaration`) and the existing `DO`/`WAIT` guards in
this same file (`if (while_stmts && !while_stmts->empty())`).

## Validation

Built `surelog-bin` locally and confirmed on the resulting executable:

- **Without the fix**: `surelog -parse repro.sv` segfaults (exit 139, core
  dumped). Instrumentation confirms `compileStmt` returns a non-null but
  size-0 vector here, so `(*sts)[0]` reads out of bounds.
- **With the fix**: the primary reproducer and the class-method
  (`class C; function int f(int x); typedef int T; endfunction endclass`) and
  struct-typedef (`typedef struct{int a;} T;`) variants all parse cleanly
  (exit 0).
- **Regression**: a normal function body (`function int f(); return 1;
  endfunction`) still parses successfully (exit 0).

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
