### PR TITLE
NumUtils: clamp field size to avoid size_t underflow / length_error in toBinary

### DIFF
--- a/src/Utils/NumUtils.cpp
+++ b/src/Utils/NumUtils.cpp
@@ -84,6 +84,11 @@ std::string NumUtils::toBinary(int32_t size, uint64_t val) {
       }
     }
   }
+  // Clamp size to the bit field width: a wider field (for instance an
+  // element of a sized concatenation exceeding bitFieldSize bits) makes
+  // the size_t reserve() argument below underflow, throwing
+  // std::length_error.
+  if (size > bitFieldSize) size = bitFieldSize;
   std::string result;
   result.reserve(bitFieldSize - size + 1);
   for (uint32_t i = bitFieldSize - size; i < bitFieldSize; i++)


### PR DESCRIPTION
### Problem

`NumUtils::toBinary(int32_t size, uint64_t val)` computes its `reserve()`
argument as `bitFieldSize - size + 1`, where `bitFieldSize == 100`. When
`size > bitFieldSize + 1` the subtraction is converted to `size_t` for
`std::string::reserve`, underflows to a huge value, and `reserve` throws
`std::length_error`, aborting the process (`SIGABRT`).

This is reachable from valid input: a sized enum literal whose value is a
concatenation containing an element wider than 100 bits produces such a
`size`. Minimal repro (`test.sv`):

```systemverilog
module top; typedef enum logic [127:0] { E0 = {102'h1, 26'h0} } e_t; endmodule
```

```
$ surelog -parse -nocache test.sv
...
[INF:CP0303] Compile module "work@top".
terminate called after throwing an instance of 'std::length_error'
  what():  basic_string::_M_create
Aborted (core dumped)
```

A single `<= 100`-bit literal (e.g. `E0 = 128'h1`) elaborates fine; the
crash requires a concatenation element wider than `bitFieldSize`.

### Fix

Clamp `size` to `bitFieldSize` before the `reserve()`/copy so the `size_t`
argument can no longer underflow. `val` is a `uint64_t` (already bounded by
the `std::bitset<bitFieldSize>` used to build the source string), so the
clamp does not lose representable bits. This matches the existing
guard/underflow fixes in this file/library.

### Verification

Reproduced the `SIGABRT` (`std::length_error`) on the prebuilt `surelog`
binary. The fix is a bounds clamp verified by static analysis (I can't
rebuild Surelog on my dev box). With the clamp, for any `size > 100` the
`reserve` argument becomes `bitFieldSize - bitFieldSize + 1 == 1` and the
copy loop stays within the 100-char `bitset` string, so the underflow path
is removed while behavior for `size <= 100` is unchanged.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
