### PR TITLE
PpTreeShapeListener: read STRING token (not null ESCAPED_CR) in text_blob

### DIFF
--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -1664,7 +1664,7 @@ void SV3_1aPpTreeShapeListener::exitText_blob(
     } else if (ctx->ESCAPED_CR()) {
       addVObject(ctx, VObjectType::ppESCAPED_CR);
     } else if (ctx->STRING()) {
-      addVObject(ctx, ctx->ESCAPED_CR()->getText(), VObjectType::ppString);
+      addVObject(ctx, ctx->STRING()->getText(), VObjectType::ppString);
     } else if (ctx->OPEN_PARENS()) {
       addVObject(ctx, ctx->getText(), VObjectType::ppText_blob);
     } else if (ctx->CLOSE_PARENS()) {


### PR DESCRIPTION
## Problem

`SV3_1aPpTreeShapeListener::exitText_blob` handles each `text_blob` alternative
with an `else if` chain in which every branch reads `getText()` from the very
accessor its guard tested — except the `STRING` branch, which reads the wrong
one:

```cpp
} else if (ctx->ESCAPED_CR()) {
  addVObject(ctx, VObjectType::ppESCAPED_CR);
} else if (ctx->STRING()) {
  addVObject(ctx, ctx->ESCAPED_CR()->getText(), VObjectType::ppString);
  //              ^^^^^^^^^^^^^^^^ guarded by STRING(), but derefs ESCAPED_CR()
}
```

Because the preceding `else if (ctx->ESCAPED_CR())` already evaluated false to
reach this branch, `ctx->ESCAPED_CR()` is null here, so
`ctx->ESCAPED_CR()->getText()` is a null-pointer dereference.

A double-quoted string reaches this branch through the `` `uselib `` directive:
`uselib_directive: TICK_USELIB text_blob+;`, and `text_blob` lists `STRING` as
one of its single-token alternatives, so the string after `` `uselib `` parses
as a `text_blob` whose `STRING()` is non-null and `ESCAPED_CR()` is null. (A
bare top-level string does not hit this — the `string` rule wins there; it takes
`` `uselib `` to route a `STRING` into `text_blob`.)

## Reproducer

```systemverilog
`uselib "foo"
```

```
$ surelog -E t.sv          # (and -parse)
Segmentation fault (core dumped)     # exit 139
```

`` `uselib abc "z" `` and `` `uselib "a" "b" `` crash the same way;
`` `uselib foo `` (identifier) and `` `uselib 12.3 `` (number) do not.

## Fix

Read the `STRING` token the branch is guarded on, mirroring the sibling
branches (`Simple_identifier` and `Fixed_point_number` a few lines up, each of
which calls `getText()` on the accessor its own guard tested):

```cpp
addVObject(ctx, ctx->STRING()->getText(), VObjectType::ppString);
```

## Validation

Built `surelog-bin` and confirmed on the resulting executable:

- **Without the fix**: `` `uselib "foo" `` segfaults (exit 139) under both `-E`
  and `-parse`; `` `uselib abc "z" `` and multi-string forms crash too.
- **With the fix**: all of those complete without crashing, and the string is
  recorded as a `ppString` object (the branch now reads the correct token).
- **Regressions** (all clean): `` `uselib `` with an identifier or a number, a
  bare string literal, `` `define ``/`` `ifdef `` conditional compilation, an
  include-guard `` `ifndef `` pattern, and a normal module containing a string
  literal.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
