### PR TITLE
Fix Windows build: LibrarySet needs a complete Library type

### DIFF
--- a/include/Surelog/Library/LibrarySet.h
+++ b/include/Surelog/Library/LibrarySet.h
@@ -26,6 +26,10 @@
 #pragma once
 
 #include <Surelog/Common/PathId.h>
+// Library must be complete here: std::deque -- unlike std::vector -- is not
+// one of the containers the standard allows to instantiate with an incomplete
+// element type, and MSVC's implementation takes sizeof(Library) eagerly.
+#include <Surelog/Library/Library.h>
 
 #include <deque>
 #include <ostream>
@@ -34,7 +38,6 @@
 namespace SURELOG {
 
 class ErrorContainer;
-class Library;
 class SymbolTable;
 
 class LibrarySet final {


### PR DESCRIPTION
Both `Windows | Install` jobs (cl and clang) fail compiling `LibrarySet.cpp`:

```
deque(547): error C2027: use of undefined type 'SURELOG::Library'
deque:547:38: error: invalid application of 'sizeof' to an incomplete type
                     'value_type' (aka 'SURELOG::Library')
```

`37d426b48f` switched `LibrarySet::m_libraries` from `std::vector` to `std::deque`, to keep handed-out `Library*` stable across later additions. `std::vector` is one of the three containers the standard permits to instantiate with an **incomplete** element type; `std::deque` is not. libstdc++ happens to tolerate it, which is why Linux stayed green — but MSVC's `_Deque_val` takes `sizeof(Library)` eagerly and rejects the forward declaration.

Fix: include `Library.h` and drop the forward declaration. No include cycle — `Library.h` does not reach back to `LibrarySet.h`.

This failure predates #4145 (same error in the Aug 20 run on `master`); it was just hidden behind the earlier Linux breakage.

### Verification

On Linux: clean build and all 90 ctest unit tests pass. clang-format 17 and clang-tidy 18 are clean on the touched file, so `CodeFormatting` and `ClangTidy` stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)