### PR TITLE
Keep the packed dimension on a type-parameter-typed member

### DIFF
--- a/src/DesignCompile/CompileType.cpp
+++ b/src/DesignCompile/CompileType.cpp
@@ -1933,8 +1933,34 @@ UHDM::typespec* CompileHelper::compileTypespec(
         }
       }
       if (result == nullptr) {
-        result = compileDatastructureTypespec(
-            component, fC, type, compileDesign, reduce, instance, "", typeName);
+        // `tp_t [N-1:0] member;` where tp_t is a TYPE PARAMETER.  Resolve the
+        // parameter against the component's own list FIRST: at the point a
+        // struct's members are compiled, compileDatastructureTypespec returns
+        // null for such a name, so the packed-dimension wrap below never ran
+        // and the element type was patched in later WITHOUT the ranges — the
+        // member ended up ONE element wide.  CVA6's forwarding_t
+        // (`writeback_t [NrWbPorts-1:0] wb;` and
+        // `scoreboard_entry_t [NR_SB_ENTRIES-1:0] sbe;`) measured 518 bits
+        // instead of 3860, so scoreboard and issue_read_operands could not be
+        // compared port-for-port at all.  Gated on `ranges` so a bare type
+        // parameter name keeps resolving exactly as before.
+        if (ranges != nullptr && component) {
+          if (UHDM::VectorOfany* params = component->getParameters()) {
+            for (any* param : *params) {
+              if (param->UhdmType() == uhdmtype_parameter &&
+                  param->VpiName() == typeName) {
+                if (ref_typespec* rt = ((type_parameter*)param)->Typespec())
+                  result = rt->Actual_typespec();
+                break;
+              }
+            }
+          }
+        }
+        if (result == nullptr) {
+          result = compileDatastructureTypespec(
+              component, fC, type, compileDesign, reduce, instance, "",
+              typeName);
+        }
         if (ranges && result) {
           UHDM_OBJECT_TYPE dstype = result->UhdmType();
           ref_typespec* resultRef = s.MakeRef_typespec();

--- a/tests/HierPathPackedVar/HierPathPackedVar.log
+++ b/tests/HierPathPackedVar/HierPathPackedVar.log
@@ -290,13 +290,14 @@ logic_typespec                                        16
 module_inst                                            5
 operation                                              5
 package                                                2
+packed_array_typespec                                  3
 packed_array_var                                       1
 param_assign                                           2
 parameter                                              2
 port                                                   2
 range                                                 14
 ref_obj                                                9
-ref_typespec                                          30
+ref_typespec                                          33
 struct_typespec                                        2
 struct_var                                             1
 type_parameter                                         1
@@ -319,13 +320,14 @@ logic_typespec                                        16
 module_inst                                            5
 operation                                              6
 package                                                2
+packed_array_typespec                                  3
 packed_array_var                                       1
 param_assign                                           2
 parameter                                              2
 port                                                   3
 range                                                 14
 ref_obj                                               14
-ref_typespec                                          31
+ref_typespec                                          34
 struct_typespec                                        2
 struct_var                                             1
 type_parameter                                         1
@@ -785,7 +787,7 @@ design: (work@axi_adapter_arbiter)
       \_port: (req_i), line:19:34, endln:19:39
       |vpiFullName:work@axi_adapter_arbiter.req_i
       |vpiActual:
-      \_struct_typespec: (std_cache_pkg::bypass_req_t), line:2:12, endln:12:2
+      \_packed_array_typespec: , line:19:13, endln:19:33
   |vpiProcess:
   \_always: , line:21:5, endln:25:8
     |vpiParent:
@@ -990,7 +992,7 @@ design: (work@axi_adapter_arbiter)
       \_port: (req_i), line:19:34, endln:19:39
       |vpiFullName:work@axi_adapter_arbiter.req_i
       |vpiActual:
-      \_struct_typespec: (std_cache_pkg::bypass_req_t), line:2:12, endln:12:2
+      \_packed_array_typespec: , line:19:13, endln:19:33
     |vpiInstance:
     \_module_inst: work@axi_adapter_arbiter (work@axi_adapter_arbiter), file:${SURELOG_DIR}/tests/HierPathPackedVar/dut.sv, line:16:1, endln:26:10
   |vpiProcess:
@@ -1366,9 +1368,73 @@ design: (work@axi_adapter_arbiter)
       |UINT:0
       |vpiConstType:9
 \_int_typespec: , line:17:5, endln:17:27
+\_packed_array_typespec: , line:19:13, endln:19:33
+  |vpiRange:
+  \_range: , line:19:19, endln:19:33
+    |vpiParent:
+    \_packed_array_typespec: , line:19:13, endln:19:33
+    |vpiLeftRange:
+    \_constant: , line:19:20, endln:19:28
+      |vpiParent:
+      \_range: , line:19:19, endln:19:33
+      |vpiDecompile:3
+      |vpiSize:64
+      |INT:3
+      |vpiConstType:7
+    |vpiRightRange:
+    \_constant: , line:19:31, endln:19:32
+      |vpiParent:
+      \_range: , line:19:19, endln:19:33
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+  |vpiElemTypespec:
+  \_ref_typespec: 
+    |vpiParent:
+    \_packed_array_typespec: , line:19:13, endln:19:33
+    |vpiActual:
+    \_struct_typespec: (std_cache_pkg::bypass_req_t), line:2:12, endln:12:2
 \_logic_typespec: , line:20:5, endln:20:8
   |vpiParent:
   \_logic_net: (work@axi_adapter_arbiter.state_d), line:20:9, endln:20:16
+\_packed_array_typespec: , line:19:13, endln:19:33
+  |vpiRange:
+  \_range: , line:19:19, endln:19:33
+    |vpiParent:
+    \_packed_array_typespec: , line:19:13, endln:19:33
+    |vpiLeftRange:
+    \_operation: , line:19:20, endln:19:30
+      |vpiParent:
+      \_range: , line:19:19, endln:19:33
+      |vpiOpType:11
+      |vpiOperand:
+      \_ref_obj: (NR_PORTS), line:19:20, endln:19:28
+        |vpiParent:
+        \_operation: , line:19:20, endln:19:30
+        |vpiName:NR_PORTS
+      |vpiOperand:
+      \_constant: , line:19:29, endln:19:30
+        |vpiParent:
+        \_operation: , line:19:20, endln:19:30
+        |vpiDecompile:1
+        |vpiSize:64
+        |UINT:1
+        |vpiConstType:9
+    |vpiRightRange:
+    \_constant: , line:19:31, endln:19:32
+      |vpiParent:
+      \_range: , line:19:19, endln:19:33
+      |vpiDecompile:0
+      |vpiSize:64
+      |UINT:0
+      |vpiConstType:9
+  |vpiElemTypespec:
+  \_ref_typespec: 
+    |vpiParent:
+    \_packed_array_typespec: , line:19:13, endln:19:33
+    |vpiActual:
+    \_struct_typespec: (std_cache_pkg::bypass_req_t), line:2:12, endln:12:2
 \_logic_typespec: , line:20:5, endln:20:8
 \_int_typespec: , line:17:5, endln:17:27
   |vpiParent:


### PR DESCRIPTION
## The bug

`tp_t [N-1:0] arr;` where `tp_t` is a **type parameter** loses its `[N-1:0]` dimension. The elaborated member carries the bare element typespec — no `packed_array_typespec`, no range — so the declaration measures **one element wide**.

The same spelling with a plain typedef element is already correct, so the two differ only in whether the element names a type parameter:

| member element type | elaborated typespec |
|---|---|
| `p::entry_t [N-1:0]` (typedef) | `packed_array_typespec` + `range` ✅ |
| `tp_t [N-1:0]` (type parameter) | bare `struct_typespec` ❌ |

### Impact

CVA6's `forwarding_t`:

```systemverilog
logic [NR_SB_ENTRIES-1:0]              still_issued;
logic [TRANS_ID_BITS-1:0]              issue_pointer;
writeback_t        [NrWbPorts-1:0]     wb;
scoreboard_entry_t [NR_SB_ENTRIES-1:0] sbe;
```

measured **518** bits (`8 + 3 + 1*69 + 1*438`) instead of **3860** (`8 + 3 + 5*69 + 8*438`) — both arrays collapsed to a single element. Downstream, `scoreboard` and `issue_read_operands` could not be compared port-for-port at all.

This **cannot be worked around downstream**: UHDM's `typespec_member` exposes no `Ranges()`, so a dimension that is not inside the member's own typespec is unrecoverable.

## Root cause

At the point a struct's members are compiled, `compileDatastructureTypespec` returns null for a type-parameter name — its type-parameter branch only resolves on a *later* call, once `tparam->Typespec()` has been set. So the packed-dimension wrap that follows never ran, and the element type was patched in afterwards without the ranges.

## Fix

Resolve the parameter against the component's own parameter list first, and let the existing wrap apply.

Two deliberate constraints:
- **gated on `ranges` being present**, so a bare type-parameter name resolves exactly as before;
- **kept inside the original `if (result == nullptr)` guard** — moving the wrap out would double-apply ranges to the `logic`/`bit` branches, which already set them themselves.

## Test

`tests/HierPathPackedVar` already exercises the same shape on a port (`input req_t [NR_PORTS-1:0] req_i`, `req_t` a type parameter). Its golden gains the `packed_array_typespec` and its `[3:0]` range — that test's typespec was silently collapsed before.

Regression: **788 PASS, 0 FAIL** (was 787). The golden diff is exactly the intended `+3 packed_array_typespec` / `+3 ref_typespec` and the `struct_typespec` → `packed_array_typespec` substitution; no other test changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)