### PR TITLE
CompileExpression: keep [lo:hi] ranges in expression-form inside operator

### DIFF
--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -2337,6 +2337,28 @@ UHDM::any *CompileHelper::compileExpression(
               rval = fC->Sibling(rval);
           }
           if (opType == VObjectType::paINSIDE) {
+            // When ANY `[lo:hi]` range member is present, the braces parse as
+            // a true Open_range_list (each member wrapped in a Value_range
+            // node) instead of the false-Concatenation shape below.  The old
+            // navigation (Child(Child(rval))) then landed INSIDE the first
+            // Value_range and compiled ONLY its low bound — `rm inside
+            // {[3'b000:3'b010]}` lost the range entirely (CVA6 decoder FP
+            // rounding-mode checks flagged legal instructions illegal).
+            // compileExpression on a Value_range node builds the proper
+            // vpiListOp(lo, hi).
+            if (fC->Type(rval) == VObjectType::paOpen_range_list) {
+              NodeId Member = fC->Child(rval);
+              while (Member) {
+                if (UHDM::any *exp = compileExpression(
+                        component, fC, Member, compileDesign, reduce,
+                        operation, instance, muteErrors)) {
+                  operands->push_back(exp);
+                }
+                Member = fC->Sibling(Member);
+              }
+              // RHS is done, skip handling below
+              break;
+            }
             // Because open_range_list is stored in { }, it is being interpreted
             // as a concatenation operation. Code below constructs it manually.
             // Example tree:


### PR DESCRIPTION
## Summary

`x inside {[lo:hi], ...}` loses every range member: when any range is present, the braces parse as a **true `Open_range_list`** (each member wrapped in a `Value_range` node) instead of the false-Concatenation shape the `paINSIDE` branch assumes. The hardcoded `Child(Child(rval))` navigation then lands *inside* the first `Value_range` and compiles only its **low bound** as a plain member — both elaborated and non-elaborated views end up with `InsideOp(x, <low-bound constant>)` and the range is gone.

The case-inside form is unaffected (it iterates `Value_range` nodes); only the expression form is broken.

**Fix:** when `rval` is a `paOpen_range_list`, iterate its children through `compileExpression` — the existing `paValue_range` case already builds the proper `vpiListOp(lo, hi)` member (and wraps plain values in single-element ListOps).

## Impact / how found

Found by CVA6 decoder formal equivalence (Yosys UHDM frontend vs slang): the FP rounding-mode windows `instr.rftype.rm inside {[3'b000:3'b010]}` (cva6 decoder.sv 1485–1525) matched only `rm==0`, flagging legal FLT/FCMP/FCVT instructions illegal.

Verified on:
```systemverilog
always_comb y = !(rm inside {[3'b000:3'b010]});
assign z = rm inside {3'b111, [3'b011:3'b100]};
```
UHDM now carries `ListOp(3'b000, 3'b010)` / `ListOp(3'b111)` + `ListOp(3'b011, 3'b100)`; downstream truth tables are exact, and the CVA6 decoder's FP decode layer matches slang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)