### PR TITLE
CompileAssertion: handle disable iff and sequence local variables in declarations

### DIFF
--- a/src/DesignCompile/CompileAssertion.cpp
+++ b/src/DesignCompile/CompileAssertion.cpp
@@ -498,11 +498,20 @@ UHDM::property_decl* CompileHelper::compilePropertyDeclaration(
       Property_spec = fC->Sibling(Property_spec);
     }
   }
-  NodeId Clocking_event = fC->Child(Property_spec);
-  NodeId Property_expr = fC->Sibling(Clocking_event);
-  if (Property_expr == InvalidNodeId) {
-    Property_expr = Clocking_event;
-    Clocking_event = InvalidNodeId;
+  // property_spec ::= [clocking_event] [ disable iff (expression_or_dist) ]
+  //                   property_expr
+  // Both leading parts are optional, so select by node type rather than by
+  // position; otherwise a `disable iff` condition is taken as the property
+  // expression.
+  NodeId Clocking_event = InvalidNodeId;
+  NodeId Property_expr = fC->Child(Property_spec);
+  if (fC->Type(Property_expr) == VObjectType::paClocking_event) {
+    Clocking_event = Property_expr;
+    Property_expr = fC->Sibling(Property_expr);
+  }
+  if (fC->Type(Property_expr) == VObjectType::paExpression_or_dist) {
+    // The `disable iff` condition; not the property expression.
+    Property_expr = fC->Sibling(Property_expr);
   }
   UHDM::property_spec* prop_spec = s.MakeProperty_spec();
   prop_spec->VpiParent(result);
@@ -559,6 +568,15 @@ UHDM::sequence_decl* CompileHelper::compileSequenceDeclaration(
       prop_port_decl->Typespec(rtps);
       Sequence_port_item = fC->Sibling(Sequence_port_item);
     }
+    Sequence_expr = fC->Sibling(Sequence_expr);
+  }
+  // sequence_declaration ::= sequence name [(ports)] ;
+  //                          { assertion_variable_declaration } sequence_expr ;
+  // Skip the optional local variable declarations, as
+  // compilePropertyDeclaration already does, so the sequence body is not
+  // mistaken for one of them.
+  while (fC->Type(Sequence_expr) ==
+         VObjectType::paAssertion_variable_declaration) {
     Sequence_expr = fC->Sibling(Sequence_expr);
   }
   NodeId lookup = fC->Child(Sequence_expr);


### PR DESCRIPTION
Two fixes in the property/sequence **declaration** compilers, each mirroring an
idiom already used elsewhere in the same file.

## 1. `disable iff` is compiled as the property expression

`compilePropertyDeclaration` picked the parts of `property_spec` by position:

```cpp
NodeId Clocking_event = fC->Child(Property_spec);
NodeId Property_expr = fC->Sibling(Clocking_event);
if (Property_expr == InvalidNodeId) { /* no clocking event */ }
```

But `property_spec ::= [clocking_event] [ disable iff ( expression_or_dist ) ]
property_expr` — both leading parts are optional. With a `disable iff` present,
`Property_expr` lands on the `expression_or_dist` node, so the disable
condition is compiled as the property expression and its signal is reported as
an undefined property:

```systemverilog
module m;
  logic a, b, clk, rst;
  property p;
    @(posedge clk) disable iff (rst) a |-> b;
  endproperty
  assert property (p);
endmodule
```

```
[ERR:UH0729] repro.sv:4:33: Unresolved property "rst".     # exit 4
```

`rst` is a plain `logic`, and the code is legal SystemVerilog.

**Fix**: select by node type rather than position, the way
`compileConcurrentAssertion` already does for the clocking event
(`if (fC->Type(Property_expr) == VObjectType::paClocking_event) ...`), and step
over the `expression_or_dist` node.

## 2. A sequence body is dropped when the sequence declares local variables

`sequence_declaration ::= sequence name [(ports)] ;
{ assertion_variable_declaration } sequence_expr ;`

`compileSequenceDeclaration` skipped the optional port list but not the
optional `assertion_variable_declaration`s, so it read the sequence expression
out of the wrong node:

```systemverilog
module m;
  logic a, b, clk;
  sequence s;
    logic v;        // legal: assertion_variable_declaration
    a ##1 b;
  endsequence
  assert property (@(posedge clk) s);
endmodule
```

The resulting `sequence_decl` has no `vpiExpr` at all — the body `a ##1 b` is
silently gone. Removing the `logic v;` line makes it reappear. There is no
error, so the sequence just quietly loses its contents.

**Fix**: skip the declarations before reading the sequence expression, exactly
as `compilePropertyDeclaration` already does a few lines above.

## Validation

Built `surelog-bin` and confirmed on the resulting executable:

- Case 1: exit 4 with `Unresolved property "rst"` before, exit 0 with 0 errors
  after.
- Case 2: the `vpiExpr` count in the UHDM dump now matches the identical design
  without the local variable (it was one short before), i.e. the body is
  preserved.
- **Regressions** (all exit 0, 0 errors): property declarations that are plain,
  clocking-event-only, `disable iff`-only, both, and both-plus-local-variables;
  sequence declarations plain, with a local variable, and with a port list;
  plus struct/union typedefs, task/function port lists, classes, a
  parameterized module hierarchy, interfaces with modports and gate primitives.

## Related, not fixed here

While building the regression matrix I found the same `disable iff` confusion
in the **inline** statement path (`compileConcurrentAssertion`), which this PR
deliberately does not touch — it behaves inconsistently per keyword and I did
not want to guess at the intended modelling:

| form | result |
| --- | --- |
| `assert property (disable iff (rst) a \|-> b)` | `Unresolved property "rst"` |
| `assert property (@(posedge clk) disable iff (rst) a \|-> b)` | OK |
| `assume property (disable iff (rst) a \|-> b)` | `Unresolved property "rst"` |
| `assume property (@(posedge clk) disable iff (rst) a \|-> b)` | `Unresolved property "rst"` |
| `cover property (disable iff (rst) a)` | `Unresolved property "rst"` |
| `restrict property (disable iff (rst) a)` | `Unresolved property "rst"` |

(`assert` differs from `assume` here because `assert` passes the clocking-event
node straight to `compileExpression` while `assume` steps over it first.)
Separately, `cover property (a)` on a plain signal also reports
`Unresolved property "a"`, which looks unrelated to `disable iff`.

Happy to follow up on those in a separate PR if you can say how you'd like the
disable condition represented — nothing currently sets a disable condition on
`property_spec`, so today it is simply not modelled.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
