### PR TITLE
Skip attribute_instance in struct members and tf port items

### DIFF
--- a/src/DesignCompile/CompileStmt.cpp
+++ b/src/DesignCompile/CompileStmt.cpp
@@ -1767,6 +1767,12 @@ std::vector<io_decl*>* CompileHelper::compileTfPortList(
     io_decl* decl = s.MakeIo_decl();
     ios->push_back(decl);
     NodeId tf_data_type_or_implicit = fC->Child(tf_port_item);
+    // tf_port_item ::= { attribute_instance } [ tf_port_direction ] ...
+    // Skip the optional leading attributes before classifying the node.
+    while (fC->Type(tf_data_type_or_implicit) ==
+           VObjectType::paAttribute_instance) {
+      tf_data_type_or_implicit = fC->Sibling(tf_data_type_or_implicit);
+    }
     NodeId tf_data_type = fC->Child(tf_data_type_or_implicit);
     VObjectType tf_port_direction_type = fC->Type(tf_data_type_or_implicit);
     if (tf_port_direction_type != VObjectType::paData_type_or_implicit)
@@ -1786,7 +1792,7 @@ std::vector<io_decl*>* CompileHelper::compileTfPortList(
     if (fC->Type(type) == VObjectType::paVIRTUAL) type = fC->Sibling(type);
 
     NodeId unpackedDimension =
-        fC->Sibling(fC->Sibling(fC->Child(tf_port_item)));
+        fC->Sibling(fC->Sibling(tf_data_type_or_implicit));
     if (unpackedDimension &&
         (fC->Type(unpackedDimension) != VObjectType::paVariable_dimension))
       unpackedDimension = fC->Sibling(unpackedDimension);

--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -1682,6 +1682,12 @@ UHDM::typespec* CompileHelper::compileTypespec(
 
       while (struct_or_union_member) {
         NodeId Data_type_or_void = fC->Child(struct_or_union_member);
+        // struct_union_member ::= { attribute_instance } [random_qualifier]
+        // data_type_or_void ... - skip the optional leading attributes.
+        while (fC->Type(Data_type_or_void) ==
+               VObjectType::paAttribute_instance) {
+          Data_type_or_void = fC->Sibling(Data_type_or_void);
+        }
         NodeId Data_type = fC->Child(Data_type_or_void);
         NodeId List_of_variable_decl_assignments =
             fC->Sibling(Data_type_or_void);


### PR DESCRIPTION
## Problem

Two more places classify a grammar node without first skipping the optional
leading `attribute_instance`s the grammar allows — the same shape as #4124.

**1. `CompileHelper::compileTypespec`, `paStruct_union` case (`CompileType.cpp`)**

```cpp
NodeId Data_type_or_void = fC->Child(struct_or_union_member);
NodeId Data_type = fC->Child(Data_type_or_void);
```

`struct_union_member ::= { attribute_instance } [random_qualifier]
data_type_or_void ...`, so on an attributed member `Data_type_or_void` is an
`Attribute_instance` node. The member typespec then comes out null and the
struct is compiled with a member that has no typespec, which **segfaults**
during netlist elaboration.

**2. `CompileHelper::compileTfPortList` (`CompileStmt.cpp`)**

```cpp
NodeId tf_data_type_or_implicit = fC->Child(tf_port_item);
NodeId tf_data_type = fC->Child(tf_data_type_or_implicit);
VObjectType tf_port_direction_type = fC->Type(tf_data_type_or_implicit);
```

`tf_port_item ::= { attribute_instance } [ tf_port_direction ] ...`, so an
attributed function/task port is classified from the attribute node and
reported as `[ERR:UH0705] Unsupported data type "<... t<Attr_name> ...>"` on
legal code. `let_port_item` goes through the same function and misbehaves
identically.

## Reproducers

Struct member (segfault):

```systemverilog
module m;
  typedef struct {
    (* foo = 1 *) int a;
  } s_t;
  s_t s;
endmodule
```

```
$ surelog -parse -mt 0 -mp 0 repro.sv
Segmentation fault (core dumped)     # exit 139
```

Function port (spurious error):

```systemverilog
module m;
  function automatic int f((* foo = 1 *) input int a);
    return a;
  endfunction
  initial $display(f(3));
endmodule
```

```
$ surelog -parse -mt 0 -mp 0 repro2.sv
[ERR:UH0705] repro2.sv:2:31: Unsupported data type "<... t<Attr_name> ...>"   # exit 4
```

Both files parse and elaborate cleanly with the attribute removed.

## Fix

Skip the leading `attribute_instance`s before classifying, using the idiom
already in `CompileModule.cpp` (`:291-297`, `:319-325`) and `CompileStmt.cpp`
(`:128-133`):

```cpp
while (fC->Type(X) == VObjectType::paAttribute_instance) X = fC->Sibling(X);
```

In `compileTfPortList` the later `unpackedDimension` navigation re-read
`fC->Child(tf_port_item)`, which would pick the attribute back up, so it now
reuses the already-skipped `tf_data_type_or_implicit` (identical when there is
no attribute).

## Validation

Built `surelog-bin` and confirmed on the resulting executable:

- **Without the fix**: struct case exits 139 (segfault); function-port case
  exits 4 with the spurious `UH0705`.
- **With the fix**: both exit 0 with 0 errors.
- **Regressions** (all exit 0, 0 errors): packed/unpacked/nested structs and a
  packed union; task and function port lists covering `input`/`output`/`inout`,
  `ref`/`const ref`, unpacked-array ports and defaulted ports; class methods
  including a `ref` arg; a parameterized module hierarchy; interfaces with
  modports; and gate primitives. Also specifically checked an unpacked-array
  port both with and without an attribute, to cover the `unpackedDimension`
  change, and a file carrying attributes on several struct members and several
  tf ports at once.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
