### PR TITLE
Bump version to 1.87

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 # Version changes whenever some new features accumulated, or the
 # grammar or the cache format changes to make sure caches
 # are invalidated.
-project(SURELOG VERSION 1.86)
+project(SURELOG VERSION 1.87)
 
 # Detect build type, fallback to release and throw a warning if use didn't
 # specify any


### PR DESCRIPTION
Cuts the **v1.87** release.

`Version Tagging` tags the commit where `project(SURELOG VERSION ...)` changes, so merging this automatically creates the `v1.87` tag.

Also moves the UHDM submodule to UHDM master at v1.87 (chipsalliance/UHDM#1143, now merged — `v1.87` tags `18837c1`). Surelog and UHDM version numbers go in tandem — `Surelog.pc.in` pins `Requires: UHDM >= @PROJECT_VERSION@` — so a Surelog 1.87 pinning a UHDM that still calls itself 1.86 would fail its own `test_install_pkgconfig` check.

The submodule moves by exactly two commits — UHDM's version bump and its merge — because master's pin was already at the previous UHDM master tip. So there is no UHDM behavior change in this PR, and no golden-log movement expected.

### What's in Surelog 1.87 (96 commits since v1.86)

**Interface parameters and modports**
- Resolve interface parameters/localparams reached through a modport port; fix override propagation through modport ports
- Fold interface-param struct-field and interface-port-localparam generate conditions and generate-for bounds
- Preserve unpacked-array dimensions on interface definition nets; interface array sizing

**Type parameters and structs**
- Resolve `parameter type A = B` chains; build a `packed_array_typespec` for `parameter type X = <type> [msb:lsb]`; re-resolve packed-array elements from overridden type parameters
- Resolve and reduce struct-typed-parameter field references in localparam struct member ranges and pattern init values
- Elaborate generate-for bounded by a struct-parameter field
- Keep the packed dimension of a multi-member anonymous struct; implicit packed struct net support

**Robustness** — a broad sweep of crash and UB fixes
- Guards against null-deref in pattern ops, empty statement vectors, null initializers, out-of-range positional overrides
- Divide/modulo by zero (SIGFPE), 32-bit shift UB, `size_t` underflow in `-cmd_ren`/`-cmd_mrg`
- Out-of-bounds reads in `fromString`, the preprocessor token-paste look-ahead, and the `StringUtils` separator table
- No longer throws on oversized `` `timescale `` values or unparseable numeric command-line arguments

**Preprocessor**
- `// synthesis translate_off/on` support, with region stripping decoupled via `-filterprotected`
- Preserve interior whitespace in macro default arguments; guard empty formal arguments

**Grammar and misc**
- Accept `hierarchical_identifier` as a `bind` target
- Skip `attribute_instance` in struct members, tf port items, and modport port declarations
- Handle `disable iff` and sequence local variables in assertion declarations
- Allow the path to the Surelog folder to contain a dot
- Treat definitions without `FileContent` as black boxes; fire elaboration diagnostics for instantiated modules only

**CI** (this cycle)
- Fixed the antlr4 absolute-install-path bug that broke all four Linux Install jobs, plus ClangTidy, CodeFormatting, and the non_vendored UHDM pin (#4145)
- Fixed the Windows build — `LibrarySet` needs a complete `Library` type for `std::deque` (#4146)

### Known-red at release time

`Windows | Regression` fails on all 12 shards — every test emits an empty log. That job had been *skipped* for months behind the broken Windows Install, so v1.86 shipped without it running at all; #4146 made it visible again. Tracked separately, not a regression introduced by this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)