### PR TITLE
$bits of a struct with type-parameter members must use the instance's types

### DIFF
--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -4503,6 +4503,100 @@ uint64_t CompileHelper::Bits(const UHDM::any *typespec, bool &invalidValue,
         m_exprEvalPlaceHolder->Param_assigns()->begin(),
         m_exprEvalPlaceHolder->Param_assigns()->end());
   }
+  // A struct whose members are typed by TYPE PARAMETERS is sized here with
+  // the parameters' DEFAULTS: the struct typespec is built once, at
+  // definition time, so its members point at `parameter type tag_t = logic`
+  // (1 bit) no matter what the instance overrides them with.  CVA6's
+  // hpdcache_mshr computes `$bits(mshr_entry_t)` that way and got 10 bits
+  // instead of 57, mis-sizing the whole MSHR RAM (every ack field read out
+  // of the wrong slice).  Substitute each member typed by a type parameter
+  // with THIS instance's override before summing.
+  if (typespec && (typespec->UhdmType() == uhdmstruct_typespec) && !sizeMode) {
+    if (ModuleInstance *minst =
+            valuedcomponenti_cast<ModuleInstance *>(instance)) {
+      const struct_typespec *sts = (const struct_typespec *)typespec;
+      // The instance's type-param override may not have its UHDM object
+      // built yet at this point in elaboration; fall back to compiling the
+      // override's declared type from the Parameter's own source node (the
+      // same path ElaborationStep uses when uparam has no typespec).
+      auto param_ts = [&](Parameter *p,
+                          ValuedComponentI *ctx) -> const UHDM::typespec * {
+        if (p == nullptr) return nullptr;
+        if (any *up = p->getUhdmParam())
+          if (type_parameter *tp = any_cast<type_parameter *>(up))
+            if (const ref_typespec *rt = tp->Typespec())
+              if (const UHDM::typespec *a = rt->Actual_typespec()) return a;
+        if (p->getFileContent() && p->getNodeType())
+          return compileTypespec(component, p->getFileContent(),
+                                 p->getNodeType(), compileDesign, Reduce::Yes,
+                                 nullptr, ctx, false);
+        return nullptr;
+      };
+      // Same declaration site => same type (clone_tree copies compare equal
+      // here even when the pointers differ).
+      auto same_decl = [](const UHDM::typespec *a,
+                          const UHDM::typespec *b) -> bool {
+        if (a == b) return true;
+        if ((a == nullptr) || (b == nullptr)) return false;
+        return (a->UhdmType() == b->UhdmType()) &&
+               (a->VpiFile() == b->VpiFile()) &&
+               (a->VpiLineNo() == b->VpiLineNo()) &&
+               (a->VpiColumnNo() == b->VpiColumnNo()) &&
+               (a->VpiEndLineNo() == b->VpiEndLineNo()) &&
+               (a->VpiEndColumnNo() == b->VpiEndColumnNo());
+      };
+      std::vector<std::pair<const UHDM::typespec *, const UHDM::typespec *>>
+          subst;
+      for (Parameter *p : minst->getTypeParams()) {
+        // The override is declared in the PARENT's scope.
+        ValuedComponentI *povr = minst->getParent()
+                                     ? (ValuedComponentI *)minst->getParent()
+                                     : (ValuedComponentI *)minst;
+        const UHDM::typespec *ov = param_ts(p, povr);
+        if (ov == nullptr) continue;
+        const UHDM::typespec *def = nullptr;
+        if (DesignComponent *dc = minst->getDefinition())
+          def = param_ts(dc->getParameter(p->getName()), minst);
+        if ((def != nullptr) && !same_decl(def, ov))
+          subst.emplace_back(def, ov);
+      }
+      if (!subst.empty() && (sts->Members() != nullptr)) {
+        bool ok = true;
+        bool any_subst = false;
+        uint64_t total = 0;
+        for (typespec_member *memb : *sts->Members()) {
+          const UHDM::typespec *mt = nullptr;
+          if (const ref_typespec *rt = memb->Typespec())
+            mt = rt->Actual_typespec();
+          if (mt == nullptr) {
+            ok = false;
+            break;
+          }
+          const UHDM::typespec *use = mt;
+          for (const auto &sub : subst) {
+            if (same_decl(mt, sub.first)) {
+              use = sub.second;
+              any_subst = true;
+              break;
+            }
+          }
+          bool iv = false;
+          uint64_t w = eval.size(use, iv, m_exprEvalPlaceHolder, nullptr, true);
+          if (iv || (w == 0)) {
+            ok = false;
+            break;
+          }
+          total += w;
+        }
+        if (ok && any_subst && (total > 0)) {
+          if (m_checkForLoops) {
+            m_stackLevel--;
+          }
+          return total;
+        }
+      }
+    }
+  }
   uint64_t size = eval.size(typespec, invalidValue, m_exprEvalPlaceHolder,
                             nullptr, !sizeMode);
   if (m_checkForLoops) {

--- a/third_party/tests/Ariane2024/Ariane2024.log
+++ b/third_party/tests/Ariane2024/Ariane2024.log
@@ -6652,7 +6652,7 @@ case_stmt                                            249
 class_defn                                             8
 class_typespec                                         4
 class_var                                              3
-constant                                          275851
+constant                                          275887
 cont_assign                                        13127
 design                                                 1
 enum_const                                         11151

--- a/third_party/tests/AzadiRTL/AzadiRTL.log
+++ b/third_party/tests/AzadiRTL/AzadiRTL.log
@@ -17409,7 +17409,7 @@ case_stmt                                            183
 class_defn                                             8
 class_typespec                                         4
 class_var                                              3
-constant                                          324364
+constant                                          324374
 cont_assign                                         8981
 delay_control                                          4
 design                                                 1
@@ -17440,13 +17440,13 @@ integer_typespec                                     590
 integer_var                                           22
 io_decl                                              197
 logic_net                                          10991
-logic_typespec                                     37641
+logic_typespec                                     37645
 logic_var                                          11338
 long_int_typespec                                      6
 long_int_var                                           2
 module_inst                                         9650
 named_begin                                          357
-operation                                          57576
+operation                                          57577
 package                                               28
 packed_array_net                                      19
 packed_array_typespec                                252
@@ -17456,7 +17456,7 @@ parameter                                          99652
 part_select                                         2009
 port                                               13660
 property_spec                                         31
-range                                              81061
+range                                              81062
 ref_module                                           488
 ref_obj                                            88087
 ref_typespec                                      216968
@@ -17490,7 +17490,7 @@ case_stmt                                            876
 class_defn                                             8
 class_typespec                                         4
 class_var                                              3
-constant                                          358889
+constant                                          358899
 cont_assign                                        43681
 delay_control                                          8
 design                                                 1
@@ -17521,13 +17521,13 @@ integer_typespec                                     590
 integer_var                                           94
 io_decl                                              485
 logic_net                                          10991
-logic_typespec                                     37641
+logic_typespec                                     37645
 logic_var                                          18966
 long_int_typespec                                      6
 long_int_var                                           6
 module_inst                                        10042
 named_begin                                         1018
-operation                                         220074
+operation                                         220075
 package                                               28
 packed_array_net                                      19
 packed_array_typespec                                252
@@ -17537,7 +17537,7 @@ parameter                                          99653
 part_select                                        12214
 port                                               28769
 property_spec                                        110
-range                                              81488
+range                                              81489
 ref_module                                           488
 ref_obj                                           301227
 ref_typespec                                      896534


### PR DESCRIPTION
A struct typespec is built once, at definition time, so members typed by a type parameter point at the parameter's **default** (`parameter type tag_t = logic`). `$bits()` then sized every such member as 1 bit regardless of the instance's override:

```systemverilog
module m #(parameter type tag_t = logic, parameter type id_t = logic);
  typedef struct packed { tag_t tag; id_t req_id; logic v; } entry_t;
  localparam int unsigned BITS = $bits(entry_t);   // 3, should be 50
endmodule

m #(.tag_t(logic [43:0]), .id_t(logic [4:0])) u (...);
```

CVA6's `hpdcache_mshr` computes `HPDCACHE_MSHR_ENTRY_BITS` exactly this way and got **10 instead of 57**, so the MSHR RAM was sized — and every ack field sliced — from the wrong geometry. slang resolves it correctly, which is how the divergence was found.

**Fix** — `CompileHelper::Bits()` substitutes, per member, the *instance's* type-parameter override before summing:
- members are matched to a parameter by **declaration site** rather than pointer identity, so `clone_tree` copies compare equal;
- the override typespec is compiled from the `Parameter`'s own source node when its UHDM object isn't populated yet at this point in elaboration (the same path `ElaborationStep` already uses);
- if no member matches a type parameter, or any member fails to size, the existing `eval.size()` path runs unchanged — only designs that are wrong today are affected.

**Regression: 791 PASS / 0 DIFF / 0 FAIL** after refreshing two goldens. Every diff is a UHDM object-count delta, with no new errors/warnings and no elaboration changes:

| test | delta |
|---|---|
| Ariane2024 | +36 `constant` |
| AzadiRTL | +10 `constant`, +4 `logic_typespec`, +1 `operation`, +1 `range` |

The extra typespec/range objects come from compiling the override typespecs; the extra constants from the corrected widths. `CoresSweRVMP` was deliberately left untouched — its only diff is reordered `Generating NN_*.sv` lines from the parallel codegen step, i.e. pre-existing nondeterminism unrelated to this change.

Downstream (uhdm2rtlil) confirms `HPDCACHE_MSHR_ENTRY_BITS` 10 → 57 and `HPDCACHE_MSHR_RAM_ENTRY_BITS` 32 → 64, both matching slang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)