### PR TITLE
DesignElaboration: guard null parameter on out-of-range positional override

### DIFF
--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -2378,9 +2378,15 @@ std::vector<std::string_view> DesignElaboration::collectParams_(
               complex = true;
               instance->setComplexValue(name, complexV);
               instance->setOverridenParam(name);
-              m_helper.reorderAssignmentPattern(module, p->getUhdmParam(),
-                                                complexV, m_compileDesign,
-                                                instance, 0);
+              // An out-of-range positional override leaves p null (no declared
+              // parameter to reorder against); the out-of-range error is
+              // already reported above. Guard the reorder as the sibling call
+              // below does.
+              if (p) {
+                m_helper.reorderAssignmentPattern(module, p->getUhdmParam(),
+                                                  complexV, m_compileDesign,
+                                                  instance, 0);
+              }
             }
           }
         }


### PR DESCRIPTION
## Problem

In `DesignElaboration::collectParams_`, the positional (ordered)
parameter-override branch declares `Parameter* p = nullptr;` and only assigns it
inside an in-range guard:

```cpp
Parameter* p = nullptr;
if (index < params.size()) {
  p = params.at(index);
  ...
}
```

When an instantiation supplies **more** positional parameter overrides than the
module declares, `index` reaches `params.size()` and `p` stays null. That
out-of-range case is detected and reported
(`ELAB_OUT_OF_RANGE_PARAM_INDEX`), but execution does not skip the rest of the
loop body. If the extra override is an assignment pattern (which survives
reduction as a UHDM `operation`), the `uhdmoperation` branch runs and calls
`p->getUhdmParam()` on the null `p`:

```cpp
} else if (complexV->UhdmType() == UHDM::uhdmoperation) {
  if (instance) {
    ...
    m_helper.reorderAssignmentPattern(module, p->getUhdmParam(), ...);
    //                                        ^ p is null on an out-of-range override
```

`getUhdmParam()` is a member load through `this`, so this is a null dereference
→ segfault during design elaboration. The sibling `reorderAssignmentPattern`
call later in the same function (in the named-override path) is already guarded
by `if (p)`; this branch omits that guard.

## Reproducer

```systemverilog
module sub #(parameter W = 1) (); endmodule
module top; sub #(1, '{1,2}) u(); endmodule
```

```
$ surelog -parse -mt 0 t.sv
Segmentation fault (core dumped)     # exit 139
```

`sub #(1, '{0:1,1:2})` (keyed pattern) crashes identically. An extra **constant**
override (`sub #(1, 2)`) does not — it takes the `uhdmconstant` branch, which
never touches `p` — so only an out-of-range override that is an assignment
pattern reaches the null dereference.

## Fix

Guard the reorder call on non-null `p`, mirroring the sibling guard on the
identical call later in this function. An out-of-range positional override has
no declared parameter to reorder against, so skipping the reorder is correct;
the out-of-range error is already reported and `setComplexValue`/
`setOverridenParam` have already run.

```cpp
if (p) {
  m_helper.reorderAssignmentPattern(module, p->getUhdmParam(), ...);
}
```

## Validation

Built `surelog-bin` and confirmed on the resulting executable:

- **Without the fix**: the reproducer and its keyed-pattern variant segfault
  (exit 139).
- **With the fix**: both exit cleanly (exit 4) with
  `Out of range parameter index`, the same diagnostic the constant-override case
  already produces.
- **Controls unchanged**: an in-range assignment-pattern override, an extra
  constant override, the correct parameter count, and a two-parameter module
  where the pattern index is in range all behave exactly as before.
- **Regressions** (exit 0): a parameterized module hierarchy with a `type`
  parameter, and a module whose parameter default and named override are
  assignment patterns (exercising the reorder path with a valid `p`).

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
