### PR TITLE
Config: erase the cell use-clause from the map it was found in

### DIFF
--- a/src/Config/Config.cpp
+++ b/src/Config/Config.cpp
@@ -48,7 +48,7 @@ void Config::addInstanceUseClause(std::string_view instance,
 void Config::addCellUseClause(std::string_view cell, const UseClause& use) {
   auto previous = m_cellUseClauses.find(cell);
   if (previous != m_cellUseClauses.end()) {
-    m_instanceUseClauses.erase(previous);
+    m_cellUseClauses.erase(previous);
   }
   m_cellUseClauses.emplace(cell, use);
 }


### PR DESCRIPTION
## Problem

`Config::addCellUseClause` looks a key up in `m_cellUseClauses` but erases the
resulting iterator from **`m_instanceUseClauses`**:

```cpp
void Config::addCellUseClause(std::string_view cell, const UseClause& use) {
  auto previous = m_cellUseClauses.find(cell);
  if (previous != m_cellUseClauses.end()) {
    m_instanceUseClauses.erase(previous);   // <-- wrong container
  }
  m_cellUseClauses.emplace(cell, use);
}
```

The correct twin sits ten lines above it — `Config::addInstanceUseClause` does
`m_instanceUseClauses.find(...)` followed by `m_instanceUseClauses.erase(previous)`.
`addCellUseClause` looks like a copy of it with one member name left un-renamed.
Both members are the same type (`Config::UseClauseMap`), so this compiles, but
erasing an iterator that does not belong to the container is undefined
behaviour: libstdc++ rebalances with the wrong tree header, which frees a node
still reachable from `m_cellUseClauses` and decrements the *other* map's node
count. Iterating the cell use-clauses afterwards
(`DesignElaboration.cpp`, `for (auto& cellClause : config.getCellUseClauses())`)
then walks freed memory.

This is reached whenever a config declares two `cell` rules naming the same
cell — `ParseLibraryDef::parseConfigDefinition` calls `addCellUseClause` once
per `cell_clause`, keyed on the textual cell name, and the grammar
(`config_rule_statement*`) places no uniqueness constraint on it. No diagnostic
is emitted for the duplicate, so nothing blocks the path.

## Reproducer

`top.v`

```systemverilog
module top();
  m m1();
endmodule
module m();
endmodule
```

`dup.cfg`

```
config cfgdup;
design work.top;
default liblist work;
cell m liblist work;
cell m use work.m;
endconfig
```

```
$ surelog -parse -mt 0 -cfgfile dup.cfg -cfg cfgdup top.v
free(): invalid pointer / munmap_chunk(): invalid pointer
Aborted (core dumped)          # exit 134
```

Two identical `cell m liblist work;` rules abort the same way.

## Fix

Erase from the map the iterator came from, matching `addInstanceUseClause`:

```cpp
    m_cellUseClauses.erase(previous);
```

(`insert_or_assign` is not an option here: `UseClause` has const data members,
so it is not copy-assignable — which is presumably why the author used
erase-then-emplace.)

## Validation

Built `surelog-bin` and confirmed on the resulting executable:

- **Without the fix**: the reproducer aborts (exit 134, core dumped).
- **With the fix**: it elaborates cleanly (exit 0, 0 errors), and the intended
  last-rule-wins replacement still happens.
- **Controls**: a config with two *different* cell names, and one with
  duplicate **instance** rules (the sibling code path that erases from the
  correct map), both exit 0 before and after — so the crash is specific to this
  line.
- **Regressions** (all exit 0, 0 errors): struct/union typedefs, task/function
  port lists, classes, a parameterized module hierarchy, interfaces with
  modports, and gate primitives.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
