### PR TITLE
CompileModule: skip attribute_instance in modport port declarations

### DIFF
--- a/src/DesignCompile/CompileModule.cpp
+++ b/src/DesignCompile/CompileModule.cpp
@@ -1284,6 +1284,12 @@ bool CompileModule::collectInterfaceObjects_(CollectType collectType) {
             VObjectType port_direction_type = VObjectType::slNoType;
             while (modport_ports_declaration) {
               NodeId port_declaration = fC->Child(modport_ports_declaration);
+              // modport_ports_declaration allows leading attribute_instance
+              // nodes; skip them before classifying, as done for UDP port
+              // declarations above.
+              while (fC->Type(port_declaration) ==
+                     VObjectType::paAttribute_instance)
+                port_declaration = fC->Sibling(port_declaration);
               VObjectType port_declaration_type = fC->Type(port_declaration);
               if (port_declaration_type ==
                   VObjectType::paModport_simple_ports_declaration) {


### PR DESCRIPTION
## Problem

In `CompileModule::collectInterfaceObjects_`, the `paModport_item` case
classifies a modport port declaration by looking at the first child:

```cpp
NodeId port_declaration = fC->Child(modport_ports_declaration);
VObjectType port_declaration_type = fC->Type(port_declaration);
if (port_declaration_type == paModport_simple_ports_declaration) { ... }
else if (... paModport_hierarchical_ports_declaration) {}
else if (... paModport_tf_ports_declaration) {}
else {
  // assumed to be a clocking block name
  SymbolId clocking_block_symbol =
      m_symbols->registerSymbol(fC->SymName(clocking_block_name));
  ...
}
```

The grammar allows leading attributes —
`modport_ports_declaration : attribute_instance* ( modport_simple_ports_declaration | ... )`
— so when a modport port is annotated with an attribute, the first child is an
`Attribute_instance` node. It matches none of the three declaration types, so
control falls into the final `else`, which assumes the node is a clocking-block
name. The result is a spurious error on valid input:

```
[ERR:CP0312] repro.sv:3:15: Undefined clocking block used in modport: "%s".
```

(The unformatted `"%s"` is itself a symptom — the symbol name is empty because
the node is an attribute, not an identifier.)

## Reproducer

```systemverilog
interface I;
  logic a, b;
  modport mp ((* foo *) input a, output b);
endinterface
```

```
$ surelog -parse repro.sv     # exit 4, spurious CP0312
```

## Fix

Skip leading `attribute_instance` nodes before classifying, mirroring the idiom
this same file already uses twice for UDP port declarations
(`while (fC->Type(Output) == paAttribute_instance) Output = fC->Sibling(Output);`):

```cpp
while (fC->Type(port_declaration) == VObjectType::paAttribute_instance)
  port_declaration = fC->Sibling(port_declaration);
```

The loop terminates because `Sibling()` of the last node yields an invalid
NodeId, whose type is not `paAttribute_instance`.

## Validation

Built `surelog-bin` and confirmed on the resulting executable:

- **Without the fix**: exit 4 with the spurious `CP0312` error.
- **With the fix**: exit 0, 0 errors, and the `CP0312` message is gone.
- **Regressions** (all exit 0, 0 errors): an interface with two normal modports
  (`master`/`slave`) consumed by modport-typed module ports, plus a module
  hierarchy and gate primitives.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
