### PR TITLE
NetlistElaboration: guard null initializer expression in elabSignal

### DIFF
--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -2196,11 +2196,13 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
             var->Attributes(sig->attributes());
             for (auto a : *sig->attributes()) a->VpiParent(var);
           }
-          var->Expr(exp);
           var->VpiConstantVariable(sig->isConst());
           var->VpiSigned(sig->isSigned());
           var->VpiName(signame);
-          exp->VpiParent(var);
+          if (exp) {
+            var->Expr(exp);
+            exp->VpiParent(var);
+          }
           obj = var;
         }
       } else if (const Enum* en = datatype_cast<const Enum*>(dtype)) {
@@ -2386,11 +2388,13 @@ bool NetlistElaboration::elabSignal(Signal* sig, ModuleInstance* instance,
             var->Attributes(sig->attributes());
             for (auto a : *sig->attributes()) a->VpiParent(var);
           }
-          var->Expr(exp);
           var->VpiConstantVariable(sig->isConst());
           var->VpiSigned(sig->isSigned());
           var->VpiName(signame);
-          exp->VpiParent(var);
+          if (exp) {
+            var->Expr(exp);
+            exp->VpiParent(var);
+          }
           obj = var;
         }
       } else {


### PR DESCRIPTION
## Problem

`NetlistElaboration::elabSignal` dereferences the net/variable initializer
expression `exp` unconditionally in two byte-identical `else` branches (the
`DummyType` branch and the `SIMPLE_TYPEDEF`/parameter branch):

```cpp
variables* var = m_helper.getSimpleVarFromTypespec(spec, packedDimensions,
                                                   m_compileDesign);
...
var->Expr(exp);            // setter tolerates null
var->VpiName(signame);
exp->VpiParent(var);       // <-- exp may be nullptr
```

`exp` is the *optional* declaration initializer. For a net declared without
`= value`, `exprFromAssign_` returns `nullptr` and the `getDefaultValue`
fallback does not apply (`compileNetDeclaration` never calls `setDefaultValue`
for nets), so `exp` is null and `exp->VpiParent(var)` segfaults during netlist
elaboration — after the input has already parsed and type-resolved
successfully.

The same function already treats `exp` as nullable a few lines later
(`if (exp && ((!signalIsPort) || ...))`), and the direct analogue
`ElaborationStep::makeVar_` guards it around the identical
`getSimpleVarFromTypespec` call (`if (assignExp != nullptr) { var->Expr(...);
assignExp->VpiParent(var); }`).

## Reproducer

```systemverilog
module top;
  typedef integer my_int_t;
  wire my_int_t w;
endmodule
```

```
$ surelog -parse repro.sv
Segmentation fault (core dumped)
```

`wire <data_type>` is legal SystemVerilog (IEEE 1800-2017 6.7.1 — a net's data
type must be a 4-state integral type, and `integer` is one), and the tool has
explicit support for it (`CompileHelper::compileNetDeclaration` has a dedicated
`wire <data_type>` path, whose comments name "wand typename"/"wand integer" as
intended inputs).

## Fix

Guard the dereference in both branches, mirroring the existing sibling guards:

```cpp
if (exp) {
  var->Expr(exp);
  exp->VpiParent(var);
}
```

## Validation

Built `surelog-bin` and confirmed on the resulting executable:

- **Without the fix**: the reproducer segfaults (exit 139, core dumped).
- **With the fix**: it parses cleanly (exit 0, 0 errors).
- **Regressions** (all exit 0, 0 errors): the same net *with* an initializer
  (`wire my_int_t w = 1;`), a parameterized module hierarchy, gate primitives,
  and an interface/modport design.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
