### PR TITLE
CompileType: keep the packed dimension of a multi-member anonymous struct

### DIFF
--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -1273,6 +1273,14 @@ UHDM::typespec* CompileHelper::compileTypespec(
   if (fC->Type(Packed_dimension) == VObjectType::paStruct_union_member ||
       fC->Type(Packed_dimension) == VObjectType::slStringConst) {
     Packed_dimension = fC->Sibling(Packed_dimension);
+    // An anonymous struct/union has ALL of its members as siblings before
+    // any trailing packed dimension — a single skip only handled one-member
+    // structs, so `struct packed { a; b; } [N-1:0] x;` silently LOST the
+    // outer [N-1:0] (CVA6 cva6_tlb tags_q/content_q collapsed to a single
+    // element).  Skip every member.
+    while (fC->Type(Packed_dimension) == VObjectType::paStruct_union_member) {
+      Packed_dimension = fC->Sibling(Packed_dimension);
+    }
   }
 
   if (fC->Type(Packed_dimension) == VObjectType::paSigning_Signed ||


### PR DESCRIPTION
## Problem

`compileTypespec` walks past a struct/union body to find a trailing packed
dimension, but it skipped only **one** `Struct_union_member` sibling:

```cpp
if (fC->Type(Packed_dimension) == VObjectType::paStruct_union_member ||
    fC->Type(Packed_dimension) == VObjectType::slStringConst) {
  Packed_dimension = fC->Sibling(Packed_dimension);
}
```

An anonymous struct lists **every** member as a sibling, so for a struct with
more than one member the search lands on the second member instead of the
`Packed_dimension` node, and the outer dimension is silently dropped:

```systemverilog
struct packed {
  logic [15:0] vpn;
  logic        valid;
} [TLB_ENTRIES-1:0] tags_q;   // [TLB_ENTRIES-1:0] LOST
```

The net then collapses to a single element. A single-member anonymous struct
happens to work, which is why this went unnoticed.

Real-world impact — CVA6's `cva6_tlb`:

```systemverilog
struct packed { ... } [TLB_ENTRIES-1:0] tags_q, tags_n;
struct packed { pte_cva6_t pte; pte_cva6_t gpte; } [TLB_ENTRIES-1:0] content_q, content_n;
```

became 62 and 128 bits instead of 248 and 512 (1 entry instead of 4), so TLB
entries 1..3 read as X and no lookup could ever hit.

## Fix

Skip *every* member before looking for the packed dimension.

## Verification

- The elaborated nets are now correctly sized (`tags_q` 248 bits, `content_q`
  512 bits), and CVA6's `cva6_tlb` becomes formally equivalent to the
  `read_slang` reference under a SAT miter.
- Surelog regression (`scripts/regression.py run --filters` over the affected
  large designs, and a full run): **no new DIFFs, 0 FAIL, 0 SEGFLT**. Verified
  by bisection against a pristine build of the same tree.