### PR TITLE
Bump UHDM: element-select on multi-range packed arrays

### DIFF
--- a/third_party/tests/Ariane2024/Ariane2024.log
+++ b/third_party/tests/Ariane2024/Ariane2024.log
@@ -6652,7 +6652,7 @@ case_stmt                                            249
 class_defn                                             8
 class_typespec                                         4
 class_var                                              3
-constant                                          275884
+constant                                          275900
 cont_assign                                        13127
 design                                                 1
 enum_const                                         11151
@@ -6684,7 +6684,7 @@ integer_typespec                                    3190
 integer_var                                            6
 io_decl                                              349
 logic_net                                           6726
-logic_typespec                                     24257
+logic_typespec                                     24261
 logic_var                                           3670
 long_int_typespec                                     10
 long_int_var                                           2
@@ -6700,7 +6700,7 @@ parameter                                          17761
 part_select                                         2520
 port                                                8880
 property_spec                                        404
-range                                              28121
+range                                              28129
 ref_module                                           362
 ref_obj                                            90292
 ref_typespec                                      113831

--- a/third_party/tests/AzadiRTL/AzadiRTL.log
+++ b/third_party/tests/AzadiRTL/AzadiRTL.log
@@ -17409,7 +17409,7 @@ case_stmt                                            183
 class_defn                                             8
 class_typespec                                         4
 class_var                                              3
-constant                                          324374
+constant                                          324414
 cont_assign                                         8981
 delay_control                                          4
 design                                                 1
@@ -17440,7 +17440,7 @@ integer_typespec                                     590
 integer_var                                           22
 io_decl                                              197
 logic_net                                          10991
-logic_typespec                                     37708
+logic_typespec                                     37718
 logic_var                                          11338
 long_int_typespec                                      6
 long_int_var                                           2
@@ -17456,10 +17456,10 @@ parameter                                          99652
 part_select                                         2009
 port                                               13660
 property_spec                                         31
-range                                              81062
+range                                              81082
 ref_module                                           488
 ref_obj                                            88087
-ref_typespec                                      217031
+ref_typespec                                      217035
 ref_var                                                8
 return_stmt                                          118
 string_typespec                                     2724
@@ -17490,7 +17490,7 @@ case_stmt                                            876
 class_defn                                             8
 class_typespec                                         4
 class_var                                              3
-constant                                          358899
+constant                                          358939
 cont_assign                                        43681
 delay_control                                          8
 design                                                 1
@@ -17521,7 +17521,7 @@ integer_typespec                                     590
 integer_var                                           94
 io_decl                                              485
 logic_net                                          10991
-logic_typespec                                     37708
+logic_typespec                                     37718
 logic_var                                          18966
 long_int_typespec                                      6
 long_int_var                                           6
@@ -17537,10 +17537,10 @@ parameter                                          99653
 part_select                                        12214
 port                                               28769
 property_spec                                        110
-range                                              81489
+range                                              81509
 ref_module                                           488
 ref_obj                                           301227
-ref_typespec                                      896597
+ref_typespec                                      896601
 ref_var                                               36
 return_stmt                                          317
 string_typespec                                     2895

--- a/third_party/tests/Earlgrey_0_1/sim-icarus/Earlgrey_0_1.log
+++ b/third_party/tests/Earlgrey_0_1/sim-icarus/Earlgrey_0_1.log
@@ -6169,7 +6169,7 @@ case_stmt                                            231
 class_defn                                             8
 class_typespec                                         4
 class_var                                              3
-constant                                          326286
+constant                                          342926
 cont_assign                                        19794
 design                                                 1
 enum_const                                          3632
@@ -6197,7 +6197,7 @@ integer_typespec                                     480
 integer_var                                            1
 io_decl                                              253
 logic_net                                          27103
-logic_typespec                                     67336
+logic_typespec                                     71496
 logic_var                                          13044
 module_inst                                         6189
 named_begin                                          496
@@ -6211,10 +6211,10 @@ parameter                                          25421
 part_select                                         3319
 port                                               38152
 property_spec                                          2
-range                                              47840
+range                                              56160
 ref_module                                          1917
 ref_obj                                           155546
-ref_typespec                                      128391
+ref_typespec                                      132487
 return_stmt                                          111
 string_typespec                                     3531
 struct_net                                           184
@@ -6243,7 +6243,7 @@ case_stmt                                            614
 class_defn                                             8
 class_typespec                                         4
 class_var                                              3
-constant                                          331420
+constant                                          348060
 cont_assign                                        47364
 design                                                 1
 enum_const                                          3637
@@ -6271,7 +6271,7 @@ integer_typespec                                     480
 integer_var                                            1
 io_decl                                             2275
 logic_net                                          27103
-logic_typespec                                     67336
+logic_typespec                                     71496
 logic_var                                          23278
 module_inst                                         6953
 named_begin                                          984
@@ -6285,10 +6285,10 @@ parameter                                          25421
 part_select                                         9422
 port                                               67958
 property_spec                                          4
-range                                              48319
+range                                              56639
 ref_module                                          1917
 ref_obj                                           389033
-ref_typespec                                      206737
+ref_typespec                                      210833
 return_stmt                                         1419
 string_typespec                                     3821
 struct_net                                           184

--- a/third_party/tests/Earlgrey_Verilator_0_1/sim-verilator/Earlgrey_Verilator_0_1.log
+++ b/third_party/tests/Earlgrey_Verilator_0_1/sim-verilator/Earlgrey_Verilator_0_1.log
@@ -5824,7 +5824,7 @@ chandle_var                                           11
 class_defn                                             8
 class_typespec                                         4
 class_var                                              3
-constant                                          320306
+constant                                          320826
 cont_assign                                        19205
 design                                                 1
 enum_const                                          3532
@@ -5854,7 +5854,7 @@ integer_var                                            1
 interface_inst                                         1
 io_decl                                              357
 logic_net                                          26802
-logic_typespec                                     67766
+logic_typespec                                     67896
 logic_var                                          12617
 module_inst                                         5797
 named_begin                                          491
@@ -5867,10 +5867,10 @@ param_assign                                       18173
 parameter                                          22114
 part_select                                         3296
 port                                               37447
-range                                              49006
+range                                              49266
 ref_module                                          1821
 ref_obj                                           155176
-ref_typespec                                      126914
+ref_typespec                                      127042
 return_stmt                                          369
 string_typespec                                     3590
 string_var                                            14
@@ -5904,7 +5904,7 @@ chandle_var                                           11
 class_defn                                             8
 class_typespec                                         4
 class_var                                              3
-constant                                          325515
+constant                                          326035
 cont_assign                                        43470
 design                                                 1
 enum_const                                          3537
@@ -5934,7 +5934,7 @@ integer_var                                            1
 interface_inst                                         1
 io_decl                                             2569
 logic_net                                          26802
-logic_typespec                                     67766
+logic_typespec                                     67896
 logic_var                                          21763
 module_inst                                         6364
 named_begin                                          955
@@ -5947,10 +5947,10 @@ param_assign                                       24510
 parameter                                          22114
 part_select                                         9045
 port                                               64704
-range                                              49485
+range                                              49745
 ref_module                                          1821
 ref_obj                                           371900
-ref_typespec                                      200809
+ref_typespec                                      200937
 return_stmt                                         2045
 string_typespec                                     3880
 string_var                                            31

--- a/third_party/tests/IncompTitan/IncompTitan.log
+++ b/third_party/tests/IncompTitan/IncompTitan.log
@@ -5336,7 +5336,7 @@ case_stmt                                            117
 class_defn                                             8
 class_typespec                                         4
 class_var                                              3
-constant                                          376945
+constant                                          377041
 cont_assign                                        18019
 cover                                                 20
 design                                                 1
@@ -5367,11 +5367,11 @@ integer_typespec                                     226
 integer_var                                            8
 io_decl                                              273
 logic_net                                          35465
-logic_typespec                                     93683
+logic_typespec                                     93715
 logic_var                                          12596
 module_inst                                        10358
 named_begin                                          395
-operation                                         103008
+operation                                         103072
 package                                               92
 packed_array_net                                       8
 packed_array_typespec                                233
@@ -5384,10 +5384,10 @@ prop_formal_decl                                       3
 property_decl                                          1
 property_inst                                          4
 property_spec                                        479
-range                                              71439
+range                                              71503
 ref_module                                          2376
-ref_obj                                           166458
-ref_typespec                                      158557
+ref_obj                                           166522
+ref_typespec                                      158589
 ref_var                                                2
 return_stmt                                          137
 sequence_decl                                         36
@@ -5395,7 +5395,7 @@ string_typespec                                     8895
 struct_net                                           147
 struct_typespec                                     4258
 struct_var                                          1295
-sys_func_call                                       2745
+sys_func_call                                       2777
 tagged_pattern                                      6169
 task                                                   9
 typespec_member                                    11527


### PR DESCRIPTION
Bumps third_party/UHDM to master with chipsalliance/UHDM#1148: `ExprEval::reducePackedElemSelect` now resolves the element typespec of a **multi-range** `logic_typespec` (`logic [0:4][31:0]`) instead of falling through to `reduceBitSelect`.

Impact: `parameter int unsigned NumPipeRegs = FmtPipeRegs[fmt]` on fpnew_pkg's `fmt_unsigned_t` previously stamped **bit fmt** of the 160-bit array value (`1,0,0,0,0` from a `'{default: 1}` fill) into the elaborated paramods, electing the wrong generate arm in fpnew slices. CVA6's `fpu_wrap`/`ex_stage` lost their pipeline registers (`early_valid` never asserted): 26 and 32 Verilator co-sim mismatches vs RTL over 300 cycles, both now 0.

Golden log updates (Ariane2024, AzadiRTL, Earlgrey_0_1, Earlgrey_Verilator_0_1, IncompTitan): UHDM object-count statistics only — more constants/logic_typespecs/ranges from the now-folding element-selects and their cloned element typespecs. No error/warning/note message changes anywhere.

Validation: `scripts/regression.py run` — 786 PASS, 5 stat-only DIFFs analyzed and updated, re-run clean (0 DIFF / 0 FAIL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)