### PR TITLE
LibrarySet: use a deque so Library pointers survive later additions

### DIFF
--- a/include/Surelog/Library/LibrarySet.h
+++ b/include/Surelog/Library/LibrarySet.h
@@ -27,9 +27,9 @@
 
 #include <Surelog/Common/PathId.h>
 
+#include <deque>
 #include <ostream>
 #include <string_view>
-#include <vector>
 
 namespace SURELOG {
 
@@ -42,7 +42,7 @@ class LibrarySet final {
   LibrarySet() = default;
 
   Library* addLibrary(std::string_view name, SymbolTable* symbolTable);
-  std::vector<Library>& getLibraries() { return m_libraries; }
+  std::deque<Library>& getLibraries() { return m_libraries; }
   Library* getLibrary(std::string_view libName);
   Library* getLibrary(PathId fileId);
   void checkErrors(SymbolTable* symbols, ErrorContainer* errors) const;
@@ -50,7 +50,11 @@ class LibrarySet final {
 
  private:
   LibrarySet(const LibrarySet& orig) = default;
-  std::vector<Library> m_libraries;
+  // A deque (not a vector) so that Library* pointers handed out by
+  // addLibrary()/getLibrary() stay valid when a later library is added -- a
+  // library map file may recursively parse a nested .map/.cfg that appends
+  // more libraries while an earlier Library* is still in use.
+  std::deque<Library> m_libraries;
 };
 
 }  // namespace SURELOG


### PR DESCRIPTION
## Problem

`LibrarySet` stores its libraries in a `std::vector<Library>` and hands out raw
`Library*` pointers into it (`addLibrary` returns
`&m_libraries.emplace_back(...)`, `getLibrary` returns `&library`). Those
pointers are dangling as soon as another library is appended, because a
`vector` reallocates and moves its elements.

`SVLibShapeListener::enterLibrary_declaration` keeps such a pointer live across
exactly that event:

```cpp
Library *lib = librarySet->addLibrary(name, ...);   // pointer into the vector
for (auto pathSpec : ctx->file_path_spec()) {
  for (const auto &id : fileIds) {
    lib->addFileId(id);
    ...
    if ((type == ".cfg") || (type == ".map")) {
      ParseLibraryDef parser(...);
      parser.parseLibraryDefinition(id, lib);   // may append a Library -> vector realloc
    }
  }
}
```

When a library-map file lists a nested `.map`/`.cfg` before other files,
`parseLibraryDefinition` recurses and appends a new `Library`, reallocating the
vector. Every subsequent `lib->addFileId(...)` (and any `Library*` stored
earlier, e.g. via `setLibrary`) then writes through freed memory.

## Reproducers

`lib.map`

```
library LA nested.map, a.v, c.v;
```

`nested.map`

```
library LB b.v;
```

with trivial `a.v`, `b.v`, `c.v`, `top.v`:

```
$ surelog -parse -mt 0 -map lib.map top.v
Segmentation fault (core dumped)          # exit 139
```

A glob that matches both a nested map and ordinary sources
(`library LA src/*;` where `src/` holds `sub.map`, `a.v`, `z.v`) aborts the
same way with `free(): double free detected in tcache 2` (exit 134).

## Fix

Store the libraries in a `std::deque<Library>` instead. `std::deque` never
invalidates references or pointers to existing elements when a new element is
appended, so every `Library*` handed out stays valid for the lifetime of the
`LibrarySet`. The container is only ever `emplace_back`-ed and iterated with
range-`for` (no indexing, `.data()`, or random access, and the sole external
consumer — `Compiler.cpp` — is a range-`for`), so `deque` is a drop-in.

## Validation

Built `surelog-bin` and confirmed on the resulting executable:

- **Without the fix**: the nested-map reproducer segfaults (exit 139) and the
  glob reproducer double-frees (exit 134).
- **With the fix**: both exit 0. The nested case correctly registers each file
  under its own library (`LA@a`, `LA@c`, `LB@b` are compiled), 3-level map
  nesting works, and a map that recurses into a `.cfg` works. The glob case now
  emits the legitimate `[ERR:LIB0600] ... maps to multiple libraries` diagnostic
  (`src/a.v` really is claimed by both `LA` and `LB`) and exits cleanly instead
  of crashing.
- **Regressions** (isolated working directories, all clean): a plain module
  hierarchy, a single-library map, a plain (non-nested) library map, and a
  struct/function/sequence/property design all parse with no new errors.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
