### PR TITLE
Fix Linux CI: antlr4 install path, clang-tidy, formatting, non_vendored UHDM

### DIFF
--- a/.github/workflows/non_vendored.yml
+++ b/.github/workflows/non_vendored.yml
@@ -58,8 +58,18 @@ jobs:
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DJSON_BuildTests=OFF . && cmake --build build && sudo cmake --install build
         popd
 
-        git clone --depth 1 --branch v1.84 https://github.com/chipsalliance/UHDM.git
+        # Track the exact UHDM revision this tree is pinned to (the submodule
+        # gitlink is present even though we checked out without submodules).
+        # Surelog master routinely uses UHDM APIs that are newer than the
+        # latest UHDM release tag, so pinning to a tag here breaks the build.
+        UHDM_COMMIT=$(git rev-parse HEAD:third_party/UHDM)
+        echo "Building UHDM at ${UHDM_COMMIT}"
+        # Blobless clone: cheap, but still lets us check out an exact SHA and
+        # keeps the tags UHDM's CMakeLists uses to derive its version.
+        # No submodules needed: gtest & capnp come from the host below.
+        git clone --filter=blob:none https://github.com/chipsalliance/UHDM.git
         pushd UHDM
+        git checkout "${UHDM_COMMIT}"
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DUHDM_USE_HOST_GTEST=ON -DUHDM_USE_HOST_CAPNP=ON . && cmake --build build && sudo cmake --install build
         popd
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,12 @@ endif()
 set(WITH_STATIC_CRT OFF CACHE BOOL "Use Static CRT")
 set(ANTLR_BUILD_CPP_TESTS OFF CACHE BOOL "Skip ANTLR tests")
 
+# Must come before any add_subdirectory() of a vendored dependency: some of them
+# (antlr4) use CMAKE_INSTALL_INCLUDEDIR & friends in their install() rules
+# without including GNUInstallDirs first. Left undefined, those destinations
+# become absolute paths ("/antlr4-runtime") and escape CMAKE_INSTALL_PREFIX.
+include(GNUInstallDirs)
+
 if(SURELOG_USE_HOST_ANTLR)
   find_package(ANTLR REQUIRED)
 else()
@@ -796,8 +802,6 @@ if (NOT QUICK_COMP)
   add_dependencies(hellosureworld PrecompileOVM)
   add_dependencies(hellosureworld PrecompileUVM)
 endif()
-
-include(GNUInstallDirs)
 
 # Installation target
 if (QUICK_COMP)

--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -1191,9 +1191,9 @@ UHDM::any *CompileHelper::resolveInterfacePortMember(
   const std::string baseName =
       std::string(path->Path_elems()->at(0)->VpiName());
   // Walk up the enclosing-scope chain: when the read sits inside a nested
-  // generate block (`generate if (ALIGNED) begin: aligned for (i<sub.BYT) ...`),
-  // `component` is the gen-scope definition, which has no ports — the interface
-  // port `sub` lives on the enclosing MODULE definition (the degu SoC
+  // generate block (`generate if (ALIGNED) begin: aligned for (i<sub.BYT)
+  // ...`), `component` is the gen-scope definition, which has no ports — the
+  // interface port `sub` lives on the enclosing MODULE definition (the degu SoC
   // logsize2byteena aligned/unaligned byte-enable loops).
   for (const ValuedComponentI *scope = component; scope;
        scope = scope->getParentScope()) {
@@ -1218,17 +1218,18 @@ UHDM::any *CompileHelper::resolveInterfacePortMember(
       if (elems.size() == 2) {
         // `sub.BYT`: a single param/localparam read — evaluate the member in
         // the interface definition's own context (default/overridden params).
-        if (any *v = getValue(std::string(elems.at(1)->VpiName()), ifaceDef,
-                              compileDesign, Reduce::Yes, nullptr,
-                              fC->getFileId(), fC->Line(locId), nullptr, true)) {
+        if (any *v =
+                getValue(std::string(elems.at(1)->VpiName()), ifaceDef,
+                         compileDesign, Reduce::Yes, nullptr, fC->getFileId(),
+                         fC->Line(locId), nullptr, true)) {
           if (v->UhdmType() == uhdmconstant) return v;
         }
         return nullptr;
       }
       // `sub.CFG.HSK.DLY`: a nested struct-PARAMETER field chain (`CFG` is a
       // struct param of the interface, `.HSK.DLY` walks its members).  Build a
-      // sub-path from the member elements (dropping the interface-port base) and
-      // decode it in the interface definition, where the struct-param-field
+      // sub-path from the member elements (dropping the interface-port base)
+      // and decode it in the interface definition, where the struct-param-field
       // navigation resolves it to a constant.  Needed for the degu SoC
       // demultiplexer / register generate conditions `if (sub.CFG.HSK.DLY==N)`.
       UHDM::Serializer &s = compileDesign->getSerializer();
@@ -1408,7 +1409,8 @@ UHDM::any *CompileHelper::compileSelectExpression(
           //   `field[hi:lo]`        → part_select(field, hi, lo)
           //   `field[idx]`          → bit_select(field, idx)
           //   `field[i0][i1]...`    → var_select(field, [i0,i1,...])
-          //   `field[idx][hi:lo]`   → bit_select(field, idx) + part_select(_, hi, lo)
+          //   `field[idx][hi:lo]`   → bit_select(field, idx) + part_select(_,
+          //   hi, lo)
           //
           // The Select grammar interleaves empty paBit_select sentinels
           // between an indexed paBit_select and a trailing range, so
@@ -1425,7 +1427,7 @@ UHDM::any *CompileHelper::compileSelectExpression(
           // walk both the outer paBit_select chain AND the Expression
           // children of each.
           std::vector<NodeId> idx_exprs;  // Expression NodeIds (one per index)
-          NodeId last_indexed;            // last paBit_select containing indices
+          NodeId last_indexed;  // last paBit_select containing indices
           NodeId cursor = fC->Sibling(Bit_select);
           while (cursor &&
                  (fC->Type(cursor) == VObjectType::paBit_select ||
@@ -1480,8 +1482,7 @@ UHDM::any *CompileHelper::compileSelectExpression(
               fC->populateCoreMembers(Bit_select, rangeNode, sel);
               sel->VpiParent(path);
               elems->push_back(sel);
-              hname.append(".").append(field_name).append(
-                  decompileHelper(sel));
+              hname.append(".").append(field_name).append(decompileHelper(sel));
             }
             advance_to = rangeNode;
           } else {
@@ -1528,8 +1529,8 @@ UHDM::any *CompileHelper::compileSelectExpression(
             if (rangeNode) {
               NodeId Constant_range = fC->Child(rangeNode);
               if (expr *psel = (expr *)compilePartSelectRange(
-                      component, fC, Constant_range, "", compileDesign,
-                      reduce, path, instance, muteErrors)) {
+                      component, fC, Constant_range, "", compileDesign, reduce,
+                      path, instance, muteErrors)) {
                 fC->populateCoreMembers(rangeNode, rangeNode, psel);
                 psel->VpiParent(path);
                 elems->push_back(psel);
@@ -2350,8 +2351,8 @@ UHDM::any *CompileHelper::compileExpression(
               NodeId Member = fC->Child(rval);
               while (Member) {
                 if (UHDM::any *exp = compileExpression(
-                        component, fC, Member, compileDesign, reduce,
-                        operation, instance, muteErrors)) {
+                        component, fC, Member, compileDesign, reduce, operation,
+                        instance, muteErrors)) {
                   operands->push_back(exp);
                 }
                 Member = fC->Sibling(Member);

--- a/src/DesignCompile/DesignElaboration.cpp
+++ b/src/DesignCompile/DesignElaboration.cpp
@@ -1746,8 +1746,8 @@ void DesignElaboration::elaborateInstance_(
         // Built-in primitive definitions are created without a FileContent, so
         // getNodeIds()/getFileContents() are empty. Treat them as undefined
         // here so the instance takes the existing black-box path below.
-        if (def && (def->getNodeIds().empty() ||
-                    def->getFileContents().empty())) {
+        if (def &&
+            (def->getNodeIds().empty() || def->getFileContents().empty())) {
           def = nullptr;
         }
 
@@ -1828,8 +1828,8 @@ void DesignElaboration::elaborateInstance_(
 
           // A use-clause above may have re-resolved def to a built-in
           // primitive, which carries no FileContent/NodeId.
-          if (def && (def->getNodeIds().empty() ||
-                      def->getFileContents().empty())) {
+          if (def &&
+              (def->getNodeIds().empty() || def->getFileContents().empty())) {
             def = nullptr;
           }
 
@@ -1860,15 +1860,16 @@ void DesignElaboration::elaborateInstance_(
               if (fC->Type(unpackedDimId) ==
                   VObjectType::paUnpacked_dimension) {
                 NodeId constantRangeId = fC->Child(unpackedDimId);
-                // A SIZE dimension `[N]` is a bare constant_expression (no `:`),
-                // a RANGE `[msb:lsb]` is a constant_range.  They must be handled
-                // differently: `[N]` denotes indices [0 : N-1] (N instances),
-                // NOT the `[N:0]` range (N+1 instances) the old code produced for
-                // both.  So `myif m[2]` / `child c[2]` are TWO instances (m[0],
-                // m[1]) — matching Verilator/slang and the SV unpacked-dimension
-                // rule (github interface/module array off-by-one).
-                const bool isRange =
-                    (fC->Type(constantRangeId) == VObjectType::paConstant_range);
+                // A SIZE dimension `[N]` is a bare constant_expression (no
+                // `:`), a RANGE `[msb:lsb]` is a constant_range.  They must be
+                // handled differently: `[N]` denotes indices [0 : N-1] (N
+                // instances), NOT the `[N:0]` range (N+1 instances) the old
+                // code produced for both.  So `myif m[2]` / `child c[2]` are
+                // TWO instances (m[0], m[1]) — matching Verilator/slang and the
+                // SV unpacked-dimension rule (github interface/module array
+                // off-by-one).
+                const bool isRange = (fC->Type(constantRangeId) ==
+                                      VObjectType::paConstant_range);
                 NodeId leftNode = fC->Child(constantRangeId);
                 NodeId rightNode = fC->Sibling(leftNode);
                 bool validValue;
@@ -2190,21 +2191,22 @@ std::vector<std::string_view> DesignElaboration::collectParams_(
                      (exprtype == UHDM::uhdmsys_func_call) ||
                      (exprtype == UHDM::uhdmindexed_part_select) ||
                      (exprtype == UHDM::uhdmhier_path)) {
-            // An interface-port hier_path override (`.SYS_DAT(sub.CFG.BUS.DAT)`,
-            // where `sub` is an interface port of the instantiating module):
-            // resolve `<port>.<member>` through the port's interface TYPE
-            // definition to a constant, so the child instance receives a real
-            // width instead of an unresolvable hier_path (which later surfaces
-            // as UHDM_UNRESOLVED_HIER_PATH during full elaboration).
-            // `parentDefinition` owns the `sub` port.  rp32 degu/mouse SoC
-            // peripherals (tcb_lite_dev_gpio/uart).
+            // An interface-port hier_path override
+            // (`.SYS_DAT(sub.CFG.BUS.DAT)`, where `sub` is an interface port of
+            // the instantiating module): resolve `<port>.<member>` through the
+            // port's interface TYPE definition to a constant, so the child
+            // instance receives a real width instead of an unresolvable
+            // hier_path (which later surfaces as UHDM_UNRESOLVED_HIER_PATH
+            // during full elaboration). `parentDefinition` owns the `sub` port.
+            // rp32 degu/mouse SoC peripherals (tcb_lite_dev_gpio/uart).
             if (exprtype == UHDM::uhdmhier_path) {
               if (UHDM::any* iv = m_helper.resolveInterfacePortMember(
                       parentDefinition, (UHDM::hier_path*)complexV,
                       m_compileDesign, parentFile, expr)) {
                 if (iv->UhdmType() == UHDM::uhdmconstant) {
                   UHDM::constant* c = (UHDM::constant*)iv;
-                  value = m_exprBuilder.fromVpiValue(c->VpiValue(), c->VpiSize());
+                  value =
+                      m_exprBuilder.fromVpiValue(c->VpiValue(), c->VpiSize());
                 }
               }
             }

--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -84,7 +84,6 @@ namespace SURELOG {
 
 using namespace UHDM;  // NOLINT (using a bunch of these)
 
-
 ElaborationStep::ElaborationStep(CompileDesign* compileDesign)
     : m_compileDesign(compileDesign) {
   m_exprBuilder.seterrorReporting(
@@ -1725,8 +1724,7 @@ UHDM::typespec* ElaborationStep::elabTypeParameter_(DesignComponent* component,
     if (ref_typespec* elemRef = pats->Elem_typespec()) {
       const std::string_view elemName = elemRef->VpiName();
       if (!elemName.empty()) {
-        if (const typespec* bound =
-                bindTypespec(elemName, instance, s)) {
+        if (const typespec* bound = bindTypespec(elemName, instance, s)) {
           const typespec* cur = elemRef->Actual_typespec();
           if (bound != cur) {
             packed_array_typespec* reb = s.MakePacked_array_typespec();

--- a/src/DesignCompile/NetlistElaboration.cpp
+++ b/src/DesignCompile/NetlistElaboration.cpp
@@ -298,13 +298,13 @@ bool NetlistElaboration::elab_parameters_(ModuleInstance* instance,
                 // `Cfg.XLEN`) in a struct typespec's member ranges to constants
                 // using this instance's parameter values.
                 // flattenPatternAssignments below clones the pattern operation
-                // AND its struct typespec; a cloned member range that references
-                // a struct-typed parameter is unreachable in that detached clone
-                // context and reported as UHDM_UNRESOLVED_HIER_PATH (and
-                // mis-sizes the flattened value) — CVA6 core/cva6.sv
-                // `interrupts_t` / `INTERRUPTS`.  The parameter typespec and the
-                // pattern operation's typespec are distinct objects of the same
-                // struct type, so reduce both.
+                // AND its struct typespec; a cloned member range that
+                // references a struct-typed parameter is unreachable in that
+                // detached clone context and reported as
+                // UHDM_UNRESOLVED_HIER_PATH (and mis-sizes the flattened value)
+                // — CVA6 core/cva6.sv `interrupts_t` / `INTERRUPTS`.  The
+                // parameter typespec and the pattern operation's typespec are
+                // distinct objects of the same struct type, so reduce both.
                 auto reduceBound = [&](UHDM::expr* b) -> UHDM::expr* {
                   if (b == nullptr || b->UhdmType() == uhdmconstant)
                     return nullptr;
@@ -332,32 +332,33 @@ bool NetlistElaboration::elab_parameters_(ModuleInstance* instance,
                 };
                 // Reduce the member ranges of a struct typespec and the direct
                 // ranges of packed/array typespecs (e.g. a cast size
-                // `CVA6Cfg.XLEN'(..)` whose typespec is `logic [CVA6Cfg.XLEN-1:0]`).
-                std::function<void(const UHDM::typespec*)> reduceTypespecRanges =
-                    [&](const UHDM::typespec* t) {
-                  if (t == nullptr) return;
-                  switch (t->UhdmType()) {
-                    case uhdmstruct_typespec:
-                      for (typespec_member* memb :
-                           *((struct_typespec*)t)->Members()) {
-                        if (UHDM::ref_typespec* mrt = memb->Typespec())
-                          reduceTypespecRanges(mrt->Actual_typespec());
+                // `CVA6Cfg.XLEN'(..)` whose typespec is `logic
+                // [CVA6Cfg.XLEN-1:0]`).
+                std::function<void(const UHDM::typespec*)>
+                    reduceTypespecRanges = [&](const UHDM::typespec* t) {
+                      if (t == nullptr) return;
+                      switch (t->UhdmType()) {
+                        case uhdmstruct_typespec:
+                          for (typespec_member* memb :
+                               *((struct_typespec*)t)->Members()) {
+                            if (UHDM::ref_typespec* mrt = memb->Typespec())
+                              reduceTypespecRanges(mrt->Actual_typespec());
+                          }
+                          break;
+                        case uhdmlogic_typespec:
+                          reduceRangeVec(((UHDM::logic_typespec*)t)->Ranges());
+                          break;
+                        case uhdmpacked_array_typespec:
+                          reduceRangeVec(
+                              ((UHDM::packed_array_typespec*)t)->Ranges());
+                          break;
+                        case uhdmarray_typespec:
+                          reduceRangeVec(((UHDM::array_typespec*)t)->Ranges());
+                          break;
+                        default:
+                          break;
                       }
-                      break;
-                    case uhdmlogic_typespec:
-                      reduceRangeVec(((UHDM::logic_typespec*)t)->Ranges());
-                      break;
-                    case uhdmpacked_array_typespec:
-                      reduceRangeVec(
-                          ((UHDM::packed_array_typespec*)t)->Ranges());
-                      break;
-                    case uhdmarray_typespec:
-                      reduceRangeVec(((UHDM::array_typespec*)t)->Ranges());
-                      break;
-                    default:
-                      break;
-                  }
-                };
+                    };
                 // Recursively walk the pattern's value expressions, reducing
                 // cast/operation typespec ranges and folding any hier_path
                 // operand (e.g. `CVA6Cfg.XLEN`) to a constant.  Without this,
@@ -367,33 +368,33 @@ bool NetlistElaboration::elab_parameters_(ModuleInstance* instance,
                 // UHDM_UNRESOLVED_HIER_PATH (CVA6 core/cva6.sv `INTERRUPTS`).
                 std::function<void(UHDM::any*)> reduceExprTree =
                     [&](UHDM::any* e) {
-                  if (e == nullptr) return;
-                  switch (e->UhdmType()) {
-                    case uhdmoperation: {
-                      UHDM::operation* op = (UHDM::operation*)e;
-                      if (UHDM::ref_typespec* ort = op->Typespec())
-                        reduceTypespecRanges(ort->Actual_typespec());
-                      if (UHDM::VectorOfany* ops = op->Operands()) {
-                        for (size_t i = 0; i < ops->size(); i++) {
-                          UHDM::any* o = (*ops)[i];
-                          if (o && o->UhdmType() == uhdmhier_path) {
-                            if (UHDM::expr* red = reduceBound((UHDM::expr*)o)) {
-                              (*ops)[i] = red;
-                              continue;
+                      if (e == nullptr) return;
+                      switch (e->UhdmType()) {
+                        case uhdmoperation: {
+                          UHDM::operation* op = (UHDM::operation*)e;
+                          if (UHDM::ref_typespec* ort = op->Typespec())
+                            reduceTypespecRanges(ort->Actual_typespec());
+                          if (UHDM::VectorOfany* ops = op->Operands()) {
+                            for (UHDM::any*& o : *ops) {
+                              if (o && o->UhdmType() == uhdmhier_path) {
+                                if (UHDM::expr* red =
+                                        reduceBound((UHDM::expr*)o)) {
+                                  o = red;
+                                  continue;
+                                }
+                              }
+                              reduceExprTree(o);
                             }
                           }
-                          reduceExprTree(o);
+                          break;
                         }
+                        case uhdmtagged_pattern:
+                          reduceExprTree(((UHDM::tagged_pattern*)e)->Pattern());
+                          break;
+                        default:
+                          break;
                       }
-                      break;
-                    }
-                    case uhdmtagged_pattern:
-                      reduceExprTree(((UHDM::tagged_pattern*)e)->Pattern());
-                      break;
-                    default:
-                      break;
-                  }
-                };
+                    };
                 // Only struct-typed parameters need this: a struct-typed
                 // parameter's field (`Cfg.XLEN`) may appear both in the struct
                 // member ranges AND in the pattern init value expressions, and
@@ -801,7 +802,8 @@ static void propagateIfaceParams_(Serializer& s, ModuleInstance* refInst,
     dst->setComplexValue(cv.first, cv.second);
   if (Netlist* refNl = refInst->getNetlist()) {
     if (UHDM::VectorOfparam_assign* pa = refNl->param_assigns()) {
-      if (dstNetlist && dstNetlist->param_assigns() == nullptr && !pa->empty()) {
+      if (dstNetlist && dstNetlist->param_assigns() == nullptr &&
+          !pa->empty()) {
         ElaboratorContext ctx(&s, false, true);
         UHDM::VectorOfparam_assign* clone = s.MakeParam_assignVec();
         for (auto p : *pa)
@@ -951,8 +953,9 @@ ModuleInstance* NetlistElaboration::getInterfaceInstance_(
         if (formalName == portName) {
           for (auto inst : parent->getAllSubInstances()) {
             // A modport actual `inst.mp` names the interface INSTANCE `inst`
-            // (baseName); `sigName` (`inst.mp`) matches no sub-instance, so also
-            // match the base instance name to reach the parameterized instance.
+            // (baseName); `sigName` (`inst.mp`) matches no sub-instance, so
+            // also match the base instance name to reach the parameterized
+            // instance.
             if (inst->getInstanceName() == sigName ||
                 (!selectName.empty() && inst->getInstanceName() == baseName)) {
               return inst;
@@ -1456,8 +1459,9 @@ bool NetlistElaboration::high_conn_(ModuleInstance* instance) {
           // `.sys_wen(sub.req.wen & sub.trn)`) reduces the member access to the
           // WHOLE struct_net — the member is dropped (a net member has no
           // constant value, so hierarchicalSelector returns the containing
-          // struct_net).  Recompile WITHOUT reduction so the hier_path (with the
-          // member) is preserved (degu SoC tcb_dev_gpio sys_wdt/sys_wen/...).
+          // struct_net).  Recompile WITHOUT reduction so the hier_path (with
+          // the member) is preserved (degu SoC tcb_dev_gpio
+          // sys_wdt/sys_wen/...).
           bool needsUnreduced = (hexpr && hexpr->UhdmType() == uhdmstruct_net);
           if (hexpr && hexpr->UhdmType() == uhdmoperation) {
             operation* op = (operation*)hexpr;
@@ -1911,14 +1915,14 @@ interface_inst* NetlistElaboration::elab_interface_(
     }
     // Expose the interface's elaborated parameters/localparams on the UHDM
     // interface_inst.  An interface reached only through a modport PORT
-    // (`tcb_lite_if.man tcb_lsu`, e.g. a core synthesised standalone) never went
-    // through elab_parameters_ for its OWN scope, so localparams computed from
-    // the interface's CFG (`CFG_BUS_BYT = CFG.BUS.DAT/8`,
-    // `CFG_BUS_SIZ = $clog2($clog2(CFG_BUS_BYT)+1)`) had no per-instance constant
-    // value — a read of the modport-port param, or of a struct-field width that
-    // uses it (`logic [CFG_BUS_SIZ-1:0] siz`), then resolved to nothing.
-    // Elaborate them from the interface's (default or overridden) parameters and
-    // hand the valued param_assigns to the interface_inst.
+    // (`tcb_lite_if.man tcb_lsu`, e.g. a core synthesised standalone) never
+    // went through elab_parameters_ for its OWN scope, so localparams computed
+    // from the interface's CFG (`CFG_BUS_BYT = CFG.BUS.DAT/8`, `CFG_BUS_SIZ =
+    // $clog2($clog2(CFG_BUS_BYT)+1)`) had no per-instance constant value — a
+    // read of the modport-port param, or of a struct-field width that uses it
+    // (`logic [CFG_BUS_SIZ-1:0] siz`), then resolved to nothing. Elaborate them
+    // from the interface's (default or overridden) parameters and hand the
+    // valued param_assigns to the interface_inst.
     if (netl->param_assigns() == nullptr) {
       elab_parameters_(interf_instance, true);
       elab_parameters_(interf_instance, false);

--- a/src/DesignCompile/UhdmWriter.cpp
+++ b/src/DesignCompile/UhdmWriter.cpp
@@ -915,9 +915,9 @@ void UhdmWriter::writeNets(DesignComponent* mod,
               anet->VpiSize(unpackedSize);
               fC->populateCoreMembers(orig_net->getNodeId(),
                                       orig_net->getNodeId(), anet);
-              // Fresh inner element net (a copy of the collapsed element) so the
-              // array_net carries the element type without stealing the Nets()
-              // entry's parent.
+              // Fresh inner element net (a copy of the collapsed element) so
+              // the array_net carries the element type without stealing the
+              // Nets() entry's parent.
               logic_net* elem = s.MakeLogic_net();
               elem->VpiName(orig_net->getName());
               elem->VpiNetType(dest_net->VpiNetType());
@@ -4506,10 +4506,11 @@ void UhdmWriter::writeInstance(ModuleDefinition* mod, ModuleInstance* instance,
           interf->VpiParent(m);
         }
       }
-      // Interface-port copies (`sub (.t(inst.mp))`) are only attached here, never
-      // sent through writeElabInterface, so their parameter overrides were
-      // missing.  Emit them now from the copy's ModuleInstance, which carries the
-      // connected instance's overrides propagated during netlist elaboration.
+      // Interface-port copies (`sub (.t(inst.mp))`) are only attached here,
+      // never sent through writeElabInterface, so their parameter overrides
+      // were missing.  Emit them now from the copy's ModuleInstance, which
+      // carries the connected instance's overrides propagated during netlist
+      // elaboration.
       for (interface_inst* interf : *subInterfaces) {
         if (interf->Param_assigns()) continue;
         for (const auto& e : netlist->getInstanceMap()) {

--- a/src/SourceCompile/PreprocessFile.cpp
+++ b/src/SourceCompile/PreprocessFile.cpp
@@ -938,8 +938,7 @@ std::pair<bool, std::string> PreprocessFile::evaluateMacro_(
       // at the use site (yosys/tests/simple/macro_arg_spaces.sv).  The
       // formal name (line 898 above) is a single identifier so stripping
       // ws there is fine.
-      const std::string default_val(
-          StringUtils::trim(formal_arg_default[1]));
+      const std::string default_val(StringUtils::trim(formal_arg_default[1]));
       StringUtils::replaceInTokenVector(body_tokens, {"``", formal, "``"},
                                         default_val);
       StringUtils::replaceInTokenVector(body_tokens, "``" + formal + "``",

--- a/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
+++ b/src/SourceCompile/SV3_1aPpTreeShapeListener.cpp
@@ -80,11 +80,11 @@ void SV3_1aPpTreeShapeListener::enterComment(
   // Strip `translate_off`..`translate_on` regions from the synthesizable model
   // under `-synth` OR the lighter `-filterprotected` (which only removes these
   // pragma-guarded regions, WITHOUT the full non-synthesizable-object filtering
-  // that `-synth` also performs — the uhdm2rtlil synthesis flow wants the former
-  // but must keep $display/assertions/etc.).
+  // that `-synth` also performs — the uhdm2rtlil synthesis flow wants the
+  // former but must keep $display/assertions/etc.).
   if (m_pp->getCompileSourceFile()
-              ->getCommandLineParser()
-              ->reportNonSynthesizable() ||
+          ->getCommandLineParser()
+          ->reportNonSynthesizable() ||
       m_pp->getCompileSourceFile()
           ->getCommandLineParser()
           ->filterProtectedRegions()) {
@@ -118,8 +118,8 @@ void SV3_1aPpTreeShapeListener::enterComment(
     }
   }
   if (m_pp->getCompileSourceFile()
-              ->getCommandLineParser()
-              ->reportNonSynthesizable() ||
+          ->getCommandLineParser()
+          ->reportNonSynthesizable() ||
       m_pp->getCompileSourceFile()
           ->getCommandLineParser()
           ->filterProtectedRegions()) {

--- a/tests/StructParamFuncBodyFieldCompare/StructParamFuncBodyFieldCompare.log
+++ b/tests/StructParamFuncBodyFieldCompare/StructParamFuncBodyFieldCompare.log
@@ -1,0 +1,69 @@
+[INF:CM0023] Creating log file "${SURELOG_DIR}/build/regression/StructParamFuncBodyFieldCompare/slpp_all/surelog.log".
+[WRN:PA0205] ${SURELOG_DIR}/tests/StructParamFuncBodyFieldCompare/dut.sv:12:1: No timescale set for "cfg_pkg".
+[WRN:PA0205] ${SURELOG_DIR}/tests/StructParamFuncBodyFieldCompare/dut.sv:35:1: No timescale set for "StructParamFuncBodyFieldCompare".
+[INF:CP0300] Compilation...
+[INF:CP0301] ${SURELOG_DIR}/tests/StructParamFuncBodyFieldCompare/dut.sv:12:1: Compile package "cfg_pkg".
+[INF:CP0303] ${SURELOG_DIR}/tests/StructParamFuncBodyFieldCompare/dut.sv:35:1: Compile module "work@StructParamFuncBodyFieldCompare".
+[INF:CP0302] Compile class "work@mailbox".
+[INF:CP0302] Compile class "work@process".
+[INF:CP0302] Compile class "work@semaphore".
+[INF:EL0526] Design Elaboration...
+[NTE:EL0503] ${SURELOG_DIR}/tests/StructParamFuncBodyFieldCompare/dut.sv:35:1: Top level module "work@StructParamFuncBodyFieldCompare".
+[NTE:EL0508] Nb Top level modules: 1.
+[NTE:EL0509] Max instance depth: 1.
+[NTE:EL0510] Nb instances: 1.
+[NTE:EL0511] Nb leaf instances: 1.
+[INF:UH0706] Creating UHDM Model...
+=== UHDM Object Stats Begin (Non-Elaborated Model) ===
+assignment                                             6
+begin                                                  2
+class_defn                                             8
+class_typespec                                         4
+class_var                                              3
+constant                                             178
+cont_assign                                            3
+design                                                 1
+enum_const                                             5
+enum_typespec                                          1
+enum_var                                               1
+func_call                                             28
+function                                              11
+hier_path                                             51
+int_typespec                                          29
+int_var                                                4
+integer_typespec                                      10
+io_decl                                               13
+logic_net                                              6
+logic_typespec                                        32
+logic_var                                              3
+module_inst                                            9
+operation                                            143
+package                                                4
+param_assign                                          16
+parameter                                             17
+port                                                   6
+range                                                 24
+ref_obj                                              147
+ref_typespec                                         184
+return_stmt                                            2
+string_typespec                                       44
+struct_typespec                                       17
+struct_var                                             6
+sys_func_call                                         12
+tagged_pattern                                        44
+task                                                   9
+type_parameter                                         1
+typespec_member                                       38
+void_typespec                                         20
+=== UHDM Object Stats End ===
+[INF:UH0708] Writing UHDM DB: ${SURELOG_DIR}/build/regression/StructParamFuncBodyFieldCompare/slpp_all/surelog.uhdm ...
+[  FATAL] : 0
+[ SYNTAX] : 0
+[  ERROR] : 0
+[WARNING] : 2
+[   NOTE] : 5
+
+============================== Begin RoundTrip Results ==============================
+[roundtrip]: ${SURELOG_DIR}/tests/StructParamFuncBodyFieldCompare/builtin.sv | ${SURELOG_DIR}/build/regression/StructParamFuncBodyFieldCompare/roundtrip/builtin_000.sv | 0 | 0 |
+[roundtrip]: ${SURELOG_DIR}/tests/StructParamFuncBodyFieldCompare/dut.sv     | ${SURELOG_DIR}/build/regression/StructParamFuncBodyFieldCompare/roundtrip/dut_000.sv     | 23 | 52 |
+============================== End RoundTrip Results ==============================


### PR DESCRIPTION
Every Linux job on `master` is currently red. Four independent causes, one fix each.

### 1. `Linux | Install` (gcc/clang × debug/release) — all four failed

`cmake --install` died with:

```
CMake Error at build/third_party/antlr4/runtime/Cpp/runtime/cmake_install.cmake:78 (file):
  file INSTALL cannot make directory "/antlr4-runtime": Permission denied.
```

The vendored antlr4 does `add_subdirectory(runtime)` **before** `include(GNUInstallDirs)`, so `CMAKE_INSTALL_INCLUDEDIR` is still empty when the runtime's `install()` rules are read, and the header destination collapses to the absolute path `/antlr4-runtime` — outside `CMAKE_INSTALL_PREFIX` entirely.

Fixed by including `GNUInstallDirs` before any vendored `add_subdirectory()`, and dropping the now-redundant later include.

### 2. `ClangTidy`

One `modernize-loop-convert` at `src/DesignCompile/NetlistElaboration.cpp:377`. Converted to a range-based loop over `UHDM::any*&`, which preserves the write-back of the reduced operand.

### 3. `CodeFormatting`

Seven files had drifted. Re-ran clang-format 17 (the version CI pins) over `src/` and `include/`. Whitespace only.

### 4. `non_vendored`

Pinned to UHDM tag `v1.84`, but master calls `ExprEval::setGetTypespecFunctor()` and `ExprEval::ReturnType`, which landed *after* `v1.86` — no release tag carries them:

```
error: 'class UHDM::ExprEval' has no member named 'setGetTypespecFunctor'
error: 'UHDM::ExprEval::ReturnType' has not been declared
```

Now builds UHDM at the exact revision the submodule pins, so the two can't drift again.

### Also

`tests/StructParamFuncBodyFieldCompare/` was added without its golden log and reports `NOGOLD`. Committed the golden — behavior is unchanged, it matches current output as-is. Happy to split this out if you'd rather land it separately.

### Verification

Locally, on Linux: clean build, `cmake --install`, all 90 ctest unit tests, `TestInstall`, and `make test_install_pkgconfig` all pass. clang-tidy 18 goes from 1 warning to 0 on `NetlistElaboration.cpp`.

### Out of scope (not addressed here)

- `yosys-systemverilog-plugin` fails during GCP VM provisioning (`VM starter exited with non-zero exit code: 1`) — infrastructure, nothing in this repo.
- MSYS2 regression shards 0 and 2 diff on `LoopParam.msys.log` / `LoopParamOver.msys.log`. Those `.msys` goldens are stale relative to the log-quoting and blank-line-removal commits that updated the Linux goldens.
- The `main` run's 24h wall-clock is macOS runners queueing, not a Linux job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)