### PR TITLE
Cache: catch kj::Exception on read so a corrupt cache recompiles instead of aborting

### DIFF
--- a/src/Cache/PPCache.cpp
+++ b/src/Cache/PPCache.cpp
@@ -28,6 +28,7 @@
 #include <capnp/list.h>
 #include <capnp/message.h>
 #include <capnp/serialize-packed.h>
+#include <kj/exception.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 
@@ -254,14 +255,19 @@ bool PPCache::checkCacheIsValid(PathId cacheFileId) const {
   if (fd < 0) return false;
 
   bool result = false;
-  do {
+  try {
     ::capnp::ReaderOptions options;
     options.traversalLimitInWords = std::numeric_limits<uint64_t>::max();
     options.nestingLimit = 1024;
     ::capnp::PackedFdMessageReader message(fd, options);
     const ::PPCache::Reader& root = message.getRoot<::PPCache>();
     result = checkCacheIsValid(cacheFileId, root);
-  } while (false);
+  } catch (const ::kj::Exception& e) {
+    // A truncated or corrupt cache file makes Cap'n Proto throw a
+    // kj::Exception; treat it as an invalid cache (recompile) instead of
+    // letting the exception abort the whole tool.
+    result = false;
+  }
 
   ::close(fd);
   return result;

--- a/src/Cache/ParseCache.cpp
+++ b/src/Cache/ParseCache.cpp
@@ -28,6 +28,7 @@
 #include <capnp/list.h>
 #include <capnp/message.h>
 #include <capnp/serialize-packed.h>
+#include <kj/exception.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 
@@ -136,14 +137,19 @@ bool ParseCache::checkCacheIsValid(PathId cacheFileId) const {
   if (fd < 0) return false;
 
   bool result = false;
-  do {
+  try {
     ::capnp::ReaderOptions options;
     options.traversalLimitInWords = std::numeric_limits<uint64_t>::max();
     options.nestingLimit = 1024;
     ::capnp::PackedFdMessageReader message(fd, options);
     const ::ParseCache::Reader& root = message.getRoot<::ParseCache>();
     result = checkCacheIsValid(cacheFileId, root);
-  } while (false);
+  } catch (const ::kj::Exception& e) {
+    // A truncated or corrupt cache file makes Cap'n Proto throw a
+    // kj::Exception; treat it as an invalid cache (recompile) instead of
+    // letting the exception abort the whole tool.
+    result = false;
+  }
 
   ::close(fd);
   return result;

--- a/src/Cache/PythonAPICache.cpp
+++ b/src/Cache/PythonAPICache.cpp
@@ -28,6 +28,7 @@
 #include <capnp/list.h>
 #include <capnp/message.h>
 #include <capnp/serialize-packed.h>
+#include <kj/exception.h>
 #include <fcntl.h>
 
 #include <cstdint>
@@ -123,14 +124,19 @@ bool PythonAPICache::checkCacheIsValid(PathId cacheFileId) const {
   if (fd < 0) return false;
 
   bool result = false;
-  do {
+  try {
     ::capnp::ReaderOptions options;
     options.traversalLimitInWords = std::numeric_limits<uint64_t>::max();
     options.nestingLimit = 1024;
     ::capnp::PackedFdMessageReader message(fd, options);
     const ::PythonAPICache::Reader& root = message.getRoot<::PythonAPICache>();
     result = checkCacheIsValid(cacheFileId, root);
-  } while (false);
+  } catch (const ::kj::Exception& e) {
+    // A truncated or corrupt cache file makes Cap'n Proto throw a
+    // kj::Exception; treat it as an invalid cache (recompile) instead of
+    // letting the exception abort the whole tool.
+    result = false;
+  }
 
   ::close(fd);
   return result;


### PR DESCRIPTION
## Problem

The cache validity checks in `src/Cache/PPCache.cpp`, `ParseCache.cpp`, and `PythonAPICache.cpp` do:

```cpp
::capnp::PackedFdMessageReader message(fd, options);
const ::PPCache::Reader& root = message.getRoot<::PPCache>();
result = checkCacheIsValid(cacheFileId, root);
```

with no exception handling. When the cache file is truncated or corrupt, Cap'n Proto throws a `kj::Exception` (`Premature EOF` / `Packed input did not end cleanly`). It propagates out of `checkCacheIsValid` uncaught, and `std::terminate` **aborts Surelog (SIGABRT)** — on its default, cache-enabled invocation.

### Reproduce (surelog 1.86)

```
$ surelog -parse f.sv           # f.sv: module m; initial $display("hi"); endmodule  -> writes slpp_all/cache/.../f.sv.slpp
$ truncate -s 8 slpp_all/cache/work/f.sv.slpp
$ surelog -parse f.sv
terminate called after throwing an instance of 'kj::ExceptionImpl'
  what():  kj/io.c++:117: failed: expected result.size() > 0 [0 > 0]; Premature EOF
Aborted (core dumped)           # exit 134
```

`-parse -nocache` is unaffected, confirming the abort is on the cache-read path.

## Fix

#2849 made cache *writes* atomic, which stops Surelog's own interrupted writes from leaving a partial file. This guards the *read* side for what write-atomicity can't cover — external truncation/corruption, a partial copy, a disk/filesystem error, or a version-skewed file: catch `kj::Exception` in the three `checkCacheIsValid` paths and return "invalid", so the cache is recompiled rather than aborting the tool. A cache that cannot be read is, by definition, not a valid cache.

The three cache *restore* reads (reached only after a cache passes validity) have the same unguarded pattern; I'm happy to guard those in a follow-up if you'd prefer.

## Testing

Reproduced the SIGABRT on the prebuilt `surelog`. I can't rebuild Surelog on my dev box (RAM), so the fix itself is verified by static reasoning: the `catch (const ::kj::Exception&)` turns the throw that currently aborts into `result = false` (cache miss → recompile), the exact contract `checkCacheIsValid` already returns for an out-of-date cache. Brace balance verified.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
