### PR TITLE
Build a packed_array_typespec for `parameter type X = <type> [msb:lsb]`

### DIFF
--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -3509,6 +3509,75 @@ bool CompileHelper::compileParameterDeclaration(
       typespec* tps = compileTypespec(component, fC, Data_type, compileDesign,
                                       Reduce::No, p, nullptr, false);
       typespec* borrowed_tps = nullptr;
+
+      // `parameter type X = <other type> [msb:lsb]` — a named type carrying a
+      // PACKED DIMENSION.  The grammar parses this as an EXPRESSION (a
+      // Constant_primary naming the type, with a Constant_select holding the
+      // range) rather than as a data type, so compileTypespec sizes it as a
+      // plain integer: `type rt_t = resp_id_t [DEPTH-1:0]` came out 32 bits
+      // regardless of the element type (CVA6 hpdcache_mem_resp_demux's
+      // rt_t, 32 instead of 8).  Detect the shape and build the
+      // packed_array_typespec the declaration actually means.
+      {
+        NodeId elemNameId = Data_type;
+        while (elemNameId && fC->Type(elemNameId) != VObjectType::slStringConst)
+          elemNameId = fC->Child(elemNameId);
+        NodeId selectId = elemNameId ? fC->Sibling(elemNameId) : InvalidNodeId;
+        // Constant_select -> [Constant_bit_select] Constant_part_select_range
+        NodeId rangeId;
+        if (selectId && fC->Type(selectId) == VObjectType::paConstant_select) {
+          for (NodeId c = fC->Child(selectId); c; c = fC->Sibling(c)) {
+            if (fC->Type(c) == VObjectType::paConstant_part_select_range) {
+              NodeId cr = fC->Child(c);
+              if (cr && fC->Type(cr) == VObjectType::paConstant_range)
+                rangeId = cr;
+              break;
+            }
+          }
+        }
+        if (rangeId) {
+          // Element type: another type parameter in this same list (the
+          // common case), else whatever compileTypespec makes of the bare
+          // name on its own.
+          typespec* elemTs = nullptr;
+          const std::string_view elemName = fC->SymName(elemNameId);
+          for (UHDM::any* prev : *parameters) {
+            if (prev == p) continue;
+            if (prev->UhdmType() != UHDM::uhdmtype_parameter) continue;
+            if (prev->VpiName() != elemName) continue;
+            if (UHDM::ref_typespec* prt =
+                    ((UHDM::type_parameter*)prev)->Typespec())
+              elemTs = prt->Actual_typespec();
+            break;
+          }
+          if (elemTs == nullptr)
+            elemTs = compileTypespec(component, fC, elemNameId, compileDesign,
+                                     Reduce::No, p, nullptr, false);
+          NodeId lexpr = fC->Child(rangeId);
+          NodeId rexpr = lexpr ? fC->Sibling(lexpr) : InvalidNodeId;
+          if (elemTs && lexpr && rexpr) {
+            packed_array_typespec* pats = s.MakePacked_array_typespec();
+            ref_typespec* elemRef = s.MakeRef_typespec();
+            elemRef->Actual_typespec(elemTs);
+            elemRef->VpiParent(pats);
+            pats->Elem_typespec(elemRef);
+            range* rg = s.MakeRange();
+            rg->Left_expr((expr*)compileExpression(
+                component, fC, lexpr, compileDesign, Reduce::No, rg, nullptr));
+            rg->Right_expr((expr*)compileExpression(
+                component, fC, rexpr, compileDesign, Reduce::No, rg, nullptr));
+            rg->VpiParent(pats);
+            VectorOfrange* rgs = s.MakeRangeVec();
+            rgs->push_back(rg);
+            pats->Ranges(rgs);
+            fC->populateCoreMembers(Data_type, Data_type, pats);
+            // Do NOT re-parent elemTs: like the chained case below, the
+            // element typespec still belongs to its own declaration.
+            tps = pats;
+          }
+        }
+      }
+
       if (tps == nullptr) {
         // `parameter type A = B` where B is ANOTHER type parameter of the
         // same list.  compileTypespec is called with no instance here, so

--- a/tests/ClassScope/ClassScope.log
+++ b/tests/ClassScope/ClassScope.log
@@ -10144,7 +10144,7 @@ AST_DEBUG_END
 begin                                                 24
 bit_select                                            32
 class_defn                                             1
-constant                                             903
+constant                                             905
 delay_control                                         18
 design                                                 1
 gen_if                                                 8
@@ -10156,15 +10156,16 @@ integer_typespec                                       1
 interface_inst                                        49
 logic_typespec                                         4
 module_inst                                           46
-operation                                            134
+operation                                            135
 package                                                2
+packed_array_typespec                                  1
 param_assign                                         242
 parameter                                            242
 part_select                                           31
-range                                                  3
+range                                                  4
 ref_module                                            96
-ref_obj                                              533
-ref_typespec                                          94
+ref_obj                                              534
+ref_typespec                                          95
 sys_func_call                                        213
 type_parameter                                        15
 unsupported_typespec                                  38
@@ -10174,7 +10175,7 @@ unsupported_typespec                                  38
 begin                                                 32
 bit_select                                            32
 class_defn                                             1
-constant                                             919
+constant                                             921
 delay_control                                        122
 design                                                 1
 gen_if                                                 8
@@ -10186,15 +10187,16 @@ integer_typespec                                       1
 interface_inst                                        73
 logic_typespec                                         4
 module_inst                                           70
-operation                                            151
+operation                                            152
 package                                                2
+packed_array_typespec                                  1
 param_assign                                         444
 parameter                                            434
 part_select                                           31
-range                                                  3
+range                                                  4
 ref_module                                            96
-ref_obj                                             1282
-ref_typespec                                         126
+ref_obj                                             1283
+ref_typespec                                         127
 sys_func_call                                        510
 type_parameter                                        15
 unsupported_typespec                                  38
@@ -10374,7 +10376,7 @@ design: (work@top)
       \_type_parameter: (work@C::T), line:6:21, endln:6:22
       |vpiFullName:work@C::T
       |vpiActual:
-      \_integer_typespec: , line:6:25, endln:6:48
+      \_packed_array_typespec: , line:6:25, endln:6:48
   |vpiParamAssign:
   \_param_assign: , line:2:15, endln:2:26
     |vpiParent:
@@ -24170,30 +24172,24 @@ design: (work@top)
 \_logic_typespec: , line:3:30, endln:3:35
   |vpiParent:
   \_type_parameter: (work@C::PARAM_T), line:3:20, endln:3:27
-\_integer_typespec: , line:6:25, endln:6:48
+\_packed_array_typespec: , line:6:25, endln:6:48
   |vpiParent:
   \_type_parameter: (work@C::T), line:6:21, endln:6:22
-  |vpiExpr:
-  \_part_select: PARAM_T (work@C::T::PARAM_T), line:6:25, endln:6:48
+  |vpiRange:
+  \_range: 
     |vpiParent:
-    \_type_parameter: (work@C::T), line:6:21, endln:6:22
-    |vpiName:PARAM_T
-    |vpiFullName:work@C::T::PARAM_T
-    |vpiDefName:PARAM_T
-    |vpiActual:
-    \_type_parameter: (work@C::PARAM_T), line:3:20, endln:3:27
-    |vpiConstantSelect:1
+    \_packed_array_typespec: , line:6:25, endln:6:48
     |vpiLeftRange:
     \_operation: , line:6:34, endln:6:45
       |vpiParent:
-      \_part_select: PARAM_T (work@C::T::PARAM_T), line:6:25, endln:6:48
+      \_range: 
       |vpiOpType:11
       |vpiOperand:
-      \_ref_obj: (work@C::T::PARAM_T::PARAM_E), line:6:34, endln:6:41
+      \_ref_obj: (work@C::T::PARAM_E), line:6:34, endln:6:41
         |vpiParent:
         \_operation: , line:6:34, endln:6:45
         |vpiName:PARAM_E
-        |vpiFullName:work@C::T::PARAM_T::PARAM_E
+        |vpiFullName:work@C::T::PARAM_E
         |vpiActual:
         \_parameter: (work@C::PARAM_E), line:2:15, endln:2:22
       |vpiOperand:
@@ -24210,6 +24206,13 @@ design: (work@top)
       |vpiSize:64
       |UINT:0
       |vpiConstType:9
+  |vpiElemTypespec:
+  \_ref_typespec: (work@C::T)
+    |vpiParent:
+    \_packed_array_typespec: , line:6:25, endln:6:48
+    |vpiFullName:work@C::T
+    |vpiActual:
+    \_logic_typespec: , line:3:30, endln:3:35
 \_int_typespec: , line:44:13, endln:44:36
 \_unsupported_typespec: (T), line:45:40, endln:45:41
   |vpiParent:


### PR DESCRIPTION
A type parameter whose default is a named type carrying a **packed dimension** was sized as a plain 32-bit integer, regardless of the element type:

```systemverilog
parameter  type resp_id_t = logic [1:0],
localparam int  DEPTH     = 4,
localparam type rt_t      = resp_id_t [DEPTH-1:0]   // 2*4 = 8 bits
```

`rt_t` came out **32 bits instead of 8**.

### Cause

`<name> [msb:lsb]` does **not** parse as a data type with a packed dimension. The grammar produces an *expression*:

```
Constant_primary
  ├─ StringConst  "resp_id_t"          <- element type
  └─ Constant_select
       └─ Constant_part_select_range
            └─ Constant_range          <- [DEPTH-1 : 0]
```

so `compileTypespec` falls through to its integer handling and the dimension is lost along with the element type.

### Fix

Detect that shape in `compileParameterDeclaration`'s `paTYPE` branch and build the `packed_array_typespec` the declaration actually means. The element type is resolved from the same parameter list first (the common case is a chain onto another type parameter, as fixed in #4142), else by compiling the bare name.

As in that fix, the element typespec is referenced **without re-parenting** — it still belongs to its own declaration.

### Regression — 791 PASS / 0 DIFF / 0 FAIL

The `ClassScope` golden is regenerated. That test **already contained the construct**:

```systemverilog
localparam type T = PARAM_T [PARAM_E - 1:0];   // tests/ClassScope/dut.sv:6
```

It now gets a proper `packed_array_typespec` with its range, where before it had **no array typespec at all**; `PARAM_E`'s reference is also now bound to `parameter work@C::PARAM_E`, which it previously was not. The golden delta is only that typespec's own object counts (+1 `packed_array_typespec`, +1 `range`, +1 `ref_typespec`, plus the range's operands) — no message or semantic row changes.

Attribution is direct rather than inferred: the same tree at `master` gave 791 PASS / **0 DIFF** immediately before this patch was applied.

That an existing upstream test exercises the construct independently is also the stronger evidence here — it is not only the CVA6-derived case that improves.

### How it was found

A per-module SystemVerilog frontend equivalence sweep over CVA6, where it mis-sized `hpdcache_mem_resp_demux`'s `localparam type rt_t = resp_id_t [RT_DEPTH-1:0]` as 32 bits instead of 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)