### PR TITLE
Fire elaboration diagnostics for instantiated modules only

### DIFF
--- a/include/Surelog/DesignCompile/CompileHelper.h
+++ b/include/Surelog/DesignCompile/CompileHelper.h
@@ -674,6 +674,15 @@ class CompileHelper final {
 
   void setElabMode(bool on) { m_elabMode = on; }
 
+  // When true, reduction errors (e.g. divide-by-zero) raised while computing a
+  // typespec's ranges are muted.  Set only around definition-level typedef
+  // binding (ElaborationStep::bindTypedefs_), where a parameter-dependent range
+  // (`logic [A/B-1:0]`) is evaluated with the module's *default* parameter
+  // values (e.g. a struct config `'0`) that are meant to be overridden at
+  // instantiation.  Genuine errors are still reported when the real instance is
+  // elaborated (DesignElaboration::collectParams_).
+  void setMuteTypedefRangeErrors(bool on) { m_muteTypedefRangeErrors = on; }
+
  private:
   ErrorContainer* m_errors = nullptr;
   SymbolTable* m_symbols = nullptr;
@@ -698,6 +707,7 @@ class CompileHelper final {
   int32_t m_stackLevel = 0;
   bool m_unwind = false;
   bool m_elabMode = true;
+  bool m_muteTypedefRangeErrors = false;
 };
 
 }  // namespace SURELOG

--- a/include/Surelog/DesignCompile/UhdmWriter.h
+++ b/include/Surelog/DesignCompile/UhdmWriter.h
@@ -35,6 +35,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <set>
 #include <string_view>
 #include <vector>
 
@@ -110,6 +111,11 @@ class UhdmWriter final {
                       ModuleInstance* instance = nullptr);
   bool writeElabInterface(UHDM::Serializer& s, ModuleInstance* instance,
                           UHDM::interface_inst* m, ExprBuilder& exprBuilder);
+  // Fire the deferred elaboration system-task diagnostics ($error/$fatal/
+  // $warning/$info) stored on a module/interface DEFINITION, but only once and
+  // only when the (instantiated) elaborated instance is written -- so a module
+  // that is never instantiated in this configuration reports nothing.
+  void fireElabSysCalls(DesignComponent* mod);
   void writeInstance(ModuleDefinition* mod, ModuleInstance* instance,
                      UHDM::any* m, CompileDesign* compileDesign,
                      ModPortMap& modPortMap, InstanceMap& instanceMap,
@@ -150,6 +156,7 @@ class UhdmWriter final {
   UHDM::design* m_uhdmDesign;
   ComponentMap m_componentMap;
   CompileHelper m_helper;
+  std::set<DesignComponent*> m_firedElabSysCalls;
 };
 
 }  // namespace SURELOG

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -5504,23 +5504,13 @@ bool CompileHelper::elaborationSystemTask(DesignComponent* component,
   c->VpiDecompile(text);
   c->VpiConstType(vpiStringConst);
   component->addElabSysCall(scall);
-  Location loc(fC->getFileId(id), fC->Line(id), fC->Column(id),
-               m_symbols->registerSymbol(text));
-  if (name == "fatal") {
-    Error err(ErrorDefinition::ELAB_SYSTEM_FATAL, loc);
-    m_errors->addError(err);
-  } else if (name == "error") {
-    Error err(ErrorDefinition::ELAB_SYSTEM_ERROR, loc);
-    m_errors->addError(err);
-  }
-  if (name == "warning") {
-    Error err(ErrorDefinition::ELAB_SYSTEM_WARNING, loc);
-    m_errors->addError(err);
-  }
-  if (name == "info") {
-    Error err(ErrorDefinition::ELAB_SYSTEM_INFO, loc);
-    m_errors->addError(err);
-  }
+  // Do NOT emit the diagnostic here: this runs while compiling the module
+  // DEFINITION, before the instantiation hierarchy is known, so it would fire
+  // even for a module that is only conditionally instantiated and excluded in
+  // this configuration (e.g. CVA6 `cva6_accel_first_pass_decoder`, guarded by
+  // `if (CVA6Cfg.EnableAccelerator)` = false).  The stored elab sys call is
+  // instead fired by UhdmWriter when the ELABORATED (instantiated) module is
+  // written, so it only reports for modules actually present in the design.
   return true;
 }
 

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -1285,7 +1285,7 @@ UHDM::typespec* CompileHelper::compileTypespec(
   int32_t size;
   VectorOfrange* ranges =
       compileRanges(component, fC, Packed_dimension, compileDesign, reduce,
-                    pstmt, instance, size, false);
+                    pstmt, instance, size, m_muteTypedefRangeErrors);
   switch (the_type) {
     case VObjectType::paConstant_mintypmax_expression:
     case VObjectType::paConstant_primary: {

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -106,6 +106,12 @@ bool ElaborationStep::bindTypedefs_() {
   SymbolTable* symbols = compiler->getSymbolTable();
   Design* design = compiler->getDesign();
   Serializer& s = m_compileDesign->getSerializer();
+  // Binding a typedef whose range depends on a parameter (`logic [A/B-1:0]`)
+  // evaluates it with the module's DEFAULT parameter values (e.g. a struct
+  // config `'0`), which may legitimately divide by zero; those are not user
+  // errors (the real range is computed per-instance in
+  // DesignElaboration::collectParams_).  Mute range-reduction errors here.
+  m_helper.setMuteTypedefRangeErrors(true);
   std::vector<std::pair<TypeDef*, DesignComponent*>> defs;
   std::map<std::string, typespec*, std::less<>> specs;
   for (const auto& file : design->getAllFileContents()) {
@@ -415,6 +421,7 @@ bool ElaborationStep::bindTypedefs_() {
   swapTypespecPointersInUhdm(s, m_compileDesign->getSwapedObjects());
   swapTypespecPointersInTypedef(design, m_compileDesign->getSwapedObjects());
 
+  m_helper.setMuteTypedefRangeErrors(false);
   return true;
 }
 

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -2342,6 +2342,9 @@ bool UhdmWriter::writeElabGenScope(Serializer& s, ModuleInstance* instance,
         et->VpiParent(m);
       }
     }
+    // Fire the deferred elaboration system-task diagnostics now that this
+    // (instantiated) module/interface is part of the elaborated design.
+    fireElabSysCalls(mod);
     // Assertions
     if (mod->getAssertions()) {
       m->Assertions(mod->getAssertions());
@@ -4010,6 +4013,45 @@ void UhdmWriter::lateBinding(Serializer& s, DesignComponent* mod, scope* m) {
   }
 }
 
+void UhdmWriter::fireElabSysCalls(DesignComponent* mod) {
+  if (mod == nullptr || mod->getElabSysCalls().empty()) return;
+  // Fire once per definition (matches the historical definition-time behavior:
+  // one diagnostic per module, not one per instance).
+  if (!m_firedElabSysCalls.insert(mod).second) return;
+  FileSystem* const fileSystem = FileSystem::getInstance();
+  Compiler* compiler = m_compileDesign->getCompiler();
+  ErrorContainer* errors = compiler->getErrorContainer();
+  SymbolTable* symbols = compiler->getSymbolTable();
+  for (UHDM::tf_call* et : mod->getElabSysCalls()) {
+    const std::string_view name = et->VpiName();
+    std::string_view text;
+    if (et->Tf_call_args() && !et->Tf_call_args()->empty()) {
+      if (const UHDM::constant* c =
+              any_cast<const UHDM::constant*>(et->Tf_call_args()->at(0))) {
+        text = c->VpiValue();
+        if (text.substr(0, 7) == "STRING:") text = text.substr(7);
+      }
+    }
+    const PathId fileId = fileSystem->toPathId(et->VpiFile(), symbols);
+    Location loc(fileId, et->VpiLineNo(), et->VpiColumnNo(),
+                 symbols->registerSymbol(text));
+    ErrorDefinition::ErrorType type = ErrorDefinition::NO_ERROR_MESSAGE;
+    if (name == "fatal") {
+      type = ErrorDefinition::ELAB_SYSTEM_FATAL;
+    } else if (name == "error") {
+      type = ErrorDefinition::ELAB_SYSTEM_ERROR;
+    } else if (name == "warning") {
+      type = ErrorDefinition::ELAB_SYSTEM_WARNING;
+    } else if (name == "info") {
+      type = ErrorDefinition::ELAB_SYSTEM_INFO;
+    } else {
+      continue;
+    }
+    Error err(type, loc);
+    errors->addError(err);
+  }
+}
+
 bool UhdmWriter::writeElabModule(Serializer& s, ModuleInstance* instance,
                                  module_inst* m, ExprBuilder& exprBuilder) {
   Netlist* netlist = instance->getNetlist();
@@ -4045,6 +4087,9 @@ bool UhdmWriter::writeElabModule(Serializer& s, ModuleInstance* instance,
         et->VpiParent(m);
       }
     }
+    // Fire the deferred elaboration system-task diagnostics now that this
+    // (instantiated) module/interface is part of the elaborated design.
+    fireElabSysCalls(mod);
     // Assertions
     if (mod->getAssertions()) {
       m->Assertions(mod->getAssertions());
@@ -4193,6 +4238,9 @@ bool UhdmWriter::writeElabInterface(Serializer& s, ModuleInstance* instance,
         et->VpiParent(m);
       }
     }
+    // Fire the deferred elaboration system-task diagnostics now that this
+    // (instantiated) module/interface is part of the elaborated design.
+    fireElabSysCalls(mod);
     // Assertions
     if (mod->getAssertions()) {
       m->Assertions(mod->getAssertions());

--- a/tests/ElabDefinitionDiagnostics/ElabDefinitionDiagnostics.log
+++ b/tests/ElabDefinitionDiagnostics/ElabDefinitionDiagnostics.log
@@ -1,0 +1,64 @@
+[INF:CM0023] Creating log file "${SURELOG_DIR}/build/regression/ElabDefinitionDiagnostics/slpp_all/surelog.log".
+[WRN:PA0205] ${SURELOG_DIR}/tests/ElabDefinitionDiagnostics/dut.sv:8:1: No timescale set for "dut".
+[WRN:PA0205] ${SURELOG_DIR}/tests/ElabDefinitionDiagnostics/dut.sv:15:1: No timescale set for "unused_stub".
+[WRN:PA0205] ${SURELOG_DIR}/tests/ElabDefinitionDiagnostics/dut.sv:21:1: No timescale set for "used_stub".
+[WRN:PA0205] ${SURELOG_DIR}/tests/ElabDefinitionDiagnostics/dut.sv:27:1: No timescale set for "ElabDefinitionDiagnostics".
+[INF:CP0300] Compilation...
+[INF:CP0303] ${SURELOG_DIR}/tests/ElabDefinitionDiagnostics/dut.sv:27:1: Compile module "work@ElabDefinitionDiagnostics".
+[INF:CP0303] ${SURELOG_DIR}/tests/ElabDefinitionDiagnostics/dut.sv:8:1: Compile module "work@dut".
+[INF:CP0303] ${SURELOG_DIR}/tests/ElabDefinitionDiagnostics/dut.sv:15:1: Compile module "work@unused_stub".
+[INF:CP0303] ${SURELOG_DIR}/tests/ElabDefinitionDiagnostics/dut.sv:21:1: Compile module "work@used_stub".
+[INF:CP0302] Compile class "work@mailbox".
+[INF:CP0302] Compile class "work@process".
+[INF:CP0302] Compile class "work@semaphore".
+[INF:EL0526] Design Elaboration...
+[NTE:EL0503] ${SURELOG_DIR}/tests/ElabDefinitionDiagnostics/dut.sv:27:1: Top level module "work@ElabDefinitionDiagnostics".
+[NTE:EL0508] Nb Top level modules: 1.
+[NTE:EL0509] Max instance depth: 2.
+[NTE:EL0510] Nb instances: 3.
+[NTE:EL0511] Nb leaf instances: 2.
+[INF:UH0706] Creating UHDM Model...
+=== UHDM Object Stats Begin (Non-Elaborated Model) ===
+class_defn                                             8
+class_typespec                                         4
+class_var                                              3
+constant                                              49
+cont_assign                                            6
+design                                                 1
+enum_const                                             5
+enum_typespec                                          1
+enum_var                                               1
+function                                               9
+int_typespec                                          12
+int_var                                                4
+io_decl                                               11
+logic_net                                              8
+logic_typespec                                        15
+logic_var                                              4
+module_inst                                           12
+operation                                             10
+package                                                2
+packed_array_typespec                                  1
+param_assign                                           3
+parameter                                              3
+part_select                                            1
+port                                                   7
+range                                                 12
+ref_module                                             2
+ref_obj                                               20
+ref_typespec                                          34
+sys_task_call                                          2
+task                                                   9
+=== UHDM Object Stats End ===
+[ERR:EL0547] ${SURELOG_DIR}/tests/ElabDefinitionDiagnostics/dut.sv:23:3: Elaboration error "used_stub: instantiated stub error".
+[INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/ElabDefinitionDiagnostics/slpp_all/surelog.uhdm ...
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 1
+[WARNING] : 4
+[   NOTE] : 5
+
+============================== Begin RoundTrip Results ==============================
+[roundtrip]: ${SURELOG_DIR}/tests/ElabDefinitionDiagnostics/builtin.sv | ${SURELOG_DIR}/build/regression/ElabDefinitionDiagnostics/roundtrip/builtin_000.sv | 0 | 0 |
+[roundtrip]: ${SURELOG_DIR}/tests/ElabDefinitionDiagnostics/dut.sv     | ${SURELOG_DIR}/build/regression/ElabDefinitionDiagnostics/roundtrip/dut_000.sv     | 9 | 32 |
+============================== End RoundTrip Results ==============================

--- a/tests/ElabDefinitionDiagnostics/ElabDefinitionDiagnostics.sl
+++ b/tests/ElabDefinitionDiagnostics/ElabDefinitionDiagnostics.sl
@@ -1,0 +1,1 @@
+-parse -sverilog -top ElabDefinitionDiagnostics dut.sv

--- a/tests/ElabDefinitionDiagnostics/dut.sv
+++ b/tests/ElabDefinitionDiagnostics/dut.sv
@@ -1,0 +1,32 @@
+// Guards two definition-time elaboration-diagnostic fixes:
+//  1. A module-scope $error must fire only when the module is INSTANTIATED,
+//     not for a definition that is excluded in this configuration.
+//  2. A typedef whose range divides by a parameter (`logic [64/N-1:0]`) is
+//     bound (ElaborationStep::bindTypedefs_) with the module's DEFAULT param
+//     value (N=0) -> a divide-by-zero that must be muted; the real range is
+//     computed per-instance with the overriding value (N=8).
+module dut #(parameter int N = 0) (output logic [7:0] o);
+  typedef logic [64/N-1:0] word_t;
+  word_t w;
+  assign w = '0;
+  assign o = w[7:0];
+endmodule
+
+module unused_stub #(parameter int M = 0) (output logic e);
+  // Never instantiated in this configuration -> $error must NOT fire.
+  $error("unused_stub: this stub must not be elaborated");
+  assign e = 1'b0;
+endmodule
+
+module used_stub (output logic e);
+  // Instantiated below -> $error MUST fire.
+  $error("used_stub: instantiated stub error");
+  assign e = 1'b0;
+endmodule
+
+module ElabDefinitionDiagnostics;
+  logic [7:0] o;
+  logic       e;
+  dut #(.N(8)) i_dut (.o(o));
+  used_stub    i_used (.e(e));
+endmodule


### PR DESCRIPTION
Two definition-time elaboration diagnostics were reported for module DEFINITIONS compiled/bound with their DEFAULT parameters, even when the module is excluded from (or overridden in) the actual instantiated design. Both now fire only in the elaborated (instantiated) context.  On CVA6 (cv64a6_imafdc_sv39) this removes the last two elaboration errors.

1. $error / $fatal / $warning / $info (ELAB_SYSTEM_*) CompileHelper::elaborationSystemTask ran while compiling the module DEFINITION (before the instantiation hierarchy is known) and emitted the diagnostic unconditionally -- so a conditionally-instantiated module that is excluded in this configuration still fired it (CVA6 cva6_accel_first_pass_decoder, guarded by `if (CVA6Cfg.EnableAccelerator)` = false).  The diagnostic is now deferred: the elab sys call is only stored at definition time (addElabSysCall) and fired by UhdmWriter (fireElabSysCalls) when the ELABORATED module/interface instance is written -- once per definition, and only for modules actually present in the design.  Genuinely-instantiated $error/$fatal still fire (unchanged goldens: BlackBox, DefaultPattern*, GenCaseStmt, LoopParam*, ...).

2. Divide-by-zero (UHDM_DIVIDE_BY_ZERO) ElaborationStep::bindTypedefs_ binds a typedef whose range depends on a parameter (`logic [clWords/accessWords-1:0]`) using the module's DEFAULT parameter values (a struct config `'0` => 0 divisor), producing a spurious divide-by-zero.  A new CompileHelper::setMuteTypedefRangeErrors flag scopes bindTypedefs_ so its typespec-range reductions are muted; the real range is computed per-instance with the overriding value.  Genuine divide-by-zero raised during real instance elaboration (DesignElaboration::collectParams_) still fires (unchanged goldens: DoublePres, CondOpLazyEval).

Full regression: 789 PASS, 0 DIFF.  New test tests/ElabDefinitionDiagnostics guards the $error deferral (an instantiated stub fires; an uninstantiated one does not).