### PR TITLE
getValue: re-attach the declared typespec to ascending-range constants (fpnew CPK mirror)

### DIFF
--- a/src/DesignCompile/CompileExpression.cpp
+++ b/src/DesignCompile/CompileExpression.cpp
@@ -1316,6 +1316,89 @@ any *CompileHelper::getValue(std::string_view name, DesignComponent *component,
       setBreakpointHere++;
     }
   }
+  // A Value-store constant carries no typespec, so an ascending-range base
+  // read (`CPK_FORMATS[fmt]` on fpnew_pkg's `logic [0:4]`) later defaults to
+  // DESCENDING index mapping and reads MIRRORED — the CPK term of
+  // get_conv_lane_formats never fired and every CONV lane above 0 lost its
+  // FP64/CPK width.  Re-attach the declaring parameter's typespec: search
+  // the component chain, then every package (same last-resort spirit as
+  // getTaskFunc).
+  if (result != nullptr && result->UhdmType() == uhdmconstant &&
+      ((UHDM::constant *)result)->Typespec() == nullptr) {
+    std::string_view bare = name;
+    if (auto pos = name.rfind("::"); pos != std::string_view::npos)
+      bare = name.substr(pos + 2);
+    const UHDM::parameter *declp = nullptr;
+    DesignComponent *declc = nullptr;
+    for (DesignComponent *comp = component; comp && !declp;
+         comp = valuedcomponenti_cast<DesignComponent *>(
+             (DesignComponent *)comp->getParentScope())) {
+      if (comp->getParameters()) {
+        for (auto p : *comp->getParameters()) {
+          if (p->VpiName() == bare) {
+            declp = any_cast<const UHDM::parameter *>(p);
+            declc = comp;
+            break;
+          }
+        }
+      }
+    }
+    if (declp == nullptr) {
+      Design *design = compileDesign->getCompiler()->getDesign();
+      for (auto &pentry : design->getPackageDefinitions()) {
+        Package *pack = pentry.second;
+        if (pack == nullptr || pack->getParameters() == nullptr) continue;
+        for (auto p : *pack->getParameters()) {
+          if (p->VpiName() == bare) {
+            declp = any_cast<const UHDM::parameter *>(p);
+            declc = pack;
+            break;
+          }
+        }
+        if (declp) break;
+      }
+    }
+    // Attach ONLY for a provably ASCENDING single-range logic vector — the
+    // one shape where the missing typespec flips the read (everything else
+    // keeps the historical typeless behavior, containing the blast radius).
+    if (declp && declp->Typespec() && declp->Typespec()->Actual_typespec()) {
+      const UHDM::typespec *dts0 = declp->Typespec()->Actual_typespec();
+      if (const UHDM::logic_typespec *lts =
+              any_cast<const UHDM::logic_typespec *>(dts0)) {
+        if (lts->Ranges() && lts->Ranges()->size() == 1) {
+          UHDM::range *r0 = lts->Ranges()->at(0);
+          bool ok = false;
+          int64_t lv = 0, rv = 0;
+          if (r0->Left_expr() && r0->Right_expr()) {
+            bool inv = false;
+            UHDM::expr *le =
+                reduceExpr((any *)r0->Left_expr(), inv,
+                           declc ? declc : component, compileDesign, nullptr,
+                           fileId, lineNumber, nullptr, true);
+            UHDM::expr *re =
+                reduceExpr((any *)r0->Right_expr(), inv,
+                           declc ? declc : component, compileDesign, nullptr,
+                           fileId, lineNumber, nullptr, true);
+            if (!inv && le && re &&
+                le->UhdmType() == uhdmconstant &&
+                re->UhdmType() == uhdmconstant) {
+              UHDM::ExprEval eval;
+              bool giv = false;
+              lv = eval.get_value(giv, le);
+              rv = eval.get_value(giv, re);
+              ok = !giv;
+            }
+          }
+          if (ok && lv < rv) {
+            ref_typespec *rt = s.MakeRef_typespec();
+            rt->Actual_typespec((UHDM::typespec *)dts0);
+            rt->VpiParent(result);
+            ((UHDM::constant *)result)->Typespec(rt);
+          }
+        }
+      }
+    }
+  }
   if (m_checkForLoops) {
     m_stackLevel--;
   }

--- a/third_party/tests/AzadiRTL/AzadiRTL.log
+++ b/third_party/tests/AzadiRTL/AzadiRTL.log
@@ -17724,7 +17724,7 @@ property_spec                                         31
 range                                              72196
 ref_module                                           488
 ref_obj                                            67715
-ref_typespec                                      171635
+ref_typespec                                      171675
 ref_var                                                8
 return_stmt                                          118
 string_typespec                                     2724
@@ -17805,7 +17805,7 @@ property_spec                                        110
 range                                              72623
 ref_module                                           488
 ref_obj                                           287088
-ref_typespec                                      852395
+ref_typespec                                      852435
 ref_var                                               36
 return_stmt                                          317
 string_typespec                                     2895

--- a/third_party/tests/IncompTitan/IncompTitan.log
+++ b/third_party/tests/IncompTitan/IncompTitan.log
@@ -5336,7 +5336,7 @@ case_stmt                                            117
 class_defn                                             8
 class_typespec                                         4
 class_var                                              3
-constant                                          377041
+constant                                          377045
 cont_assign                                        18019
 cover                                                 20
 design                                                 1
@@ -5361,7 +5361,7 @@ import_typespec                                       92
 include_file_info                                     70
 indexed_part_select                                  830
 initial                                               64
-int_typespec                                       16712
+int_typespec                                       16714
 int_var                                              381
 integer_typespec                                     231
 integer_var                                            8
@@ -5371,7 +5371,7 @@ logic_typespec                                     93715
 logic_var                                          12596
 module_inst                                        10358
 named_begin                                          395
-operation                                         103072
+operation                                         103073
 package                                               92
 packed_array_net                                       8
 packed_array_typespec                                233
@@ -5386,8 +5386,8 @@ property_inst                                          4
 property_spec                                        479
 range                                              71503
 ref_module                                          2376
-ref_obj                                           166522
-ref_typespec                                      158649
+ref_obj                                           166523
+ref_typespec                                      158651
 ref_var                                                2
 return_stmt                                          137
 sequence_decl                                         36


### PR DESCRIPTION
A Value-store constant carries no typespec, so an ascending-range base read (`fpnew_pkg::CPK_FORMATS[fmt]` on `logic [0:4]`) later defaults to DESCENDING index mapping in `ExprEval::reduceBitSelect` and reads MIRRORED: the CPK term of `get_conv_lane_formats` never fired, CONV lanes above 0 lost their FP64/CPK width, and CVA6's `fpnew_opgroup_multifmt_slice` elaborated lane 1 with 32-bit internals where the RTL has 64.

At `getValue`'s exit, when the result is a typeless constant, find the declaring parameter (component chain, then every package — same last-resort spirit as `getTaskFunc`) and re-attach its typespec — but **only for a provably ASCENDING single-range logic vector**, the one shape where the missing typespec flips the read. Everything else keeps the historical typeless behavior, containing the blast radius (an unconditional variant churned 80 goldens; this one touches 2, stat-level only — object-count deltas from the added ref_typespecs).

Attaching lazily at the read (in ExprEval) does not work: the declared typespec's range exprs (`[0:NUM_FP_FORMATS-1]`) don't resolve in the evaluation frame, `reduceBitSelect` leaks that range-eval failure into the caller's `invalidValue`, and neither `m_design` nor the UHDM design tree exist yet during elaboration.

Validation: regression 789 PASS / 0 FAIL (2 stat-level goldens updated and verified PASS 2 / DIFF 0). Downstream uhdm2rtlil: full parallel regression PASSED, CVA6 sweep 0 regressions; together with a reader-side bit-select-index fix, `fpnew_opgroup_multifmt_slice` co-sim reaches **0 divergences** (97 at the start of the campaign round) and `fpnew_cast_multi`'s equivalence miter proves again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)