### PR TITLE
Support `// synthesis translate_off/on` + decouple region stripping v…

### DIFF
--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -77,14 +77,28 @@ void SV3_1aPpTreeShapeListener::enterTop_level_rule(
 
 void SV3_1aPpTreeShapeListener::enterComment(
     SV3_1aPpParser::CommentContext *ctx) {
+  // Strip `translate_off`..`translate_on` regions from the synthesizable model
+  // under `-synth` OR the lighter `-filterprotected` (which only removes these
+  // pragma-guarded regions, WITHOUT the full non-synthesizable-object filtering
+  // that `-synth` also performs — the uhdm2rtlil synthesis flow wants the former
+  // but must keep $display/assertions/etc.).
   if (m_pp->getCompileSourceFile()
+              ->getCommandLineParser()
+              ->reportNonSynthesizable() ||
+      m_pp->getCompileSourceFile()
           ->getCommandLineParser()
-          ->reportNonSynthesizable()) {
+          ->filterProtectedRegions()) {
     if (ctx->One_line_comment()) {
+      // Accept the `synopsys`, `synthesis` and `pragma` pragma prefixes — CVA6
+      // and many other designs guard simulation-only code with
+      // `// synthesis translate_off`, which must be excluded from the
+      // synthesizable model just like `synopsys`/`pragma translate_off`.
       static const std::regex reg1(R"(\/\/\s*synopsys\s+translate_off\s*)");
       static const std::regex reg2(R"(\/\/\s*pragma\s+translate_off\s*)");
+      static const std::regex reg3(R"(\/\/\s*synthesis\s+translate_off\s*)");
       const std::string &text = ctx->One_line_comment()->getText();
-      if (std::regex_match(text, reg1) || std::regex_match(text, reg2)) {
+      if (std::regex_match(text, reg1) || std::regex_match(text, reg2) ||
+          std::regex_match(text, reg3)) {
         m_filterProtectedRegions = true;
         m_inProtectedRegion = true;
       }
@@ -104,13 +118,18 @@ void SV3_1aPpTreeShapeListener::enterComment(
     }
   }
   if (m_pp->getCompileSourceFile()
+              ->getCommandLineParser()
+              ->reportNonSynthesizable() ||
+      m_pp->getCompileSourceFile()
           ->getCommandLineParser()
-          ->reportNonSynthesizable()) {
+          ->filterProtectedRegions()) {
     if (ctx->One_line_comment()) {
       static const std::regex reg1(R"(\/\/\s*synopsys\s+translate_on\s*)");
       static const std::regex reg2(R"(\/\/\s*pragma\s+translate_on\s*)");
+      static const std::regex reg3(R"(\/\/\s*synthesis\s+translate_on\s*)");
       const std::string &text = ctx->One_line_comment()->getText();
-      if (std::regex_match(text, reg1) || std::regex_match(text, reg2)) {
+      if (std::regex_match(text, reg1) || std::regex_match(text, reg2) ||
+          std::regex_match(text, reg3)) {
         if (!m_pp->getCompileSourceFile()
                  ->getCommandLineParser()
                  ->filterProtectedRegions()) {


### PR DESCRIPTION
…ia -filterprotected

Two related preprocessor improvements to `translate_off`..`translate_on` handling in SV3_1aPpTreeShapeListener::enterComment:

1. Recognize the `synthesis` pragma prefix.  Previously only `// synopsys translate_off` and `// pragma translate_off` were stripped; `// synthesis translate_off` — used by CVA6 (e.g. tc_sram_wrapper) and many other designs to guard simulation-only code — was left in the model.  Added a third regex for the `synthesis` prefix to both the translate_off and translate_on handlers.

2. Allow `-filterprotected` to trigger region stripping on its own.  The detection was gated solely on `reportNonSynthesizable()` (`-synth`), which also performs the heavier non-synthesizable-object filtering (dropping $display, tasks, class constructs, etc.).  A synthesis frontend often wants to exclude only the pragma-guarded regions while KEEPING $display/assertions. The gate is now `reportNonSynthesizable() || filterProtectedRegions()`, so the existing lightweight `-filterprotected` flag strips translate_off..translate_on regions without the object filtering.  Under `-synth` behaviour is unchanged (the `||` short-circuits), so the existing TranslateOff test is unaffected.

Verified directly: `-synth` still strips `// pragma translate_off` regions; `-filterprotected` strips `// synthesis translate_off` regions; without either flag nothing is stripped.