### PR TITLE
Keep module-scope typedef packed dims symbolic at definition

### DIFF
--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -193,9 +193,21 @@ bool ElaborationStep::bindTypedefs_() {
           typespec* tpclone = nullptr;
           if (Packed_dimension &&
               fC->Type(Packed_dimension) == VObjectType::paPacked_dimension) {
+            // Module-scope typedef dimensions (`typedef entry_t
+            // [FlushEntries-1:0] dir_t`) must stay SYMBOLIC: reducing here
+            // folds them with the module's DEFAULT parameter values (a
+            // struct config '0 gave [-1:0] — hpdcache_flush's directory
+            // collapsed from 8 entries to 2), and the shared typespec is
+            // never re-elaborated per instance.  Packages and file scopes
+            // have final parameter values, so reduction stays correct there.
+            Reduce tdReduce =
+                (valuedcomponenti_cast<Package*>(comp) ||
+                 valuedcomponenti_cast<FileContent*>(comp))
+                    ? Reduce::Yes
+                    : Reduce::No;
             tpclone = m_helper.compileTypespec(
                 defTuple.second, typd->getFileContent(),
-                typd->getDefinitionNode(), m_compileDesign, Reduce::Yes,
+                typd->getDefinitionNode(), m_compileDesign, tdReduce,
                 nullptr, nullptr, false);
           } else if (typespec* tps = def->getTypespec()) {
             ElaboratorContext elaboratorContext(&s, false, true);

--- a/tests/ModPortTest/ModPortTest.log
+++ b/tests/ModPortTest/ModPortTest.log
@@ -284,9 +284,6 @@ PP TREE: (top_level_rule null_rule (source_text (description (module module)) (d
 [INF:CP0303] ${SURELOG_DIR}/tests/ModPortTest/top.v:45:1: Compile module "work@memory_ctrl2".
 [ERR:CP0311] ${SURELOG_DIR}/tests/ModPortTest/top.v:23:12: Undefined net used in modport: "ww_id".
 [INF:EL0526] Design Elaboration...
-[NTE:EL0531] ${SURELOG_DIR}/tests/ModPortTest/top.v:12:18: Negative value in instance "work@AXI_BUS"
-             text:   typedef logic [AXI_ID_WIDTH-1:0]   id_t;
-             value: INT:-2.
 [NTE:EL0503] ${SURELOG_DIR}/tests/ModPortTest/top.v:1:1: Top level module "work@dff0_test".
 [NTE:EL0503] ${SURELOG_DIR}/tests/ModPortTest/top.v:36:1: Top level module "work@memory_ctrl1".
 [NTE:EL0503] ${SURELOG_DIR}/tests/ModPortTest/top.v:45:1: Top level module "work@memory_ctrl2".
@@ -300,7 +297,7 @@ PP TREE: (top_level_rule null_rule (source_text (description (module module)) (d
 [INF:UH0706] Creating UHDM Model...
 === UHDM Object Stats Begin (Non-Elaborated Model) ===
 attribute                                              2
-constant                                              12
+constant                                               9
 cont_assign                                            2
 design                                                 1
 enum_const                                             8
@@ -312,14 +309,14 @@ io_decl                                                7
 logic_net                                             14
 logic_typespec                                         9
 modport                                                7
-module_inst                                            8
-operation                                              4
+module_inst                                            7
+operation                                              3
 packed_array_typespec                                  1
 param_assign                                           1
 parameter                                              1
 port                                                   9
 range                                                  2
-ref_obj                                               11
+ref_obj                                               12
 ref_typespec                                          20
 unsupported_typespec                                   3
 === UHDM Object Stats End ===
@@ -370,13 +367,24 @@ design: (work@dff0_test)
       |vpiParent:
       \_logic_typespec: (id_t), line:12:11, endln:12:16
       |vpiLeftRange:
-      \_constant: , line:12:18, endln:12:30
+      \_operation: , line:12:18, endln:12:32
         |vpiParent:
         \_range: , line:12:17, endln:12:35
-        |vpiDecompile:-2
-        |vpiSize:64
-        |INT:-2
-        |vpiConstType:7
+        |vpiOpType:11
+        |vpiOperand:
+        \_ref_obj: (work@AXI_BUS.id_t.AXI_ID_WIDTH), line:12:18, endln:12:30
+          |vpiParent:
+          \_operation: , line:12:18, endln:12:32
+          |vpiName:AXI_ID_WIDTH
+          |vpiFullName:work@AXI_BUS.id_t.AXI_ID_WIDTH
+        |vpiOperand:
+        \_constant: , line:12:31, endln:12:32
+          |vpiParent:
+          \_operation: , line:12:18, endln:12:32
+          |vpiDecompile:1
+          |vpiSize:64
+          |UINT:1
+          |vpiConstType:9
       |vpiRightRange:
       \_constant: , line:12:33, endln:12:34
         |vpiParent:
@@ -1047,7 +1055,7 @@ design: (work@dff0_test)
 [ SYNTAX] : 0
 [  ERROR] : 3
 [WARNING] : 5
-[   NOTE] : 9
+[   NOTE] : 8
 
 ============================== Begin Linting Results ==============================
 [LINT]: ${SURELOG_DIR}/tests/ModPortTest/top.v:51:1: Unsupported typespec, DD

--- a/tests/PackedArrayEnum/PackedArrayEnum.log
+++ b/tests/PackedArrayEnum/PackedArrayEnum.log
@@ -95,7 +95,7 @@ enum_const                                             2
 enum_typespec                                          1
 logic_net                                              1
 logic_typespec                                         1
-module_inst                                            4
+module_inst                                            3
 packed_array_typespec                                  2
 packed_array_var                                       1
 range                                                  3
@@ -109,7 +109,7 @@ enum_const                                             2
 enum_typespec                                          1
 logic_net                                              1
 logic_typespec                                         1
-module_inst                                            4
+module_inst                                            3
 packed_array_typespec                                  2
 packed_array_var                                       1
 range                                                  3

--- a/tests/PackedArrayTypespec/PackedArrayTypespec.log
+++ b/tests/PackedArrayTypespec/PackedArrayTypespec.log
@@ -101,7 +101,7 @@ design                                                 1
 enum_const                                             3
 enum_typespec                                          1
 logic_typespec                                         1
-module_inst                                            4
+module_inst                                            3
 packed_array_typespec                                  4
 range                                                  5
 ref_typespec                                           3
@@ -113,7 +113,7 @@ design                                                 1
 enum_const                                             3
 enum_typespec                                          1
 logic_typespec                                         1
-module_inst                                            4
+module_inst                                            3
 packed_array_typespec                                  4
 range                                                  5
 ref_typespec                                           3

--- a/tests/UnpackedTypespec/UnpackedTypespec.log
+++ b/tests/UnpackedTypespec/UnpackedTypespec.log
@@ -222,7 +222,7 @@ int_typespec                                           4
 integer_typespec                                       1
 logic_net                                              1
 logic_typespec                                         2
-module_inst                                            5
+module_inst                                            4
 operation                                              1
 packed_array_typespec                                  7
 range                                                 16
@@ -242,7 +242,7 @@ int_typespec                                           4
 integer_typespec                                       1
 logic_net                                              1
 logic_typespec                                         2
-module_inst                                            5
+module_inst                                            4
 operation                                              1
 packed_array_typespec                                  7
 range                                                 16


### PR DESCRIPTION
`bindTypedefs_` compiled typedef packed dimensions with `Reduce::Yes` at **definition** scope, folding parameter-built bounds with the module's DEFAULT parameter values. For `typedef flush_entry_t [FlushEntries-1:0] flush_dir_t` (CVA6 hpdcache_flush, `FlushEntries` derived from a struct config parameter defaulting to `'0`) the range baked to `[-1:0]`, and since the shared typespec is never re-elaborated per instance, every consumer saw a 2-entry (104-bit) flush directory instead of the real 8-entry (416-bit) one — 298/300 co-sim divergences vs RTL.

Fix: compile module/program/class-scope typedef packed dimensions with `Reduce::No` so the bounds stay **symbolic** — the same form the logic-typespec typedef path already produces (its `$clog2`-built bounds fail to reduce, and everything downstream evaluates them per instance; that asymmetry was the tell). Package and file scopes keep `Reduce::Yes` since their parameters are final. The muted-error comment above the call already acknowledged definition-time folds of parameter-dependent ranges are meaningless.

Validation:
- CVA6 `hpdcache_flush` directory geometry restored (104 → 416 bits); together with downstream reader fixes the module co-sims 0/300 and is newly PROVEN by SAT sweep (as are hpdcache_data_resize/upsize).
- Full regression: 787 PASS, 4 analyzed stat-level DIFFs updated (bounds now operations instead of default-folded constants; one fewer cloned instance node; ModPortTest's spurious "Negative value in instance ... INT:-2" note gone), re-run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)