### PR TITLE
Guard the 64-bit Value engine against dotted member paths and wide values

### DIFF
--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -3760,8 +3760,17 @@ bool CompileHelper::compileParameterDeclaration(
             if (!invalidValue) size = sizetmp;
           }
           adjustSize(ts, component, compileDesign, instance, c);
-          Value* val = m_exprBuilder.fromVpiValue(c->VpiValue(), size);
-          component->setValue(the_name, val, m_exprBuilder);
+          // A value wider than 64 bits must NOT enter the Value store: the
+          // StValue accessors convert through strtoull/strtoll, which
+          // SATURATE, so a 96-bit function-computed struct parameter read
+          // back through getValueUL() becomes 0xFFFF...F and every member
+          // select of it folds to stamped garbage
+          // (param_nested_struct_field_width's SID_W).  The constant stays
+          // on the parameter/param_assign for the UHDM-level evaluator.
+          if (size <= 64) {
+            Value* val = m_exprBuilder.fromVpiValue(c->VpiValue(), size);
+            component->setValue(the_name, val, m_exprBuilder);
+          }
         } else if (expr && (reduce == Reduce::Yes) && (!isMultiDimension)) {
           UHDM::expr* the_expr = (UHDM::expr*)expr;
           if (the_expr->Typespec() == nullptr) {

--- a/src/DesignCompile/EvalFunc.cpp
+++ b/src/DesignCompile/EvalFunc.cpp
@@ -96,8 +96,17 @@ void CompileHelper::evalScheduledExprs(DesignComponent* component,
                    expr_eval.m_lineNumber, expr_eval.m_pexpr);
     if (result && result->UhdmType() == uhdmconstant) {
       UHDM::constant* c = (UHDM::constant*)result;
-      Value* val = m_exprBuilder.fromVpiValue(c->VpiValue(), c->VpiSize());
-      component->setValue(name, val, m_exprBuilder);
+      // Do NOT feed a value wider than 64 bits into the Value store: the
+      // Value/StValue accessors convert through strtoull/strtoll, which
+      // SATURATE (a 96-bit struct value read back as 0xFFFF...F), and every
+      // downstream member select of the parameter then folds to garbage that
+      // is stamped as a "valid" constant (param_nested_struct_field_width's
+      // SID_W).  The UHDM param_assign RHS below still carries the full
+      // constant, which the UHDM-level evaluator and consumers handle.
+      if (c->VpiSize() <= 64) {
+        Value* val = m_exprBuilder.fromVpiValue(c->VpiValue(), c->VpiSize());
+        component->setValue(name, val, m_exprBuilder);
+      }
       for (ParamAssign* pass : component->getParamAssignVec()) {
         if (param_assign* upass = pass->getUhdmParamAssign()) {
           if (upass->Lhs()->VpiName() == name) {

--- a/src/Expression/ExprBuilder.cpp
+++ b/src/Expression/ExprBuilder.cpp
@@ -69,6 +69,25 @@ Value* ExprBuilder::clone(Value* val) {
 //              and fix the intended places.
 //
 // NOLINTBEGIN(*.DeadStores)
+
+static bool isDottedMemberTail(const FileContent* fC, NodeId sib) {
+  // Trailing member-access shape after a base identifier: either a direct
+  // sibling StringConst (`.u`) or a Constant_select/Select whose children
+  // include a StringConst member name (a pure index select has only
+  // bit-select children).  Such paths cannot be evaluated by this 64-bit
+  // Value engine — looking up just the base identifier hands back the whole
+  // packed struct value as the member's value.
+  if (!sib) return false;
+  if (fC->Type(sib) == VObjectType::slStringConst) return true;
+  if ((fC->Type(sib) == VObjectType::paConstant_select) ||
+      (fC->Type(sib) == VObjectType::paSelect)) {
+    for (NodeId c = fC->Child(sib); c; c = fC->Sibling(c)) {
+      if (fC->Type(c) == VObjectType::slStringConst) return true;
+    }
+  }
+  return false;
+}
+
 Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
                              ValuedComponentI* instance, bool muteErrors) {
   Value* value = m_valueFactory.newLValue();
@@ -220,6 +239,18 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
         value = evalExpr(fC, child, instance, muteErrors);
         break;
       case VObjectType::paHierarchical_identifier: {
+        // A DOTTED member path (`CFG.u.sidWidth`) cannot be evaluated by this
+        // 64-bit Value engine: recursing evaluates only the BASE identifier
+        // and hands back the whole packed struct value as the member's value
+        // (and a >64-bit value saturates to 0xFF..F through strtoull on the
+        // way into an LValue).  Leave it invalid for the UHDM-level
+        // evaluator, which resolves member selects properly
+        // (param_nested_struct_field_width's `SID_W = CFG.u.sidWidth`).
+        NodeId first = fC->Child(child);
+        if (first && fC->Sibling(first)) {
+          value->setInvalid();
+          break;
+        }
         m_valueFactory.deleteValue(value);
         value = evalExpr(fC, child, instance, muteErrors);
         break;
@@ -533,6 +564,18 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
           if (sval == nullptr) fullName = StrCat(packageName, "::", name);
         } else {
           const std::string_view name = fC->SymName(child);
+          // A DOTTED member path (`CFG.u.sidWidth` — the trailing member
+          // names are SIBLING StringConsts) cannot be evaluated by this
+          // 64-bit Value engine: looking up just the BASE hands back the
+          // whole packed struct value as the member's value (and a >64-bit
+          // value saturates through strtoull on its way into an LValue).
+          // Leave it invalid for the UHDM-level evaluator
+          // (param_nested_struct_field_width's `SID_W = CFG.u.sidWidth`).
+          if (isDottedMemberTail(fC, fC->Sibling(child))) {
+            muteErrors = true;
+            value->setInvalid();
+            break;
+          }
           if (instance) {
             if (instance->getComplexValue(name)) {
               muteErrors = true;
@@ -755,6 +798,17 @@ Value* ExprBuilder::evalExpr(const FileContent* fC, NodeId parent,
         Value* sval = nullptr;
         std::string fullName;
         const std::string_view name = fC->SymName(parent);
+        // A DOTTED member path (`CFG.u.sidWidth` — trailing member names are
+        // SIBLING StringConsts of the base) cannot be evaluated by this
+        // 64-bit Value engine: looking up just the BASE hands back the whole
+        // packed struct value as the member's value (saturated through
+        // strtoull for >64 bits).  Leave it invalid for the UHDM-level
+        // evaluator (param_nested_struct_field_width's SID_W).
+        if (isDottedMemberTail(fC, fC->Sibling(parent))) {
+          muteErrors = true;
+          value->setInvalid();
+          break;
+        }
         if (instance) {
           if (instance->getComplexValue(name)) {
             muteErrors = true;


### PR DESCRIPTION
Companion to chipsalliance/UHDM#1141 (struct_var constant assembly — bumped here; **merge that first**). Making function-computed struct parameters (CVA6's `HPDcacheCfg = hpdcacheBuildConfig(hpdcacheSetConfig())`) reduce to real constants exposed three soft spots in the legacy Value engine:

1. **`ExprBuilder::evalExpr`** evaluated a DOTTED member path (`CFG.u.sidWidth`) by looking up just the BASE identifier — the whole packed struct value became the member's value, and a >64-bit `StValue` saturates to 0xFF..F through `strtoull` on its way into an `LValue`. The garbage was stamped as a VALID instance-parameter constant and every port width derived from it collapsed. New `isDottedMemberTail()` guard: a base identifier followed by a sibling StringConst, or by a `Constant_select`/`Select` carrying a StringConst member name, is left INVALID for the UHDM-level evaluator (which resolves member selects properly).

2/3. **`EvalFunc::evalScheduledExprs`** and **`compileParameterDeclaration`** no longer feed values wider than 64 bits into the Value store (the `StValue`/`LValue` accessors cannot represent them); the UHDM `param_assign` RHS keeps the full constant for the UHDM-level evaluator and downstream tools.

Verified downstream in uhdm2rtlil: CVA6 `hpdcache_ctrl_pe` proves equivalent to read_slang (was a 2/2000 co-sim counterexample), `hpdcache_sync_buffer`/`param_nested_struct_field_width` width regressions from the first iteration are covered by dedicated checks, the full CVA6 per-module sweep is clean (144 as expected, 0 regressions), and the 865-test regression suite passes with no unexpected failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)