### PR TITLE
Reduce struct-param field refs in localparam pattern init values

### DIFF
--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdlib>
+#include <functional>
 #include <map>
 #include <set>
 #include <string>
@@ -304,53 +305,109 @@ bool NetlistElaboration::elab_parameters_(ModuleInstance* instance,
                 // `interrupts_t` / `INTERRUPTS`.  The parameter typespec and the
                 // pattern operation's typespec are distinct objects of the same
                 // struct type, so reduce both.
-                auto reduceStructRanges = [&](const UHDM::typespec* t) {
-                  if (t == nullptr || t->UhdmType() != uhdmstruct_typespec)
-                    return;
-                  auto reduceBound = [&](UHDM::expr* b) -> UHDM::expr* {
-                    if (b == nullptr || b->UhdmType() == uhdmconstant)
-                      return nullptr;
-                    bool inv = false;
-                    m_helper.checkForLoops(true);
-                    UHDM::expr* red = m_helper.reduceExpr(
-                        b, inv, mod, m_compileDesign, instance,
-                        fileSystem->toPathId(
-                            b->VpiFile(),
-                            m_compileDesign->getCompiler()->getSymbolTable()),
-                        b->VpiLineNo(), nullptr, true);
-                    m_helper.checkForLoops(false);
-                    if (red && !inv && red->UhdmType() == uhdmconstant)
-                      return red;
+                auto reduceBound = [&](UHDM::expr* b) -> UHDM::expr* {
+                  if (b == nullptr || b->UhdmType() == uhdmconstant)
                     return nullptr;
-                  };
-                  for (typespec_member* memb :
-                       *((struct_typespec*)t)->Members()) {
-                    const UHDM::typespec* mtps = nullptr;
-                    if (UHDM::ref_typespec* mrt = memb->Typespec())
-                      mtps = mrt->Actual_typespec();
-                    UHDM::VectorOfrange* ranges = nullptr;
-                    if (mtps) {
-                      if (mtps->UhdmType() == uhdmlogic_typespec)
-                        ranges = ((UHDM::logic_typespec*)mtps)->Ranges();
-                      else if (mtps->UhdmType() == uhdmpacked_array_typespec)
-                        ranges = ((UHDM::packed_array_typespec*)mtps)->Ranges();
-                      else if (mtps->UhdmType() == uhdmarray_typespec)
-                        ranges = ((UHDM::array_typespec*)mtps)->Ranges();
-                    }
-                    if (ranges == nullptr) continue;
-                    for (UHDM::range* r : *ranges) {
-                      if (UHDM::expr* red = reduceBound(r->Left_expr()))
-                        r->Left_expr(red);
-                      if (UHDM::expr* red = reduceBound(r->Right_expr()))
-                        r->Right_expr(red);
-                    }
+                  bool inv = false;
+                  m_helper.checkForLoops(true);
+                  UHDM::expr* red = m_helper.reduceExpr(
+                      b, inv, mod, m_compileDesign, instance,
+                      fileSystem->toPathId(
+                          b->VpiFile(),
+                          m_compileDesign->getCompiler()->getSymbolTable()),
+                      b->VpiLineNo(), nullptr, true);
+                  m_helper.checkForLoops(false);
+                  if (red && !inv && red->UhdmType() == uhdmconstant)
+                    return red;
+                  return nullptr;
+                };
+                auto reduceRangeVec = [&](UHDM::VectorOfrange* ranges) {
+                  if (ranges == nullptr) return;
+                  for (UHDM::range* r : *ranges) {
+                    if (UHDM::expr* red = reduceBound(r->Left_expr()))
+                      r->Left_expr(red);
+                    if (UHDM::expr* red = reduceBound(r->Right_expr()))
+                      r->Right_expr(red);
                   }
                 };
-                reduceStructRanges(tps);
-                if (rhs->UhdmType() == uhdmoperation) {
-                  if (const UHDM::ref_typespec* ort =
-                          ((operation*)rhs)->Typespec())
-                    reduceStructRanges(ort->Actual_typespec());
+                // Reduce the member ranges of a struct typespec and the direct
+                // ranges of packed/array typespecs (e.g. a cast size
+                // `CVA6Cfg.XLEN'(..)` whose typespec is `logic [CVA6Cfg.XLEN-1:0]`).
+                std::function<void(const UHDM::typespec*)> reduceTypespecRanges =
+                    [&](const UHDM::typespec* t) {
+                  if (t == nullptr) return;
+                  switch (t->UhdmType()) {
+                    case uhdmstruct_typespec:
+                      for (typespec_member* memb :
+                           *((struct_typespec*)t)->Members()) {
+                        if (UHDM::ref_typespec* mrt = memb->Typespec())
+                          reduceTypespecRanges(mrt->Actual_typespec());
+                      }
+                      break;
+                    case uhdmlogic_typespec:
+                      reduceRangeVec(((UHDM::logic_typespec*)t)->Ranges());
+                      break;
+                    case uhdmpacked_array_typespec:
+                      reduceRangeVec(
+                          ((UHDM::packed_array_typespec*)t)->Ranges());
+                      break;
+                    case uhdmarray_typespec:
+                      reduceRangeVec(((UHDM::array_typespec*)t)->Ranges());
+                      break;
+                    default:
+                      break;
+                  }
+                };
+                // Recursively walk the pattern's value expressions, reducing
+                // cast/operation typespec ranges and folding any hier_path
+                // operand (e.g. `CVA6Cfg.XLEN`) to a constant.  Without this,
+                // flattenPatternAssignments below deep-clones these init
+                // expressions and the struct-parameter field references become
+                // unreachable in the detached clone context — reported as
+                // UHDM_UNRESOLVED_HIER_PATH (CVA6 core/cva6.sv `INTERRUPTS`).
+                std::function<void(UHDM::any*)> reduceExprTree =
+                    [&](UHDM::any* e) {
+                  if (e == nullptr) return;
+                  switch (e->UhdmType()) {
+                    case uhdmoperation: {
+                      UHDM::operation* op = (UHDM::operation*)e;
+                      if (UHDM::ref_typespec* ort = op->Typespec())
+                        reduceTypespecRanges(ort->Actual_typespec());
+                      if (UHDM::VectorOfany* ops = op->Operands()) {
+                        for (size_t i = 0; i < ops->size(); i++) {
+                          UHDM::any* o = (*ops)[i];
+                          if (o && o->UhdmType() == uhdmhier_path) {
+                            if (UHDM::expr* red = reduceBound((UHDM::expr*)o)) {
+                              (*ops)[i] = red;
+                              continue;
+                            }
+                          }
+                          reduceExprTree(o);
+                        }
+                      }
+                      break;
+                    }
+                    case uhdmtagged_pattern:
+                      reduceExprTree(((UHDM::tagged_pattern*)e)->Pattern());
+                      break;
+                    default:
+                      break;
+                  }
+                };
+                // Only struct-typed parameters need this: a struct-typed
+                // parameter's field (`Cfg.XLEN`) may appear both in the struct
+                // member ranges AND in the pattern init value expressions, and
+                // flattenPatternAssignments deep-clones both.  Restricting to
+                // struct typespecs keeps the reduction surgical (a non-struct
+                // param's ranges are handled by the normal elaboration path).
+                if (tps->UhdmType() == uhdmstruct_typespec) {
+                  reduceTypespecRanges(tps);
+                  if (rhs->UhdmType() == uhdmoperation) {
+                    if (const UHDM::ref_typespec* ort =
+                            ((operation*)rhs)->Typespec())
+                      reduceTypespecRanges(ort->Actual_typespec());
+                    reduceExprTree(rhs);
+                  }
                 }
                 UHDM::ExprEval eval;
                 if (expr* tmp =

--- a/tests/StructParamPatternInitCast/StructParamPatternInitCast.log
+++ b/tests/StructParamPatternInitCast/StructParamPatternInitCast.log
@@ -1,0 +1,67 @@
+[INF:CM0023] Creating log file "${SURELOG_DIR}/build/regression/StructParamPatternInitCast/slpp_all/surelog.log".
+[WRN:PA0205] ${SURELOG_DIR}/tests/StructParamPatternInitCast/dut.sv:9:1: No timescale set for "cfg_pkg".
+[WRN:PA0205] ${SURELOG_DIR}/tests/StructParamPatternInitCast/dut.sv:24:1: No timescale set for "StructParamPatternInitCast".
+[INF:CP0300] Compilation...
+[INF:CP0301] ${SURELOG_DIR}/tests/StructParamPatternInitCast/dut.sv:9:1: Compile package "cfg_pkg".
+[INF:CP0303] ${SURELOG_DIR}/tests/StructParamPatternInitCast/dut.sv:24:1: Compile module "work@StructParamPatternInitCast".
+[INF:CP0302] Compile class "work@mailbox".
+[INF:CP0302] Compile class "work@process".
+[INF:CP0302] Compile class "work@semaphore".
+[INF:EL0526] Design Elaboration...
+[NTE:EL0503] ${SURELOG_DIR}/tests/StructParamPatternInitCast/dut.sv:24:1: Top level module "work@StructParamPatternInitCast".
+[NTE:EL0508] Nb Top level modules: 1.
+[NTE:EL0509] Max instance depth: 1.
+[NTE:EL0510] Nb instances: 1.
+[NTE:EL0511] Nb leaf instances: 1.
+[INF:UH0706] Creating UHDM Model...
+=== UHDM Object Stats Begin (Non-Elaborated Model) ===
+assignment                                             4
+begin                                                  2
+class_defn                                             8
+class_typespec                                         4
+class_var                                              3
+constant                                             105
+cont_assign                                            2
+design                                                 1
+enum_const                                             5
+enum_typespec                                          1
+enum_var                                               1
+func_call                                             28
+function                                              11
+hier_path                                             34
+int_typespec                                          22
+int_var                                                4
+io_decl                                               13
+logic_net                                              4
+logic_typespec                                        18
+logic_var                                              3
+module_inst                                            9
+operation                                            102
+package                                                4
+param_assign                                          12
+parameter                                             13
+port                                                   4
+range                                                 16
+ref_obj                                              108
+ref_typespec                                         125
+return_stmt                                            2
+string_typespec                                       21
+struct_typespec                                       19
+struct_var                                             6
+tagged_pattern                                        21
+task                                                   9
+type_parameter                                         1
+typespec_member                                       25
+void_typespec                                         20
+=== UHDM Object Stats End ===
+[INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/StructParamPatternInitCast/slpp_all/surelog.uhdm ...
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
+[WARNING] : 2
+[   NOTE] : 5
+
+============================== Begin RoundTrip Results ==============================
+[roundtrip]: ${SURELOG_DIR}/tests/StructParamPatternInitCast/builtin.sv | ${SURELOG_DIR}/build/regression/StructParamPatternInitCast/roundtrip/builtin_000.sv | 0 | 0 |
+[roundtrip]: ${SURELOG_DIR}/tests/StructParamPatternInitCast/dut.sv     | ${SURELOG_DIR}/build/regression/StructParamPatternInitCast/roundtrip/dut_000.sv     | 17 | 39 |
+============================== End RoundTrip Results ==============================

--- a/tests/StructParamPatternInitCast/StructParamPatternInitCast.sl
+++ b/tests/StructParamPatternInitCast/StructParamPatternInitCast.sl
@@ -1,0 +1,1 @@
+-parse -sverilog -top StructParamPatternInitCast dut.sv

--- a/tests/StructParamPatternInitCast/dut.sv
+++ b/tests/StructParamPatternInitCast/dut.sv
@@ -1,0 +1,39 @@
+// Minimal repro of CVA6 core/cva6.sv `INTERRUPTS`: a struct-typed parameter
+// whose value comes from a constant FUNCTION (like build_config), so the field
+// `Cfg.XLEN` is not a plain struct-literal member.  `Cfg.XLEN` then appears in
+// the CAST size and SHIFT operands of an assignment-pattern initializer.
+// flattenPatternAssignments deep-clones these init expressions; the cast
+// typespec range `[Cfg.XLEN-1:0]` and the shift operand `(Cfg.XLEN-1)` must be
+// reduced to constants first, else the detached clone reports
+// UHDM_UNRESOLVED_HIER_PATH (UH0725) -- NetlistElaboration reduceExprTree.
+package cfg_pkg;
+  typedef struct packed {
+    int unsigned XLEN;
+  } user_cfg_t;
+  typedef struct packed {
+    int unsigned XLEN;
+  } cfg_t;
+  function automatic cfg_t build_config(user_cfg_t c);
+    cfg_t r;
+    r.XLEN = c.XLEN;
+    return r;
+  endfunction
+  localparam user_cfg_t Base = '{XLEN: 32'd64};
+endpackage
+
+module StructParamPatternInitCast #(
+    parameter cfg_pkg::cfg_t Cfg = cfg_pkg::build_config(cfg_pkg::Base)
+) (
+    input  logic                a_i,
+    output logic [Cfg.XLEN-1:0] b_o
+);
+  localparam type it_t = struct packed {
+    logic [Cfg.XLEN-1:0] S_SW;
+    logic [Cfg.XLEN-1:0] M_SW;
+  };
+  localparam it_t INT = '{
+      S_SW: (Cfg.XLEN'(1) << (Cfg.XLEN - 1)) | Cfg.XLEN'(1),
+      M_SW: (Cfg.XLEN'(1) << (Cfg.XLEN - 1)) | Cfg.XLEN'(3)
+  };
+  assign b_o = a_i ? INT.S_SW : INT.M_SW;
+endmodule

--- a/third_party/tests/Ariane2024/Ariane2024.log
+++ b/third_party/tests/Ariane2024/Ariane2024.log
@@ -6622,12 +6622,6 @@ there are 2 more instances of this message.
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/Ariane2024/sc_collected_files/wt_cache_subsystem_10800b06ce2d34d69729c82a70a4b9a1fc5e2804.sv:272:45: Compile generate block "work@cva6.gen_cache_wt.i_cache_subsystem.gen_assertion[2]".
 [INF:CP0335] ${SURELOG_DIR}/third_party/tests/Ariane2024/sc_collected_files/cva6_896bbc9de65d3fccda60b666ce12c66c1281ea4e.sv:1343:8: Compile generate block "work@cva6.gen_no_accelerator".
 [NTE:EL0503] ${SURELOG_DIR}/third_party/tests/Ariane2024/sc_collected_files/cva6_896bbc9de65d3fccda60b666ce12c66c1281ea4e.sv:17:1: Top level module "work@cva6".
-[ERR:UH0725] ${SURELOG_DIR}/third_party/tests/Ariane2024/sc_collected_files/cva6_896bbc9de65d3fccda60b666ce12c66c1281ea4e.sv:308:20: Unresolved hierarchical reference "CVA6Cfg.XLEN".
-[ERR:UH0725] ${SURELOG_DIR}/third_party/tests/Ariane2024/sc_collected_files/cva6_896bbc9de65d3fccda60b666ce12c66c1281ea4e.sv:309:20: Unresolved hierarchical reference "CVA6Cfg.XLEN".
-[ERR:UH0725] ${SURELOG_DIR}/third_party/tests/Ariane2024/sc_collected_files/cva6_896bbc9de65d3fccda60b666ce12c66c1281ea4e.sv:310:23: Unresolved hierarchical reference "CVA6Cfg.XLEN".
-[ERR:UH0725] ${SURELOG_DIR}/third_party/tests/Ariane2024/sc_collected_files/cva6_896bbc9de65d3fccda60b666ce12c66c1281ea4e.sv:311:23: Unresolved hierarchical reference "CVA6Cfg.XLEN".
-[ERR:UH0725] ${SURELOG_DIR}/third_party/tests/Ariane2024/sc_collected_files/cva6_896bbc9de65d3fccda60b666ce12c66c1281ea4e.sv:312:21: Unresolved hierarchical reference "CVA6Cfg.XLEN".
-[ERR:UH0725] ${SURELOG_DIR}/third_party/tests/Ariane2024/sc_collected_files/cva6_896bbc9de65d3fccda60b666ce12c66c1281ea4e.sv:313:21: Unresolved hierarchical reference "CVA6Cfg.XLEN".
 [ERR:UH0725] ${SURELOG_DIR}/third_party/tests/Ariane2024/sc_collected_files/include_ed7874b3c5d225c29b1c057efd1e6a84739683cf/build_config_pkg.sv:102:28: Unresolved hierarchical reference "CVA6Cfg.NrNonIdempotentRules".
 [ERR:UH0725] ${SURELOG_DIR}/third_party/tests/Ariane2024/sc_collected_files/include_ed7874b3c5d225c29b1c057efd1e6a84739683cf/build_config_pkg.sv:102:60: Unresolved hierarchical reference "CVA6Cfg.NonIdempotentLength".
 [WRN:EL0500] ${SURELOG_DIR}/third_party/tests/Ariane2024/sc_collected_files/cva6_896bbc9de65d3fccda60b666ce12c66c1281ea4e.sv:1430:3: Cannot find a module definition for "work@cva6::instr_tracer_if".
@@ -6658,7 +6652,7 @@ case_stmt                                            249
 class_defn                                             8
 class_typespec                                         4
 class_var                                              3
-constant                                          271210
+constant                                          271246
 cont_assign                                        13127
 design                                                 1
 enum_const                                         10305
@@ -6675,7 +6669,7 @@ gen_if_else                                          104
 gen_region                                            24
 gen_scope                                          12630
 gen_scope_array                                    12630
-hier_path                                          11481
+hier_path                                          11445
 if_else                                              985
 if_stmt                                              908
 immediate_assert                                     202
@@ -6684,7 +6678,7 @@ import_typespec                                       71
 include_file_info                                      9
 indexed_part_select                                  687
 initial                                              123
-int_typespec                                       48069
+int_typespec                                       48105
 int_var                                              661
 integer_typespec                                    3190
 integer_var                                            6
@@ -6708,8 +6702,8 @@ port                                                8880
 property_spec                                        404
 range                                              25863
 ref_module                                           362
-ref_obj                                            90341
-ref_typespec                                      104515
+ref_obj                                            90269
+ref_typespec                                      104551
 ref_var                                               21
 return_stmt                                          342
 short_int_typespec                                    16
@@ -6732,6 +6726,6 @@ void_typespec                                         72
 === UHDM Object Stats End ===
 [  FATAL] : 0
 [ SYNTAX] : 0
-[  ERROR] : 9
+[  ERROR] : 3
 [WARNING] : 134
 [   NOTE] : 43


### PR DESCRIPTION
Extends the struct-typed-parameter field resolution (PR #4126) from the struct member ranges to the assignment-pattern INITIALIZER expressions.

CVA6 core/cva6.sv `INTERRUPTS` is a localparam of a struct type whose members are `logic [CVA6Cfg.XLEN-1:0]`, initialized with a pattern whose values are `(CVA6Cfg.XLEN'(1) << (CVA6Cfg.XLEN-1)) | CVA6Cfg.XLEN'(..)`. `ExprEval::flattenPatternAssignments` deep-clones both the struct typespec AND these init expressions; in the detached clone the struct-parameter field reference `CVA6Cfg.XLEN` is unreachable, reported as UHDM_UNRESOLVED_HIER_PATH (UH0725) and mis-sizing the flattened value.

NetlistElaboration::elab_parameters_ now, for a struct-typed parameter, before flattening:
  - recursively reduces the ranges of struct member / packed-array / array typespecs to constants (`reduceTypespecRanges`), and
  - walks the pattern's value expression tree (`reduceExprTree`), reducing cast/operation typespec ranges (the cast size `CVA6Cfg.XLEN'(..)`) and folding any `hier_path` operand (`CVA6Cfg.XLEN`) to a constant, using this instance's parameter values.

Restricted to struct-typed parameters so a non-struct parameter's ranges keep going through the normal elaboration path (no collateral golden churn).

CVA6 (cv64a6_imafdc_sv39): UH0725 12 -> 2 (the 10 INTERRUPTS errors). Ariane2024 golden: ERROR 9 -> 3.  New test tests/StructParamPatternInitCast (2 UH0725 without the fix, 0 with it).