### PR TITLE
Resolve `parameter type A = B` where B is another type parameter

### DIFF
--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -3506,16 +3506,45 @@ bool CompileHelper::compileParameterDeclaration(
       p->VpiName(fC->SymName(Identifier));
       fC->populateCoreMembers(Identifier, Identifier, p);
       NodeId Data_type = fC->Child(Constant_param_expression);
-      if (typespec* tps =
-              compileTypespec(component, fC, Data_type, compileDesign,
-                              Reduce::No, p, nullptr, false)) {
+      typespec* tps = compileTypespec(component, fC, Data_type, compileDesign,
+                                      Reduce::No, p, nullptr, false);
+      typespec* borrowed_tps = nullptr;
+      if (tps == nullptr) {
+        // `parameter type A = B` where B is ANOTHER type parameter of the
+        // same list.  compileTypespec is called with no instance here, so
+        // its paExpression case cannot bindTypespec(B) and returns null —
+        // the parameter is then left with NO typespec at all, and every
+        // port declared `A` collapses to 1 bit (CVA6's hpdcache modules
+        // chain `parameter type fifo_data_t = hpdcache_mem_req_t`).  B is
+        // already in `parameters` if it was declared earlier, so resolve
+        // the chain directly against that list.
+        NodeId nameId = Data_type;
+        while (nameId && fC->Type(nameId) != VObjectType::slStringConst)
+          nameId = fC->Child(nameId);
+        if (nameId) {
+          const std::string_view refName = fC->SymName(nameId);
+          for (UHDM::any* prev : *parameters) {
+            if (prev == p) continue;
+            if (prev->UhdmType() != UHDM::uhdmtype_parameter) continue;
+            if (prev->VpiName() != refName) continue;
+            if (UHDM::ref_typespec* prt =
+                    ((UHDM::type_parameter*)prev)->Typespec())
+              borrowed_tps = prt->Actual_typespec();
+            break;
+          }
+        }
+      }
+      if (tps || borrowed_tps) {
         if (p->Typespec() == nullptr) {
           ref_typespec* tpsRef = s.MakeRef_typespec();
           tpsRef->VpiParent(p);
           p->Typespec(tpsRef);
         }
-        p->Typespec()->Actual_typespec(tps);
-        tps->VpiParent(p);
+        // A borrowed typespec still BELONGS to the parameter it was declared
+        // on — point at it without re-parenting, or the original loses its
+        // owner and the chain breaks in the other direction.
+        p->Typespec()->Actual_typespec(tps ? tps : borrowed_tps);
+        if (tps) tps->VpiParent(p);
       }
       if (localParam) {
         p->VpiLocalParam(true);

--- a/third_party/tests/Ariane2024/Ariane2024.log
+++ b/third_party/tests/Ariane2024/Ariane2024.log
@@ -6703,7 +6703,7 @@ property_spec                                        404
 range                                              25869
 ref_module                                           362
 ref_obj                                            90273
-ref_typespec                                      104557
+ref_typespec                                      104559
 ref_var                                               21
 return_stmt                                          342
 short_int_typespec                                    16


### PR DESCRIPTION
A type parameter whose default is **another type parameter** was left with no typespec at all, so every port declared with it collapsed to 1 bit.

```systemverilog
parameter type noc_req_t = struct packed { ... 49 bits ... },
parameter type req_t     = noc_req_t     // chained
...
input req_t in_i                          // -> 1 bit, should be 49
```

A type parameter defaulted **directly** to a struct, or to a package-qualified struct, always resolved — only the chain failed. In the elaborated UHDM the chained parameter has no `vpiTypespec`, where the non-chained one carries `ref_typespec → struct_typespec`; the port's LowConn is a bare `logic_var`, so a consumer has nothing to size from.

### Cause

`compileParameterDeclaration`'s `paTYPE` branch compiles the default with

```cpp
compileTypespec(component, fC, Data_type, compileDesign, Reduce::No,
                p, /*instance=*/nullptr, false)
```

and `compileTypespec`'s `paExpression` case can only resolve a named type through `bindTypespec(name, instance, s)` — which it skips entirely when `instance` is null. The call returns null and the parameter is never given a typespec.

### Fix

The referenced parameter is already in the `parameters` vector being built, so the chain resolves against that list directly — no instance required.

The borrowed typespec still **belongs to the parameter it was declared on**, so it is referenced *without* re-parenting. Re-parenting would leave the original without an owner and break the chain in the other direction.

### Regression — 791 PASS / 0 DIFF / 0 FAIL

`Ariane2024`'s golden is regenerated for `ref_typespec` 104557 → 104559.

That +2 is this fix's own footprint: two chained type parameters in that design now carry a typespec they previously lacked, each allocating one `ref_typespec`. No other object count moves. **Verified by A/B** — with the patch reverted and the binary rebuilt, Ariane2024 passes against the *old* golden; with it applied, only that single row differs.

### How it was found

A per-module SystemVerilog frontend equivalence sweep over CVA6, where it 1-bit-sized the data ports of the hpdcache modules that chain their types — `parameter type fifo_data_t = hpdcache_mem_req_t` in `hpdcache_fifo_reg` and `hpdcache_sync_buffer`, giving 1 bit instead of 84.

### Known limitation, not addressed here

`type X = <type_param> [range]` — a chained type parameter carrying a **packed dimension** — still compiles to a bare `integer_typespec` and measures 32 bits regardless of the element type (seen on `hpdcache_mem_resp_demux`'s `localparam type rt_t = resp_id_t [RT_DEPTH-1:0]`). Same family, separate defect; kept out of this change so the two remain bisectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)