### PR TITLE
CommandLineParser: avoid size_t underflow in -cmd_ren/-cmd_mrg/ignore guards

### DIFF
--- a/src/CommandLine/CommandLineParser.cpp
+++ b/src/CommandLine/CommandLineParser.cpp
@@ -610,7 +610,7 @@ void CommandLineParser::processArgs_(const std::vector<std::string>& args,
       }
       continue;
     } else if (arg == "-cmd_ren") {
-      if (i < args.size() - 2) {
+      if (i + 2 < args.size()) {
         cmd_rename[args[i + 1]] = args[i + 2];
         i += 2;  // also skip two arguments
       } else {
@@ -619,7 +619,7 @@ void CommandLineParser::processArgs_(const std::vector<std::string>& args,
       }
       continue;
     } else if (arg == "-cmd_mrg") {
-      if (i < args.size() - 2) {
+      if (i + 2 < args.size()) {
         cmd_merge[args[i + 1]] = args[i + 2];
         i += 2;  // also skip two arguments
       } else {
@@ -631,7 +631,7 @@ void CommandLineParser::processArgs_(const std::vector<std::string>& args,
     auto cmd_ignore_it = cmd_ignore.find(arg);
     if (cmd_ignore_it != cmd_ignore.end()) {
       // found arg in list of commands to be ignored
-      if (i < args.size() - cmd_ignore_it->second) {
+      if (i + cmd_ignore_it->second < args.size()) {
         i += cmd_ignore_it->second;
       } else {
         std::cerr << "Missing arguments to ignored command " << arg


### PR DESCRIPTION
## Problem

`CommandLineParser::processArgs_` has three option guards written as
`if (i < args.size() - N)`. `args.size()` is `size_t`, so `args.size() - N`
underflows to a huge value whenever `args.size() < N`, making the guard pass
when it should fail:

```cpp
} else if (arg == "-cmd_ren") {
  if (i < args.size() - 2) {                 // 1u - 2u == SIZE_MAX
    cmd_rename[args[i + 1]] = args[i + 2];    // out-of-bounds read
```

- **`-cmd_ren` (line 613)** and **`-cmd_mrg` (line 622)**: running Surelog with
  just `-cmd_ren` (or `-cmd_mrg`) as the only argument makes `args.size() == 1`,
  so `1 - 2` wraps to `SIZE_MAX`, `0 < SIZE_MAX` is true, and the body reads
  `args[1]`/`args[2]` past the end of a one-element vector and copies those
  garbage `std::string` references into a map — **segfault**.
- **custom ignored-command (line 634)**: `if (i < args.size() - cmd_ignore_it->second)`,
  where `second` is the 0–100 skip-count registered via `-cmd_ign`. When fewer
  than `second` args follow, the subtraction underflows and the code silently
  takes the skip branch (`i += second`) instead of reporting the missing
  arguments — a suppressed diagnostic rather than a crash.

The sibling `-cmd_ign` handler (line 597) already uses the correct,
underflow-free form `if (i + 2 < args.size())`.

## Reproducers

```
$ surelog -cmd_ren
Segmentation fault (core dumped)     # exit 139

$ surelog -cmd_mrg
Segmentation fault (core dumped)     # exit 139
```

Both are also reachable through a `-f` command file whose sole token is the
option. `surelog -cmd_ign FOO 5 FOO` silently skips instead of reporting the
missing arguments.

## Fix

Rewrite each guard in the `i + N < args.size()` form used by `-cmd_ign`, which
never underflows:

- line 613: `if (i + 2 < args.size())`
- line 622: `if (i + 2 < args.size())`
- line 634: `if (i + cmd_ignore_it->second < args.size())`

## Validation

Built `surelog-bin` and confirmed on the resulting executable:

- **Without the fix**: `surelog -cmd_ren` and `surelog -cmd_mrg` segfault
  (exit 139); `-cmd_ign FOO 5 FOO` silently skips.
- **With the fix**: `-cmd_ren` and `-cmd_mrg` alone exit cleanly with
  `Missing arguments to -cmd_ren` / `-cmd_mrg`; `-cmd_ign FOO 5 FOO` now reports
  `Missing arguments to ignored command FOO`.
- **Regressions** (all exit 0, no error): `-cmd_ren OLD NEW`, `-cmd_mrg OLD NEW`,
  `-cmd_ign FOO 1 FOO extra`, `-cmd_ign` alone (already-correct sibling), and a
  normal design compiled alongside `-cmd_ren OLD NEW`.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
