### PR TITLE
DesignElaboration: treat definitions without FileContent as black boxes

### DIFF
--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -1743,6 +1743,14 @@ void DesignElaboration::elaborateInstance_(
           }
         }
 
+        // Built-in primitive definitions are created without a FileContent, so
+        // getNodeIds()/getFileContents() are empty. Treat them as undefined
+        // here so the instance takes the existing black-box path below.
+        if (def && (def->getNodeIds().empty() ||
+                    def->getFileContents().empty())) {
+          def = nullptr;
+        }
+
         if (def) childId = def->getNodeIds()[0];
 
         NodeId tmpId = fC->Sibling(moduleName);
@@ -1816,6 +1824,13 @@ void DesignElaboration::elaborateInstance_(
               default:
                 break;
             }
+          }
+
+          // A use-clause above may have re-resolved def to a built-in
+          // primitive, which carries no FileContent/NodeId.
+          if (def && (def->getNodeIds().empty() ||
+                      def->getFileContents().empty())) {
+            def = nullptr;
           }
 
           if (def)


### PR DESCRIPTION
## Problem

`DesignElaboration::elaborateInstance_` indexes a resolved definition's node
list without checking that it has one:

```cpp
if (def) childId = def->getNodeIds()[0];      // and again in the inner loop
...
elaborateInstance_(def->getFileContents()[0], childId, ...);
```

Built-in primitive definitions (created by `createBuiltinPrimitives_`) are
constructed with a null `FileContent`, so both `getNodeIds()` and
`getFileContents()` are **empty**. When an instantiation resolves to one of
those names, `def` is non-null but `getNodeIds()[0]` reads out of bounds and
elaboration segfaults.

The same file already uses the `.empty()` guard as its idiom for exactly this
situation — `bindDataTypes_` does
`if (component->getFileContents().empty()) return true;` and again
`if (mod->getFileContents().empty()) { // Built-in primitive }` before
indexing `getFileContents()[0]`.

## Reproducer

```systemverilog
module top;
  UnsupportedPrimitive u1();
endmodule
```

```
$ surelog -parse repro.sv
Segmentation fault (core dumped)
```

## Fix

Normalize a definition that carries no `FileContent`/`NodeId` to "no
definition", so the instance falls through to the **existing** black-box path
just below (which is how unresolved instances are already handled):

```cpp
if (def && (def->getNodeIds().empty() ||
            def->getFileContents().empty())) {
  def = nullptr;
}
```

This is applied at both indexing sites, because the inner per-instance loop can
re-resolve `def` from a config use-clause after the first normalization.

## Validation

Built `surelog-bin` and confirmed on the resulting executable:

- **Without the fix**: the reproducer segfaults (exit 139, core dumped).
- **With the fix**: it parses cleanly (exit 0, 0 errors) via the black-box path.
- **Regressions** (all exit 0, 0 errors) — in particular the paths this change
  could plausibly affect: **gate primitives** (`and`/`or`/`nand`/`buf`/`not`
  instantiations), a parameterized module hierarchy with named port
  connections, and an interface/modport design.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
