### PR TITLE
Re-resolve a packed-array element built from an overridden type parameter

### DIFF
--- a/include/Surelog/DesignCompile/CompileHelper.h
+++ b/include/Surelog/DesignCompile/CompileHelper.h
@@ -710,6 +710,12 @@ class CompileHelper final {
   bool m_muteTypedefRangeErrors = false;
 };
 
+// Resolve a type name against an instance's type parameters, walking up the
+// hierarchy.  Defined in CompileType.cpp.
+const UHDM::typespec* bindTypespec(std::string_view name,
+                                   ValuedComponentI* instance,
+                                   UHDM::Serializer& s);
+
 }  // namespace SURELOG
 
 #endif /* SURELOG_COMPILEHELPER_H */

--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -3560,6 +3560,15 @@ bool CompileHelper::compileParameterDeclaration(
             ref_typespec* elemRef = s.MakeRef_typespec();
             elemRef->Actual_typespec(elemTs);
             elemRef->VpiParent(pats);
+            // Record WHICH type the element came from.  When that name is a
+            // `parameter type` this resolved to its DECLARATION DEFAULT, and
+            // an instance that overrides the parameter needs the element
+            // re-resolved against its own binding — elabTypeParameter_ uses
+            // this name to do that.  Without it a child declared
+            // `parameter type id_t = logic` and instantiated with a 2-bit
+            // type keeps a 1-BIT element, and `arr[idx]` degenerates into an
+            // unscaled bit select (CVA6 hpdcache_mem_resp_demux's routing).
+            elemRef->VpiName(elemName);
             pats->Elem_typespec(elemRef);
             range* rg = s.MakeRange();
             rg->Left_expr((expr*)compileExpression(

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -84,6 +84,7 @@ namespace SURELOG {
 
 using namespace UHDM;  // NOLINT (using a bunch of these)
 
+
 ElaborationStep::ElaborationStep(CompileDesign* compileDesign)
     : m_compileDesign(compileDesign) {
   m_exprBuilder.seterrorReporting(
@@ -1702,6 +1703,58 @@ UHDM::typespec* ElaborationStep::elabTypeParameter_(DesignComponent* component,
         spec->VpiParent(uparam);
       }
       break;
+    }
+  }
+
+  // `localparam type rt_t = id_t [DEPTH-1:0]` where `id_t` is a `parameter
+  // type` OVERRIDDEN at this instantiation.  The packed_array_typespec was
+  // built at definition time, so its element is `id_t`'s DECLARATION DEFAULT
+  // (typically the erased `= logic`, one bit).  This localparam is not itself
+  // overridden, so nothing above re-resolves it, and the element stays 1 bit
+  // even though the instance binds something wider — `rt[idx]` then becomes an
+  // unscaled BIT select instead of an element select, reading bit `idx`
+  // instead of the element at `idx * ELEM_W`.  (CVA6
+  // hpdcache_mem_resp_demux's `mem_resp_rt_i[int'(mem_resp_id_i)]`: correct
+  // only for index 0.)
+  //
+  // compileParameterDeclaration recorded the element's source name on the
+  // Elem_typespec reference; re-bind it against this instance.
+  if (spec && instance &&
+      spec->UhdmType() == UHDM_OBJECT_TYPE::uhdmpacked_array_typespec) {
+    packed_array_typespec* pats = (packed_array_typespec*)spec;
+    if (ref_typespec* elemRef = pats->Elem_typespec()) {
+      const std::string_view elemName = elemRef->VpiName();
+      if (!elemName.empty()) {
+        if (const typespec* bound =
+                bindTypespec(elemName, instance, s)) {
+          const typespec* cur = elemRef->Actual_typespec();
+          if (bound != cur) {
+            packed_array_typespec* reb = s.MakePacked_array_typespec();
+            reb->VpiParent(pats->VpiParent());
+            reb->VpiFile(pats->VpiFile());
+            reb->VpiLineNo(pats->VpiLineNo());
+            reb->VpiColumnNo(pats->VpiColumnNo());
+            reb->VpiEndLineNo(pats->VpiEndLineNo());
+            reb->VpiEndColumnNo(pats->VpiEndColumnNo());
+            ref_typespec* nr = s.MakeRef_typespec();
+            nr->Actual_typespec((typespec*)bound);
+            nr->VpiName(elemName);
+            nr->VpiParent(reb);
+            reb->Elem_typespec(nr);
+            reb->Ranges(pats->Ranges());
+            spec = reb;
+            if (uparam->UhdmType() == uhdmtype_parameter) {
+              type_parameter* tparam = (type_parameter*)uparam;
+              if (tparam->Typespec() == nullptr) {
+                ref_typespec* r = s.MakeRef_typespec();
+                r->VpiParent(tparam);
+                tparam->Typespec(r);
+              }
+              tparam->Typespec()->Actual_typespec(spec);
+            }
+          }
+        }
+      }
     }
   }
   return spec;

--- a/tests/ClassScope/ClassScope.log
+++ b/tests/ClassScope/ClassScope.log
@@ -24207,10 +24207,11 @@ design: (work@top)
       |UINT:0
       |vpiConstType:9
   |vpiElemTypespec:
-  \_ref_typespec: (work@C::T)
+  \_ref_typespec: (work@C::T::PARAM_T)
     |vpiParent:
     \_packed_array_typespec: , line:6:25, endln:6:48
-    |vpiFullName:work@C::T
+    |vpiName:PARAM_T
+    |vpiFullName:work@C::T::PARAM_T
     |vpiActual:
     \_logic_typespec: , line:3:30, endln:3:35
 \_int_typespec: , line:44:13, endln:44:36


### PR DESCRIPTION
`localparam type rt_t = id_t [DEPTH-1:0]`, where `id_t` is a `parameter type` **overridden at the instantiation**, kept the element type from `id_t`'s **declaration default**:

```systemverilog
module child #(
    parameter  type id_t  = logic,                 // default: 1 bit
    localparam int  DEPTH = (1 << $bits(id_t)),
    localparam type rt_t  = id_t [DEPTH-1:0]
) (input rt_t rt_i, input id_t id_i, output logic sel_o);
  assign sel_o = rt_i[int'(id_i)];
endmodule

child #(.id_t(logic [1:0])) u (...);               // element is really 2 bits
```

### Cause

`compileParameterDeclaration` builds `rt_t`'s `packed_array_typespec` at **definition** time, where `id_t` is still `logic` (one bit). `rt_t` is a *localparam* type, so it is not in the instance's overridden-parameter list and `elabTypeParameter_` never re-resolved it — the element stayed 1 bit however wide the instance's binding was.

A consumer then reads `rt_i[idx]` as a single **bit** at `idx` instead of the element at `idx * ELEM_W` — correct only for index 0.

### Fix

The element reference now records the name of the type it was built from, and `elabTypeParameter_` re-binds that name against the instance (`bindTypespec`), rebuilding the `packed_array_typespec` when the binding differs from the definition default.

`bindTypespec` moves from a `CompileType.cpp`-local definition to a declaration in `CompileHelper.h` — which both translation units already include — so the signature is checked against the definition rather than duplicated in a hand-written extern.

### Regression — 791 PASS / 0 DIFF / 0 FAIL

The `ClassScope` golden gains `vpiName:PARAM_T` on one `ref_typespec`: the recorded provenance. `ClassScope` is the upstream test that **already contained this construct** (`localparam type T = PARAM_T [PARAM_E - 1:0]`), so it exercises the change independently. No message or semantic row changes.

### How it was found

A per-module SystemVerilog frontend equivalence sweep over CVA6, where it mis-routed `hpdcache_mem_resp_demux`'s responses — `mem_resp_rt_i[int'(mem_resp_id_i)]` selected the wrong output port for three of its four index values (~35% of simulated cycles).

Reaching it needed a bisect: four narrower reproducers were built first and **all passed**, each rejecting a hypothesis (dynamic index on a type-param packed array; a pack/unpack generate loop; an assignment target narrower than the element; a chained element type). The missing ingredient in every one was the **override at the instantiation** — with defaults only, the definition-time and bound types coincide and the bug is invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)