### PR TITLE
bindTypedefs_: bind same-scope typedef chains base-first

### DIFF
--- a/src/DesignCompile/ElaborationStep.cpp
+++ b/src/DesignCompile/ElaborationStep.cpp
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <algorithm>
 #include <map>
 #include <queue>
 #include <string>
@@ -152,6 +153,43 @@ bool ElaborationStep::bindTypedefs_() {
       TypeDef* typd = typed.second;
       defs.emplace_back(typd, classp);
     }
+  }
+
+  // getTypeDefMap() is name-ordered, so a typedef whose BASE is a
+  // later-alphabetical typedef of the SAME scope binds first, finds the base
+  // still DUMMY (no typespec yet), and comes out unsupported_typespec
+  // (`typedef pair_t [1:0][1:0] entry_t;` with `typedef word_t [1:0]
+  // pair_t;` — hpdcache_memctrl's hpdcache_data_entry_t left
+  // data_wentry/data_rentry as 1-bit nets and dropped every data-SRAM
+  // connection).  Reorder by the actual BY-NAME dependency: when a
+  // typedef's definition node is a plain type name naming another typedef
+  // of the same scope, emit that base first.  Everything else keeps its
+  // original position (source line order is NOT usable here — typedefs of
+  // one package can come from different include files whose line numbers
+  // interleave), and a cycle falls back to the original order.
+  {
+    std::vector<std::pair<TypeDef*, DesignComponent*>> ordered;
+    ordered.reserve(defs.size());
+    std::map<DesignComponent*, std::map<std::string_view, size_t>> byScope;
+    for (size_t i = 0; i < defs.size(); i++)
+      byScope[defs[i].second].emplace(defs[i].first->getName(), i);
+    std::vector<char> emitted(defs.size(), 0);
+    std::function<void(size_t)> emit = [&](size_t i) {
+      if (emitted[i]) return;
+      emitted[i] = 1;  // mark before recursing: breaks dependency cycles
+      TypeDef* typd = defs[i].first;
+      const FileContent* fC = typd->getFileContent();
+      NodeId defNode = typd->getDefinitionNode();
+      if (fC && defNode &&
+          fC->Type(defNode) == VObjectType::slStringConst) {
+        auto& scopeMap = byScope[defs[i].second];
+        auto it = scopeMap.find(fC->SymName(defNode));
+        if (it != scopeMap.end() && it->second != i) emit(it->second);
+      }
+      ordered.push_back(defs[i]);
+    };
+    for (size_t i = 0; i < defs.size(); i++) emit(i);
+    defs = std::move(ordered);
   }
 
   for (auto& defTuple : defs) {


### PR DESCRIPTION
`getTypeDefMap()` is name-ordered, so a typedef whose base is a later-alphabetical typedef of the same scope binds first, finds the base still DUMMY (no typespec yet), and comes out `unsupported_typespec`:

```systemverilog
typedef word_t [1:0]      pair_t;    // word_t is a type parameter
typedef pair_t [1:0][1:0] entry_t;   // bound BEFORE pair_t -> unsupported_typespec
```

Found in CVA6's hpdcache_memctrl: `hpdcache_data_entry_t` (the same shape over `hpdcache_data_ram_data_t`) elaborated as `unsupported_typespec`, its `data_wentry`/`data_rentry` nets came out 1-bit, and every data-SRAM port connection was dropped downstream.

This PR reorders the `defs` vector by the actual **by-name dependency** before binding: when a typedef's definition node is a plain type name naming another typedef of the same scope, that base is emitted first; everything else keeps its original position. Source line order is deliberately NOT used — typedefs of one package can come from different include files whose line numbers interleave (a line-sorted attempt broke OVM's `urm_type_compatibility` aliases with "Undefined type ovm_event_pool"). A dependency cycle falls back to the original order.

Full regression: **786 PASS, 0 DIFF** — no golden log changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)