### PR TITLE
clang-format CompileHelper.cpp

### DIFF
--- a/src/DesignCompile/CompileHelper.cpp
+++ b/src/DesignCompile/CompileHelper.cpp
@@ -4650,8 +4650,8 @@ UHDM::assignment* CompileHelper::compileBlockingAssignment(
            VObjectType::paPs_or_hierarchical_identifier) &&
           (lhs_rf != nullptr) && (lhs_rf->UhdmType() == uhdmhier_path)) {
         NodeId Select = fC->Sibling(Ps_or_hier);
-        bool pure_selects = (fC->Type(Select) == VObjectType::paSelect) &&
-                            fC->Child(Select);
+        bool pure_selects =
+            (fC->Type(Select) == VObjectType::paSelect) && fC->Child(Select);
         for (NodeId sc = fC->Child(Select); pure_selects && sc;
              sc = fC->Sibling(sc)) {
           if (fC->Type(sc) != VObjectType::paBit_select &&


### PR DESCRIPTION
`CodeFormatting` is red on master, so it fails every PR opened against it.

One hunk drifted in with the hierarchical-lvalue select work:

```diff
-        bool pure_selects = (fC->Type(Select) == VObjectType::paSelect) &&
-                            fC->Child(Select);
+        bool pure_selects =
+            (fC->Type(Select) == VObjectType::paSelect) && fC->Child(Select);
```

Whitespace only — the output of `.github/bin/run-clang-format.sh` with clang-format 17, the version CI pins. After this, the script exits 0 on a clean tree.

This was originally the second commit on #4150, but that PR merged before the commit landed on its branch, so it missed the 1.87 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)